### PR TITLE
[ticket/10352] Add missing break for Oracle's sql_table_drop()

### DIFF
--- a/phpBB/includes/db/db_tools.php
+++ b/phpBB/includes/db/db_tools.php
@@ -1956,6 +1956,7 @@ class phpbb_db_tools
 					$statements[] = "DROP SEQUENCE {$row['referenced_name']}";
 				}
 				$this->db->sql_freeresult($result);
+			break;
 
 			case 'postgres':
 				// PGSQL does not "tightly" bind sequences and tables, we must guess...


### PR DESCRIPTION
http://tracker.phpbb.com/browse/PHPBB3-10352
