### PR TITLE
[ticket/11061] Add the --dev flag to the composer instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Find support and lots more on [phpBB.com](http://www.phpbb.com)! Discuss the dev
 To be able to run an installation from the repo (and not from a pre-built package) you need to run the following commands to install phpBB's dependencies.
 
 	cd phpBB
-	php ../composer.phar install
+	php ../composer.phar install --dev
 
 
 ## CONTRIBUTE


### PR DESCRIPTION
It is needed to install dev dependencies, such as goutte, which are
needed to run the tests.

Ticket: http://tracker.phpbb.com/browse/PHPBB3-11061
