### PR TITLE
[ticket/9949] $user->lang() uses last int-value to get the key not first

### DIFF
--- a/phpBB/includes/session.php
+++ b/phpBB/includes/session.php
@@ -1966,6 +1966,7 @@ class user extends session
 
 					$key_found = $num;
 				}
+				break;
 			}
 		}
 


### PR DESCRIPTION
The comment in the code says: "We now get the first number passed and will
select the key based upon this number". But the loop over the arguments is not
left and therefore it uses the last int-value not the first one.
