### PR TITLE
[ticket/10233] IE Emulation fix breaks PM posting layout

### DIFF
--- a/phpBB/styles/prosilver/theme/forms.css
+++ b/phpBB/styles/prosilver/theme/forms.css
@@ -262,7 +262,7 @@ fieldset.submit-buttons input {
 
 #message-box textarea {
 	font-family: "Trebuchet MS", Verdana, Helvetica, Arial, sans-serif;
-	width: 700px;
+	width: 450px;
 	height: 270px;
 	min-width: 100%;
 	max-width: 100%;


### PR DESCRIPTION
The minimum and maximum width of 100% make the textarea dynamically
adjust. However the smilies next to the textarea will float out of
their containing div when the default width pre-min/max is specified
as a too high value.

http://tracker.phpbb.com/browse/PHPBB3-10233
