### PR TITLE
Function validate_config_vars() improperly validates multibyte strings

### DIFF
--- a/phpBB/adm/index.php
+++ b/phpBB/adm/index.php
@@ -402,7 +402,7 @@ function validate_config_vars($config_vars, &$cfg_array, &$error)
 		switch ($validator[$type])
 		{
 			case 'string':
-				$length = strlen($cfg_array[$config_name]);
+				$length = utf8_strlen($cfg_array[$config_name]);
 
 				// the column is a VARCHAR
 				$validator[$max] = (isset($validator[$max])) ? min(255, $validator[$max]) : 255;


### PR DESCRIPTION
<a href="http://tracker.phpbb.com/browse/PHPBB3-10198">PHPBB3-10198</a>.
