### PR TITLE
[ticket/11398] Correctly call permission_set method in permission tool

### DIFF
--- a/phpBB/includes/db/migration/tool/permission.php
+++ b/phpBB/includes/db/migration/tool/permission.php
@@ -422,7 +422,7 @@ class phpbb_db_migration_tool_permission implements phpbb_db_migration_tool_inte
 					$this->db->sql_query($sql);
 					$role_name = $this->db->sql_fetchfield('role_name');
 
-					return $this->set($role_name, $auth_option, 'role', $has_permission);
+					return $this->permission_set($role_name, $auth_option, 'role', $has_permission);
 				}
 
 				$sql = 'SELECT auth_option_id, auth_setting


### PR DESCRIPTION
The permission_set method calls itself inside the permission tool.
Probably due to an oversight, it is called as $this->set(), which causes a
fatal error. This patch will get rid of this issue.

Ticket: http://tracker.phpbb.com/browse/PHPBB3-11398

PHPBB3-11398
