### PR TITLE
[ticket/10290] fixed malformed SQL query in viewonline.php

### DIFF
--- a/phpBB/viewonline.php
+++ b/phpBB/viewonline.php
@@ -377,7 +377,7 @@ if ($auth->acl_gets('a_group', 'a_groupadd', 'a_groupdel'))
 {
 	$sql = 'SELECT group_id, group_name, group_colour, group_type, group_legend
 		FROM ' . GROUPS_TABLE . '
-		WHERE group_legend = > 0
+		WHERE group_legend > 0
 		ORDER BY ' . $order_legend . ' ASC';
 }
 else


### PR DESCRIPTION
As per Oleg's suggestion, the offending equals sign was removed so that the query did not return an error.

PHPBB3-10290
