### PR TITLE
[ticket/7138] Allow simple_header.html and simple_footer.html in trigger_

### DIFF
--- a/phpBB/styles/prosilver/template/message_body.html
+++ b/phpBB/styles/prosilver/template/message_body.html
@@ -1,5 +1,8 @@
+<!-- IF S_SIMPLE_ERROR -->
+<!-- INCLUDE simple_header.html -->
+<!-- ELSE -->
 <!-- INCLUDE overall_header.html -->
-
+<!-- ENDIF -->
 <div class="panel" id="message">
 	<div class="inner"><span class="corners-top"><span></span></span>
 	<h2>{MESSAGE_TITLE}</h2>
@@ -7,5 +10,8 @@
 	<!-- IF SCRIPT_NAME == "search" and not S_BOARD_DISABLED and not S_NO_SEARCH and L_RETURN_TO_SEARCH_ADV --><p><a href="{U_SEARCH}" class="{S_CONTENT_FLOW_BEGIN}">{L_RETURN_TO_SEARCH_ADV}</a></p><!-- ENDIF -->
 	<span class="corners-bottom"><span></span></span></div>
 </div>
-
+<!-- IF S_SIMPLE_ERROR -->
+<!-- INCLUDE simple_footer.html -->
+<!-- ELSE -->
 <!-- INCLUDE overall_footer.html -->
+<!-- ENDIF -->


### PR DESCRIPTION
[ticket/7138] Allow simple_header.html and simple_footer.html in trigger_error() messages

Adds a template condition using S_SIMPLE_ERROR that must be set to true before calling trigger_error() which
will automatically use the simple header/footer files in the template directory instead of the overall
header/footer files.

http://tracker.phpbb.com/browse/PHPBB3-7138
