### PR TITLE
Correctly check for empty image paths

### DIFF
--- a/phpBB/includes/functions_convert.php
+++ b/phpBB/includes/functions_convert.php
@@ -424,7 +424,9 @@ function import_avatar_gallery($gallery_name = '', $subdirs_as_galleries = false
 
 	$relative_path = empty($convert->convertor['source_path_absolute']);
 
-	if (empty($convert->convertor['avatar_gallery_path']))
+	//strip trailing slash
+	$avatar_gallery_path = (string) substr($convert->convertor['avatar_gallery_path'], 0, strrpos($convert->convertor['avatar_gallery_path'], '/'));
+	if (empty($avatar_gallery_path))
 	{
 		$convert->p_master->error(sprintf($user->lang['CONV_ERROR_NO_GALLERY_PATH'], 'import_avatar_gallery()'), __LINE__, __FILE__);
 	}
@@ -588,7 +590,10 @@ function import_attachment($source, $use_target = false)
 
 	global $convert, $phpbb_root_path, $config, $user;
 
-	if (empty($convert->convertor['upload_path']))
+	//strip trailing slash
+	$upload_path = (string) substr($convert->convertor['upload_path'], 0, strrpos($convert->convertor['upload_path'], '/'));
+
+	if (empty($upload_path))
 	{
 		$convert->p_master->error(sprintf($user->lang['CONV_ERROR_NO_UPLOAD_DIR'], 'import_attachment()'), __LINE__, __FILE__);
 	}
@@ -647,7 +652,10 @@ function import_smiley($source, $use_target = false)
 
 	global $convert, $phpbb_root_path, $config, $user;
 
-	if (!isset($convert->convertor['smilies_path']))
+	//strip trailing slash
+	$smilies_path = (string) substr($convert->convertor['smilies_path'], 0, strrpos($convert->convertor['smilies_path'], '/'));
+
+	if (empty($smilies_path))
 	{
 		$convert->p_master->error(sprintf($user->lang['CONV_ERROR_NO_SMILIES_PATH'], 'import_smiley()'), __LINE__, __FILE__);
 	}
@@ -667,7 +675,9 @@ function import_avatar($source, $use_target = false, $user_id = false)
 
 	global $convert, $phpbb_root_path, $config, $user;
 
-	if (!isset($convert->convertor['avatar_path']))
+	//strip trailing slash
+	$avatar_path = (string) substr($convert->convertor['avatar_path'], 0, strrpos($convert->convertor['avatar_path'], '/'));
+	if (empty($avatar_path))
 	{
 		$convert->p_master->error(sprintf($user->lang['CONV_ERROR_NO_AVATAR_PATH'], 'import_avatar()'), __LINE__, __FILE__);
 	}
@@ -2469,3 +2479,7 @@ function fill_dateformat($user_dateformat)
 
 	return ((empty($user_dateformat)) ? $config['default_dateformat'] : $user_dateformat);
 }
+
+
+
+?>


### PR DESCRIPTION
This applies to avatar_path,avatar_gallery_path,smilies_path and
upload_path.
Currently, the convertor gets each path from the config table and adds a
trailing slash. If there is no entry in the config table for the path, the
path can never be empty because of the added trailing slash. This patch
will temporarily remove the trailing slash, then check if the path is
empty.
