### PR TITLE
[ticket/10602] Use last_queue_run for its intended purpose.

### DIFF
--- a/phpBB/includes/functions_messenger.php
+++ b/phpBB/includes/functions_messenger.php
@@ -715,9 +715,11 @@ class queue
 
 		$lock_fp = $this->lock();
 
-		if (!file_exists($this->cache_file) || $config['last_queue_run'] > time() - $config['queue_interval'])
+		// avoid races, check file existence once
+		$have_cache_file = file_exists($this->cache_file);
+		if (!$have_cache_file || $config['last_queue_run'] > time() - $config['queue_interval'])
 		{
-			if (!file_exists($this->cache_file))
+			if (!$have_cache_file)
 			{
 				set_config('last_queue_run', time(), true);
 			}


### PR DESCRIPTION
We keep the last queue run time around, therefore for determining
whether enough time has passed since the last run we can simply
use this config variable.

When there is no queue file we consider a queue run successful.

Previously queue.php ("cache file") modification time would be used
for determining whether enough time has passed since last queue run.
The problem was that modification time would be updated whenever
anything was added to the queue, creating a situation where if
queue is processed less frequently than it is added to that email
would not be sent.

http://tracker.phpbb.com/browse/PHPBB3-10602

Queue still works after this.
