### PR TITLE
Ticket/10875 More SQL cache fixes

### DIFF
--- a/tests/cache/cache_test.php
+++ b/tests/cache/cache_test.php
@@ -94,7 +94,7 @@ class phpbb_cache_test extends phpbb_database_test_case
 
 		$this->assertFileExists($this->cache_dir . 'sql_' . md5(preg_replace('/[\n\r\s\t]+/', ' ', $sql)) . '.php');
 
-		$sql = "DELETE FROM phpbb_config";
+		$sql = 'DELETE FROM phpbb_config';
 		$result = $db->sql_query($sql);
 
 		$sql = "SELECT * FROM phpbb_config
@@ -128,7 +128,7 @@ class phpbb_cache_test extends phpbb_database_test_case
 		$expected = array('config_name' => 'foo', 'config_value' => '23', 'is_dynamic' => 0);
 		$this->assertEquals($expected, $first_result);
 
-		$sql = "DELETE FROM phpbb_config";
+		$sql = 'DELETE FROM phpbb_config';
 		$result = $db->sql_query($sql);
 
 		// As null cache driver does not actually cache,


### PR DESCRIPTION
[16:50:50] <bantu> in olympus $query_result was passed by reference and returned as such
[16:51:01] <bantu> in develop it was changed to an actual return value
[16:51:26] <bantu> but the changes were incomplete
[16:51:50] <bantu> a no-op is not an empty function definition but returning the query result

http://tracker.phpbb.com/browse/PHPBB3-10875
