### PR TITLE
[ticket/10414] Skip functional tests on PHP 5.2 - requires PHPUnit 3.6 on

### DIFF
--- a/phpunit.xml.all
+++ b/phpunit.xml.all
@@ -14,6 +14,10 @@
     <testsuites>
         <testsuite name="phpBB Test Suite">
             <directory suffix="_test.php">./tests/</directory>
+            <exclude>./tests/functional</exclude>
+        </testsuite>
+        <testsuite name="phpBB Functional Tests">
+            <directory suffix="_test.php" phpVersion="5.3.0" phpVersionOperator=">=">./tests/functional</directory>
         </testsuite>
     </testsuites>
 

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -14,6 +14,10 @@
     <testsuites>
         <testsuite name="phpBB Test Suite">
             <directory suffix="_test.php">./tests/</directory>
+            <exclude>./tests/functional</exclude>
+        </testsuite>
+        <testsuite name="phpBB Functional Tests">
+            <directory suffix="_test.php" phpVersion="5.3.0" phpVersionOperator=">=">./tests/functional</directory>
         </testsuite>
     </testsuites>
 

--- a/phpunit.xml.functional
+++ b/phpunit.xml.functional
@@ -14,6 +14,10 @@
     <testsuites>
         <testsuite name="phpBB Test Suite">
             <directory suffix="_test.php">./tests/</directory>
+            <exclude>./tests/functional</exclude>
+        </testsuite>
+        <testsuite name="phpBB Functional Tests">
+            <directory suffix="_test.php" phpVersion="5.3.0" phpVersionOperator=">=">./tests/functional</directory>
         </testsuite>
     </testsuites>
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -39,4 +39,8 @@ require_once 'test_framework/phpbb_test_case_helpers.php';
 require_once 'test_framework/phpbb_test_case.php';
 require_once 'test_framework/phpbb_database_test_case.php';
 require_once 'test_framework/phpbb_database_test_connection_manager.php';
-require_once 'test_framework/phpbb_functional_test_case.php';
+
+if (version_compare(PHP_VERSION, '5.3.0-dev', '>='))
+{
+	require_once 'test_framework/phpbb_functional_test_case.php';
+}


### PR DESCRIPTION
[ticket/10414] Skip functional tests on PHP 5.2 - requires PHPUnit 3.6 on 5.2

Tests still execute correctly using PHPUnit 3.5 on PHP 5.3 and above. The php
version limitation for a directory was added in PHPUnit 3.6. A separate test
suite is required because the functional tests are in the whitelisted tests
directory. The base test for functional testing is only included in bootstrap
in versions 5.3 and above.

PHPBB3-10414
