### PR TITLE
[ticket/10458] Fix xHTML errors when print-viewing PMs

### DIFF
--- a/phpBB/styles/prosilver/template/ucp_pm_viewmessage_print.html
+++ b/phpBB/styles/prosilver/template/ucp_pm_viewmessage_print.html
@@ -1,10 +1,7 @@
 <!DOCTYPE html>
 <html dir="{S_CONTENT_DIRECTION}" lang="{S_USER_LANG}">
 <head>
-
-<meta http-equiv="imagetoolbar" content="no" />
-<meta name="resource-type" content="document" />
-<meta name="distribution" content="global" />
+<meta charset="utf-8">
 <meta name="keywords" content="" />
 <meta name="description" content="" />
 <meta name="robots" content="noindex" />
@@ -16,7 +13,7 @@
 
 <body id="phpbb">
 <div id="wrap">
-	<a id="top" name="top" accesskey="t"></a>
+	<a id="top" accesskey="t"></a>
 
 	<div id="page-header">
 		<h1>{SITENAME}</h1>


### PR DESCRIPTION
Also changed the layout of prosilvers PM print-view, so it looks like the post
print-view and not like the subsilver2 print-view.

http://tracker.phpbb.com/browse/PHPBB3-10458
