### PR TITLE
[ticket/10157] Add notification to update cpfs when installing a language

### DIFF
--- a/phpBB/includes/acp/acp_language.php
+++ b/phpBB/includes/acp/acp_language.php
@@ -919,6 +919,9 @@ class acp_language
 				$default_lang_id = (int) $db->sql_fetchfield('lang_id');
 				$db->sql_freeresult($result);
 
+				// We want to notify the admin that custom profile fields need to be updated for the new language.
+				$notify_cpf_update = false;
+
 				// From the mysql documentation:
 				// Prior to MySQL 4.0.14, the target table of the INSERT statement cannot appear in the FROM clause of the SELECT part of the query. This limitation is lifted in 4.0.14.
 				// Due to this we stay on the safe side if we do the insertion "the manual way"
@@ -932,6 +935,7 @@ class acp_language
 				{
 					$row['lang_id'] = $lang_id;
 					$db->sql_query('INSERT INTO ' . PROFILE_LANG_TABLE . ' ' . $db->sql_build_array('INSERT', $row));
+					$notify_cpf_update = true;
 				}
 				$db->sql_freeresult($result);
 
@@ -944,12 +948,15 @@ class acp_language
 				{
 					$row['lang_id'] = $lang_id;
 					$db->sql_query('INSERT INTO ' . PROFILE_FIELDS_LANG_TABLE . ' ' . $db->sql_build_array('INSERT', $row));
+					$notify_cpf_update = true;
 				}
 				$db->sql_freeresult($result);
 
 				add_log('admin', 'LOG_LANGUAGE_PACK_INSTALLED', $lang_pack['name']);
 
-				trigger_error(sprintf($user->lang['LANGUAGE_PACK_INSTALLED'], $lang_pack['name']) . adm_back_link($this->u_action));
+				$message = sprintf($user->lang['LANGUAGE_PACK_INSTALLED'], $lang_pack['name']);
+				$message .= ($notify_cpf_update) ? '<br /><br />' . $user->lang['LANGUAGE_PACK_CPF_UPDATE'] : '';
+				trigger_error($message . adm_back_link($this->u_action));
 
 			break;
 

--- a/phpBB/language/en/acp/language.php
+++ b/phpBB/language/en/acp/language.php
@@ -59,6 +59,7 @@ $lang = array_merge($lang, array(
 	'LANGUAGE_PACK_DELETED'				=> 'The language pack <strong>%s</strong> has been removed successfully. All users using this language have been reset to the boards default language.',
 	'LANGUAGE_PACK_DETAILS'				=> 'Language pack details',
 	'LANGUAGE_PACK_INSTALLED'			=> 'The language pack <strong>%s</strong> has been successfully installed.',
+	'LANGUAGE_PACK_CPF_UPDATE'			=> 'The custom profile fields’ language strings were copied from the default language. Please change them if necessary.',
 	'LANGUAGE_PACK_ISO'					=> 'ISO',
 	'LANGUAGE_PACK_LOCALNAME'			=> 'Local name',
 	'LANGUAGE_PACK_NAME'				=> 'Name',


### PR DESCRIPTION
We currently just copy the language-strings from the default language. But the
admin should be reminded to change them.

http://tracker.phpbb.com/browse/PHPBB3-10157
