### PR TITLE
[ticket/11037] Eliminate global $db usage in cache drivers.

### DIFF
--- a/phpBB/includes/cache/driver/file.php
+++ b/phpBB/includes/cache/driver/file.php
@@ -367,12 +367,10 @@ class phpbb_cache_driver_file extends phpbb_cache_driver_base
 	}
 
 	/**
-	* Save sql query
+	* {@inheritDoc}
 	*/
-	function sql_save($query, $query_result, $ttl)
+	function sql_save(phpbb_db_driver $db, $query, $query_result, $ttl)
 	{
-		global $db;
-
 		// Remove extra spaces and tabs
 		$query = preg_replace('/[\n\r\s\t]+/', ' ', $query);
 

--- a/phpBB/includes/cache/driver/interface.php
+++ b/phpBB/includes/cache/driver/interface.php
@@ -85,6 +85,7 @@ interface phpbb_cache_driver_interface
 	* result to persistent storage. In other words, there is no need
 	* to call save() afterwards.
 	*
+	* @param phpbb_db_driver $db	Database connection
 	* @param string $query			SQL query, should be used for generating storage key
 	* @param mixed $query_result	The result from dbal::sql_query, to be passed to
 	* 								dbal::sql_fetchrow to get all rows and store them
@@ -95,7 +96,7 @@ interface phpbb_cache_driver_interface
 	* 								representing the query should be returned. Otherwise
 	* 								the original $query_result should be returned.
 	*/
-	public function sql_save($query, $query_result, $ttl);
+	public function sql_save(phpbb_db_driver $db, $query, $query_result, $ttl);
 
 	/**
 	* Check if result for a given SQL query exists in cache.

--- a/phpBB/includes/cache/driver/memory.php
+++ b/phpBB/includes/cache/driver/memory.php
@@ -283,12 +283,10 @@ abstract class phpbb_cache_driver_memory extends phpbb_cache_driver_base
 	}
 
 	/**
-	* Save sql query
+	* {@inheritDoc}
 	*/
-	function sql_save($query, $query_result, $ttl)
+	function sql_save(phpbb_db_driver $db, $query, $query_result, $ttl)
 	{
-		global $db;
-
 		// Remove extra spaces and tabs
 		$query = preg_replace('/[\n\r\s\t]+/', ' ', $query);
 		$hash = md5($query);

--- a/phpBB/includes/cache/driver/null.php
+++ b/phpBB/includes/cache/driver/null.php
@@ -105,9 +105,9 @@ class phpbb_cache_driver_null extends phpbb_cache_driver_base
 	}
 
 	/**
-	* Save sql query
+	* {@inheritDoc}
 	*/
-	function sql_save($query, $query_result, $ttl)
+	function sql_save(phpbb_db_driver $db, $query, $query_result, $ttl)
 	{
 		return $query_result;
 	}

--- a/phpBB/includes/db/driver/firebird.php
+++ b/phpBB/includes/db/driver/firebird.php
@@ -270,7 +270,7 @@ class phpbb_db_driver_firebird extends phpbb_db_driver
 				if ($cache_ttl)
 				{
 					$this->open_queries[(int) $this->query_result] = $this->query_result;
-					$this->query_result = $cache->sql_save($query, $this->query_result, $cache_ttl);
+					$this->query_result = $cache->sql_save($this, $query, $this->query_result, $cache_ttl);
 				}
 				else if (strpos($query, 'SELECT') === 0 && $this->query_result)
 				{

--- a/phpBB/includes/db/driver/mssql.php
+++ b/phpBB/includes/db/driver/mssql.php
@@ -168,7 +168,7 @@ class phpbb_db_driver_mssql extends phpbb_db_driver
 				if ($cache_ttl)
 				{
 					$this->open_queries[(int) $this->query_result] = $this->query_result;
-					$this->query_result = $cache->sql_save($query, $this->query_result, $cache_ttl);
+					$this->query_result = $cache->sql_save($this, $query, $this->query_result, $cache_ttl);
 				}
 				else if (strpos($query, 'SELECT') === 0 && $this->query_result)
 				{

--- a/phpBB/includes/db/driver/mssql_odbc.php
+++ b/phpBB/includes/db/driver/mssql_odbc.php
@@ -197,7 +197,7 @@ class phpbb_db_driver_mssql_odbc extends phpbb_db_driver
 				if ($cache_ttl)
 				{
 					$this->open_queries[(int) $this->query_result] = $this->query_result;
-					$this->query_result = $cache->sql_save($query, $this->query_result, $cache_ttl);
+					$this->query_result = $cache->sql_save($this, $query, $this->query_result, $cache_ttl);
 				}
 				else if (strpos($query, 'SELECT') === 0 && $this->query_result)
 				{

--- a/phpBB/includes/db/driver/mssqlnative.php
+++ b/phpBB/includes/db/driver/mssqlnative.php
@@ -337,7 +337,7 @@ class phpbb_db_driver_mssqlnative extends phpbb_db_driver
 				if ($cache_ttl)
 				{
 					$this->open_queries[(int) $this->query_result] = $this->query_result;
-					$this->query_result = $cache->sql_save($query, $this->query_result, $cache_ttl);
+					$this->query_result = $cache->sql_save($this, $query, $this->query_result, $cache_ttl);
 				}
 				else if (strpos($query, 'SELECT') === 0 && $this->query_result)
 				{

--- a/phpBB/includes/db/driver/mysql.php
+++ b/phpBB/includes/db/driver/mysql.php
@@ -206,7 +206,7 @@ class phpbb_db_driver_mysql extends phpbb_db_driver
 				if ($cache_ttl)
 				{
 					$this->open_queries[(int) $this->query_result] = $this->query_result;
-					$this->query_result = $cache->sql_save($query, $this->query_result, $cache_ttl);
+					$this->query_result = $cache->sql_save($this, $query, $this->query_result, $cache_ttl);
 				}
 				else if (strpos($query, 'SELECT') === 0 && $this->query_result)
 				{

--- a/phpBB/includes/db/driver/mysqli.php
+++ b/phpBB/includes/db/driver/mysqli.php
@@ -201,7 +201,7 @@ class phpbb_db_driver_mysqli extends phpbb_db_driver
 
 				if ($cache_ttl)
 				{
-					$this->query_result = $cache->sql_save($query, $this->query_result, $cache_ttl);
+					$this->query_result = $cache->sql_save($this, $query, $this->query_result, $cache_ttl);
 				}
 			}
 			else if (defined('DEBUG'))

--- a/phpBB/includes/db/driver/oracle.php
+++ b/phpBB/includes/db/driver/oracle.php
@@ -446,7 +446,7 @@ class phpbb_db_driver_oracle extends phpbb_db_driver
 				if ($cache_ttl)
 				{
 					$this->open_queries[(int) $this->query_result] = $this->query_result;
-					$this->query_result = $cache->sql_save($query, $this->query_result, $cache_ttl);
+					$this->query_result = $cache->sql_save($this, $query, $this->query_result, $cache_ttl);
 				}
 				else if (strpos($query, 'SELECT') === 0 && $this->query_result)
 				{

--- a/phpBB/includes/db/driver/postgres.php
+++ b/phpBB/includes/db/driver/postgres.php
@@ -211,7 +211,7 @@ class phpbb_db_driver_postgres extends phpbb_db_driver
 				if ($cache_ttl)
 				{
 					$this->open_queries[(int) $this->query_result] = $this->query_result;
-					$this->query_result = $cache->sql_save($query, $this->query_result, $cache_ttl);
+					$this->query_result = $cache->sql_save($this, $query, $this->query_result, $cache_ttl);
 				}
 				else if (strpos($query, 'SELECT') === 0 && $this->query_result)
 				{

--- a/phpBB/includes/db/driver/sqlite.php
+++ b/phpBB/includes/db/driver/sqlite.php
@@ -152,7 +152,7 @@ class phpbb_db_driver_sqlite extends phpbb_db_driver
 				if ($cache_ttl)
 				{
 					$this->open_queries[(int) $this->query_result] = $this->query_result;
-					$this->query_result = $cache->sql_save($query, $this->query_result, $cache_ttl);
+					$this->query_result = $cache->sql_save($this, $query, $this->query_result, $cache_ttl);
 				}
 				else if (strpos($query, 'SELECT') === 0 && $this->query_result)
 				{

--- a/tests/mock/cache.php
+++ b/tests/mock/cache.php
@@ -121,7 +121,11 @@ class phpbb_mock_cache implements phpbb_cache_driver_interface
 	public function sql_load($query)
 	{
 	}
-	public function sql_save($query, $query_result, $ttl)
+
+	/**
+	* {@inheritDoc}
+	*/
+	public function sql_save(phpbb_db_driver $db, $query, $query_result, $ttl)
 	{
 		return $query_result;
 	}


### PR DESCRIPTION
The only time $db is needed in cache drivers is to navigate the
result set in sql_save. Pass it as a parameter in that function.

http://tracker.phpbb.com/browse/PHPBB3-11037

This is an alternative implementation to part of what #934 attempts that does not have any drawbacks/issues I can think of.
