### PR TITLE
[ticket/10186] UCP signature panel displays when not authed for signature

### DIFF
--- a/phpBB/ucp.php
+++ b/phpBB/ucp.php
@@ -314,6 +314,12 @@ if (!$config['allow_topic_notify'] && !$config['allow_forum_notify'])
 	$module->set_display('main', 'subscribed', false);
 }
 
+// Do not display signature panel if not authed to do so
+if (!$auth->acl_get('u_sig'))
+{
+	$module->set_display('profile', 'signature', false);
+}
+
 // Select the active module
 $module->set_active($id, $mode);
 


### PR DESCRIPTION
[ticket/10186] UCP signature panel displays when not authed for signatures

The signature panel link was displayed even when a user did not have the
auths to create/edit their signature. Clicking on the link gave a
trigger_error of "Not authorised to have a signature". Hide the link
when user does not have permissions to edit their signature.

http://tracker.phpbb.com/browse/PHPBB3-10186
