### PR TITLE
Who's online broken due to malformed SQL

### DIFF
--- a/phpBB/viewonline.php
+++ b/phpBB/viewonline.php
@@ -377,7 +377,7 @@ if ($auth->acl_gets('a_group', 'a_groupadd', 'a_groupdel'))
 {
 	$sql = 'SELECT group_id, group_name, group_colour, group_type, group_legend
 		FROM ' . GROUPS_TABLE . '
-		WHERE group_legend = > 0
+		WHERE group_legend > 0
 		ORDER BY ' . $order_legend . ' ASC';
 }
 else


### PR DESCRIPTION
As per Oleg's suggestion, the offending equals sign was removed
so that the query did not return an error.

http://tracker.phpbb.com/browse/PHPBB3-10290

Supersedes https://github.com/phpbb/phpbb3/pull/311 - commit message fixed in 2 places.
