### PR TITLE
[ticket/10232] Renamed S_SEARCH_HIDDEN_FIELDS to S_SEARCH_LOCAL_HIDDEN_FI

### DIFF
--- a/phpBB/styles/prosilver/template/viewforum_body.html
+++ b/phpBB/styles/prosilver/template/viewforum_body.html
@@ -49,7 +49,7 @@
 			<fieldset>
 				<input class="inputbox search tiny" type="text" name="keywords" id="search_keywords" size="20" value="{L_SEARCH_FORUM}" onclick="if (this.value == '{LA_SEARCH_FORUM}') this.value = '';" onblur="if (this.value == '') this.value = '{LA_SEARCH_FORUM}';" />
 				<input class="button2" type="submit" value="{L_SEARCH}" />
-				{S_SEARCH_HIDDEN_FIELDS}
+				{S_SEARCH_LOCAL_HIDDEN_FIELDS}
 			</fieldset>
 			</form>
 		</div>

--- a/phpBB/styles/prosilver/template/viewtopic_body.html
+++ b/phpBB/styles/prosilver/template/viewtopic_body.html
@@ -42,7 +42,7 @@
 			<fieldset>
 				<input class="inputbox search tiny"  type="text" name="keywords" id="search_keywords" size="20" value="{L_SEARCH_TOPIC}" onclick="if(this.value=='{LA_SEARCH_TOPIC}')this.value='';" onblur="if(this.value=='')this.value='{LA_SEARCH_TOPIC}';" />
 				<input class="button2" type="submit" value="{L_SEARCH}" />
-				{S_SEARCH_HIDDEN_FIELDS}
+				{S_SEARCH_LOCAL_HIDDEN_FIELDS}
 			</fieldset>
 			</form>
 		</div>

--- a/phpBB/styles/subsilver2/template/searchbox.html
+++ b/phpBB/styles/subsilver2/template/searchbox.html
@@ -1,1 +1,1 @@
-<form method="get" name="search" action="{S_SEARCHBOX_ACTION}"><span class="gensmall">{L_SEARCH_FOR}:</span> <input class="post" type="text" name="keywords" size="20" /> <input class="btnlite" type="submit" value="{L_GO}" />{S_SEARCH_HIDDEN_FIELDS}</form>
+<form method="get" name="search" action="{S_SEARCHBOX_ACTION}"><span class="gensmall">{L_SEARCH_FOR}:</span> <input class="post" type="text" name="keywords" size="20" /> <input class="btnlite" type="submit" value="{L_GO}" />{S_SEARCH_LOCAL_HIDDEN_FIELDS}</form>

--- a/phpBB/viewforum.php
+++ b/phpBB/viewforum.php
@@ -311,7 +311,7 @@ $template->assign_vars(array(
 	'S_FORUM_ACTION'		=> append_sid("{$phpbb_root_path}viewforum.$phpEx", "f=$forum_id" . (($start == 0) ? '' : "&amp;start=$start")),
 	'S_DISPLAY_SEARCHBOX'	=> ($auth->acl_get('u_search') && $auth->acl_get('f_search', $forum_id) && $config['load_search']) ? true : false,
 	'S_SEARCHBOX_ACTION'	=> append_sid("{$phpbb_root_path}search.$phpEx"),
-	'S_SEARCH_HIDDEN_FIELDS'	=> build_hidden_fields($s_search_hidden_fields),
+	'S_SEARCH_LOCAL_HIDDEN_FIELDS'	=> build_hidden_fields($s_search_hidden_fields),
 	'S_SINGLE_MODERATOR'	=> (!empty($moderators[$forum_id]) && sizeof($moderators[$forum_id]) > 1) ? false : true,
 	'S_IS_LOCKED'			=> ($forum_data['forum_status'] == ITEM_LOCKED) ? true : false,
 	'S_VIEWFORUM'			=> true,

--- a/phpBB/viewtopic.php
+++ b/phpBB/viewtopic.php
@@ -646,7 +646,7 @@ $template->assign_vars(array(
 	'S_VIEWTOPIC'			=> true,
 	'S_DISPLAY_SEARCHBOX'	=> ($auth->acl_get('u_search') && $auth->acl_get('f_search', $forum_id) && $config['load_search']) ? true : false,
 	'S_SEARCHBOX_ACTION'	=> append_sid("{$phpbb_root_path}search.$phpEx"),
-	'S_SEARCH_HIDDEN_FIELDS'	=> build_hidden_fields($s_search_hidden_fields),
+	'S_SEARCH_LOCAL_HIDDEN_FIELDS'	=> build_hidden_fields($s_search_hidden_fields),
 
 	'S_DISPLAY_POST_INFO'	=> ($topic_data['forum_type'] == FORUM_POST && ($auth->acl_get('f_post', $forum_id) || $user->data['user_id'] == ANONYMOUS)) ? true : false,
 	'S_DISPLAY_REPLY_INFO'	=> ($topic_data['forum_type'] == FORUM_POST && ($auth->acl_get('f_reply', $forum_id) || $user->data['user_id'] == ANONYMOUS)) ? true : false,


### PR DESCRIPTION
[ticket/10232] Renamed S_SEARCH_HIDDEN_FIELDS to S_SEARCH_LOCAL_HIDDEN_FIELDS

Avoids the global hidden fields from functions.php overwriting local
searches.

http://tracker.phpbb.com/browse/PHPBB3-10232
