### PR TITLE
[ticket/10542] Unnecessary class="postlink" in styles/subsilver2/template/faq_body.html

### DIFF
--- a/phpBB/styles/subsilver2/template/faq_body.html
+++ b/phpBB/styles/subsilver2/template/faq_body.html
@@ -13,7 +13,7 @@
 		<!-- BEGIN faq_block -->
 			<span class="gen"><b>{faq_block.BLOCK_TITLE}</b></span><br />
 			<!-- BEGIN faq_row -->
-				<span class="gen"><a class="postlink" href="#f{faq_block.S_ROW_COUNT}r{faq_block.faq_row.S_ROW_COUNT}">{faq_block.faq_row.FAQ_QUESTION}</a></span><br />
+				<span class="gen"><a href="#f{faq_block.S_ROW_COUNT}r{faq_block.faq_row.S_ROW_COUNT}">{faq_block.faq_row.FAQ_QUESTION}</a></span><br />
 			<!-- END faq_row -->
 			<br />
 		<!-- END faq_block -->


### PR DESCRIPTION
class="postlink" is not defined in stylesheet.css so remove it from
styles/subsilver2/template/faq_body.html
