### PR TITLE
[ticket/10300] Always set group attributes for teampage and legend

### DIFF
--- a/phpBB/includes/acp/acp_groups.php
+++ b/phpBB/includes/acp/acp_groups.php
@@ -415,6 +415,9 @@ class acp_groups
 						// Only set the rank, colour, etc. if it's changed or if we're adding a new
 						// group. This prevents existing group members being updated if no changes
 						// were made.
+						// However there are some attributes that need to be set everytime,
+						// otherwise the group gets removed from the feature.
+						$set_attributes = array('legend', 'teampage');
 
 						$group_attributes = array();
 						$test_variables = array(
@@ -435,7 +438,7 @@ class acp_groups
 
 						foreach ($test_variables as $test => $type)
 						{
-							if (isset($submit_ary[$test]) && ($action == 'add' || $group_row['group_' . $test] != $submit_ary[$test]))
+							if (isset($submit_ary[$test]) && ($action == 'add' || $group_row['group_' . $test] != $submit_ary[$test] || in_array($test, $set_attributes)))
 							{
 								settype($submit_ary[$test], $type);
 								$group_attributes['group_' . $test] = $group_row['group_' . $test] = $submit_ary[$test];


### PR DESCRIPTION
The code in acp_groups.php removes unchanged attributes from the
group_attributes array, to prevent issues with reapplying avatar/rank and more.
This code causes problems with the new teampage/legend feature, because when
the attribute is not set, the group is removed from the feature. Therefore I
added an array with the keys that need to be set, when calling the function.

http://tracker.phpbb.com/browse/PHPBB3-10300
