### PR TITLE
[ticket/10890] Fix test_sql_fetchrow_returns_false_when_empty() on MS an...

### DIFF
--- a/tests/dbal/select_test.php
+++ b/tests/dbal/select_test.php
@@ -375,7 +375,9 @@ class phpbb_dbal_select_test extends phpbb_database_test_case
 	{
 		$db = $this->new_dbal();
 
-		$sql = 'SELECT * FROM (SELECT 1) AS TBL WHERE 1 = 0';
+		$sql = 'SELECT user_id
+			FROM phpbb_users
+			WHERE 1 = 0';
 		$result = $db->sql_query($sql);
 
 		$row = $db->sql_fetchrow($result);


### PR DESCRIPTION
...d ORA.

Fix phpbb_dbal_select_test::test_sql_fetchrow_returns_false_when_empty() on
MSSQL and Oracle by specifying an existing table in the query.

PHPBB3-10890

http://tracker.phpbb.com/browse/PHPBB3-10890
