### PR TITLE
[ticket/10797] user rank is displayed in mcp_warn.php

### DIFF
--- a/phpBB/language/en/common.php
+++ b/phpBB/language/en/common.php
@@ -459,6 +459,7 @@ $lang = array_merge($lang, array(
 	'PRIVATE_MESSAGING'		=> 'Private messaging',
 	'PROFILE'				=> 'User Control Panel',
 
+	'RANK'						=> 'Rank',
 	'READING_FORUM'				=> 'Viewing topics in %s',
 	'READING_GLOBAL_ANNOUNCE'	=> 'Reading global announcement',
 	'READING_LINK'				=> 'Following forum link %s',

--- a/phpBB/language/en/mcp.php
+++ b/phpBB/language/en/mcp.php
@@ -274,7 +274,6 @@ $lang = array_merge($lang, array(
 	'POST_REPORTED_SUCCESS'		=> 'This post has been successfully reported.',
 	'POST_UNLOCKED_SUCCESS'		=> 'Post unlocked successfully.',
 
-	'RANK'						=> 'User rank',
 	'READ_USERNOTES'			=> 'User notes',
 	'READ_WARNINGS'				=> 'User warnings',
 	'REPORTER'					=> 'Reporter',

--- a/phpBB/language/en/memberlist.php
+++ b/phpBB/language/en/memberlist.php
@@ -110,7 +110,6 @@ $lang = array_merge($lang, array(
 
 	'POST_IP'				=> 'Posted from IP/domain',
 
-	'RANK'					=> 'Rank',
 	'REAL_NAME'				=> 'Recipient name',
 	'RECIPIENT'				=> 'Recipient',
 	'REMOVE_FOE'			=> 'Remove foe',


### PR DESCRIPTION
When warning a user in MCP, the user's rank title and image are displayed.
language key user rank also added.

PHPBB3-10797
