### PR TITLE
[ticket/8652] Sending 2 emails on 2 replies

### DIFF
--- a/phpBB/includes/functions_posting.php
+++ b/phpBB/includes/functions_posting.php
@@ -1286,10 +1286,15 @@ function user_notification($mode, $subject, $topic_title, $forum_name, $forum_id
 		{
 			$msg_users[] = $row;
 			$update_notification[$row['notify_type']][] = $row['user_id'];
+			/* 	If the user subscribes to the thread and the forum and he is now being warned for the new post
+				in the topic, then don't warn for the post in this topic as a forum's new post when a user writes
+				a post in that thread. #bug8652
+				This fix uses SQL characteristics to simplify the code and checks. If a row didn't exist, an edit will not create it.
+				Anyway, this will not be a performance hit, it's really rare not to have people registered in the topic and not a
+				single user (for the whole forum) registered in the forum.
+			*/
 			if ($row['notify_type'] === 'topic')
 			{
-				// Using SQL characteristics. If it didn't exist it isn't added.
-				// It's very rare to find someone that is registered in topic and noone is registered in the forum
 				$update_notification['forum'][] = $row['user_id'];
 			}
 		}


### PR DESCRIPTION
This is a fix for the problem of the system sending 2 emails when there are 2 replies to a topic where the user is subscribed in a topic and the forum that contains the topic.
This simple fix seems to solve the problem. In simple tests I made it shows it does.

PHPBB3-8652
