### PR TITLE
[ticket/11292] Newlines removed in display of PM reports,...

### DIFF
--- a/phpBB/includes/mcp/mcp_pm_reports.php
+++ b/phpBB/includes/mcp/mcp_pm_reports.php
@@ -123,6 +123,7 @@ class mcp_pm_reports
 
 				$message = bbcode_nl2br($message);
 				$message = smiley_text($message);
+				$report['report_text'] = make_clickable(bbcode_nl2br($report['report_text']));
 
 				if ($pm_info['message_attachment'] && $auth->acl_get('u_pm_download'))
 				{


### PR DESCRIPTION
...no clickable links in PM reports

Report text is run through make_clickable and bbcode_nl2br for PMs just as it is for posts.

http://tracker.phpbb.com/browse/PHPBB3-11292
