### PR TITLE
[ticket/develop/10435] Remove global announcement from forums total topic count

### DIFF
--- a/phpBB/viewforum.php
+++ b/phpBB/viewforum.php
@@ -561,6 +561,9 @@ if (sizeof($shadow_topic_list))
 }
 unset($shadow_topic_list);
 
+// We need to remove the global announcements from the forums total topic count, otherwise the number is different from the one on the forum list
+$total_topics_count = $topics_count - sizeof($global_announce_forums);
+
 // Ok, adjust topics count for active topics list
 if ($s_display_active)
 {
@@ -570,7 +573,7 @@ if ($s_display_active)
 $template->assign_vars(array(
 	'PAGINATION'	=> generate_pagination(append_sid("{$phpbb_root_path}viewforum.$phpEx", "f=$forum_id" . ((strlen($u_sort_param)) ? "&amp;$u_sort_param" : '')), $topics_count, $config['topics_per_page'], $start),
 	'PAGE_NUMBER'	=> on_page($topics_count, $config['topics_per_page'], $start),
-	'TOTAL_TOPICS'	=> ($s_display_active) ? false : (($topics_count == 1) ? $user->lang['VIEW_FORUM_TOPIC'] : sprintf($user->lang['VIEW_FORUM_TOPICS'], $topics_count)))
+	'TOTAL_TOPICS'	=> ($s_display_active) ? false : (($total_topics_count == 1) ? $user->lang['VIEW_FORUM_TOPIC'] : sprintf($user->lang['VIEW_FORUM_TOPICS'], $total_topics_count)))
 );
 
 $topic_list = ($store_reverse) ? array_merge($announcement_list, array_reverse($topic_list)) : array_merge($announcement_list, $topic_list);


### PR DESCRIPTION
We need to remove the global announcements from the forums total topic count,
otherwise the number is different from the one on the forum list.

http://tracker.phpbb.com/browse/PHPBB3-10435
