### PR TITLE
[ticket/11361] Make sure that array passed to strtr() has the proper for...

### DIFF
--- a/phpBB/includes/session.php
+++ b/phpBB/includes/session.php
@@ -2156,7 +2156,8 @@ class user extends session
 				'is_short'		=> strpos($format, '|'),
 				'format_short'	=> substr($format, 0, strpos($format, '|')) . '||' . substr(strrchr($format, '|'), 1),
 				'format_long'	=> str_replace('|', '', $format),
-				'lang'			=> $this->lang['datetime'],
+				// Filter out values that are not strings (e.g. arrays) for strtr().
+				'lang'			=> array_filter($this->lang['datetime'], 'is_string'),
 			);
 
 			// Short representation of month in format? Some languages use different terms for the long and short format of May


### PR DESCRIPTION
...mat.

The array $date_cache[$format]['lang'] passed to strtr() contains a sub-array
which results in an E_NOTICE being thrown for 'Array to string conversion' on
PHP 5.4.
Ensure that the array passed to strtr() is one-dimensional by filtering out
non-string values.

PHPBB3-11361

http://tracker.phpbb.com/browse/PHPBB3-11361
