### PR TITLE
[ticket/11355] Wrong error message when no user is selected.

### DIFF
--- a/phpBB/includes/acp/acp_groups.php
+++ b/phpBB/includes/acp/acp_groups.php
@@ -185,7 +185,7 @@ class acp_groups
 			break;
 
 			case 'deleteusers':
-				if (!$name_ary)
+				if (empty($mark_ary))
 				{
 					trigger_error($user->lang['NO_USERS'] . adm_back_link($this->u_action . '&amp;action=list&amp;g=' . $group_id), E_USER_WARNING);
 				}


### PR DESCRIPTION
In ACP group membership management, if you select 'remove member
from group' without selecting any users and submit,it will display
a wrong error after confirmbox. Since no users are selected, this
should not go even until confirmbox. Added a new condition to check
weather any users are selected when the action is 'deleteusers'
in acp_groups.php and disply a correct error.

PHPBB3-11355
