### PR TITLE
[ticket/10126] Use binary "and not" instead of binary "xor" in error_repo

### DIFF
--- a/phpBB/common.php
+++ b/phpBB/common.php
@@ -24,7 +24,7 @@ if (!defined('E_DEPRECATED'))
 {
 	define('E_DEPRECATED', 8192);
 }
-error_reporting(E_ALL ^ E_NOTICE ^ E_DEPRECATED);
+error_reporting(E_ALL & ~E_NOTICE & ~E_DEPRECATED);
 
 /*
 * Remove variables created by register_globals from the global scope

--- a/phpBB/download/file.php
+++ b/phpBB/download/file.php
@@ -35,7 +35,7 @@ if (isset($_GET['avatar']))
 	{
 		define('E_DEPRECATED', 8192);
 	}
-	error_reporting(E_ALL ^ E_NOTICE ^ E_DEPRECATED);
+	error_reporting(E_ALL & ~E_NOTICE & ~E_DEPRECATED);
 
 	require($phpbb_root_path . 'config.' . $phpEx);
 

--- a/phpBB/install/database_update.php
+++ b/phpBB/install/database_update.php
@@ -35,7 +35,7 @@ if (!defined('E_DEPRECATED'))
 {
 	define('E_DEPRECATED', 8192);
 }
-//error_reporting(E_ALL ^ E_NOTICE ^ E_DEPRECATED);
+//error_reporting(E_ALL & ~E_NOTICE & ~E_DEPRECATED);
 error_reporting(E_ALL);
 
 @set_time_limit(0);

--- a/phpBB/install/index.php
+++ b/phpBB/install/index.php
@@ -23,7 +23,7 @@ if (!defined('E_DEPRECATED'))
 {
 	define('E_DEPRECATED', 8192);
 }
-error_reporting(E_ALL ^ E_NOTICE ^ E_DEPRECATED);
+error_reporting(E_ALL & ~E_NOTICE & ~E_DEPRECATED);
 
 // @todo Review this test and see if we can find out what it is which prevents PHP 4.2.x from even displaying the page with requirements on it
 if (version_compare(PHP_VERSION, '4.3.3') < 0)

--- a/phpBB/style.php
+++ b/phpBB/style.php
@@ -20,7 +20,7 @@ if (!defined('E_DEPRECATED'))
 {
 	define('E_DEPRECATED', 8192);
 }
-error_reporting(E_ALL ^ E_NOTICE ^ E_DEPRECATED);
+error_reporting(E_ALL & ~E_NOTICE & ~E_DEPRECATED);
 
 require($phpbb_root_path . 'config.' . $phpEx);
 


### PR DESCRIPTION
http://tracker.phpbb.com/browse/PHPBB3-10126

[ticket/10126] Use binary "and not" instead of binary "xor" in error_reporting.

Make what we want to achieve clear by using "and not" instead of "xor".

PHPBB3-10126
