### PR TITLE
[ticket/10658] Use get_user_rank() for group ranks on group view.

### DIFF
--- a/phpBB/memberlist.php
+++ b/phpBB/memberlist.php
@@ -62,11 +62,6 @@ $default_key = 'c';
 $sort_key = request_var('sk', $default_key);
 $sort_dir = request_var('sd', 'a');
 
-
-// Grab rank information for later
-$ranks = $cache->obtain_ranks();
-
-
 // What do you want to do today? ... oops, I think that line is taken ...
 switch ($mode)
 {


### PR DESCRIPTION
The old code was buggy because it did not prefix the path with the phpBB root
path which causes problems with bridges and other URL rewriting.

PHPBB3-10658

http://tracker.phpbb.com/browse/PHPBB3-10658
