### PR TITLE
[ticket/10377] Do not allow all moderators to sticky posts

### DIFF
--- a/phpBB/includes/mcp/mcp_main.php
+++ b/phpBB/includes/mcp/mcp_main.php
@@ -286,14 +286,6 @@ function change_topic_type($action, $topic_ids)
 {
 	global $auth, $user, $db, $phpEx, $phpbb_root_path;
 
-	// For changing topic types, we only allow operations in one forum.
-	$forum_id = check_ids($topic_ids, TOPICS_TABLE, 'topic_id', array('f_announce', 'f_sticky', 'm_'), true);
-
-	if ($forum_id === false)
-	{
-		return;
-	}
-
 	switch ($action)
 	{
 		case 'make_announce':
@@ -316,9 +308,16 @@ function change_topic_type($action, $topic_ids)
 
 		default:
 			$new_topic_type = POST_NORMAL;
-			$check_acl = '';
+			$check_acl = false;
 			$l_new_type = (sizeof($topic_ids) == 1) ? 'MCP_MAKE_NORMAL' : 'MCP_MAKE_NORMALS';
 		break;
+	}
+
+	$forum_id = check_ids($topic_ids, TOPICS_TABLE, 'topic_id', $check_acl, true);
+
+	if ($forum_id === false)
+	{
+		return;
 	}
 
 	$redirect = request_var('redirect', build_url(array('action', 'quickmod')));


### PR DESCRIPTION
In the mcp the change_topic_type does not properly check permissions,
allowing moderators to make any post sticky or announced by visiting the
correct URL.

http://tracker.phpbb.com/browse/PHPBB3-10377
