### PR TITLE
[ticket/11177] return no results when query has only negation

### DIFF
--- a/phpBB/includes/search/fulltext_postgres.php
+++ b/phpBB/includes/search/fulltext_postgres.php
@@ -281,6 +281,12 @@ class phpbb_search_fulltext_postgres extends phpbb_search_base
 			return false;
 		}
 
+		// When search query contains queries like -foo
+		if (strpos($this->search_query, '+') === false)
+		{
+			return false;
+		}
+
 		// generate a search_key from all the options to identify the results
 		$search_key = md5(implode('#', array(
 			implode(', ', $this->split_words),


### PR DESCRIPTION
If search query has only -foo then instead of displaying all results that
do not have foo, should display no results found.
http://tracker.phpbb.com/browse/PHPBB3-11177

PHPBB3-11177
