### PR TITLE
[ticket/10214] Correct Oracle create table query syntax in db_tools

### DIFF
--- a/phpBB/includes/db/db_tools.php
+++ b/phpBB/includes/db/db_tools.php
@@ -543,7 +543,7 @@ class phpbb_db_tools
 			break;
 
 			case 'oracle':
-				$table_sql .= "\n);";
+				$table_sql .= "\n)";
 				$statements[] = $table_sql;
 
 				// do we need to add a sequence and a tigger for auto incrementing columns?
@@ -561,7 +561,7 @@ class phpbb_db_tools
 					$trigger .= "BEGIN\n";
 					$trigger .= "\tSELECT {$table_name}_seq.nextval\n";
 					$trigger .= "\tINTO :new.{$create_sequence}\n";
-					$trigger .= "\tFROM dual\n";
+					$trigger .= "\tFROM dual;\n";
 					$trigger .= "END;";
 
 					$statements[] = $trigger;

--- a/phpBB/install/database_update.php
+++ b/phpBB/install/database_update.php
@@ -2484,7 +2484,7 @@ class updater_db_tools
 			break;
 
 			case 'oracle':
-				$table_sql .= "\n);";
+				$table_sql .= "\n)";
 				$statements[] = $table_sql;
 
 				// do we need to add a sequence and a tigger for auto incrementing columns?
@@ -2502,7 +2502,7 @@ class updater_db_tools
 					$trigger .= "BEGIN\n";
 					$trigger .= "\tSELECT {$table_name}_seq.nextval\n";
 					$trigger .= "\tINTO :new.{$create_sequence}\n";
-					$trigger .= "\tFROM dual\n";
+					$trigger .= "\tFROM dual;\n";
 					$trigger .= "END;";
 
 					$statements[] = $trigger;


### PR DESCRIPTION
Removes the semicolon at end of oracle CREATE TABLE queries and adds a
semicolon to the end of a SELECT query inside of the trigger for a new
table's auto increment column before the end keyword

http://tracker.phpbb.com/browse/PHPBB3-10214
