### PR TITLE
[ticket/10575] Fixing non-static access to static functions get_instance

### DIFF
--- a/phpBB/includes/captcha/captcha_factory.php
+++ b/phpBB/includes/captcha/captcha_factory.php
@@ -25,7 +25,7 @@ class phpbb_captcha_factory
 	/**
 	* return an instance of class $name in file $name_plugin.php
 	*/
-	static function get_instance($name)
+	public static function get_instance($name)
 	{
 		global $phpbb_root_path, $phpEx;
 

--- a/phpBB/includes/captcha/plugins/phpbb_captcha_gd_plugin.php
+++ b/phpBB/includes/captcha/plugins/phpbb_captcha_gd_plugin.php
@@ -49,7 +49,7 @@ class phpbb_captcha_gd extends phpbb_default_captcha
 		}
 	}
 
-	static function get_instance()
+	public static function get_instance()
 	{
 		$instance = new phpbb_captcha_gd();
 		return $instance;

--- a/phpBB/includes/captcha/plugins/phpbb_captcha_gd_wave_plugin.php
+++ b/phpBB/includes/captcha/plugins/phpbb_captcha_gd_wave_plugin.php
@@ -39,7 +39,7 @@ class phpbb_captcha_gd_wave extends phpbb_default_captcha
 		}
 	}
 
-	static function get_instance()
+	public static function get_instance()
 	{
 		return new phpbb_captcha_gd_wave();
 	}

--- a/phpBB/includes/captcha/plugins/phpbb_captcha_nogd_plugin.php
+++ b/phpBB/includes/captcha/plugins/phpbb_captcha_nogd_plugin.php
@@ -39,7 +39,7 @@ class phpbb_captcha_nogd extends phpbb_default_captcha
 		}
 	}
 
-	static function get_instance()
+	public static function get_instance()
 	{
 		$instance = new phpbb_captcha_nogd();
 		return $instance;

--- a/phpBB/includes/captcha/plugins/phpbb_captcha_qa_plugin.php
+++ b/phpBB/includes/captcha/plugins/phpbb_captcha_qa_plugin.php
@@ -98,7 +98,7 @@ class phpbb_captcha_qa
 	/**
 	*  API function
 	*/
-	static function get_instance()
+	public static function get_instance()
 	{
 		$instance = new phpbb_captcha_qa();
 

--- a/phpBB/includes/captcha/plugins/phpbb_recaptcha_plugin.php
+++ b/phpBB/includes/captcha/plugins/phpbb_recaptcha_plugin.php
@@ -54,7 +54,7 @@ class phpbb_recaptcha extends phpbb_default_captcha
 		$this->response = request_var('recaptcha_response_field', '');
 	}
 
-	static function get_instance()
+	public static function get_instance()
 	{
 		$instance = new phpbb_recaptcha();
 		return $instance;


### PR DESCRIPTION
These changes should solve the strict standards error about accessing
the non-static get_instance() in a non-static way.
For that, I changed the get_instance methods to static methods.

PHPBB3-10575
