### PR TITLE
[ticket/10444] Do not default to the previous post edit reason.

### DIFF
--- a/phpBB/posting.php
+++ b/phpBB/posting.php
@@ -1376,7 +1376,7 @@ $template->assign_vars(array(
 	'POST_DATE'				=> ($post_data['post_time']) ? $user->format_date($post_data['post_time']) : '',
 	'ERROR'					=> (sizeof($error)) ? implode('<br />', $error) : '',
 	'TOPIC_TIME_LIMIT'		=> (int) $post_data['topic_time_limit'],
-	'EDIT_REASON'			=> $post_data['post_edit_reason'],
+	'EDIT_REASON'			=> $request->variable('edit_reason', ''),
 	'U_VIEW_FORUM'			=> append_sid("{$phpbb_root_path}viewforum.$phpEx", "f=$forum_id"),
 	'U_VIEW_TOPIC'			=> ($mode != 'post') ? append_sid("{$phpbb_root_path}viewtopic.$phpEx", "f=$forum_id&amp;t=$topic_id") : '',
 	'U_PROGRESS_BAR'		=> append_sid("{$phpbb_root_path}posting.$phpEx", "f=$forum_id&amp;mode=popup"),


### PR DESCRIPTION
This makes the most sense when paired with the post revisioning system I am working on. Basically, as it is, the post edit reason is carried over from the previous edit, so if unchanged, it is a duplicate reason from when the previous edit was made. So if two people edit a post but the second does not change the reason entered by the first, then it is misleading; the username and edit time are updated, but the reason is not.

With revisions, each one can have its own edit reason, so it would not make sense to carry it over from the previous revision. Instead, I propose we clear the field each time a new edit is being made.

---

Current behavior: The post edit reason is served from the database, if one is available. If changed by the form, the new value is used instead.

New behavior: Only use the value given to the form; do not serve from database.

http://tracker.phpbb.com/browse/PHPBB3-10444
