### PR TITLE
[ticket/11054] Fixed documentation syntax for @var in extension/controller.php

### DIFF
--- a/phpBB/includes/extension/controller.php
+++ b/phpBB/includes/extension/controller.php
@@ -47,8 +47,8 @@ abstract class phpbb_extension_controller implements phpbb_extension_controller_
 	protected $template;
 
 	/**
-	* Config array
-	* @var array
+	* Config object
+	* @var phpbb_config
 	*/
 	protected $config;
 


### PR DESCRIPTION
Moved from the incorrect
    \* @var type description
syntax to the correct
    \* Description
    \* @var type
syntax.

http://tracker.phpbb.com/browse/PHPBB3-11054
