### PR TITLE
Ticket/10003 resolve db_tools proliferation - the end

### DIFF
--- a/phpBB/install/database_update.php
+++ b/phpBB/install/database_update.php
@@ -180,8 +180,8 @@ while ($row = $db->sql_fetchrow($result))
 }
 $db->sql_freeresult($result);
 
-// We do not include DB Tools here, because we can not be sure the file is up-to-date ;)
-// Instead, this file defines a clean db_tools version (we are also not able to provide a different file, else the database update will not work standalone)
+// phpbb_db_tools will be taken from new files (under install/update/new)
+// if possible, falling back to the board's copy.
 $db_tools = new phpbb_db_tools($db, true);
 
 $database_update_info = database_update_info();


### PR DESCRIPTION
Deleted db_tools copy from database_updater, use the master copy instead. Thanks to require_updated I don't have to do much work.
