### PR TITLE
[ticket/10463] fixed malformed SQL in acp_styles.php

### DIFF
--- a/phpBB/includes/acp/acp_styles.php
+++ b/phpBB/includes/acp/acp_styles.php
@@ -2400,7 +2400,7 @@ version = {VERSION}
 				$select_bf = '';
 			}
 
-			$sql = "SELECT {$mode}_id, {$mode}_name, {$mode}_path, $select_bf
+			$sql = "SELECT {$mode}_id, {$mode}_name, {$mode}_path $select_bf
 				FROM $sql_from
 				WHERE {$mode}_name = '" . $db->sql_escape($cfg_data['inherit_from']) . "'
 					AND {$mode}_inherits_id = 0";


### PR DESCRIPTION
The query had a comma before the variable. However, the variable, depending on the conditional just above the query, would either add a comma and another column, or add nothing. So in either case it would throw an SQL syntax error because there would either be two commas or it would end the row list with a comma.

The fix was simply to remove the comma and the space between the previous row name and the variable.

http://tracker.phpbb.com/browse/PHPBB3-10463
