### PR TITLE
[ticket/6723] Show info that message has been deleted before delivery

### DIFF
--- a/phpBB/styles/prosilver/template/ucp_pm_history.html
+++ b/phpBB/styles/prosilver/template/ucp_pm_history.html
@@ -24,7 +24,7 @@
 			<h3><a href="{history_row.U_VIEW_MESSAGE}" <!-- IF history_row.S_CURRENT_MSG -->class="current"<!-- ENDIF -->>{history_row.SUBJECT}</a></h3>
 			<p class="author">{history_row.MINI_POST_IMG} {L_SENT_AT}: <strong>{history_row.SENT_DATE}</strong><br />
 				{L_MESSAGE_BY_AUTHOR} {history_row.MESSAGE_AUTHOR_FULL}</p>
-			<div class="content">{history_row.MESSAGE}</div>
+			<div class="content"><!-- IF history_row.MESSAGE -->{history_row.MESSAGE}<!-- ELSE --><span class="error">{L_MESSAGE_REMOVED_FROM_OUTBOX}</span><!-- ENDIF --></div>
 			<div id="message_{history_row.MSG_ID}" style="display: none;">{history_row.DECODED_MESSAGE}</div>
 		</div>
 

--- a/phpBB/styles/subsilver2/template/ucp_pm_history.html
+++ b/phpBB/styles/subsilver2/template/ucp_pm_history.html
@@ -37,7 +37,7 @@
 					<td valign="top">
 						<table width="100%" cellspacing="0" cellpadding="2">
 						<tr>
-							<td><div class="postbody">{history_row.MESSAGE}</div><div id="message_{history_row.MSG_ID}" style="display: none;">{history_row.DECODED_MESSAGE}</div></td>
+							<td><div class="postbody"><!-- IF history_row.MESSAGE -->{history_row.MESSAGE}<!-- ELSE --><span class="error">{L_MESSAGE_REMOVED_FROM_OUTBOX}</span><!-- ENDIF --></div><div id="message_{history_row.MSG_ID}" style="display: none;">{history_row.DECODED_MESSAGE}</div></td>
 						</tr>
 						</table>
 					</td>


### PR DESCRIPTION
If the message has been deleted before the delivery it will still show in
the message history, although with an empty message. This patch will
change that behavior to showing the info that it has been deleted before
it was delivered in red letters. The red letters ensure that users won't
mistake the info for the actual message.

Ticket: http://tracker.phpbb.com/browse/PHPBB3-6723

PHPBB3-6723
