### PR TITLE
[ticket/10849] Added missing helptext for listitem

### DIFF
--- a/phpBB/styles/subsilver2/template/posting_buttons.html
+++ b/phpBB/styles/subsilver2/template/posting_buttons.html
@@ -16,6 +16,7 @@
 			q: '{LA_BBCODE_Q_HELP}',
 			c: '{LA_BBCODE_C_HELP}',
 			l: '{LA_BBCODE_L_HELP}',
+			e: '{LA_BBCODE_LISTITEM_HELP}',
 			o: '{LA_BBCODE_O_HELP}',
 			p: '{LA_BBCODE_P_HELP}',
 			w: '{LA_BBCODE_W_HELP}',


### PR DESCRIPTION
Added the missing helptext for list item in subsilver2.

PHPBB3-10849

Ticket: http://tracker.phpbb.com/browse/PHPBB3-10849
