### PR TITLE
[ticket/10407] Fix check for empty image paths in convertor

### DIFF
--- a/phpBB/includes/functions_convert.php
+++ b/phpBB/includes/functions_convert.php
@@ -424,10 +424,8 @@ function import_avatar_gallery($gallery_name = '', $subdirs_as_galleries = false
 
 	$relative_path = empty($convert->convertor['source_path_absolute']);
 
-	// strip trailing slash
-	$trimmed_avatar_gallery_path = rtrim($convert->convertor['avatar_gallery_path'], '/');
-
-	if (empty($trimmed_avatar_gallery_path))
+	// check for trailing slash
+	if (rtrim($convert->convertor['avatar_gallery_path'], '/') === '')
 	{
 		$convert->p_master->error(sprintf($user->lang['CONV_ERROR_NO_GALLERY_PATH'], 'import_avatar_gallery()'), __LINE__, __FILE__);
 	}
@@ -591,10 +589,8 @@ function import_attachment($source, $use_target = false)
 
 	global $convert, $phpbb_root_path, $config, $user;
 
-	// strip trailing slash
-	$trimmed_upload_path = rtrim($convert->convertor['upload_path'], '/');
-
-	if (empty($trimmed_upload_path))
+	// check for trailing slash
+	if (rtrim($convert->convertor['upload_path'], '/') === '')
 	{
 		$convert->p_master->error(sprintf($user->lang['CONV_ERROR_NO_UPLOAD_DIR'], 'import_attachment()'), __LINE__, __FILE__);
 	}
@@ -653,10 +649,8 @@ function import_smiley($source, $use_target = false)
 
 	global $convert, $phpbb_root_path, $config, $user;
 
-	// strip trailing slash
-	$trimmed_smilies_path = rtrim($convert->convertor['smilies_path'], '/');
-
-	if (empty($trimmed_smilies_path))
+	// check for trailing slash
+	if (rtrim($convert->convertor['smilies_path'], '/') === '')
 	{
 		$convert->p_master->error(sprintf($user->lang['CONV_ERROR_NO_SMILIES_PATH'], 'import_smiley()'), __LINE__, __FILE__);
 	}
@@ -676,10 +670,8 @@ function import_avatar($source, $use_target = false, $user_id = false)
 
 	global $convert, $phpbb_root_path, $config, $user;
 
-	// strip trailing slash
-	$trimmed_avatar_path = rtrim($convert->convertor['avatar_path'], '/');
-
-	if (empty($trimmed_avatar_path))
+	// check for trailing slash
+	if (rtrim($convert->convertor['avatar_path'], '/') === '')
 	{
 		$convert->p_master->error(sprintf($user->lang['CONV_ERROR_NO_AVATAR_PATH'], 'import_avatar()'), __LINE__, __FILE__);
 	}


### PR DESCRIPTION
This applies to avatar_path,avatar_gallery_path,smilies_path and
upload_path.
Currently, the convertor gets each path from the config table and adds a
trailing slash. If there is no entry in the config table for the path, the
path can never be empty because of the added trailing slash. This patch
will temporarily remove the trailing slash, then check if the path is
empty.

PHPBB3-10407
