### PR TITLE
[ticket/10419] Add mbstring PHP ini parameters checks to ACP

### DIFF
--- a/phpBB/adm/style/acp_main.html
+++ b/phpBB/adm/style/acp_main.html
@@ -34,6 +34,36 @@
 		</div>
 	<!-- ENDIF -->
 
+	<!-- IF S_MBSTRING_LOADED -->
+		<!-- IF S_MBSTRING_FUNC_OVERLOAD_FAIL -->
+			<div class="errorbox">
+				<h3>{L_ERROR_MBSTRING_FUNC_OVERLOAD}</h3>
+				<p>{L_ERROR_MBSTRING_FUNC_OVERLOAD_EXPLAIN}</p>
+			</div>
+		<!-- ENDIF -->
+
+		<!-- IF S_MBSTRING_ENCODING_TRANSLATION_FAIL -->
+			<div class="errorbox">
+				<h3>{L_ERROR_MBSTRING_ENCODING_TRANSLATION}</h3>
+				<p>{L_ERROR_MBSTRING_ENCODING_TRANSLATION_EXPLAIN}</p>
+			</div>
+		<!-- ENDIF -->
+
+		<!-- IF S_MBSTRING_HTTP_INPUT_FAIL -->
+			<div class="errorbox">
+				<h3>{L_ERROR_MBSTRING_HTTP_INPUT}</h3>
+				<p>{L_ERROR_MBSTRING_HTTP_INPUT_EXPLAIN}</p>
+			</div>
+		<!-- ENDIF -->
+
+		<!-- IF S_MBSTRING_HTTP_OUTPUT_FAIL -->
+			<div class="errorbox">
+				<h3>{L_ERROR_MBSTRING_HTTP_OUTPUT}</h3>
+				<p>{L_ERROR_MBSTRING_HTTP_OUTPUT_EXPLAIN}</p>
+			</div>
+		<!-- ENDIF -->
+	<!-- ENDIF -->
+
 	<!-- IF S_WRITABLE_CONFIG -->
 		<div class="errorbox notice">
 			<p>{L_WRITABLE_CONFIG}</p>

--- a/phpBB/includes/acp/acp_main.php
+++ b/phpBB/includes/acp/acp_main.php
@@ -600,6 +600,17 @@ class acp_main
 			$template->assign_var('S_WRITABLE_CONFIG', (bool) (@fileperms($phpbb_root_path . 'config.' . $phpEx) & 0x0002));
 		}
 
+		if(@extension_loaded('mbstring'))
+		{
+			$template->assign_vars(array(
+				'S_MBSTRING_LOADED'						=> true,
+				'S_MBSTRING_FUNC_OVERLOAD_FAIL'			=> (intval(@ini_get('mbstring.func_overload')) & (MB_OVERLOAD_MAIL|MB_OVERLOAD_STRING)),
+				'S_MBSTRING_ENCODING_TRANSLATION_FAIL'	=> (@ini_get('mbstring.encoding_translation') != 0),
+				'S_MBSTRING_HTTP_INPUT_FAIL'			=> (@ini_get('mbstring.http_input') != 'pass'),
+				'S_MBSTRING_HTTP_OUTPUT_FAIL'			=> (@ini_get('mbstring.http_output') != 'pass'))
+			);
+		}
+
 		// Fill dbms version if not yet filled
 		if (empty($config['dbms_version']))
 		{

--- a/phpBB/language/en/acp/common.php
+++ b/phpBB/language/en/acp/common.php
@@ -327,6 +327,16 @@ $lang = array_merge($lang, array(
 	'DATABASE_SERVER_INFO'	=> 'Database server',
 	'DATABASE_SIZE'			=> 'Database size',
 
+	// Enviroment configuration checks, mbstring related
+	'ERROR_MBSTRING_FUNC_OVERLOAD'					=> 'Functions overloading setting failed',
+	'ERROR_MBSTRING_FUNC_OVERLOAD_EXPLAIN'			=> '<var>mbstring.func_overload</var> must be set to either 0 or 4. You can check current value on <samp>PHP information</samp> page.',
+	'ERROR_MBSTRING_ENCODING_TRANSLATION'			=> 'Transparent character encoding setting failed',
+	'ERROR_MBSTRING_ENCODING_TRANSLATION_EXPLAIN'	=> '<var>mbstring.encoding_translation</var> must be set to 0.  You can check current value on <samp>PHP information</samp> page.',
+	'ERROR_MBSTRING_HTTP_INPUT'						=> 'HTTP input character conversion setting failed',
+	'ERROR_MBSTRING_HTTP_INPUT_EXPLAIN'				=> '<var>mbstring.http_input</var> must be set to <samp>pass</samp>.  You can check current value on <samp>PHP information</samp> page.',
+	'ERROR_MBSTRING_HTTP_OUTPUT'					=> 'HTTP output character conversion setting failed',
+	'ERROR_MBSTRING_HTTP_OUTPUT_EXPLAIN'			=> '<var>mbstring.http_output</var> must be set to <samp>pass</samp>.  You can check current value on <samp>PHP information</samp> page.',
+
 	'FILES_PER_DAY'		=> 'Attachments per day',
 	'FORUM_STATS'		=> 'Board statistics',
 


### PR DESCRIPTION
The ACP main page should check whether mbstring PHP ini parameters still satisfy installation requirements (related to PHPBB3-7149).
<a href="http://tracker.phpbb.com/browse/PHPBB3-10419">PHPBB3-10419</a>.
