### PR TITLE
[ticket/10491] Set up functional tests sensibly.

### DIFF
--- a/tests/test_framework/phpbb_functional_test_case.php
+++ b/tests/test_framework/phpbb_functional_test_case.php
@@ -192,7 +192,7 @@ class phpbb_functional_test_case extends phpbb_test_case
 		return file_get_contents(self::$config['phpbb_functional_url'] . 'install/index.php?mode=install&sub=' . $sub, false, $context);
 	}
 
-	private function recreate_database($config)
+	static private function recreate_database($config)
 	{
 		$db_conn_mgr = new phpbb_database_test_connection_manager($config);
 		$db_conn_mgr->recreate_db();


### PR DESCRIPTION
PHPBB_FUNCTIONAL_URL goes into setup before class.

Drop PHPBB_FUNCTIONAL_URL check in board installation and
silent return if it is not set.

Take board installation out of constructor.

Install board in setup method.

http://tracker.phpbb.com/browse/PHPBB3-10491

This fails functional posting test for some reason.
