### PR TITLE
[ticket/10589] Add alias to 'user_birthday' in $leap_year_birthdays definition

### DIFF
--- a/phpBB/index.php
+++ b/phpBB/index.php
@@ -89,7 +89,7 @@ if ($config['load_birthdays'] && $config['allow_birthdays'] && $auth->acl_gets('
 	$leap_year_birthdays = '';
 	if ($now['mday'] == 28 && $now['mon'] == 2 && !$user->format_date(time(), 'L'))
 	{
-		$leap_year_birthdays = " OR user_birthday LIKE '" . $db->sql_escape(sprintf('%2d-%2d-', 29, 2)) . "%'";
+		$leap_year_birthdays = " OR u.user_birthday LIKE '" . $db->sql_escape(sprintf('%2d-%2d-', 29, 2)) . "%'";
 	}
 
 	$sql = 'SELECT u.user_id, u.username, u.user_colour, u.user_birthday


### PR DESCRIPTION
user_birthday does not use table alias in $leap_year_birthdays variable definition in index.php.

<a href="http://tracker.phpbb.com/browse/PHPBB3-10589">PHPBB3-10589</a>.
