### PR TITLE
[ticket/11359] Sphinx Improvement

### DIFF
--- a/phpBB/includes/search/fulltext_sphinx.php
+++ b/phpBB/includes/search/fulltext_sphinx.php
@@ -879,7 +879,7 @@ class phpbb_search_fulltext_sphinx
 		</dl>
 		<dl>
 			<dt><label for="fulltext_sphinx_config_file">' . $this->user->lang['FULLTEXT_SPHINX_CONFIG_FILE'] . $this->user->lang['COLON'] . '</label><br /><span>' . $this->user->lang['FULLTEXT_SPHINX_CONFIG_FILE_EXPLAIN'] . '</span></dt>
-			<dd>' . (($this->config_generate()) ? '<textarea readonly="readonly" rows="6" id="sphinx_config_data">' . $this->config_file_data . '</textarea>' : $this->config_file_data) . '</dd>
+			<dd>' . (($this->config_generate()) ? '<textarea readonly="readonly" rows="6" id="sphinx_config_data">' . htmlspecialchars($this->config_file_data) . '</textarea>' : $this->config_file_data) . '</dd>
 		<dl>
 		';
 


### PR DESCRIPTION
1. Most seriously, sphinx configuration that is shown in the textarea in acp is not html-escaped despite containing angle brackets. lxml destroys sphinx configuration when it parses the page. This should be fixed in a separate pr.
2. There is an unclosed span on the line with sphinx config file explanation. This is obviously not critical, but is something that should be fixed, in yet another pr.
3. The textarea with sphinx configuration has no id, no class and no name. I am able to find it with xpath anyway but it should be more easily identifiable.
