### PR TITLE
[ticket/10438] Alligning the Smileys on the same line as the text.

### DIFF
--- a/phpBB/includes/functions_content.php
+++ b/phpBB/includes/functions_content.php
@@ -739,7 +739,7 @@ function smiley_text($text, $force_option = false)
 	else
 	{
 		$root_path = (defined('PHPBB_USE_BOARD_URL_PATH') && PHPBB_USE_BOARD_URL_PATH) ? generate_board_url() . '/' : $phpbb_root_path;
-		return preg_replace('#<!\-\- s(.*?) \-\-><img src="\{SMILIES_PATH\}\/(.*?) \/><!\-\- s\1 \-\->#', '<img src="' . $root_path . $config['smilies_path'] . '/\2 />', $text);
+		return preg_replace('#<!\-\- s(.*?) \-\-><img src="\{SMILIES_PATH\}\/(.*?) \/><!\-\- s\1 \-\->#', '<img class="smilies" src="' . $root_path . $config['smilies_path'] . '/\2 />', $text);
 	}
 }
 

--- a/phpBB/styles/prosilver/theme/common.css
+++ b/phpBB/styles/prosilver/theme/common.css
@@ -713,3 +713,7 @@ p.rules a {
 .hidden {
 	display: none;
 }
+
+.smilies {
+	vertical-align: text-bottom;
+}


### PR DESCRIPTION
Changed the styling of smilies to appear at the same level as
text, by adding vertical-align: text-bottom css property to all
smilies. Edited functions_content.php to add class="smilies"
to all parsed smilies.

PHPBB3-10438
