### PR TITLE
[ticket/10938] Serve subforum listing on forumlist from template loop

### DIFF
--- a/phpBB/styles/prosilver/template/forumlist_body.html
+++ b/phpBB/styles/prosilver/template/forumlist_body.html
@@ -35,7 +35,12 @@
 					<!-- IF forumrow.MODERATORS -->
 						<br /><strong>{forumrow.L_MODERATOR_STR}:</strong> {forumrow.MODERATORS}
 					<!-- ENDIF -->
-					<!-- IF forumrow.SUBFORUMS and forumrow.S_LIST_SUBFORUMS --><br /><strong>{forumrow.L_SUBFORUM_STR}</strong> {forumrow.SUBFORUMS}<!-- ENDIF -->
+					<!-- IF .forumrow.subforum and forumrow.S_LIST_SUBFORUMS -->
+						<br /><strong>{forumrow.L_SUBFORUM_STR}</strong>
+						<!-- BEGIN subforum -->
+							<a href="{forumrow.subforum.U_SUBFORUM}" class="subforum<!-- IF forumrow.subforum.S_UNREAD --> unread<!-- ELSE --> read<!-- ENDIF -->" title="<!-- IF forumrow.subforum.UNREAD -->{L_UNREAD_POSTS}<!-- ELSE -->{L_NO_UNREAD_POSTS}<!-- ENDIF -->">{forumrow.subforum.SUBFORUM_NAME}</a><!-- IF not forumrow.subforum.S_LAST_ROW -->,<!-- ENDIF -->
+						<!-- END subforum -->
+					<!-- ENDIF -->
 				</dt>
 				<!-- IF forumrow.CLICKS -->
 					<dd class="redirect"><span>{L_REDIRECTS}: {forumrow.CLICKS}</span></dd>

--- a/phpBB/styles/subsilver2/template/forumlist_body.html
+++ b/phpBB/styles/subsilver2/template/forumlist_body.html
@@ -48,8 +48,12 @@
 				<!-- IF forumrow.MODERATORS -->
 					<p class="forumdesc"><strong>{forumrow.L_MODERATOR_STR}:</strong> {forumrow.MODERATORS}</p>
 				<!-- ENDIF -->
-				<!-- IF forumrow.SUBFORUMS and forumrow.S_LIST_SUBFORUMS -->
-					<p class="forumdesc"><strong>{forumrow.L_SUBFORUM_STR}</strong> {forumrow.SUBFORUMS}</p>
+				<!-- IF .forumrow.subforum and forumrow.S_LIST_SUBFORUMS -->
+					<p class="forumdesc"><strong>{forumrow.L_SUBFORUM_STR}</strong>
+					<!-- BEGIN subforum -->
+						<a href="{forumrow.subforum.U_SUBFORUM}" class="subforum<!-- IF forumrow.subforum.S_UNREAD --> unread<!-- ELSE --> read<!-- ENDIF -->" title="<!-- IF forumrow.subforum.UNREAD -->{L_UNREAD_POSTS}<!-- ELSE -->{L_NO_UNREAD_POSTS}<!-- ENDIF -->">{forumrow.subforum.SUBFORUM_NAME}</a><!-- IF not forumrow.subforum.S_LAST_ROW -->,<!-- ENDIF -->
+					<!-- END subforum -->
+					</p>
 				<!-- ENDIF -->
 			</td>
 			<td class="row2" align="center"><p class="topicdetails">{forumrow.TOPICS}</p></td>


### PR DESCRIPTION
Subforum listing is available both via implode()-ed PHP loop and
via template loop. The latter allows more flexibility for changing
the subforum listing per style, so that is the better option.

For more info, see http://tracker.phpbb.com/browse/PHPBB3-10901?focusedCommentId=37774&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-37774

http://tracker.phpbb.com/browse/PHPBB3-10938
