### PR TITLE
[ticket/10962] Request class doesn't return correct array default value

### DIFF
--- a/phpBB/includes/request/request.php
+++ b/phpBB/includes/request/request.php
@@ -217,7 +217,7 @@ class phpbb_request implements phpbb_request_interface
 
 		if (!isset($this->input[$super_global][$var_name]))
 		{
-			return (is_array($default)) ? array() : $default;
+			return $default;
 		}
 		$var = $this->input[$super_global][$var_name];
 
@@ -232,7 +232,7 @@ class phpbb_request implements phpbb_request_interface
 				}
 				else
 				{
-					return (is_array($default)) ? array() : $default;
+					return $default;
 				}
 			}
 		}


### PR DESCRIPTION
When using the request class the second parameter defines the "default" value,
if you pass a string or an integer as second parameter and the parameter isn't
set in the `$_REQUEST` array the class will neatly return the value you've
passed as default.
However when passing an array the class will return an empty array rather than
the one you've passed as default.
This behavior is unexpected and undocumented in the docblock.

PHPBB3-10962
