### PR TITLE
[ticket/11313] Use correct object el instead of eel in alt_text callback

### DIFF
--- a/phpBB/assets/javascript/core.js
+++ b/phpBB/assets/javascript/core.js
@@ -522,7 +522,7 @@ phpbb.addAjaxCallback('alt_text', function() {
 	altText = el.attr('data-alt-text');
 	el.attr('data-alt-text', el.text());
 	el.attr('title', altText);
-	eel.text(altText);
+	el.text(altText);
 });
 
 /**


### PR DESCRIPTION
This typo was added by the PRs #860 and #1178. Only the object el exists
and is correct. Due to this the text of links using the alt_text callback
were not modified while executing the callback.

Ticket: http://tracker.phpbb.com/browse/PHPBB3-11313

PHPBB3-11313
