### PR TITLE
[ticket/10294] Fix sql_affectedrows() in mssqlnative driver.

### DIFF
--- a/phpBB/includes/db/mssqlnative.php
+++ b/phpBB/includes/db/mssqlnative.php
@@ -396,7 +396,7 @@ class dbal_mssqlnative extends dbal
 	*/
 	function sql_affectedrows()
 	{
-		return ($this->db_connect_id) ? @sqlsrv_rows_affected($this->db_connect_id) : false;
+		return (!empty($this->query_result)) ? @sqlsrv_rows_affected($this->query_result) : false;
 	}
 
 	/**


### PR DESCRIPTION
http://tracker.phpbb.com/browse/PHPBB3-10294

sqlsrv_rows_affected() expects a statement resource, not a connection resource.

PHPBB3-10294
