### PR TITLE
[ticket/9911] Correctly open "Minimum posts" on editing a rank in IE.

### DIFF
--- a/phpBB/adm/style/acp_ranks.html
+++ b/phpBB/adm/style/acp_ranks.html
@@ -35,8 +35,8 @@
 	</dl>
 	<dl>
 		<dt><label for="special_rank">{L_RANK_SPECIAL}:</label></dt>
-		<dd><label><input onchange="dE('posts', -1)" type="radio" class="radio" name="special_rank" value="1" id="special_rank"<!-- IF S_SPECIAL_RANK --> checked="checked"<!-- ENDIF --> />{L_YES}</label>
-			<label><input onchange="dE('posts', 1)" type="radio" class="radio" name="special_rank" value="0"<!-- IF not S_SPECIAL_RANK --> checked="checked"<!-- ENDIF --> /> {L_NO}</label></dd>
+		<dd><label><input onclick="dE('posts', -1)" type="radio" class="radio" name="special_rank" value="1" id="special_rank"<!-- IF S_SPECIAL_RANK --> checked="checked"<!-- ENDIF --> />{L_YES}</label>
+			<label><input onclick="dE('posts', 1)" type="radio" class="radio" name="special_rank" value="0"<!-- IF not S_SPECIAL_RANK --> checked="checked"<!-- ENDIF --> /> {L_NO}</label></dd>
 	</dl>
 	<!-- IF S_SPECIAL_RANK --><div id="posts" style="display: none;"><!-- ELSE --><div id="posts"><!-- ENDIF -->
 	<dl>


### PR DESCRIPTION
IE handles onchange after the next click on the page, instead of directly like Firefox, Opera and Safari do. Changing it to onclick works.

http://tracker.phpbb.com/browse/PHPBB3-9911
