### PR TITLE
[ticket/10819] Improve side-by-side diff styling

### DIFF
--- a/phpBB/adm/style/install_update_diff.html
+++ b/phpBB/adm/style/install_update_diff.html
@@ -152,14 +152,10 @@ table.hrdiff tbody td {
 	border-right: 1px solid #999;
 }
 
-/* Variant of http://www.longren.org/wrapping-text-inside-pre-tags/ */
 table.hrdiff td pre {
 	font-family: "Consolas", monospace;
 	font-size: 1.1em;
 	white-space: pre-wrap;		/* css-3 */
-	white-space: -moz-pre-wrap !important;	/* Mozilla, since 1999 */
-	white-space: -pre-wrap;		/* Opera 4-6 */
-	white-space: -o-pre-wrap;	/* Opera 7 */
 	word-wrap: break-word;		/* Internet Explorer 5.5+ */
 }
 


### PR DESCRIPTION
Used transparent background for unchanged lines
Shortened the table headers and make the background grey
Added a border between the columns
Increased the font size on pre blocks
Added Consolas as the first pre font, for Windows users
Added wordwrapping for pre blocks

PHPBB3-10819
