### PR TITLE
[ticket/10731] Fixed addquote() to work on opera browser

### DIFF
--- a/phpBB/styles/prosilver/template/editor.js
+++ b/phpBB/styles/prosilver/template/editor.js
@@ -219,7 +219,7 @@ function addquote(post_id, username, l_wrote)
 
 	// Get text selection - not only the post content :(
 	// IE9 must use the document.selection method but has the *.getSelection so we just force no IE
-	if (window.getSelection && !is_ie)
+	if (window.getSelection && !is_ie && !window.opera)
 	{
 		theSelection = window.getSelection().toString();
 	}

--- a/phpBB/styles/subsilver2/template/editor.js
+++ b/phpBB/styles/subsilver2/template/editor.js
@@ -221,7 +221,7 @@ function addquote(post_id, username, l_wrote)
 
 	// Get text selection - not only the post content :(
 	// IE9 must use the document.selection method but has the *.getSelection so we just force no IE
-	if (window.getSelection && !is_ie)
+	if (window.getSelection && !is_ie && !window.opera)
 	{
 		theSelection = window.getSelection().toString();
 	}


### PR DESCRIPTION
In opera, window.getSelection() returned incorrect values, should be using document.getSelection() instead. Fixed in prosilver and subsilver2 templates.
