### PR TITLE
[ticket/10129] Added missing apostrophes to ACP user management language.

### DIFF
--- a/phpBB/language/en/acp/permissions.php
+++ b/phpBB/language/en/acp/permissions.php
@@ -225,8 +225,8 @@ $lang = array_merge($lang, array(
 	'SELECT_TYPE'					=> 'Select type',
 	'SET_PERMISSIONS'				=> 'Set permissions',
 	'SET_ROLE_PERMISSIONS'			=> 'Set role permissions',
-	'SET_USERS_PERMISSIONS'			=> 'Set user\'s permissions',
-	'SET_USERS_FORUM_PERMISSIONS'	=> 'Set user\'s forum permissions',
+	'SET_USERS_PERMISSIONS'			=> 'Set user’s permissions',
+	'SET_USERS_FORUM_PERMISSIONS'	=> 'Set user’s forum permissions',
 
 	'TRACE_DEFAULT'					=> 'By default every permission is <samp>NO</samp> (unset). So the permission can be overwritten by other settings.',
 	'TRACE_FOR'						=> 'Trace for',


### PR DESCRIPTION
http://tracker.phpbb.com/browse/PHPBB3-10129
