### PR TITLE
[ticket/11311] Include asset core.js in subsilver2 overall_footer.html

### DIFF
--- a/phpBB/styles/subsilver2/template/overall_footer.html
+++ b/phpBB/styles/subsilver2/template/overall_footer.html
@@ -13,6 +13,7 @@
 
 <script type="text/javascript" src="{T_JQUERY_LINK}"></script>
 <!-- IF S_JQUERY_FALLBACK --><script type="text/javascript">window.jQuery || document.write(unescape('%3Cscript src="{T_ASSETS_PATH}/javascript/jquery.js?assets_version={T_ASSETS_VERSION}" type="text/javascript"%3E%3C/script%3E'));</script><!-- ENDIF -->
+<script type="text/javascript" src="{T_ASSETS_PATH}/javascript/core.js?assets_version={T_ASSETS_VERSION}"></script>
 {SCRIPTS}
 
 <!-- EVENT overall_footer_after -->


### PR DESCRIPTION
Without the inclusion of core.js the timezone functions will not properly
work. They refer to phpbb which is defined in core.js.

Ticket: http://tracker.phpbb.com/browse/PHPBB3-11311

PHPBB3-11311
