### PR TITLE
[ticket/10401] Return correct type when ldap_bind() fails in ldap_login(...

### DIFF
--- a/phpBB/includes/auth/auth_ldap.php
+++ b/phpBB/includes/auth/auth_ldap.php
@@ -156,7 +156,11 @@ function login_ldap(&$username, &$password)
 	{
 		if (!@ldap_bind($ldap, htmlspecialchars_decode($config['ldap_user']), htmlspecialchars_decode($config['ldap_password'])))
 		{
-			return $user->lang['LDAP_NO_SERVER_CONNECTION'];
+			return array(
+				'status'		=> LOGIN_ERROR_EXTERNAL_AUTH,
+				'error_msg'		=> 'LDAP_NO_SERVER_CONNECTION',
+				'user_row'		=> array('user_id' => ANONYMOUS),
+			);
 		}
 	}
 


### PR DESCRIPTION
...).

ldap_login() is supposed to return an array.

PHPBB3-10401

http://tracker.phpbb.com/browse/PHPBB3-10401
