### PR TITLE
WIP: [ticket/11090] Cron dies with suppressed fatal error

### DIFF
--- a/phpBB/cron.php
+++ b/phpBB/cron.php
@@ -21,6 +21,8 @@ $auth->acl($user->data);
 
 function output_image()
 {
+	define('IMAGE_OUTPUT', true);
+
 	// Output transparent gif
 	header('Cache-Control: no-cache');
 	header('Content-type: image/gif');

--- a/phpBB/includes/functions.php
+++ b/phpBB/includes/functions.php
@@ -4015,7 +4015,7 @@ function msg_handler($errno, $msg_text, $errfile, $errline)
 				echo '<b>[phpBB Debug] ' . $error_name . '</b>: in file <b>' . $errfile . '</b> on line <b>' . $errline . '</b>: <b>' . $msg_text . '</b><br />' . "\n";
 
 				// we are writing an image - the user won't see the debug, so let's place it in the log
-				if (defined('IMAGE_OUTPUT') || defined('IN_CRON'))
+				if (defined('IMAGE_OUTPUT'))
 				{
 					add_log('critical', 'LOG_IMAGE_GENERATION_ERROR', $errfile, $errline, $msg_text);
 				}


### PR DESCRIPTION
Common.php includes config.php twice, triggering the error handler
to be called (because of suppressed redefined constants). This error
makes the error handler try to log to the database, which the
connection for does not exist yet, leading to a fatal error.

This patch fixes the issue by making sure that the error handler will
only perform logging for errors that occur after common.php has been
included.

Ticket: http://tracker.phpbb.com/browse/PHPBB3-11090
