### PR TITLE
[ticket/10166] No longer refer to previous mail in admin_welcome_activate

### DIFF
--- a/phpBB/language/en/email/admin_welcome_activated.txt
+++ b/phpBB/language/en/email/admin_welcome_activated.txt
@@ -2,7 +2,7 @@ Subject: Account activated
 
 Hello {USERNAME},
 
-Your account on "{SITENAME}" has now been activated, you may login using the username you received in a previous e-mail.
+Your account on "{SITENAME}" has been activated by an administrator, you may login now.
 
 Your password has been securely stored in our database and cannot be retrieved. In the event that it is forgotten, you will be able to reset it using the email address associated with your account.
 


### PR DESCRIPTION
[ticket/10166] No longer refer to previous mail in admin_welcome_activated.txt

It does not make much sense to say "the username you received in a previous
e-mail" when the message itself contains the username.

PHPBB3-10166

http://tracker.phpbb.com/browse/PHPBB3-10166
