### PR TITLE
[ticket/10568] Modify the trigger language when you edit a PM

### DIFF
--- a/phpBB/includes/ucp/ucp_pm_compose.php
+++ b/phpBB/includes/ucp/ucp_pm_compose.php
@@ -755,7 +755,8 @@ function compose_pm($id, $mode, $action, $user_folders = array())
 			$return_box_lang = ($action === 'post' || $action === 'edit') ? 'PM_OUTBOX' : 'PM_INBOX';
 
 
-			$message = $user->lang['MESSAGE_STORED'] . '<br /><br />' . sprintf($user->lang['VIEW_PRIVATE_MESSAGE'], '<a href="' . $return_message_url . '">', '</a>');
+			$save_message = ($action === 'edit') ? $user->lang['MESSAGE_EDITED'] : $user->lang['MESSAGE_STORED'];
+			$message = $save_message . '<br /><br />' . $user->lang('VIEW_PRIVATE_MESSAGE', '<a href="' . $return_message_url . '">', '</a>');
 
 			$last_click_type = 'CLICK_RETURN_FOLDER';
 			if ($folder_url)

--- a/phpBB/language/en/ucp.php
+++ b/phpBB/language/en/ucp.php
@@ -257,6 +257,7 @@ $lang = array_merge($lang, array(
 	'MESSAGE_BY_AUTHOR'				=> 'by',
 	'MESSAGE_COLOURS'				=> 'Message colours',
 	'MESSAGE_DELETED'				=> 'Message successfully deleted.',
+	'MESSAGE_EDITED'				=> 'Message successfully edited.',
 	'MESSAGE_HISTORY'				=> 'Message history',
 	'MESSAGE_REMOVED_FROM_OUTBOX'	=> 'This message has been removed by its author before it was delivered.',
 	'MESSAGE_SENT_ON'				=> 'on',


### PR DESCRIPTION
When you edit a PM you receive this trigger_error: "This message has been sent successfully."
I think it should be nice to get rather this trigger_error "Message successfully edited."

This PR fixes that.

[PHPBB3-10568](http://tracker.phpbb.com/browse/PHPBB3-10568)
