### PR TITLE
[ticket/10664] Check "Can manage bans" when displaying banning tab in MC...

### DIFF
--- a/phpBB/mcp.php
+++ b/phpBB/mcp.php
@@ -240,6 +240,12 @@ if (!$user_id && $username == '')
 	$module->set_display('warn', 'warn_user', false);
 }
 
+// Do not display ban panel if not authed to do so
+if (!$auth->acl_get('m_ban'))
+{
+	$module->set_display('ban', '', false);
+}
+
 // Load and execute the relevant module
 $module->load_active();
 


### PR DESCRIPTION
...P

Previously banning tab within the MCP was displayed to Global Moderators
even if the user did not have "Can manage bans" permissions

Replaces #588.

I fixed commit message and branch name, however I have not been able to reproduce the issue. On my board when I take away m_ban the banning tab disappears.

http://tracker.phpbb.com/browse/PHPBB3-10664
