### PR TITLE
[ticket/10354] Include cache directory path in unwritable message.

### DIFF
--- a/tests/template/template_test.php
+++ b/tests/template/template_test.php
@@ -63,9 +63,10 @@ class phpbb_template_template_test extends phpbb_test_case
 		// Test the engine can be used
 		$this->setup_engine();
 
-		if (!is_writable(dirname($this->template->cachepath)))
+		$template_cache_dir = dirname($this->template->cachepath);
+		if (!is_writable($template_cache_dir))
 		{
-			$this->markTestSkipped("Template cache directory is not writable.");
+			$this->markTestSkipped("Template cache directory ({$template_cache_dir}) is not writable.");
 		}
 
 		foreach (glob($this->template->cachepath . '*') as $file)


### PR DESCRIPTION
When template tests are skipped because cache directory is not
writable, include path to the cache directory into the message
saying it is not writable.

http://tracker.phpbb.com/browse/PHPBB3-10354
