### PR TITLE
[ticket/11002] Use translating option to rename the Etc/GMT options

### DIFF
--- a/phpBB/includes/update_helpers.php
+++ b/phpBB/includes/update_helpers.php
@@ -26,85 +26,85 @@ class phpbb_update_helpers
 		switch ($timezone)
 		{
 			case '-12':
-				return 'Etc/GMT' . $offset;		//'[UTC - 12] Baker Island Time'
+				return 'Etc/GMT+' . abs($offset);	//'[UTC - 12] Baker Island Time'
 			case '-11':
-				return 'Etc/GMT' . $offset;		//'[UTC - 11] Niue Time, Samoa Standard Time'
+				return 'Etc/GMT+' . abs($offset);	//'[UTC - 11] Niue Time, Samoa Standard Time'
 			case '-10':
-				return 'Etc/GMT' . $offset;		//'[UTC - 10] Hawaii-Aleutian Standard Time, Cook Island Time'
+				return 'Etc/GMT+' . abs($offset);	//'[UTC - 10] Hawaii-Aleutian Standard Time, Cook Island Time'
 			case '-9.5':
-				return 'Pacific/Marquesas';		//'[UTC - 9:30] Marquesas Islands Time'
+				return 'Pacific/Marquesas';			//'[UTC - 9:30] Marquesas Islands Time'
 			case '-9':
-				return 'Etc/GMT' . $offset;		//'[UTC - 9] Alaska Standard Time, Gambier Island Time'
+				return 'Etc/GMT+' . abs($offset);	//'[UTC - 9] Alaska Standard Time, Gambier Island Time'
 			case '-8':
-				return 'Etc/GMT' . $offset;		//'[UTC - 8] Pacific Standard Time'
+				return 'Etc/GMT+' . abs($offset);	//'[UTC - 8] Pacific Standard Time'
 			case '-7':
-				return 'Etc/GMT' . $offset;		//'[UTC - 7] Mountain Standard Time'
+				return 'Etc/GMT+' . abs($offset);	//'[UTC - 7] Mountain Standard Time'
 			case '-6':
-				return 'Etc/GMT' . $offset;		//'[UTC - 6] Central Standard Time'
+				return 'Etc/GMT+' . abs($offset);	//'[UTC - 6] Central Standard Time'
 			case '-5':
-				return 'Etc/GMT' . $offset;		//'[UTC - 5] Eastern Standard Time'
+				return 'Etc/GMT+' . abs($offset);	//'[UTC - 5] Eastern Standard Time'
 			case '-4.5':
-				return 'America/Caracas';		//'[UTC - 4:30] Venezuelan Standard Time'
+				return 'America/Caracas';			//'[UTC - 4:30] Venezuelan Standard Time'
 			case '-4':
-				return 'Etc/GMT' . $offset;		//'[UTC - 4] Atlantic Standard Time'
+				return 'Etc/GMT+' . abs($offset);	//'[UTC - 4] Atlantic Standard Time'
 			case '-3.5':
-				return 'America/St_Johns';		//'[UTC - 3:30] Newfoundland Standard Time'
+				return 'America/St_Johns';			//'[UTC - 3:30] Newfoundland Standard Time'
 			case '-3':
-				return 'Etc/GMT' . $offset;		//'[UTC - 3] Amazon Standard Time, Central Greenland Time'
+				return 'Etc/GMT+' . abs($offset);	//'[UTC - 3] Amazon Standard Time, Central Greenland Time'
 			case '-2':
-				return 'Etc/GMT' . $offset;		//'[UTC - 2] Fernando de Noronha Time, South Georgia &amp; the South Sandwich Islands Time'
+				return 'Etc/GMT+' . abs($offset);	//'[UTC - 2] Fernando de Noronha Time, South Georgia &amp; the South Sandwich Islands Time'
 			case '-1':
-				return 'Etc/GMT' . $offset;		//'[UTC - 1] Azores Standard Time, Cape Verde Time, Eastern Greenland Time'
+				return 'Etc/GMT+' . abs($offset);	//'[UTC - 1] Azores Standard Time, Cape Verde Time, Eastern Greenland Time'
 			case '0':
-				return (!$dst) ? 'UTC' : 'Etc/GMT+1';		//'[UTC] Western European Time, Greenwich Mean Time'
+				return (!$dst) ? 'UTC' : 'Etc/GMT-1';	//'[UTC] Western European Time, Greenwich Mean Time'
 			case '1':
-				return 'Etc/GMT+' . $offset;	//'[UTC + 1] Central European Time, West African Time'
+				return 'Etc/GMT-' . $offset;		//'[UTC + 1] Central European Time, West African Time'
 			case '2':
-				return 'Etc/GMT+' . $offset;	//'[UTC + 2] Eastern European Time, Central African Time'
+				return 'Etc/GMT-' . $offset;		//'[UTC + 2] Eastern European Time, Central African Time'
 			case '3':
-				return 'Etc/GMT+' . $offset;	//'[UTC + 3] Moscow Standard Time, Eastern African Time'
+				return 'Etc/GMT-' . $offset;		//'[UTC + 3] Moscow Standard Time, Eastern African Time'
 			case '3.5':
-				return 'Asia/Tehran';			//'[UTC + 3:30] Iran Standard Time'
+				return 'Asia/Tehran';				//'[UTC + 3:30] Iran Standard Time'
 			case '4':
-				return 'Etc/GMT+' . $offset;	//'[UTC + 4] Gulf Standard Time, Samara Standard Time'
+				return 'Etc/GMT-' . $offset;		//'[UTC + 4] Gulf Standard Time, Samara Standard Time'
 			case '4.5':
-				return 'Asia/Kabul';			//'[UTC + 4:30] Afghanistan Time'
+				return 'Asia/Kabul';				//'[UTC + 4:30] Afghanistan Time'
 			case '5':
-				return 'Etc/GMT+' . $offset;	//'[UTC + 5] Pakistan Standard Time, Yekaterinburg Standard Time'
+				return 'Etc/GMT-' . $offset;		//'[UTC + 5] Pakistan Standard Time, Yekaterinburg Standard Time'
 			case '5.5':
-				return 'Asia/Kolkata';			//'[UTC + 5:30] Indian Standard Time, Sri Lanka Time'
+				return 'Asia/Kolkata';				//'[UTC + 5:30] Indian Standard Time, Sri Lanka Time'
 			case '5.75':
-				return 'Asia/Kathmandu';		//'[UTC + 5:45] Nepal Time'
+				return 'Asia/Kathmandu';			//'[UTC + 5:45] Nepal Time'
 			case '6':
-				return 'Etc/GMT+' . $offset;	//'[UTC + 6] Bangladesh Time, Bhutan Time, Novosibirsk Standard Time'
+				return 'Etc/GMT-' . $offset;		//'[UTC + 6] Bangladesh Time, Bhutan Time, Novosibirsk Standard Time'
 			case '6.5':
-				return 'Indian/Cocos';			//'[UTC + 6:30] Cocos Islands Time, Myanmar Time'
+				return 'Indian/Cocos';				//'[UTC + 6:30] Cocos Islands Time, Myanmar Time'
 			case '7':
-				return 'Etc/GMT+' . $offset;	//'[UTC + 7] Indochina Time, Krasnoyarsk Standard Time'
+				return 'Etc/GMT-' . $offset;		//'[UTC + 7] Indochina Time, Krasnoyarsk Standard Time'
 			case '8':
-				return 'Etc/GMT+' . $offset;	//'[UTC + 8] Chinese Standard Time, Australian Western Standard Time, Irkutsk Standard Time'
+				return 'Etc/GMT-' . $offset;		//'[UTC + 8] Chinese Standard Time, Australian Western Standard Time, Irkutsk Standard Time'
 			case '8.75':
-				return 'Australia/Eucla';		//'[UTC + 8:45] Southeastern Western Australia Standard Time'
+				return 'Australia/Eucla';			//'[UTC + 8:45] Southeastern Western Australia Standard Time'
 			case '9':
-				return 'Etc/GMT+' . $offset;	//'[UTC + 9] Japan Standard Time, Korea Standard Time, Chita Standard Time'
+				return 'Etc/GMT-' . $offset;		//'[UTC + 9] Japan Standard Time, Korea Standard Time, Chita Standard Time'
 			case '9.5':
-				return 'Australia/ACT';			//'[UTC + 9:30] Australian Central Standard Time'
+				return 'Australia/ACT';				//'[UTC + 9:30] Australian Central Standard Time'
 			case '10':
-				return 'Etc/GMT+' . $offset;	//'[UTC + 10] Australian Eastern Standard Time, Vladivostok Standard Time'
+				return 'Etc/GMT-' . $offset;		//'[UTC + 10] Australian Eastern Standard Time, Vladivostok Standard Time'
 			case '10.5':
-				return 'Australia/Lord_Howe';	//'[UTC + 10:30] Lord Howe Standard Time'
+				return 'Australia/Lord_Howe';		//'[UTC + 10:30] Lord Howe Standard Time'
 			case '11':
-				return 'Etc/GMT+' . $offset;	//'[UTC + 11] Solomon Island Time, Magadan Standard Time'
+				return 'Etc/GMT-' . $offset;		//'[UTC + 11] Solomon Island Time, Magadan Standard Time'
 			case '11.5':
-				return 'Pacific/Norfolk';		//'[UTC + 11:30] Norfolk Island Time'
+				return 'Pacific/Norfolk';			//'[UTC + 11:30] Norfolk Island Time'
 			case '12':
-				return 'Etc/GMT+12';			//'[UTC + 12] New Zealand Time, Fiji Time, Kamchatka Standard Time'
+				return 'Etc/GMT-12';				//'[UTC + 12] New Zealand Time, Fiji Time, Kamchatka Standard Time'
 			case '12.75':
-				return 'Pacific/Chatham';		//'[UTC + 12:45] Chatham Islands Time'
+				return 'Pacific/Chatham';			//'[UTC + 12:45] Chatham Islands Time'
 			case '13':
-				return 'Pacific/Tongatapu';		//'[UTC + 13] Tonga Time, Phoenix Islands Time'
+				return 'Pacific/Tongatapu';			//'[UTC + 13] Tonga Time, Phoenix Islands Time'
 			case '14':
-				return 'Pacific/Kiritimati';	//'[UTC + 14] Line Island Time'
+				return 'Pacific/Kiritimati';		//'[UTC + 14] Line Island Time'
 			default:
 				return 'UTC';
 		}

