### PR TITLE
[feature/ignore-netbeans] Ignore Netbeans metadata directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@
 /tests/phpbb_unit_tests.sqlite2
 /tests/test_config.php
 /tests/tmp/*
+/phpBB/nbproject/
+/nbproject/


### PR DESCRIPTION
This ignores the .nbproject metadata directories in both the
root directory and /phpBB/

As I use Netbeans for most of my regular PHP development,
I thought that I should push this in case anyone else does.

The result of this is that people who commit no longer have
to ensure that their Netbeans metadata folders do not get
added, if it's in the same directory.

PHPBB3-11074
