### PR TITLE
[ticket/9778] Replaced "Find a member" with "Enter username"

### DIFF
--- a/phpBB/adm/style/acp_users.html
+++ b/phpBB/adm/style/acp_users.html
@@ -13,7 +13,7 @@
 	<fieldset>
 		<legend>{L_SELECT_USER}</legend>
 	<dl>
-		<dt><label for="username">{L_FIND_USERNAME}:</label></dt>
+		<dt><label for="username">{L_ENTER_USERNAME}:</label></dt>
 		<dd><input class="text medium" type="text" id="username" name="username" /></dd>
 		<dd>[ <a href="{U_FIND_USERNAME}" onclick="find_username(this.href); return false;">{L_FIND_USERNAME}</a> ]</dd>
 		<dd class="full" style="text-align: left;"><label><input type="checkbox" class="radio" id="anonymous" name="u" value="{ANONYMOUS_USER_ID}" /> {L_SELECT_ANONYMOUS}</label></dd>

--- a/phpBB/language/en/common.php
+++ b/phpBB/language/en/common.php
@@ -165,6 +165,7 @@ $lang = array_merge($lang, array(
 	'EMPTY_MESSAGE_SUBJECT'				=> 'You must specify a subject when composing a new message.',
 	'ENABLED'							=> 'Enabled',
 	'ENCLOSURE'							=> 'Enclosure',
+	'ENTER_USERNAME'					=> 'Enter username',
 	'ERR_CHANGING_DIRECTORY'			=> 'Unable to change directory.',
 	'ERR_CONNECTING_SERVER'				=> 'Error connecting to the server.',
 	'ERR_JAB_AUTH'						=> 'Could not authorise on Jabber server.',


### PR DESCRIPTION
When clicking on the "Users and groups" tab in the ACP, the user is
able to either enter the username of the member he wants to manage
or click on "Find a member" below the input field. Unfortunately,
the label for the input field is also "Find a member", which leads
some users to the idea that they can search for users using that
input field. By changing the label to "Enter username" this should
be clear to the user.

PHPBB3-9778
