### PR TITLE
[ticket/10879] prosilver: attachment-link will be displayed wrong, when filename is too long

### DIFF
--- a/phpBB/styles/prosilver/template/posting_editor.html
+++ b/phpBB/styles/prosilver/template/posting_editor.html
@@ -165,7 +165,7 @@
 
 				<dt><label for="comment_list_{attach_row.ASSOC_INDEX}">{L_FILE_COMMENT}:</label></dt>
 				<dd><textarea name="comment_list[{attach_row.ASSOC_INDEX}]" id="comment_list_{attach_row.ASSOC_INDEX}" rows="1" cols="35" class="inputbox">{attach_row.FILE_COMMENT}</textarea></dd>
-				<dd><a href="{attach_row.U_VIEW_ATTACHMENT}" class="{S_CONTENT_FLOW_END}">{attach_row.FILENAME}</a></dd>
+				<dd><a href="{attach_row.U_VIEW_ATTACHMENT}" class="{S_CONTENT_FLOW_END} attachfile">{attach_row.FILENAME}</a></dd>
 				<dd style="margin-top: 5px;">
 					<!-- IF S_INLINE_ATTACHMENT_OPTIONS --><input type="button" value="{L_PLACE_INLINE}" onclick="attach_inline({attach_row.ASSOC_INDEX}, '{attach_row.A_FILENAME}');" class="button2" />&nbsp; <!-- ENDIF -->
 					<input type="submit" name="delete_file[{attach_row.ASSOC_INDEX}]" value="{L_DELETE_FILE}" class="button2" />

--- a/phpBB/styles/prosilver/theme/links.css
+++ b/phpBB/styles/prosilver/theme/links.css
@@ -126,16 +126,16 @@ a.topictitle:active {
 }
 
 
-/* Profile searchresults */	
+/* Profile searchresults */
 .search .postprofile a {
 	color: #898989;
-	text-decoration: none; 
+	text-decoration: none;
 	font-weight: normal;
 }
 
 .search .postprofile a:hover {
 	color: #d3d3d3;
-	text-decoration: underline; 
+	text-decoration: underline;
 }
 
 /* Back to top of page */
@@ -168,6 +168,7 @@ a.up		{ background: none no-repeat left center; }
 a.down		{ background: none no-repeat right center; }
 a.left		{ background: none no-repeat 3px 60%; }
 a.right		{ background: none no-repeat 95% 60%; }
+a.attachfile		{ background: none no-repeat 100% 60%; }
 
 a.up, a.up:link, a.up:active, a.up:visited {
 	padding-left: 10px;
@@ -202,11 +203,18 @@ a.left:hover {
 a.right, a.right:active, a.right:visited {
 	padding-right: 12px;
 }
+a.attachfile, a.attachfile:active, a.attachfile:visited {
+	padding-right: 9px;
+}
 
 a.right:hover {
 	color: #d2d2d2;
 	text-decoration: none;
 	background-position: 100% 60%;
+}
+a.attachfile:hover {
+	padding-right: 12px;
+	text-decoration:none;
 }
 
 /* invisible skip link, used for accessibility  */


### PR DESCRIPTION
If you upload a file with a long filename the arrow_right.gif image is displayed on the link name instead of being placed on the right border.

http://tracker.phpbb.com/browse/PHPBB3-10879

PHPBB3-10879
