### PR TITLE
[ticket/11340] Using AJAX Delete alters pagination.

### DIFF
--- a/phpBB/assets/javascript/core.js
+++ b/phpBB/assets/javascript/core.js
@@ -273,8 +273,25 @@ phpbb.ajaxify = function(options) {
 				// callbacks.
 				if (typeof res.MESSAGE_TITLE !== 'undefined') {
 					alert = phpbb.alert(res.MESSAGE_TITLE, res.MESSAGE_TEXT);
-				} else {
+				} else if (!($(res).find('.divider:last').length > 0)) {
 					dark.fadeOut(phpbb.alertTime);
+				}
+				
+				// Checking weather its returning after post delete
+				// If so fetch first post from next page to load into current page
+				if (($('.active').length > 0) && (typeof res.AFTER_POST_DELETE !== 'undefined')) {
+					var page_number = parseInt($('.active').find('span').html());
+					var posts_exist_beyond = (((res.POST_COUNT + 1) - (page_number * res.POSTS_PER_PAGE)) > 0) ? true : false;
+					if(posts_exist_beyond){
+						var link_parts = $('.active').next('li').find('a').attr('href').split('&start=');
+						$.ajax({
+							url: link_parts[0] + '&start=' + (parseInt(link_parts[1]) - $('.divider').length).toString(),
+							type: 'GET',
+							data: '',
+							success: returnHandler,
+							error: errorHandler
+						});
+					}
 				}
 
 				if (typeof phpbb.ajaxCallbacks[callback] === 'function') {

--- a/phpBB/posting.php
+++ b/phpBB/posting.php
@@ -1540,7 +1540,7 @@ function upload_popup($forum_style = 0)
 */
 function handle_post_delete($forum_id, $topic_id, $post_id, &$post_data)
 {
-	global $user, $db, $auth, $config;
+	global $user, $db, $auth, $config, $request;
 	global $phpbb_root_path, $phpEx;
 
 	// If moderator removing post or user itself removing post, present a confirmation screen
@@ -1585,9 +1585,40 @@ function handle_post_delete($forum_id, $topic_id, $post_id, &$post_data)
 				$message = $user->lang['POST_DELETED'] . '<br /><br />' . sprintf($user->lang['RETURN_TOPIC'], '<a href="' . $meta_info . '">', '</a>');
 			}
 
-			meta_refresh(3, $meta_info);
+
 			$message .= '<br /><br />' . sprintf($user->lang['RETURN_FORUM'], '<a href="' . append_sid("{$phpbb_root_path}viewforum.$phpEx", 'f=' . $forum_id) . '">', '</a>');
-			trigger_error($message);
+
+			if($request->is_ajax())
+			{
+				$sql = 'SELECT COUNT(post_id) AS post_count
+				        FROM ' . POSTS_TABLE . '
+				        WHERE forum_id = ' . $forum_id . '
+				        AND topic_id = ' . $topic_id;
+			
+				$result = $db->sql_query($sql);
+
+				$post_count = (int) $db->sql_fetchfield('post_count');
+
+				$refresh_data = array(
+					'time'	=> 3,
+					'url'	=> str_replace('&amp;', '&', $meta_info)
+				);
+
+				$json_response = new phpbb_json_response;
+				$json_response->send(array(
+					'MESSAGE_TITLE'		=> $user->lang['INFORMATION'],
+					'MESSAGE_TEXT' 		=> $message,
+					'AFTER_POST_DELETE'	=> true,
+					'REFRESH_DATA'		=> (!empty($refresh_data)) ? $refresh_data : null,
+					'POSTS_PER_PAGE'	=> $config['posts_per_page'],
+					'POST_COUNT'		=> $post_count
+				));
+			}
+			else
+			{
+				meta_refresh(3, $meta_info);
+				trigger_error($message);
+			}
 		}
 		else
 		{

--- a/phpBB/styles/prosilver/template/ajax.js
+++ b/phpBB/styles/prosilver/template/ajax.js
@@ -91,21 +91,44 @@ phpbb.addAjaxCallback('mark_topics_read', function(res) {
 });
 
 // This callback finds the post from the delete link, and removes it.
-phpbb.addAjaxCallback('post_delete', function() {
+phpbb.addAjaxCallback('post_delete', function(response) {
 	var el = $(this),
 		postId;
 
 	if (el.attr('data-refresh') === undefined) {
-		postId = el[0].href.split('&p=')[1];
-		var post = el.parents('#p' + postId).css('pointer-events', 'none');
-		if (post.hasClass('bg1') || post.hasClass('bg2')) {
-			var posts1 = post.nextAll('.bg1');
-			post.nextAll('.bg2').removeClass('bg2').addClass('bg1');
-			posts1.removeClass('bg1').addClass('bg2');
+		// Checking weather new post from next page needs to be loaded
+		if ($(response).find('.divider:last').length > 0) {
+			var pg_last_post = $(response).find('.divider:last').prev('div');
+			pg_last_post.insertAfter('.divider:last').fadeIn();
+			$('<hr class="divider">').insertAfter(pg_last_post);
+
+			pg_last_post.find('[data-ajax]').each(function() {
+				var $this = $(this),
+					ajax = $this.attr('data-ajax'),
+					fn;
+				if (ajax !== 'false') {
+					fn = (ajax !== 'true') ? ajax : null;
+					phpbb.ajaxify({
+						selector: this,
+						refresh: $this.attr('data-refresh') !== undefined,
+						callback: fn
+					});
+				}
+			});		
+
+		} else {
+			postId = el[0].href.split('&p=')[1];
+			var post = el.parents('#p' + postId).css('pointer-events', 'none');
+			if (post.hasClass('bg1') || post.hasClass('bg2')) {
+				var posts1 = post.nextAll('.bg1');
+				post.nextAll('.bg2').removeClass('bg2').addClass('bg1');
+				posts1.removeClass('bg1').addClass('bg2');
+			}
+			post.fadeOut(function() {
+				$(this).next('hr').remove();
+				$(this).remove();
+			});
 		}
-		post.fadeOut(function() {
-			$(this).remove();
-		});
 	}
 });
 


### PR DESCRIPTION
When deleting a post from a particular page, posts should shift
back and last post from next page should come to end of the current
page. But it does not happen. When clicking the next page, the
first post that was on the next page before the post was deleted
is now on the current page. Therefore When clicking on next page
user will miss a post. Added a new ajax call to get the post from
next page and add it to the end of the current page by using
post_delete callback.

PHPBB3-11340
