### PR TITLE
[ticket/10275] Remove incorrect password information from FAQ

### DIFF
--- a/phpBB/language/en/help_faq.php
+++ b/phpBB/language/en/help_faq.php
@@ -60,7 +60,7 @@ $help = array(
 	),
 	array(
 		0 => 'I registered in the past but cannot login any more?!',
-		1 => 'Attempt to locate the e-mail sent to you when you first registered, check your username and password and try again. It is possible an administrator has deactivated or deleted your account for some reason. Also, many boards periodically remove users who have not posted for a long time to reduce the size of the database. If this has happened, try registering again and being more involved in discussions.'
+		1 => 'It is possible an administrator has deactivated or deleted your account for some reason. Also, many boards periodically remove users who have not posted for a long time to reduce the size of the database. If this has happened, try registering again and being more involved in discussions.'
 	),
 	array(
 		0 => 'What is COPPA?',


### PR DESCRIPTION
FAQ contains instructions to find the password in the registration
e-mail. We no longer send the password on registration. So let's just
remove this incorrect piece of information from the FAQ.

http://tracker.phpbb.com/browse/PHPBB3-10275
