### PR TITLE
[ticket/10307] Return false in mssqlnative sql_fetchrow on empty result

### DIFF
--- a/phpBB/includes/db/mssqlnative.php
+++ b/phpBB/includes/db/mssqlnative.php
@@ -436,7 +436,7 @@ class dbal_mssqlnative extends dbal
 				unset($row['line2'], $row['line3']);
 			}
 		}
-		return $row;
+		return (sizeof($row)) ? $row : false;
 	}
 
 	/**


### PR DESCRIPTION
http://tracker.phpbb.com/browse/PHPBB3-10307

MSSQL Native has the same behavior, but wasn't updated.
