### PR TITLE
[ticket/10778] Remove extra space in link Close Window from prosilver/template/posting_smilies.html

### DIFF
--- a/phpBB/styles/prosilver/template/posting_smilies.html
+++ b/phpBB/styles/prosilver/template/posting_smilies.html
@@ -18,6 +18,6 @@
 	<span class="corners-bottom"><span></span></span></div>
 </div>
 <div>{PAGINATION}</div>
-<a  href="#" onclick="window.close(); return false;">{L_CLOSE_WINDOW}</a>
+<a href="#" onclick="window.close(); return false;">{L_CLOSE_WINDOW}</a>
 
 <!-- INCLUDE simple_footer.html -->


### PR DESCRIPTION
Removal of the extra space in link "Close Window" from prosilver/template/posting_smilies.html

<b>Ticket:</b> http://tracker.phpbb.com/browse/PHPBB3-10778
