### PR TITLE
[ticket/9976] Fix link to post when two posts have the same post_time.

### DIFF
--- a/phpBB/viewtopic.php
+++ b/phpBB/viewtopic.php
@@ -196,7 +196,7 @@ if ($db->sql_layer === 'firebird')
 // The FROM-Order is quite important here, else t.* columns can not be correctly bound.
 if ($post_id)
 {
-	$sql_array['SELECT'] .= ', p.post_approved, p.post_time';
+	$sql_array['SELECT'] .= ', p.post_approved, p.post_time, p.post_id';
 	$sql_array['FROM'][POSTS_TABLE] = 'p';
 }
 
@@ -317,8 +317,16 @@ if ($post_id)
 		$sql = 'SELECT COUNT(p.post_id) AS prev_posts
 			FROM ' . POSTS_TABLE . " p
 			WHERE p.topic_id = {$topic_data['topic_id']}
-				" . ((!$auth->acl_get('m_approve', $forum_id)) ? 'AND p.post_approved = 1' : '') . '
-				AND ' . (($sort_dir == 'd') ? "p.post_time >= {$topic_data['post_time']}" : "p.post_time <= {$topic_data['post_time']}");
+				" . ((!$auth->acl_get('m_approve', $forum_id)) ? 'AND p.post_approved = 1' : '');
+
+		if ($sort_dir == 'd')
+		{
+			$sql .= " AND (p.post_time > {$topic_data['post_time']} OR (p.post_time = {$topic_data['post_time']} AND p.post_id >= {$topic_data['post_id']}))";
+		}
+		else
+		{
+			$sql .= " AND (p.post_time < {$topic_data['post_time']} OR (p.post_time = {$topic_data['post_time']} AND p.post_id <= {$topic_data['post_id']}))";
+		}
 
 		$result = $db->sql_query($sql);
 		$row = $db->sql_fetchrow($result);


### PR DESCRIPTION
When two posts have the same post_time, a link to the first post being on
page 1, leads you to the second post with the same timestamp on page two.
So in case the post_times are equal, we need to use the post_id to correctly
order the posts.

http://tracker.phpbb.com/browse/PHPBB3-9976

This pull request replaces https://github.com/phpbb/phpbb3/pull/151.
