### PR TITLE
[ticket/10805] Clear loading alert timeout after ajax request finished

### DIFF
--- a/phpBB/assets/javascript/core.js
+++ b/phpBB/assets/javascript/core.js
@@ -13,7 +13,7 @@ var keymap = {
 
 var dark = $('#darkenwrapper');
 var loading_alert = $('#loadingalert');
-var phpbbAlertTimer = 0;
+var phpbbAlertTimer = null;
 
 
 /**
@@ -47,9 +47,9 @@ phpbb.loading_alert = function() {
  * Clear loading alert timeout
 */
 phpbb.clearLoadingTimeout = function() {
-	if (phpbbAlertTimer != 0) {
+	if (phpbbAlertTimer != null) {
 		clearTimeout(phpbbAlertTimer);
-		phpbbAlertTimer = 0;
+		phpbbAlertTimer = null;
 	}
 }
 


### PR DESCRIPTION
The timeout for the "request timed out" popup should be cleared if it
finished. Since it is currently not cleared, the timeout alert appears as
an extra overlay if another ajaxified function is ran within 5 seconds of
the initial function call. This patch will take care of clearing the
timeout if either the success (function return_handler()) or error
(function error_handler()) functions are called.

Ticket: http://tracker.phpbb.com/browse/PHPBB3-10805

PHPBB3-10805
