### PR TITLE
[ticket/10790] Remove a (kind of) dead code section from submit_pm().

### DIFF
--- a/phpBB/includes/functions_privmsgs.php
+++ b/phpBB/includes/functions_privmsgs.php
@@ -1522,12 +1522,6 @@ function submit_pm($mode, $subject, &$data, $put_in_outbox = true)
 
 			while ($row = $db->sql_fetchrow($result))
 			{
-				// Additionally, do not include the sender if he is in the group he wants to send to. ;)
-				if ($row['user_id'] === $user->data['user_id'])
-				{
-					continue;
-				}
-
 				$field = ($data['address_list']['g'][$row['group_id']] == 'to') ? 'to' : 'bcc';
 				$recipients[$row['user_id']] = $field;
 			}


### PR DESCRIPTION
http://tracker.phpbb.com/browse/PHPBB3-10790

The type of $user->data['user_id'] is (almost) guranteed to be integer
since session::session_create() casts it to integer.
The type of $row['user_id'] is only an integer if the DB driver adjusts the
PHP type according to the DB type. This is only done by some of our
not-so-popular DB drivers and is not the case for MySQL.

As such this comparison is (almost) never true and a PM is also sent to the
author itself when it is sent to a group the author is also a member of.

Since this behaviour seems to have been accepted by the communty, the dead
code is removed and current behaviour is kept.

Also, checking this in the loop seems to be a rather bad idea.

Introduced by 78b1c4caaa17cc8760b685ad41c19f15f9d89b68.

PHPBB3-10790
