### PR TITLE
Ticket/10092 commit-msg hook aborts on overlength comment lines

### DIFF
--- a/git-tools/hooks/commit-msg
+++ b/git-tools/hooks/commit-msg
@@ -66,7 +66,7 @@ then
 	exit 0
 fi
 
-msg=$(grep -nE '.{81,}' "$1");
+msg=$(grep -v '^#' "$1" |grep -nE '.{81,}')
 
 if [ $? -eq 0 ]
 then


### PR DESCRIPTION
http://tracker.phpbb.com/browse/PHPBB3-10092
