### PR TITLE
[ticket/11433] Rename CSS class "jalert" to "phpbb_alert"

### DIFF
--- a/phpBB/styles/prosilver/template/overall_footer.html
+++ b/phpBB/styles/prosilver/template/overall_footer.html
@@ -31,7 +31,7 @@
 
 	<div id="darkenwrapper" data-ajax-error-title="{L_AJAX_ERROR_TITLE}" data-ajax-error-text="{L_AJAX_ERROR_TEXT}">
 		<div id="darken">&nbsp;</div>
-		<div class="jalert" id="loadingalert"><h3>{L_LOADING}</h3><p>{L_PLEASE_WAIT}</p></div>
+		<div class="phpbb_alert" id="loadingalert"><h3>{L_LOADING}</h3><p>{L_PLEASE_WAIT}</p></div>
 	</div>
 
 	<div id="phpbb_alert" class="phpbb_alert" data-l-err="{L_ERROR}" data-l-timeout-processing-req="{L_TIMEOUT_PROCESSING_REQ}">


### PR DESCRIPTION
This missing change caused the loading info to appear during ajax
requests. With this patch it will be properly hidden as it should.

Ticket: http://tracker.phpbb.com/browse/PHPBB3-11433

PHPBB3-11433
