### PR TITLE
[task/php54] Don't call utf_normalizer statically.

### DIFF
--- a/phpBB/common.php
+++ b/phpBB/common.php
@@ -98,6 +98,7 @@ require($phpbb_root_path . 'includes/functions_content.' . $phpEx);
 require($phpbb_root_path . 'includes/constants.' . $phpEx);
 require($phpbb_root_path . 'includes/db/' . $dbms . '.' . $phpEx);
 require($phpbb_root_path . 'includes/utf/utf_tools.' . $phpEx);
+require($phpbb_root_path . 'includes/utf/utf_normalizer.' . $phpEx);
 
 // Set PHP error handler to ours
 set_error_handler(defined('PHPBB_MSG_HANDLER') ? PHPBB_MSG_HANDLER : 'msg_handler');
@@ -108,6 +109,7 @@ $auth		= new auth();
 $template	= new template();
 $cache		= new cache();
 $db			= new $sql_db();
+$utf_normalizer	= new utf_normalizer();
 
 // Connect to DB
 $db->sql_connect($dbhost, $dbuser, $dbpasswd, $dbname, $dbport, false, defined('PHPBB_DB_NEW_LINK') ? PHPBB_DB_NEW_LINK : false);

--- a/phpBB/includes/search/fulltext_native.php
+++ b/phpBB/includes/search/fulltext_native.php
@@ -1482,7 +1482,7 @@ class fulltext_native extends search_backend
 	*/
 	function cleanup($text, $allowed_chars = null, $encoding = 'utf-8')
 	{
-		global $phpbb_root_path, $phpEx;
+		global $phpbb_root_path, $phpEx, $utf_normalizer;
 		static $conv = array(), $conv_loaded = array();
 		$words = $allow = array();
 
@@ -1511,7 +1511,7 @@ class fulltext_native extends search_backend
 		* If we use it more widely, an instance of that class should be held in a
 		* a global variable instead
 		*/
-		utf_normalizer::nfc($text);
+		$utf_normalizer->nfc($text);
 
 		/**
 		* The first thing we do is:

--- a/phpBB/includes/startup.php
+++ b/phpBB/includes/startup.php
@@ -20,21 +20,6 @@ if (!defined('E_DEPRECATED'))
 	define('E_DEPRECATED', 8192);
 }
 $level = E_ALL & ~E_NOTICE & ~E_DEPRECATED;
-if (version_compare(PHP_VERSION, '5.4.0-dev', '>='))
-{
-	// PHP 5.4 adds E_STRICT to E_ALL.
-	// Our utf8 normalizer triggers E_STRICT output on PHP 5.4.
-	// Unfortunately it cannot be made E_STRICT-clean while
-	// continuing to work on PHP 4.
-	// Therefore, in phpBB 3.0.x we disable E_STRICT on PHP 5.4+,
-	// while phpBB 3.1 will fix utf8 normalizer.
-	// E_STRICT is defined starting with PHP 5
-	if (!defined('E_STRICT'))
-	{
-		define('E_STRICT', 2048);
-	}
-	$level &= ~E_STRICT;
-}
 error_reporting($level);
 
 /*

--- a/phpBB/includes/utf/utf_normalizer.php
+++ b/phpBB/includes/utf/utf_normalizer.php
@@ -110,7 +110,7 @@ class utf_normalizer
 			"\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF\xFF"
 		);
 
-		$str = utf_normalizer::recompose($str, $pos, $len, $GLOBALS['utf_nfc_qc'], $GLOBALS['utf_canonical_decomp']);
+		$str = $this->recompose($str, $pos, $len, $GLOBALS['utf_nfc_qc'], $GLOBALS['utf_canonical_decomp']);
 	}
 
 	/**
@@ -142,7 +142,7 @@ class utf_normalizer
 			include($phpbb_root_path . 'includes/utf/data/utf_canonical_decomp.' . $phpEx);
 		}
 
-		$str = utf_normalizer::recompose($str, $pos, $len, $GLOBALS['utf_nfc_qc'], $GLOBALS['utf_canonical_decomp']);
+		$str = $this->recompose($str, $pos, $len, $GLOBALS['utf_nfc_qc'], $GLOBALS['utf_canonical_decomp']);
 	}
 
 	/**
@@ -174,7 +174,7 @@ class utf_normalizer
 			include($phpbb_root_path . 'includes/utf/data/utf_compatibility_decomp.' . $phpEx);
 		}
 
-		$str = utf_normalizer::recompose($str, $pos, $len, $GLOBALS['utf_nfkc_qc'], $GLOBALS['utf_compatibility_decomp']);
+		$str = $this->recompose($str, $pos, $len, $GLOBALS['utf_nfkc_qc'], $GLOBALS['utf_compatibility_decomp']);
 	}
 
 	/**
@@ -200,7 +200,7 @@ class utf_normalizer
 			include($phpbb_root_path . 'includes/utf/data/utf_canonical_decomp.' . $phpEx);
 		}
 
-		$str = utf_normalizer::decompose($str, $pos, $len, $GLOBALS['utf_canonical_decomp']);
+		$str = $this->decompose($str, $pos, $len, $GLOBALS['utf_canonical_decomp']);
 	}
 
 	/**
@@ -226,7 +226,7 @@ class utf_normalizer
 			include($phpbb_root_path . 'includes/utf/data/utf_compatibility_decomp.' . $phpEx);
 		}
 
-		$str = utf_normalizer::decompose($str, $pos, $len, $GLOBALS['utf_compatibility_decomp']);
+		$str = $this->decompose($str, $pos, $len, $GLOBALS['utf_compatibility_decomp']);
 	}
 
 

--- a/phpBB/includes/utf/utf_tools.php
+++ b/phpBB/includes/utf/utf_tools.php
@@ -1648,19 +1648,13 @@ function utf8_case_fold_nfkc($text, $option = 'full')
 		"\xF0\x9D\x9E\xBB"	=> "\xCF\x83",
 		"\xF0\x9D\x9F\x8A"	=> "\xCF\x9D",
 	);
-	global $phpbb_root_path, $phpEx;
+	global $phpbb_root_path, $phpEx, $utf_normalizer;
 
 	// do the case fold
 	$text = utf8_case_fold($text, $option);
 
-	if (!class_exists('utf_normalizer'))
-	{
-		global $phpbb_root_path, $phpEx;
-		include($phpbb_root_path . 'includes/utf/utf_normalizer.' . $phpEx);
-	}
-
 	// convert to NFKC
-	utf_normalizer::nfkc($text);
+	$utf_normalizer->nfkc($text);
 
 	// FC_NFKC_Closure, http://www.unicode.org/Public/5.0.0/ucd/DerivedNormalizationProps.txt
 	$text = strtr($text, $fc_nfkc_closure);
@@ -1765,20 +1759,16 @@ function utf8_case_fold_nfc($text, $option = 'full')
 */
 function utf8_normalize_nfc($strings)
 {
+	global $utf_normalizer;
+
 	if (empty($strings))
 	{
 		return $strings;
 	}
 
-	if (!class_exists('utf_normalizer'))
-	{
-		global $phpbb_root_path, $phpEx;
-		include($phpbb_root_path . 'includes/utf/utf_normalizer.' . $phpEx);
-	}
-
 	if (!is_array($strings))
 	{
-		utf_normalizer::nfc($strings);
+		$utf_normalizer->nfc($strings);
 	}
 	else if (is_array($strings))
 	{
@@ -1788,12 +1778,12 @@ function utf8_normalize_nfc($strings)
 			{
 				foreach ($string as $_key => $_string)
 				{
-					utf_normalizer::nfc($strings[$key][$_key]);
+					$utf_normalizer->nfc($strings[$key][$_key]);
 				}
 			}
 			else
 			{
-				utf_normalizer::nfc($strings[$key]);
+				$utf_normalizer->nfc($strings[$key]);
 			}
 		}
 	}

--- a/phpBB/install/data/new_normalizer.php
+++ b/phpBB/install/data/new_normalizer.php
@@ -180,7 +180,7 @@ class utf_new_normalizer
 	*/
 	function recompose($str, $pos, $len, &$qc, &$decomp_map)
 	{
-		global $utf_canonical_comp;
+		global $utf_canonical_comp, $utf_normalizer;
 
 		// Load the canonical composition table
 		if (!isset($utf_canonical_comp))
@@ -189,7 +189,7 @@ class utf_new_normalizer
 			include($phpbb_root_path . 'includes/utf/data/utf_canonical_comp.' . $phpEx);
 		}
 
-		return utf_normalizer::recompose($str, $pos, $len, $qc, $decomp_map);
+		return $utf_normalizer->recompose($str, $pos, $len, $qc, $decomp_map);
 	}
 }
 


### PR DESCRIPTION
Set $utf_normalizer in common.php and use that object instead of calling it statically. Suppressing a error message do not fix the error.

PHPBB3-10615
http://tracker.phpbb.com/browse/PHPBB3-10615
