### PR TITLE
[ticket/10351] Fix Oracle's sql_column_remove()

### DIFF
--- a/phpBB/includes/db/db_tools.php
+++ b/phpBB/includes/db/db_tools.php
@@ -1805,7 +1805,7 @@ class phpbb_db_tools
 			break;
 
 			case 'oracle':
-				$statements[] = 'ALTER TABLE ' . $table_name . ' DROP ' . $column_name;
+				$statements[] = 'ALTER TABLE ' . $table_name . ' DROP COLUMN ' . $column_name;
 			break;
 
 			case 'postgres':


### PR DESCRIPTION
http://tracker.phpbb.com/browse/PHPBB3-10351
The correct syntax is DROP COLUMN.
