### PR TITLE
[ticket/10195] Return false in session::check_dnsbl() when IPv6 is passed

### DIFF
--- a/phpBB/includes/session.php
+++ b/phpBB/includes/session.php
@@ -1238,6 +1238,12 @@ class session
 			$ip = $this->ip;
 		}
 
+		// Neither Spamhaus nor Spamcop supports IPv6 addresses.
+		if (strpos($ip, ':') !== false)
+		{
+			return false;
+		}
+
 		$dnsbl_check = array(
 			'sbl.spamhaus.org'	=> 'http://www.spamhaus.org/query/bl?ip=',
 		);


### PR DESCRIPTION
http://tracker.phpbb.com/browse/PHPBB3-10195

[ticket/10195] Return false in session::check_dnsbl() when IPv6 is passed.

There is no support for IPv6 addresses in the blacklists we check right now.

PHPBB3-10195
