### PR TITLE
[ticket/10914] Fix smiley issue in reported post text in reports

### DIFF
--- a/phpBB/includes/mcp/mcp_reports.php
+++ b/phpBB/includes/mcp/mcp_reports.php
@@ -227,7 +227,7 @@ class mcp_reports
 					'REPORTER_NAME'				=> get_username_string('username', $report['user_id'], $report['username'], $report['user_colour']),
 					'U_VIEW_REPORTER_PROFILE'	=> get_username_string('profile', $report['user_id'], $report['username'], $report['user_colour']),
 
-					'POST_PREVIEW'			=> bbcode_nl2br($report['reported_post_text']),
+					'POST_PREVIEW'			=> smiley_text(bbcode_nl2br($report['reported_post_text'])),
 					'POST_SUBJECT'			=> ($post_info['post_subject']) ? $post_info['post_subject'] : $user->lang['NO_SUBJECT'],
 					'POST_DATE'				=> $user->format_date($post_info['post_time']),
 					'POST_IP'				=> $post_info['poster_ip'],


### PR DESCRIPTION
When feature/save-post-on-report was merged, it was not tested
for parsing smilies when viewing the reported post text. BBCode
worked, but not smilies. As such, the text was never run through
smiley_text() resulting in improper image URLs because they were
not being parsed.

PHPBB3-10914
