### PR TITLE
[ticket/10784] Fix ajaxify overlay option on first call

### DIFF
--- a/phpBB/adm/style/acp_forums.html
+++ b/phpBB/adm/style/acp_forums.html
@@ -454,12 +454,12 @@
 				<td style="vertical-align: top; width: 100px; text-align: right; white-space: nowrap;">
 					<!-- IF forums.S_FIRST_ROW && not forums.S_LAST_ROW -->
 						<span class="up">{ICON_MOVE_UP_DISABLED}</span>
-						<span class="down"><a href="{forums.U_MOVE_DOWN}" data-ajax="forum_down">{ICON_MOVE_DOWN}</a></span>
+						<span class="down"><a href="{forums.U_MOVE_DOWN}" data-ajax="forum_down" data-overlay="false">{ICON_MOVE_DOWN}</a></span>
 					<!-- ELSEIF not forums.S_FIRST_ROW && not forums.S_LAST_ROW -->
-						<span class="up"><a href="{forums.U_MOVE_UP}" data-ajax="forum_up">{ICON_MOVE_UP}</a></span>
-						<span class="down"><a href="{forums.U_MOVE_DOWN}" data-ajax="forum_down">{ICON_MOVE_DOWN}</a></span>
+						<span class="up"><a href="{forums.U_MOVE_UP}" data-ajax="forum_up" data-overlay="false">{ICON_MOVE_UP}</a></span>
+						<span class="down"><a href="{forums.U_MOVE_DOWN}" data-ajax="forum_down" data-overlay="false">{ICON_MOVE_DOWN}</a></span>
 					<!-- ELSEIF forums.S_LAST_ROW && not forums.S_FIRST_ROW -->
-						<span class="up"><a href="{forums.U_MOVE_UP}" data-ajax="forum_up">{ICON_MOVE_UP}</a></span>
+						<span class="up"><a href="{forums.U_MOVE_UP}" data-ajax="forum_up" data-overlay="false">{ICON_MOVE_UP}</a></span>
 						<span class="down">{ICON_MOVE_DOWN_DISABLED}</span>
 					<!-- ELSE -->
 						<span class="up">{ICON_MOVE_UP_DISABLED}</span>

--- a/phpBB/adm/style/ajax.js
+++ b/phpBB/adm/style/ajax.js
@@ -129,7 +129,8 @@ $('[data-ajax]').each(function() {
 		phpbb.ajaxify({
 			selector: this,
 			refresh: $this.attr('data-refresh') !== undefined,
-			callback: fn
+			callback: fn,
+			overlay: $this.attr('data-overlay') === undefined
 		});
 	}
 });

--- a/phpBB/assets/javascript/core.js
+++ b/phpBB/assets/javascript/core.js
@@ -240,6 +240,8 @@ phpbb.parse_querystring = function(string) {
  * @param function callback Callback to call on completion of event. Has
  * 	three parameters: the element that the event was evoked from, the JSON
  * 	that was returned and (if it is a form) the form action.
+ * @param bool overlay Define wether the ajax overlay should be displayed
+ *  while performing the ajax request
  */
 phpbb.ajaxify = function(options) {
 	var elements = $(options.selector),

--- a/phpBB/styles/prosilver/template/ajax.js
+++ b/phpBB/styles/prosilver/template/ajax.js
@@ -60,7 +60,8 @@ $('[data-ajax]').each(function() {
 		phpbb.ajaxify({
 			selector: this,
 			refresh: $this.attr('data-refresh') !== undefined,
-			callback: fn
+			callback: fn,
+			overlay: $this.attr('data-overlay') === undefined
 		});
 	}
 });


### PR DESCRIPTION
The overlay option was specified in callback handlers, so it was
being skipped when moving forums for the first time.

PHPBB3-10784
