### PR TITLE
[ticket/11367] Migrator throws error if migrations table does not exist

### DIFF
--- a/phpBB/includes/db/migrator.php
+++ b/phpBB/includes/db/migrator.php
@@ -114,9 +114,9 @@ class phpbb_db_migrator
 
 				$this->migration_state[$migration['migration_name']]['migration_depends_on'] = unserialize($migration['migration_depends_on']);
 			}
-
-			$this->db->sql_freeresult($result);
 		}
+
+		$this->db->sql_freeresult($result);
 
 		$this->db->sql_return_on_error(false);
 	}


### PR DESCRIPTION
Force load_migration_state to not throw errors if the table does not exist.

http://tracker.phpbb.com/browse/PHPBB3-11367
