### PR TITLE
[ticket/11099] Mark acp_ban::display_ban_options() as static.

### DIFF
--- a/phpBB/includes/acp/acp_ban.php
+++ b/phpBB/includes/acp/acp_ban.php
@@ -97,7 +97,7 @@ class acp_ban
 			break;
 		}
 
-		$this->display_ban_options($mode);
+		self::display_ban_options($mode);
 
 		$template->assign_vars(array(
 			'L_TITLE'				=> $this->page_title,
@@ -118,7 +118,7 @@ class acp_ban
 	/**
 	* Display ban options
 	*/
-	function display_ban_options($mode)
+	static public function display_ban_options($mode)
 	{
 		global $user, $db, $template;
 


### PR DESCRIPTION
It is called statically from mcp_ban.

PHPBB3-11099

http://tracker.phpbb.com/browse/PHPBB3-11099
