### PR TITLE
[ticket/10110] Remove multi-server syntax from Redis ACM.

### DIFF
--- a/phpBB/includes/acm/acm_redis.php
+++ b/phpBB/includes/acm/acm_redis.php
@@ -31,12 +31,6 @@ if (!defined('PHPBB_ACM_REDIS_HOST'))
 	define('PHPBB_ACM_REDIS_HOST', 'localhost');
 }
 
-if (!defined('PHPBB_ACM_REDIS'))
-{
-	//can define multiple servers with host1/port1,host2/port2 format
-	define('PHPBB_ACM_REDIS', PHPBB_ACM_REDIS_HOST . '/' . PHPBB_ACM_REDIS_PORT);
-}
-
 /**
 * ACM for Redis
 *
@@ -57,11 +51,7 @@ class acm extends acm_memory
 		parent::acm_memory();
 
 		$this->redis = new Redis();
-		foreach (explode(',', PHPBB_ACM_REDIS) as $server)
-		{
-			$parts = explode('/', $server);
-			$this->redis->connect(trim($parts[0]), trim($parts[1]));
-		}
+		$this->redis->connect(PHPBB_ACM_REDIS_HOST, PHPBB_ACM_REDIS_PORT);
 
 		if (defined('PHPBB_ACM_REDIS_PASSWORD'))
 		{


### PR DESCRIPTION
http://tracker.phpbb.com/browse/PHPBB3-10110
