### PR TITLE
[ticket/11066] Remove debug code error_reporting(E_ALL) from mssqlnative...

### DIFF
--- a/phpBB/includes/db/mssqlnative.php
+++ b/phpBB/includes/db/mssqlnative.php
@@ -219,7 +219,6 @@ class dbal_mssqlnative extends dbal
 		$this->server = $sqlserver . (($port) ? $port_delimiter . $port : '');
 
 		//connect to database
-		error_reporting(E_ALL);
 		$this->db_connect_id = sqlsrv_connect($this->server, array(
 			'Database' => $this->dbname,
 			'UID' => $this->user,


### PR DESCRIPTION
....php

For some reason, all errors are just flipped on before connecting to the
database, despite the system as a whole having a different setting for
displayable errors. Had to add & ~E_STRICT in PHP 5.4.5 to suppress Strict
Standards messages, but I would assume that the db piece shouldn't be involved
with setting error_reporting at all.

PHPBB3-11066

http://tracker.phpbb.com/browse/PHPBB3-11066
