### PR TITLE
[ticket/10477] Normalize loaded module names to be class names or xcp_ prefixed

### DIFF
--- a/phpBB/includes/functions_module.php
+++ b/phpBB/includes/functions_module.php
@@ -805,7 +805,8 @@ class p_master
 	* Load module as the current active one without the need for registering it
 	*
 	* @param string $class module class (acp/mcp/ucp)
-	* @param string $name module name (e.g. zebra for the ucp_zebra module)
+	* @param string $name module name (class name of the module, or its basename
+    *                     phpbb_ext_foo_acp_bar_module, ucp_zebra or zebra)
 	* @param string $mode mode, as passed through to the module
 	*
 	*/


### PR DESCRIPTION
http://tracker.phpbb.com/browse/PHPBB3-10477
