### PR TITLE
[ticket/11293] Add a note that mysqli should be in front of mysql.

### DIFF
--- a/phpBB/includes/functions_install.php
+++ b/phpBB/includes/functions_install.php
@@ -55,6 +55,8 @@ function get_available_dbms($dbms = false, $return_unavailable = false, $only_20
 			'AVAILABLE'		=> true,
 			'2.0.x'			=> false,
 		),
+		// Note: php 5.5 alpha 2 deprecated mysql.
+		// Keep mysqli before mysql in this list.
 		'mysqli'	=> array(
 			'LABEL'			=> 'MySQL with MySQLi Extension',
 			'SCHEMA'		=> 'mysql_41',


### PR DESCRIPTION
php 5.5 alpha 2 deprecated mysql extension, prefer mysqli if
both are available.

http://tracker.phpbb.com/browse/PHPBB3-11293
