### PR TITLE
[ticket/10633] Stop leaking filename of attachments when thumbnail is re...

### DIFF
--- a/phpBB/download/file.php
+++ b/phpBB/download/file.php
@@ -424,7 +424,7 @@ function send_file_to_browser($attachment, $upload_dir, $category)
 	if (!@file_exists($filename))
 	{
 		send_status_line(404, 'Not Found');
-		trigger_error($user->lang['ERROR_NO_ATTACHMENT'] . '<br /><br />' . sprintf($user->lang['FILE_NOT_FOUND_404'], $filename));
+		trigger_error('ERROR_NO_ATTACHMENT');
 	}
 
 	// Correct the mime type - we force application/octetstream for all files, except images


### PR DESCRIPTION
...quested

While filenames are chosen at random and there is no correlation between the
original filename and the new filesystem filename, there is a correlation
between filesystem filename and filesytem filename of thumbnails.

Adjust error message to no longer include the physical filename and make it
consistent with the error message that is shown when there is no attachment at
all.

This information was mostly useless for regular users (i.e. non-admins) anyway.

PHPBB3-10633

http://tracker.phpbb.com/browse/PHPBB3-10633
