### PR TITLE
[ticket/10190] Do not show hint about permissions when editing forum sett

### DIFF
--- a/phpBB/includes/acp/acp_forums.php
+++ b/phpBB/includes/acp/acp_forums.php
@@ -212,15 +212,11 @@ class acp_forums
 
 						$message = ($action == 'add') ? $user->lang['FORUM_CREATED'] : $user->lang['FORUM_UPDATED'];
 
-						// Redirect to permissions
-						if ($auth->acl_get('a_fauth') && !$copied_permissions)
-						{
-							$message .= '<br /><br />' . sprintf($user->lang['REDIRECT_ACL'], '<a href="' . append_sid("{$phpbb_admin_path}index.$phpEx", 'i=permissions' . $acl_url) . '">', '</a>');
-						}
-
 						// redirect directly to permission settings screen if authed
 						if ($action == 'add' && !$copied_permissions && $auth->acl_get('a_fauth'))
 						{
+							$message .= '<br /><br />' . sprintf($user->lang['REDIRECT_ACL'], '<a href="' . append_sid("{$phpbb_admin_path}index.$phpEx", 'i=permissions' . $acl_url) . '">', '</a>');
+
 							meta_refresh(4, append_sid("{$phpbb_admin_path}index.$phpEx", 'i=permissions' . $acl_url));
 						}
 


### PR DESCRIPTION
[ticket/10190] Do not show hint about permissions when editing forum settings.

PHPBB3-10190

http://tracker.phpbb.com/browse/PHPBB3-10190