--- a/phpBB/language/en/common.php
+++ b/phpBB/language/en/common.php
@@ -836,6 +836,35 @@ $lang = array_merge($lang, array(
 		'Dec'		=> 'Dec',
 	),
 
+	// Timezones can be translated. We use this for the Etc/GMT timezones here,
+	// because they are named invers to their offset.
+	'timezones'		=> array(
+		'Etc/GMT-12'	=> 'GMT+12',
+		'Etc/GMT-11'	=> 'GMT+11',
+		'Etc/GMT-10'	=> 'GMT+10',
+		'Etc/GMT-9'		=> 'GMT+9',
+		'Etc/GMT-8'		=> 'GMT+8',
+		'Etc/GMT-7'		=> 'GMT+7',
+		'Etc/GMT-6'		=> 'GMT+6',
+		'Etc/GMT-5'		=> 'GMT+5',
+		'Etc/GMT-4'		=> 'GMT+4',
+		'Etc/GMT-3'		=> 'GMT+3',
+		'Etc/GMT-2'		=> 'GMT+2',
+		'Etc/GMT-1'		=> 'GMT+1',
+		'Etc/GMT+1'		=> 'GMT-1',
+		'Etc/GMT+2'		=> 'GMT-2',
+		'Etc/GMT+3'		=> 'GMT-3',
+		'Etc/GMT+4'		=> 'GMT-4',
+		'Etc/GMT+5'		=> 'GMT-5',
+		'Etc/GMT+6'		=> 'GMT-6',
+		'Etc/GMT+7'		=> 'GMT-7',
+		'Etc/GMT+8'		=> 'GMT-8',
+		'Etc/GMT+9'		=> 'GMT-9',
+		'Etc/GMT+10'	=> 'GMT-10',
+		'Etc/GMT+11'	=> 'GMT-11',
+		'Etc/GMT+12'	=> 'GMT-12',
+	),
+
 	// The value is only an example and will get replaced by the current time on view
 	'dateformats'	=> array(
 		'd M Y, H:i'			=> '01 Jan 2007, 13:37',


### PR DESCRIPTION
They have the invers offset of their name. So GMT+2 has the offset -7200.
To avoid additional confusion, we simply overwrite their name.

http://tracker.phpbb.com/browse/PHPBB3-11002

Update script: https://gist.github.com/3155817
