### PR TITLE
[ticket/11283] Extension manager follow symlinks.

### DIFF
--- a/phpBB/includes/extension/manager.php
+++ b/phpBB/includes/extension/manager.php
@@ -384,7 +384,7 @@ class phpbb_extension_manager
 		}
 
 		$iterator = new RecursiveIteratorIterator(
-			new RecursiveDirectoryIterator($this->phpbb_root_path . 'ext/'),
+			new RecursiveDirectoryIterator($this->phpbb_root_path . 'ext/', FilesystemIterator::NEW_CURRENT_AND_KEY | FilesystemIterator::FOLLOW_SYMLINKS),
 			RecursiveIteratorIterator::SELF_FIRST);
 		foreach ($iterator as $file_info)
 		{


### PR DESCRIPTION
All extensions are located in the `phpBB/ext` directory,
however the `phpbb_extension_manager::all_available()`
method only looks into actual directories and ignores symlinks.

Add the `RecursiveDirectoryIterator::FOLLOW_SYMLINKS` flag to
the `new RecursiveDirectoryIterator` call so that you can store
extensions in a different location and use symlinks so that
phpBB can recognise them.

http://tracker.phpbb.com/browse/PHPBB3-11283
