### PR TITLE
[ticket/10327] Change CREATE INDEX to ALTER TABLE table ADD INDEX for MyS

### DIFF
--- a/phpBB/includes/db/db_tools.php
+++ b/phpBB/includes/db/db_tools.php
@@ -2145,7 +2145,7 @@ class phpbb_db_tools
 				}
 			// no break
 			case 'mysql_41':
-				$statements[] = 'CREATE INDEX ' . $index_name . ' ON ' . $table_name . '(' . implode(', ', $column) . ')';
+				$statements[] = 'ALTER TABLE ' . $table_name . ' ADD INDEX ' . $index_name . '(' . implode(', ', $column) . ')';
 			break;
 
 			case 'mssql':

--- a/tests/dbal/db_tools_test.php
+++ b/tests/dbal/db_tools_test.php
@@ -333,4 +333,22 @@ class phpbb_dbal_db_tools_test extends phpbb_database_test_case
 			),
 		));
 	}
+
+	public function test_index_exists()
+	{
+		$db_tools = new phpbb_db_tools($this->db);
+
+		$this->assertTrue($db_tools->sql_index_exists('prefix_table_name', 'i_simple'));
+	}
+
+	public function test_create_index_against_index_exists()
+	{
+		$db_tools = new phpbb_db_tools($this->db);
+
+		$table_name = 'prefix_table_name';
+		$index_name = 'fookey';
+
+		$db_tools->sql_create_index($table_name, $index_name, array('c_timestamp', 'c_decimal'));
+		$this->assertTrue($db_tools->sql_index_exists($table_name, $index_name));
+	}
 }


### PR DESCRIPTION
[ticket/10327] Change CREATE INDEX to ALTER TABLE table ADD INDEX for MySQL.
- CREATE INDEX is internally mapped to an ALTER INDEX statement.
- CREATE INDEX requires the INDEX permission.
- ALTER TABLE requires the (more powerful) ALTER permission.
- We require the ALTER permission anyway for operation.
- Changing CREATE INDEX to ALTER TABLE thus removes dependency on the INDEX
  permission which is good because some management software does not give
  out the INDEX permission by default.

http://dev.mysql.com/doc/refman/5.0/en/create-index.html

PHPBB3-10327

http://tracker.phpbb.com/browse/PHPBB3-10327
