### PR TITLE
[ticket/11018] Attempt to fix li.pagination alignment issue

### DIFF
--- a/phpBB/styles/prosilver/theme/common.css
+++ b/phpBB/styles/prosilver/theme/common.css
@@ -510,9 +510,16 @@ li.pagination {
 	margin-bottom: 0;
 }
 
+li.pagination ul {
+	margin-top: -2px;
+	vertical-align: middle;
+}
+
 .pagination ul li, dl .pagination ul li, dl.icon .pagination ul li  {
 	display: inline;
 	padding: 0;
+	font-size: 100%;
+	line-height: normal;	
 }
 
 .pagination li a, .pagnation li span, li .pagination li a, li .pagnation li span, .pagination li.active span, .pagination li.ellipsis span {


### PR DESCRIPTION
This is somewhat kludgy fix for the vertical alignment issue
for pagination contained within a linklist parented li element.
Tested and doesn't seem to impact anything else negatively. May
need further browser testing.

PHPBB3-11018
