### PR TITLE
[ticket/11186] Database unit tests fail on windows using sqlite2

### DIFF
--- a/tests/test_framework/phpbb_database_test_connection_manager.php
+++ b/tests/test_framework/phpbb_database_test_connection_manager.php
@@ -166,12 +166,6 @@ class phpbb_database_test_connection_manager
 		switch ($this->config['dbms'])
 		{
 			case 'sqlite':
-				if (file_exists($this->config['dbhost']))
-				{
-					unlink($this->config['dbhost']);
-				}
-			break;
-
 			case 'firebird':
 				$this->connect();
 				// Drop all of the tables


### PR DESCRIPTION
The problem is, that we try to recreate the db and reconnect to it, while the
old connection is still hold. To resolve this, we just drop all tables and
recreate the tables instead of the whole db.

http://tracker.phpbb.com/browse/PHPBB3-11186
