### PR TITLE
Make the error message when cache is not writable clearer

### DIFF
--- a/phpBB/includes/acm/acm_file.php
+++ b/phpBB/includes/acm/acm_file.php
@@ -88,11 +88,11 @@ class acm
 			if (!phpbb_is_writable($this->cache_dir))
 			{
 				// We need to use die() here, because else we may encounter an infinite loop (the message handler calls $cache->unload())
-				die($this->cache_dir . ' is NOT writable.');
+				die('Fatal: ' . $this->cache_dir . ' is NOT writable.');
 				exit;
 			}
 
-			die('Not able to open ' . $this->cache_dir . 'data_global.' . $phpEx);
+			die('Fatal: Not able to open ' . $this->cache_dir . 'data_global.' . $phpEx);
 			exit;
 		}
 


### PR DESCRIPTION
Note: the name of the file with cache file implementation changed between develop-olympus and develop, but git appears to be capable of applying this diff in the right place and can automatically merge develop-olympus to develop with this change applied.
