### PR TITLE
[ticket/10664]

### DIFF
--- a/phpBB/mcp.php
+++ b/phpBB/mcp.php
@@ -240,6 +240,12 @@ if (!$user_id && $username == '')
 	$module->set_display('warn', 'warn_user', false);
 }
 
+// Do not display ban panel if not authed to do so
+if (!$auth->acl_get('m_ban'))
+{
+	$module->set_display('ban', '', false);
+}
+
 // Load and execute the relevant module
 $module->load_active();
 


### PR DESCRIPTION
Banning tab within the MCP displays to Global Moderators even if the user doesn't have "Can manage bans" permissions

PHPBB3-10664
