### PR TITLE
[ticket/10767] Revert unconditional unfatality in commit-msg hook.

### DIFF
--- a/git-tools/hooks/commit-msg
+++ b/git-tools/hooks/commit-msg
@@ -63,10 +63,17 @@ debug()
 
 quit()
 {
-	if [ $1 -gt 0 ] && [ $1 -ne $ERR_UNKNOWN ] && [ $fatal -eq 0 ]
+	if [ $1 -eq 0 ] || [ $1 -eq $ERR_UNKNOWN ]
 	then
+		# success
+		exit 0;
+	elif [ $fatal -eq 0 ]
+	then
+		# problems found but fatal is false
+		complain 'Please run `git commit --amend` and fix the problems mentioned.' 1>&2
 		exit 0;
 	else
+		complain "Aborting commit." 1>&2
 		exit $1;
 	fi
 }


### PR DESCRIPTION
Revert "[ticket/10093] Make commit-msg always not fatal by nuking all fatal logic."

This reverts commit 88cad5523e7cdac6826dd8581e27e22a65afda26.

http://tracker.phpbb.com/browse/PHPBB3-10767

PHPBB3-10093
PHPBB3-10767

Not tested at all.

Also I think per-hook namespacing of config vars is excessive, but that would be a different ticket.
