### PR TITLE
[ticket/10420] Update includes/startup.php for PHP 5.4.

### DIFF
--- a/phpBB/includes/startup.php
+++ b/phpBB/includes/startup.php
@@ -97,8 +97,8 @@ function deregister_globals()
 	unset($input);
 }
 
-// If we are on PHP >= 6.0.0 we do not need some code
-if (version_compare(PHP_VERSION, '6.0.0-dev', '>='))
+// Register globals and magic quotes have been dropped in PHP 5.4
+if (version_compare(PHP_VERSION, '5.4.0-dev', '>='))
 {
 	/**
 	* @ignore


### PR DESCRIPTION
PHP 5.4 dropped support for register globals and magic quotes.

Calling set_magic_quotes_runtime() on PHP 5.4 actually results in an
E_CORE_ERROR error.

PHPBB3-10420

http://tracker.phpbb.com/browse/PHPBB3-10420
