### PR TITLE
[ticket/10185] Always set board startdate on conversion

### DIFF
--- a/phpBB/install/install_convert.php
+++ b/phpBB/install/install_convert.php
@@ -1716,19 +1716,16 @@ class install_convert extends module
 
 			fix_empty_primary_groups();
 
-			if (!isset($config['board_startdate']))
-			{
-				$sql = 'SELECT MIN(user_regdate) AS board_startdate
-					FROM ' . USERS_TABLE;
-				$result = $db->sql_query($sql);
-				$row = $db->sql_fetchrow($result);
-				$db->sql_freeresult($result);
+			$sql = 'SELECT MIN(user_regdate) AS board_startdate
+				FROM ' . USERS_TABLE;
+			$result = $db->sql_query($sql);
+			$row = $db->sql_fetchrow($result);
+			$db->sql_freeresult($result);
 
-				if (($row['board_startdate'] < $config['board_startdate'] && $row['board_startdate'] > 0) || !isset($config['board_startdate']))
-				{
-					set_config('board_startdate', $row['board_startdate']);
-					$db->sql_query('UPDATE ' . USERS_TABLE . ' SET user_regdate = ' . $row['board_startdate'] . ' WHERE user_id = ' . ANONYMOUS);
-				}
+			if (!isset($config['board_startdate']) || ($row['board_startdate'] < $config['board_startdate'] && $row['board_startdate'] > 0))
+			{
+				set_config('board_startdate', $row['board_startdate']);
+				$db->sql_query('UPDATE ' . USERS_TABLE . ' SET user_regdate = ' . $row['board_startdate'] . ' WHERE user_id = ' . ANONYMOUS);
 			}
 
 			update_dynamic_config();


### PR DESCRIPTION
The board startdate should always be set to first user registration date.
The current code did not do anything at all, as the board_startdate was always
set on installation before running the convertor.

http://tracker.phpbb.com/browse/PHPBB3-10185
