### PR TITLE
[ticket/10764] FAQ now mentions Area51 instead of SourceForge

### DIFF
--- a/phpBB/language/en/help_faq.php
+++ b/phpBB/language/en/help_faq.php
@@ -333,7 +333,7 @@ $help = array(
 	),
 	array(
 		0 => 'Why isn’t X feature available?',
-		1 => 'This software was written by and licensed through phpBB Group. If you believe a feature needs to be added, please visit the phpbb.com website and see what phpBB Group have to say. Please do not post feature requests to the board at phpbb.com, the group uses GitHub to handle tasking of new features. Please read through the forums and see what, if any, our position may already be for a feature and then follow the procedure given there.'
+		1 => 'This software was written by and licensed through phpBB Group. If you believe a feature needs to be added, or you want to report a bug, please visit the phpBB <a href="http://area51.phpbb.com/">Area51</a> website, where you will find resources to do so.'
 	),
 	array(
 		0 => 'Who do I contact about abusive and/or legal matters related to this board?',


### PR DESCRIPTION
The answer of the question "Why isn't X feature available?" in the FAQ now mentions Area51 instead of SourceForge or GitHub as the way to handle feature requests.

PHPBB3-10764
