### PR TITLE
[ticket/10253] Fix IE9 handling in javascript, to correctly quote text.

### DIFF
--- a/phpBB/styles/prosilver/template/editor.js
+++ b/phpBB/styles/prosilver/template/editor.js
@@ -151,8 +151,10 @@ function insert_text(text, spaces, popup)
 	{
 		text = ' ' + text + ' ';
 	}
-	
-	if (!isNaN(textarea.selectionStart))
+
+	// Since IE9, IE also has textarea.selectionStart, but it still needs to be treaten the old way.
+	// Therefore we simply add a !is_ie here until IE fixed the text-selection completely.
+	if (!isNaN(textarea.selectionStart) && !is_ie)
 	{
 		var sel_start = textarea.selectionStart;
 		var sel_end = textarea.selectionEnd;
@@ -216,11 +218,12 @@ function addquote(post_id, username, l_wrote)
 	}
 
 	// Get text selection - not only the post content :(
-	if (window.getSelection)
+	// IE9 must use the document.selection methode but has the *.getSelection so we just force no IE
+	if (window.getSelection && !is_ie)
 	{
 		theSelection = window.getSelection().toString();
 	}
-	else if (document.getSelection)
+	else if (document.getSelection && !is_ie)
 	{
 		theSelection = document.getSelection();
 	}

--- a/phpBB/styles/prosilver/template/forum_fn.js
+++ b/phpBB/styles/prosilver/template/forum_fn.js
@@ -200,7 +200,7 @@ function selectCode(a)
 	// Get ID of code block
 	var e = a.parentNode.parentNode.getElementsByTagName('CODE')[0];
 
-	// Not IE
+	// Not IE and IE9+
 	if (window.getSelection)
 	{
 		var s = window.getSelection();

--- a/phpBB/styles/subsilver2/template/editor.js
+++ b/phpBB/styles/subsilver2/template/editor.js
@@ -151,8 +151,10 @@ function insert_text(text, spaces, popup)
 	{
 		text = ' ' + text + ' ';
 	}
-	
-	if (!isNaN(textarea.selectionStart))
+
+	// Since IE9, IE also has textarea.selectionStart, but it still needs to be treaten the old way.
+	// Therefore we simply add a !is_ie here until IE fixed the text-selection completely.
+	if (!isNaN(textarea.selectionStart) && !is_ie)
 	{
 		var sel_start = textarea.selectionStart;
 		var sel_end = textarea.selectionEnd;
@@ -218,11 +220,12 @@ function addquote(post_id, username, l_wrote)
 	}
 
 	// Get text selection - not only the post content :(
-	if (window.getSelection)
+	// IE9 must use the document.selection methode but has the *.getSelection so we just force no IE
+	if (window.getSelection && !is_ie)
 	{
 		theSelection = window.getSelection().toString();
 	}
-	else if (document.getSelection)
+	else if (document.getSelection && !is_ie)
 	{
 		theSelection = document.getSelection();
 	}


### PR DESCRIPTION
Since IE9 IE supports textarea.selectionStart and window.getSelection. The only problem is, that the values are still incorrect. Therefore we need to ensure that it is still treaten the old way, until IE fixed this completely.

http://tracker.phpbb.com/browse/PHPBB3-10253
