### PR TITLE
[ticket/10896] Adds email validation to email settings in ACP

### DIFF
--- a/phpBB/adm/index.php
+++ b/phpBB/adm/index.php
@@ -448,6 +448,13 @@ function validate_config_vars($config_vars, &$cfg_array, &$error)
 					}
 				}
 			break;
+			
+			case 'email':				
+				if (!preg_match('/^' . get_preg_expression('email') . '$/i', $cfg_array[$config_name]))
+				{			
+					$error[] = $user->lang['EMAIL_INVALID_EMAIL'];
+				}	
+			break;
 
 			// Absolute path
 			case 'script_path':

--- a/phpBB/includes/acp/acp_board.php
+++ b/phpBB/includes/acp/acp_board.php
@@ -408,8 +408,8 @@ class acp_board
 						'board_email_form'		=> array('lang' => 'BOARD_EMAIL_FORM',		'validate' => 'bool',	'type' => 'radio:enabled_disabled', 'explain' => true),
 						'email_function_name'	=> array('lang' => 'EMAIL_FUNCTION_NAME',	'validate' => 'string',	'type' => 'text:20:50', 'explain' => true),
 						'email_package_size'	=> array('lang' => 'EMAIL_PACKAGE_SIZE',	'validate' => 'int:0',	'type' => 'text:5:5', 'explain' => true),
-						'board_contact'			=> array('lang' => 'CONTACT_EMAIL',			'validate' => 'string',	'type' => 'text:25:100', 'explain' => true),
-						'board_email'			=> array('lang' => 'ADMIN_EMAIL',			'validate' => 'string',	'type' => 'text:25:100', 'explain' => true),
+						'board_contact'			=> array('lang' => 'CONTACT_EMAIL',			'validate' => 'email',	'type' => 'text:25:100', 'explain' => true),
+						'board_email'			=> array('lang' => 'ADMIN_EMAIL',			'validate' => 'email',	'type' => 'text:25:100', 'explain' => true),
 						'board_email_sig'		=> array('lang' => 'EMAIL_SIG',				'validate' => 'string',	'type' => 'textarea:5:30', 'explain' => true),
 						'board_hide_emails'		=> array('lang' => 'BOARD_HIDE_EMAILS',		'validate' => 'bool',	'type' => 'radio:yes_no', 'explain' => true),
 
@@ -485,7 +485,7 @@ class acp_board
 				}
 			}
 		}
-
+		
 		// Store news and exclude ids
 		if ($mode == 'feed' && $submit)
 		{

--- a/phpBB/language/en/common.php
+++ b/phpBB/language/en/common.php
@@ -160,6 +160,7 @@ $lang = array_merge($lang, array(
 	'EDIT_POST'							=> 'Edit post',
 	'EMAIL'								=> 'E-mail', // Short form for EMAIL_ADDRESS
 	'EMAIL_ADDRESS'						=> 'E-mail address',
+	'EMAIL_INVALID_EMAIL'				=> 'The e-mail address you entered is invalid.',
 	'EMAIL_SMTP_ERROR_RESPONSE'			=> 'Ran into problems sending e-mail at <strong>Line %1$s</strong>. Response: %2$s.',
 	'EMPTY_SUBJECT'						=> 'You must specify a subject when posting a new topic.',
 	'EMPTY_MESSAGE_SUBJECT'				=> 'You must specify a subject when composing a new message.',


### PR DESCRIPTION
Adds a new validation type to the ACP validate_config_vars function
and implements it on the board_contact and board_email settings.

PHPBB3-10896
