### PR TITLE
[ticket/11196] Changed 401 response message to "Unauthorized"   

### DIFF
--- a/phpBB/includes/session.php
+++ b/phpBB/includes/session.php
@@ -346,7 +346,7 @@ class phpbb_session
 		$session_id = $request->variable('sid', '');
 		if (defined('NEED_SID') && (empty($session_id) || $this->session_id !== $session_id))
 		{
-			send_status_line(401, 'Not authorized');
+			send_status_line(401, 'Unauthorized');
 			redirect(append_sid("{$phpbb_root_path}index.$phpEx"));
 		}
 


### PR DESCRIPTION
In session.php 401 response was "Not Authorized". I changed it to "Unauthorized" for consistency.
