### PR TITLE
[ticket/10394] Remove call-time pass by reference from tests for PHP 5.4

### DIFF
--- a/tests/profile/custom_test.php
+++ b/tests/profile/custom_test.php
@@ -48,7 +48,7 @@ class phpbb_profile_custom_test extends phpbb_database_test_case
 		);
 
 		$cp = new custom_profile;
-		$result = $cp->validate_profile_field(FIELD_DROPDOWN, &$field_value, $field_data);
+		$result = $cp->validate_profile_field(FIELD_DROPDOWN, $field_value, $field_data);
 
 		$this->assertEquals($expected, $result, $description);
 	}

--- a/tests/utf/normalizer_test.php
+++ b/tests/utf/normalizer_test.php
@@ -102,7 +102,7 @@ class phpbb_utf_normalizer_test extends phpbb_test_case
 					foreach ($tests as $test)
 					{
 						$utf_result = $utf_expected;
-						call_user_func(array('utf_normalizer', $form), &$utf_result);
+						call_user_func(array('utf_normalizer', $form), $utf_result);
 
 						$hex_result = $this->utf_to_hexseq($utf_result);
 						$this->assertEquals($utf_expected, $utf_result, "$expected == $form($test) ($hex_expected != $hex_result)");
@@ -154,7 +154,7 @@ class phpbb_utf_normalizer_test extends phpbb_test_case
 			foreach (array('nfc', 'nfkc', 'nfd', 'nfkd') as $form)
 			{
 				$utf_result = $utf_expected;
-				call_user_func(array('utf_normalizer', $form), &$utf_result);
+				call_user_func(array('utf_normalizer', $form), $utf_result);
 				$hex_result = $this->utf_to_hexseq($utf_result);
 
 				$this->assertEquals($utf_expected, $utf_result, "$hex_expected == $form($hex_tested) ($hex_expected != $hex_result)");


### PR DESCRIPTION
http://tracker.phpbb.com/browse/PHPBB3-10394
