### PR TITLE
[ticket/10461] Correct $log_count check in view_log() so we show logs ag...

### DIFF
--- a/phpBB/includes/functions_admin.php
+++ b/phpBB/includes/functions_admin.php
@@ -2609,6 +2609,10 @@ function view_log($mode, &$log, &$log_count, $limit = 0, $offset = 0, $forum_id 
 		$db->sql_freeresult($result);
 	}
 
+	// $log_count may be false here if false was passed in for it,
+	// because in this case we did not run the COUNT() query above.
+	// If we ran the COUNT() query and it returned zero rows, return;
+	// otherwise query for logs below.
 	if ($log_count === 0)
 	{
 		// Save the queries, because there are no logs to display


### PR DESCRIPTION
...ain.

We pass $log_count as false now when we do not need to how many log entries
there are. However when $log_count is false, $log_count == 0 will be true
as well and thus we will return early with 0.

PHPBB3-9874
PHPBB3-10461

http://tracker.phpbb.com/browse/PHPBB3-10461
