### PR TITLE
[ticket/11358] Success message even without selecting a user.

### DIFF
--- a/phpBB/includes/acp/acp_groups.php
+++ b/phpBB/includes/acp/acp_groups.php
@@ -148,12 +148,12 @@ class acp_groups
 					);
 				}
 			break;
-				
+
 			case 'set_default_on_all':
 				if (confirm_box(true))
 				{
 					$group_name = ($group_row['group_type'] == GROUP_SPECIAL) ? $user->lang['G_' . $group_row['group_name']] : $group_row['group_name'];
-						
+
 					$start = 0;
 
 					do
@@ -184,7 +184,7 @@ class acp_groups
 						$db->sql_freeresult($result);
 					}
 					while ($start);
-						
+
 					trigger_error($user->lang['GROUP_DEFS_UPDATED'] . adm_back_link($this->u_action . '&amp;action=list&amp;g=' . $group_id));
 				}
 				else
@@ -198,7 +198,7 @@ class acp_groups
 					);
 				}
 			break;
-			
+
 			case 'deleteusers':
 			case 'delete':
 				if (!$group_id)


### PR DESCRIPTION
In group membership management, if you perform the action
'Make group default for member' without selecting any user,
a confirm box will be displayed and will show a success
message after confirming. Added a new condition to fix this
issue in acp_groups.php. It will check weather any users are
selected before performing above action.

PHPBB3-11358
