### PR TITLE
[ticket/10699] Long h2 title breaks div.minitabs in MCP

### DIFF
--- a/phpBB/styles/prosilver/template/mcp_topic.html
+++ b/phpBB/styles/prosilver/template/mcp_topic.html
@@ -1,5 +1,5 @@
 <!-- INCLUDE mcp_header.html -->
-
+<div class="tabs-container">
 <h2><a href="{U_VIEW_TOPIC}">{L_TOPIC}: {TOPIC_TITLE}</a></h2>
 
 <script type="text/javascript">
@@ -35,7 +35,7 @@ onload_functions.push('subPanels()');
 		</li>
 	</ul>
 </div>
-
+</div>
 <form id="mcp" method="post" action="{S_MCP_ACTION}">
 
 <div class="panel">

--- a/phpBB/styles/prosilver/theme/cp.css
+++ b/phpBB/styles/prosilver/theme/cp.css
@@ -104,6 +104,23 @@ ul.cplist {
 	width: 100%;
 }
 
+.tabs-container h2 {
+	float: left;
+	white-space: nowrap;
+	margin-bottom: 0px;
+}
+
+.tabs-container #minitabs {
+	float: right;
+	margin-top: 19px;
+}
+
+.tabs-container:after {
+	display: block;
+	clear: both;
+	content: '';
+}
+
 /* CP tabbed menu
 ----------------------------------------*/
 #tabs {

--- a/phpBB/styles/prosilver/theme/tweaks.css
+++ b/phpBB/styles/prosilver/theme/tweaks.css
@@ -95,3 +95,13 @@ dl.icon {
 *:first-child+html #site-description p {
 	margin-bottom: 1.0em;
 }
+
+/* #minitabs fix for IE */
+.tabs-container {
+	zoom: 1;
+}
+
+#minitabs {
+	white-space: nowrap;
+	*min-width: 50%;
+}


### PR DESCRIPTION
Fixed overlapping of Subject title over the minitabs.
Added css property to cp.css under MCP Specific tweaks.

PHPBB3-10699
