### PR TITLE
[ticket/11302] Correctly select first timezone or selected timezone

### DIFF
--- a/phpBB/assets/javascript/core.js
+++ b/phpBB/assets/javascript/core.js
@@ -438,7 +438,10 @@ phpbb.timezone_switch_date = function(keep_selection) {
 	}
 
 	if (typeof keep_selection !== 'undefined' && !keep_selection) {
-		$('#timezone > option:first').attr('selected', true);
+		var timezoneOptions = $('#timezone > optgroup option');
+		if (timezoneOptions.filter(':selected').length <= 0) {
+			timezoneOptions.filter(':first').attr('selected', true);
+		}
 	}
 }
 

--- a/phpBB/styles/prosilver/template/ucp_register.html
+++ b/phpBB/styles/prosilver/template/ucp_register.html
@@ -104,7 +104,4 @@
 </div>
 </form>
 
-<script type="text/javascript" src="{T_SUPER_TEMPLATE_PATH}/timezone.js"></script>
-<script type="text/javascript">phpbb_preselect_tz_select();</script>
-
 <!-- INCLUDE overall_footer.html -->


### PR DESCRIPTION
While registering, we should default to a given timezone. By selecting the
first timezone by default, this is fulfilled. This doesn't happen
currently, as only the "Select a timezone" selection appears.
If a user selects a timezone during the registration process we should
also make sure that the selected element is still selected; even if we
have to return to the registration page, i.e. if there was an error while
submitting the form. This is currently not the case.
With this patch the javascript code will behave correctly.
Additionally, a duplicate inclusion of timezone.js has been removed as it
was not needed.

Ticket: http://tracker.phpbb.com/browse/PHPBB3-11302

PHPBB3-11302
