### PR TITLE
[task/10869] Remove PHP 5.2 check from .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ before_script:
   - sh -c "if [ '$DB' = 'pgsql' ]; then psql -c 'DROP DATABASE IF EXISTS phpbb_tests;' -U postgres; fi"
   - sh -c "if [ '$DB' = 'pgsql' ]; then psql -c 'create database phpbb_tests;' -U postgres; fi"
   - sh -c "if [ '$DB' = 'mysql' ]; then mysql -e 'create database IF NOT EXISTS phpbb_tests;'; fi"
-  - sh -c "if [ '$TRAVIS_PHP_VERSION' = '5.2' ]; then pear install --force phpunit/DbUnit; else pyrus install --force phpunit/DbUnit; fi"
+  - pyrus install --force phpunit/DbUnit
   - phpenv rehash
   - cd phpBB
   - curl -s http://getcomposer.org/installer | php


### PR DESCRIPTION
The travis configuration file contains a statement that checks whether
the test is ran against PHP 5.2 but as that version isn't tested at
all the check can be removed.

http://tracker.phpbb.com/browse/PHPBB3-10869

PHPBB3-10869
