### PR TITLE
[ticket/8652] Sending 2 emails on 2 replies

### DIFF
--- a/phpBB/includes/functions_posting.php
+++ b/phpBB/includes/functions_posting.php
@@ -1286,6 +1286,12 @@ function user_notification($mode, $subject, $topic_title, $forum_name, $forum_id
 		{
 			$msg_users[] = $row;
 			$update_notification[$row['notify_type']][] = $row['user_id'];
+			if ($row['notify_type'] === 'topic')
+			{
+				// Using SQL characteristics. If it didn't exist it isn't added.
+				// It's very rare to find someone that is registered in topic and noone is registered in the forum
+				$update_notification['forum'][] = $row['user_id'];
+			}
 		}
 	}
 	unset($notify_rows);


### PR DESCRIPTION
This is a fix for the problem of the system sending 2 emails when there are 2 replies to a topic where the user is subscribed in a topic and the forum that contains the topic.
This simple fix seems to solve the problem. In simple tests I made it shows it does.

PHPBB3-8652
