### PR TITLE
[ticket/11452] Now notification_method_email checks whether user has add...

### DIFF
--- a/phpBB/includes/notification/method/email.php
+++ b/phpBB/includes/notification/method/email.php
@@ -53,7 +53,7 @@ class phpbb_notification_method_email extends phpbb_notification_method_base
 	*/
 	public function is_available()
 	{
-		return (bool) $this->config['email_enable'];
+		return $this->config['email_enable'] && $this->user->data['user_email'];
 	}
 
 	/**


### PR DESCRIPTION
...ress.

Make sure the user has an email address set before offering email
notifications. The address could be missing for whatever reason, e.g. external
authentication. This is also consistent with XMPP/Jabber now.

PHPBB3-11452

http://tracker.phpbb.com/browse/PHPBB3-11452
