### PR TITLE
[ticket/10246] Move coding guidelines VCS section to wiki

### DIFF
--- a/phpBB/docs/coding-guidelines.html
+++ b/phpBB/docs/coding-guidelines.html
@@ -87,12 +87,6 @@
 		<li><a href="#writingstyle">Writing Style</a></li>
 	</ol>
 	</li>
-	<li><a href="#vcs">VCS Guidelines</a>
-	<ol style="list-style-type: lower-roman;">
-		<li><a href="#repostruct">Repository structure</a></li>
-		<li><a href="#commitmessage">Commit Messages and Repository Rules</a></li>
-	</ol>
-	</li>
 	<li><a href="#disclaimer">Copyright and disclaimer</a></li>
 </ol>
 
@@ -2323,51 +2317,7 @@ if (utf8_case_fold_nfc($string1) == utf8_case_fold_nfc($string2))
 
 	<hr />
 
-<a name="vcs"></a><h2>7. VCS Guidelines</h2>
-
-	<div class="paragraph">
-		<div class="inner"><span class="corners-top"><span></span></span>
-
-		<div class="content">
-
-	<p>The version control system for phpBB3 is git. The repository is available at <a href="http://github.com/phpbb/phpbb3" title="repository">http://github.com/phpbb/phpbb3</a>.</p>
-
-	<a name="repostruct"></a><h3>7.i. Repository Structure</h3>
-
-	<ul>
-		<li><strong>develop</strong><br />The latest unstable development version with new features etc.</li>
-		<li><strong>develop-*</strong><br />Development branches of stable phpBB releases. Branched off of <code>develop</code> at the time of feature freeze.
-			<ul>
-				<li><strong>phpBB3.0</strong><code>develop-olympus</code><br />Development branch of the stable 3.0 line. Bug fixes are applied here.</li>
-				<li><strong>phpBB3.1</strong><code>develop-ascraeus</code><br />Development branch of the stable 3.1 line. Bug fixes are applied here.</li>
-			</ul>
-		</li>
-		<li><strong>master</strong><br />A branch containing all stable phpBB3 release points</li>
-		<li><strong>tags</strong><br />Released versions. Stable ones get merged into the master branch.
-			<ul>
-				<li><code>release-3.Y-BX</code><br />Beta release X of the 3.Y line.</li>
-				<li><code>release-3.Y-RCX</code><br />Release candidate X of the 3.Y line.</li>
-				<li><code>release-3.Y.Z-RCX</code><br />Release candidate X of the stable 3.Y.Z release.</li>
-				<li><code>release-3.0.X</code><br />Stable <strong>3.0.X</strong> release.</li>
-				<li><code>release-2.0.X</code><br />Old stable 2.0.X release.</li>
-			</ul>
-		</li>
-	</ul>
-
-	<a name="commitmessage"></a><h3>7.ii. Commit Messages and Repository Rules</h3>
-
-	<p>Information on repository rules, such as commit messages can be found at <a href="http://wiki.phpbb.com/display/DEV/Git" title="phpBB Git Information">http://wiki.phpbb.com/display/DEV/Git</a>.</p>
-
-		</div>
-
-		<div class="back2top"><a href="#wrap" class="top">Back to Top</a></div>
-
-		<span class="corners-bottom"><span></span></span></div>
-	</div>
-
-	<hr />
-
-<a name="disclaimer"></a><h2>9. Copyright and disclaimer</h2>
+<a name="disclaimer"></a><h2>8. Copyright and disclaimer</h2>
 
 	<div class="paragraph">
 		<div class="inner"><span class="corners-top"><span></span></span>


### PR DESCRIPTION
The VCS section can now be found at:
- http://wiki.phpbb.com/Git#Branches

http://tracker.phpbb.com/browse/PHPBB3-10246
