### PR TITLE
[ticket/9220] Remove margin on table.table1 so it's centered in the blue box.

### DIFF
--- a/phpBB/styles/prosilver/template/memberlist_body.html
+++ b/phpBB/styles/prosilver/template/memberlist_body.html
@@ -80,7 +80,7 @@
 	<span class="corners-bottom"><span></span></span></div>
 </div>
 <!-- ENDIF -->
-<div class="forumbg">
+<div class="forumbg forumbg-table">
 	<div class="inner"><span class="corners-top"><span></span></span>
 
 	<table class="table1" cellspacing="1">

--- a/phpBB/styles/prosilver/template/memberlist_leaders.html
+++ b/phpBB/styles/prosilver/template/memberlist_leaders.html
@@ -4,7 +4,7 @@
 
 <form method="post" action="{S_MODE_ACTION}">
 
-<div class="forumbg">
+<div class="forumbg forumbg-table">
 	<div class="inner"><span class="corners-top"><span></span></span>
 
 	<table class="table1" cellspacing="1">
@@ -37,7 +37,7 @@
 	<span class="corners-bottom"><span></span></span></div>
 </div>
 
-<div class="forumbg">
+<div class="forumbg forumbg-table">
 	<div class="inner"><span class="corners-top"><span></span></span>
 	 
 	<table class="table1" cellspacing="1">

--- a/phpBB/styles/prosilver/template/search_body.html
+++ b/phpBB/styles/prosilver/template/search_body.html
@@ -98,7 +98,7 @@
 </form>
 
 <!-- IF .recentsearch -->
-<div class="forumbg">
+<div class="forumbg forumbg-table">
 	<div class="inner"><span class="corners-top"><span></span></span>
 
 	<table class="table1" cellspacing="1">

--- a/phpBB/styles/prosilver/template/viewonline_body.html
+++ b/phpBB/styles/prosilver/template/viewonline_body.html
@@ -7,7 +7,7 @@
 	<li class="rightside pagination"><!-- IF PAGINATION --><a href="#" onclick="jumpto(); return false;" title="{L_JUMP_TO_PAGE}">{PAGE_NUMBER}</a> &bull; <span>{PAGINATION}</span><!-- ELSE -->{PAGE_NUMBER}<!-- ENDIF --></li>
 </ul>
 
-<div class="forumbg">
+<div class="forumbg forumbg-table">
 	<div class="inner"><span class="corners-top"><span></span></span>
 	
 	<table class="table1" cellspacing="1">

--- a/phpBB/styles/prosilver/theme/common.css
+++ b/phpBB/styles/prosilver/theme/common.css
@@ -418,7 +418,19 @@ table.info tbody th {
 }
 
 .forumbg table.table1 {
-	margin: 0 -2px -1px -1px;
+	margin: 0;
+}
+
+.forumbg-table > .inner {
+	margin: 0 -1px;
+}
+
+.forumbg-table > .inner > span.corners-top {
+	margin: 0 -4px -1px -4px;
+}
+
+.forumbg-table > .inner > span.corners-bottom {
+	margin: -1px -4px 0 -4px;
 }
 
 /* Misc layout styles

--- a/phpBB/styles/prosilver/theme/tweaks.css
+++ b/phpBB/styles/prosilver/theme/tweaks.css
@@ -87,10 +87,6 @@ dl.icon {
 	float: none;
 }
 
-* html .forumbg table.table1 {
-	margin: 0 -2px 0px -1px;
-}
-
 /* Headerbar height fix for IE7 and below */
 * html #site-description p {
 	margin-bottom: 1.0em;


### PR DESCRIPTION
The problem here was, that we use width: 100% in combination with the negative
margin. This causes the element to be just moved to the side, so it's not
centered anymore. width: auto would fix this, but it causes strange behaviour
on IE and looks even more ugly. So I decided to just remove the margin at all.
The border is now 1px thicker for all sides.

http://tracker.phpbb.com/browse/PHPBB3-9220
