### PR TITLE
[ticket/11243] Show download all link on all pages of topic with attachments

### DIFF
--- a/phpBB/viewtopic.php
+++ b/phpBB/viewtopic.php
@@ -1353,7 +1353,7 @@ if (sizeof($attach_list))
 }
 
 $template->assign_vars(array(
-	'S_HAS_ATTACHMENTS' => !empty($attachments),
+	'S_HAS_ATTACHMENTS' => $topic_data['topic_attachment'],
 ));
 
 $methods = phpbb_gen_download_links('topic_id', $topic_id, $phpbb_root_path, $phpEx);


### PR DESCRIPTION
Currently, if a topic has attachments, the "Download all attachments" links only appear on pages that have attachments. This changes it so that you can download all attachments from any page of a topic that contains attachments.

This uses the same flag on the topics table that is used to determine whether or not to display the attachment icon on viewforum.

http://tracker.phpbb.com/browse/PHPBB3-11243
