### PR TITLE
[ticket/7598] Inactive users action notification (ACP)

### DIFF
--- a/phpBB/includes/acp/acp_inactive.php
+++ b/phpBB/includes/acp/acp_inactive.php
@@ -137,7 +137,7 @@ class acp_inactive
 								add_log('user', $row['user_id'], 'LOG_USER_ACTIVE_USER');
 							}
 
-							trigger_error(sprintf($user->lang['LOG_INACTIVE_ACTIVATE'], implode(', ', $user_affected) . ' ' . adm_back_link($this->u_action)));
+							trigger_error(sprintf($user->lang['LOG_INACTIVE_ACTIVATE'], implode($user->lang['COMMA_SEPARATOR'], $user_affected) . ' ' . adm_back_link($this->u_action)));
 						}
 
 						// For activate we really need to redirect, else a refresh can result in users being deactivated again
@@ -162,7 +162,7 @@ class acp_inactive
 
 							add_log('admin', 'LOG_INACTIVE_' . strtoupper($action), implode(', ', $user_affected));
 
-							trigger_error(sprintf($user->lang['LOG_INACTIVE_DELETE'], implode(', ', $user_affected) . ' ' . adm_back_link($this->u_action)));
+							trigger_error(sprintf($user->lang['LOG_INACTIVE_DELETE'], implode($user->lang['COMMA_SEPARATOR'], $user_affected) . ' ' . adm_back_link($this->u_action)));
 						}
 						else
 						{
@@ -235,7 +235,7 @@ class acp_inactive
 
 						add_log('admin', 'LOG_INACTIVE_REMIND', implode(', ', $usernames));
 
-						trigger_error(sprintf($user->lang['LOG_INACTIVE_REMIND'], implode(', ', $usernames) . ' ' . adm_back_link($this->u_action)));
+						trigger_error(sprintf($user->lang['LOG_INACTIVE_REMIND'], implode($user->lang['COMMA_SEPARATOR'], $usernames) . ' ' . adm_back_link($this->u_action)));
 					}
 					$db->sql_freeresult($result);
 


### PR DESCRIPTION
When performing an action on users in the ACP Inactive Users, such as activating, deleting, or reminding, trigger_error is now called to give a notification that the action was performed

PHPBB3-7598
