### PR TITLE
[ticket/11309] phpbb_extension_interface::disable_step correct docblock.

### DIFF
--- a/phpBB/includes/extension/interface.php
+++ b/phpBB/includes/extension/interface.php
@@ -45,7 +45,9 @@ interface phpbb_extension_interface
 	*
 	* @param	mixed	$old_state	The return value of the previous call
 	*								of this method, or false on the first call
-	* @return null
+	* @return	mixed				Returns false after last step, otherwise
+	*								temporary state which is passed as an
+	*								argument to the next step
 	*/
 	public function disable_step($old_state);
 


### PR DESCRIPTION
The `@return` documentation of the `phpbb_extension_interface::disable_step`
method states incorrect that the method returns null, as it returns
false or a state.

PHPBB-11309
