### PR TITLE
[ticket/10067] Add separator to h_radio to place options on individual li

### DIFF
--- a/phpBB/adm/index.php
+++ b/phpBB/adm/index.php
@@ -237,7 +237,7 @@ function build_select($option_ary, $option_default = false)
 /**
 * Build radio fields in acp pages
 */
-function h_radio($name, &$input_ary, $input_default = false, $id = false, $key = false)
+function h_radio($name, $input_ary, $input_default = false, $id = false, $key = false, $separator = '')
 {
 	global $user;
 
@@ -246,7 +246,7 @@ function h_radio($name, &$input_ary, $input_default = false, $id = false, $key =
 	foreach ($input_ary as $value => $title)
 	{
 		$selected = ($input_default !== false && $value == $input_default) ? ' checked="checked"' : '';
-		$html .= '<label><input type="radio" name="' . $name . '"' . (($id && !$id_assigned) ? ' id="' . $id . '"' : '') . ' value="' . $value . '"' . $selected . (($key) ? ' accesskey="' . $key . '"' : '') . ' class="radio" /> ' . $user->lang[$title] . '</label>';
+		$html .= '<label><input type="radio" name="' . $name . '"' . (($id && !$id_assigned) ? ' id="' . $id . '"' : '') . ' value="' . $value . '"' . $selected . (($key) ? ' accesskey="' . $key . '"' : '') . ' class="radio" /> ' . $user->lang[$title] . '</label>' . $separator;
 		$id_assigned = true;
 	}
 

--- a/phpBB/includes/acp/acp_board.php
+++ b/phpBB/includes/acp/acp_board.php
@@ -769,17 +769,18 @@ class acp_board
 	{
 		global $user, $config;
 
-		$radio_ary = array(USER_ACTIVATION_DISABLE => 'ACC_DISABLE', USER_ACTIVATION_NONE => 'ACC_NONE');
-		$radio_text = h_radio('config[require_activation]', $radio_ary, $value, $key);
+		$radio_ary = array(
+			USER_ACTIVATION_DISABLE => 'ACC_DISABLE',
+			USER_ACTIVATION_NONE => 'ACC_NONE',
+		);
+
 		if ($config['email_enable'])
 		{
-			$radio_ary = array(USER_ACTIVATION_SELF => 'ACC_USER', USER_ACTIVATION_ADMIN => 'ACC_ADMIN');
-			// With longer labels the four options no longer fit
-			// onto a single line. Separate them onto two lines.
-			// This also requires two h_radio calls to generate HTML.
-			$radio_text .= '<br /><br />';
-			$radio_text .= h_radio('config[require_activation]', $radio_ary, $value, $key);
+			$radio_ary[USER_ACTIVATION_SELF] = 'ACC_USER';
+			$radio_ary[USER_ACTIVATION_ADMIN] = 'ACC_ADMIN';
 		}
+
+		$radio_text = h_radio('config[require_activation]', $radio_ary, $value, 'require_activation', $key, '<br />');
 
 		return $radio_text;
 	}


### PR DESCRIPTION
[ticket/10067] Add separator to h_radio to place options on individual lines

The previous mechanism for account activation resulted in two h_radio calls
with identical id attributes for two elements.

http://tracker.phpbb.com/browse/PHPBB3-10067
