### PR TITLE
[ticket/10820] Image downloader recognize new version of ie

### DIFF
--- a/phpBB/download/file.php
+++ b/phpBB/download/file.php
@@ -491,7 +491,7 @@ function send_file_to_browser($attachment, $upload_dir, $category)
 	}
 	else
 	{
-		if (empty($user->browser) || !phpbb_is_greater_ie_version($user->browser, 7))
+		if (empty($user->browser) || ((strpos(strtolower($user->browser), 'msie') !== false) && !phpbb_is_greater_ie_version($user->browser, 7)))
 		{
 			header('Content-Disposition: attachment; ' . header_filename(htmlspecialchars_decode($attachment['real_filename'])));
 			if (empty($user->browser) || (strpos(strtolower($user->browser), 'msie 6.0') !== false))


### PR DESCRIPTION
When a user download image attachement using ie8, the file is displayed.
However, when he uses ie version greater than 8, the image is download.
A changes are made to phpbb/download/file.php to solve the problem.
We check now if the ie version is greater or equal to 8 and not only equal
to 8
http://tracker.phpbb.com/browse/PHPBB3-10820
PHPBB3-10820
