### PR TITLE
[ticket/10316] Resolve inconsistent move topic behavior

### DIFF
--- a/phpBB/styles/subsilver2/template/mcp_move.html
+++ b/phpBB/styles/subsilver2/template/mcp_move.html
@@ -20,7 +20,7 @@
 					<input type="checkbox" class="radio" name="move_leave_shadow" checked="checked" /><span class="gen">{L_LEAVE_SHADOW}</span><br />
 				<!-- ENDIF -->
 				<!-- IF S_CAN_LOCK_TOPIC -->
-					<input type="checkbox" class="radio" name="move_lock_topics" checked="checked" /><span class="gen">{L_LOCK_TOPIC}</span><br />
+					<input type="checkbox" class="radio" name="move_lock_topics" /><span class="gen">{L_LOCK_TOPIC}</span><br />
 				<!-- ENDIF -->
 				<br />{S_HIDDEN_FIELDS}<span class="gen">{MESSAGE_TEXT}</span><br /><br />
 				<input type="submit" name="confirm" value="{YES_VALUE}" class="btnmain" />&nbsp;&nbsp;<input type="submit" name="cancel" value="{L_NO}" class="btnlite" />


### PR DESCRIPTION
When moving a topic you can straight away lock it, when using proSilver
this checkbox is unchecked by default. subSilver2 however has this
checked.
Change subSilver2 to not check the box by default and behave as
proSilver does.

PHPBB3-10316
