### PR TITLE
[ticket/10257] Fix AAAA record parsing for old versions of Windows

### DIFF
--- a/phpBB/includes/functions.php
+++ b/phpBB/includes/functions.php
@@ -3686,10 +3686,16 @@ function phpbb_checkdnsrr($host, $type = 'MX')
 					{
 						return true;
 					}
+				break;
 
 				default:
-				case 'A':
 				case 'AAAA':
+					if (stripos($line, "$host AAAA IPv6 address") === 0)
+					{
+						return true;
+					}
+					//No break, newer versions of Windows output AAAA in the same way as the A records
+				case 'A':
 					if (!empty($host_matches))
 					{
 						// Second line


### PR DESCRIPTION
Older versions of Windows use a different output format for AAA records.
Added a missing break for the CNAME case.

PHPBB3-10257
