### PR TITLE
[ticket/11288] Search fooled by hyphens.

### DIFF
--- a/phpBB/includes/search/fulltext_native.php
+++ b/phpBB/includes/search/fulltext_native.php
@@ -268,6 +268,7 @@ class phpbb_search_fulltext_native extends phpbb_search_base
 			'#(\+|\-)(?:\+|\-)+#',
 			'#\(\|#',
 			'#\|\)#',
+			'#([\p{L}|0-9])-([\p{L}|0-9])#',
 		);
 		$replace = array(
 			' ',
@@ -275,6 +276,7 @@ class phpbb_search_fulltext_native extends phpbb_search_base
 			'$1',
 			'(',
 			')',
+			'$1 $2',
 		);
 
 		$keywords = preg_replace($match, $replace, $keywords);


### PR DESCRIPTION
When searching posts with keywords joined with '-' no results were
found even though there are matching posts. This is because trying
to search hyphen joined keywords as a single keyword. But 'search
_wordlist' table does not contain them as a single string joined with
hyphen. Extracted words separated from '-' as two keywords and display
search results.

PHPBB3-11288
