### PR TITLE
[ticket/11178] Do not set error_reporting to E_ALL in database_updater.p...

### DIFF
--- a/phpBB/install/database_update.php
+++ b/phpBB/install/database_update.php
@@ -60,8 +60,6 @@ $updates_to_version = UPDATES_TO_VERSION;
 $debug_from_version = DEBUG_FROM_VERSION;
 $oldest_from_version = OLDEST_FROM_VERSION;
 
-error_reporting(E_ALL);
-
 @set_time_limit(0);
 
 // Include essential scripts


### PR DESCRIPTION
...hp

Take whatever startup.php sets instead.

This especially takes care of E_STRICT messages that are generated because of
PHP4 compatibility.

PHPBB3-11178

http://tracker.phpbb.com/browse/PHPBB3-11178
