### PR TITLE
[ticket/10831] Pass language entries into `msg_handler`

### DIFF
--- a/phpBB/includes/functions.php
+++ b/phpBB/includes/functions.php
@@ -3789,6 +3789,9 @@ function msg_handler($errno, $msg_text, $errfile, $errline)
 		return;
 	}
 
+	// If a language entry is passed get the correct string
+	$msg_text = $user->lang($msg_text);
+
 	// Message handler is stripping text. In case we need it, we are possible to define long text...
 	if (isset($msg_long_text) && $msg_long_text && !$msg_text)
 	{


### PR DESCRIPTION
Update the msg_handler so it is possible to pass a language
entry as first argument of trigger_error. The msg_handler
then calls `$msg_text = $user->lang($msg_text)` to get the
appropriate language entry.
This will also make the $msg_long_text "hack" obsolete.

PHPBB3-10831
