### PR TITLE
[ticket/10837] Removed tearDownAfterClass() from extension_controller_test.php

### DIFF
--- a/tests/functional/extension_controller_test.php
+++ b/tests/functional/extension_controller_test.php
@@ -65,15 +65,6 @@ class phpbb_functional_extension_controller_test extends phpbb_functional_test_c
 		}
 	}
 
-	public static function tearDownAfterClass()
-	{
-		$phpbb_root_path = self::$config['phpbb_functional_path'];
-
-		// @todo delete the fixtures from the $phpbb_root_path board
-		// Note that it might be best to find a public domain function
-		// and port it into here instead of writing it from scratch
-	}
-
 	public function setUp()
 	{
 		parent::setUp();


### PR DESCRIPTION
This was a leftover from http://tracker.phpbb.com/browse/PHPBB3-10706, which was originally going to be included in http://tracker.phpbb.com/browse/PHPBB3-10586. 10706 was denied, and when I the stuff from 10586 to 10706, I forgot this portion. So this still needed to be removed.

http://tracker.phpbb.com/browse/PHPBB3-10837
