### PR TITLE
[ticket/7138] Allow simple header and footer for trigger_error() messages

### DIFF
--- a/phpBB/styles/prosilver/template/message_body.html
+++ b/phpBB/styles/prosilver/template/message_body.html
@@ -1,4 +1,8 @@
-<!-- INCLUDE overall_header.html -->
+<!-- IF S_SIMPLE_MESSAGE -->
+	<!-- INCLUDE simple_header.html -->
+<!-- ELSE -->
+	<!-- INCLUDE overall_header.html -->
+<!-- ENDIF -->
 
 <div class="panel" id="message">
 	<div class="inner"><span class="corners-top"><span></span></span>
@@ -8,4 +12,8 @@
 	<span class="corners-bottom"><span></span></span></div>
 </div>
 
-<!-- INCLUDE overall_footer.html -->
+<!-- IF S_SIMPLE_MESSAGE -->
+	<!-- INCLUDE simple_footer.html -->
+<!-- ELSE -->
+	<!-- INCLUDE overall_footer.html -->
+<!-- ENDIF -->


### PR DESCRIPTION
Adds a template condition using S_SIMPLE_MESSAGE that must be set to true
before calling trigger_error() which will automatically use the simple
header and footer files in the template directory instead of the overall
header and footer files.

http://tracker.phpbb.com/browse/PHPBB3-7138

based on https://github.com/phpbb/phpbb3/pull/312
