### PR TITLE
[ticket/11383] Correctly revert modules added/removed by migrator

### DIFF
--- a/phpBB/includes/db/migrator.php
+++ b/phpBB/includes/db/migrator.php
@@ -462,6 +462,12 @@ class phpbb_db_migrator
 	{
 		$state = ($state) ? unserialize($state) : false;
 
+		// reverse order of steps if reverting
+		if ($revert === true)
+		{
+			$steps = array_reverse($steps);
+		}
+
 		foreach ($steps as $step_identifier => $step)
 		{
 			$last_result = false;


### PR DESCRIPTION
This should fix issues where migrator cannot remove module categories, for extensions that add a module category, as it started reverting from the module category instead of starting from the module mode and move upwards 

PHPBB3-11383
