### PR TITLE
[ticket/10416] Pass dbport to PDO object in ...connection_manager::connec

### DIFF
--- a/tests/test_framework/phpbb_database_test_connection_manager.php
+++ b/tests/test_framework/phpbb_database_test_connection_manager.php
@@ -69,6 +69,11 @@ class phpbb_database_test_connection_manager
 			default:
 				$dsn .= 'host=' . $this->config['dbhost'];
 
+				if ($this->config['dbport'])
+				{
+					$dsn .= ';port=' . $this->config['dbport'];
+				}
+
 				if ($use_db)
 				{
 					$dsn .= ';dbname=' . $this->config['dbname'];


### PR DESCRIPTION
[ticket/10416] Pass dbport to PDO object in ...connection_manager::connect().

PHPBB3-10416

http://tracker.phpbb.com/browse/PHPBB3-10416
