### PR TITLE
[ticket/9992] The table name constant needs to be defined in the updater

### DIFF
--- a/phpBB/install/database_update.php
+++ b/phpBB/install/database_update.php
@@ -78,6 +78,13 @@ require($phpbb_root_path . 'includes/constants.' . $phpEx);
 require($phpbb_root_path . 'includes/db/' . $dbms . '.' . $phpEx);
 require($phpbb_root_path . 'includes/utf/utf_tools.' . $phpEx);
 
+// new table constants are separately defined here in case the updater is run
+// before the files are updated
+if (!defined('LOGIN_ATTEMPT_TABLE'))
+{
+	define('LOGIN_ATTEMPT_TABLE', $table_prefix . 'login_attempts');
+}
+
 // If we are on PHP >= 6.0.0 we do not need some code
 if (version_compare(PHP_VERSION, '6.0.0-dev', '>='))
 {


### PR DESCRIPTION
When the database update is run before updating the files the constant
is not yet defined.

http://tracker.phpbb.com/browse/PHPBB3-9992
