### PR TITLE
[ticket/11448] Use of $user_id parameter to mark a user's notifications read

### DIFF
--- a/phpBB/includes/notification/manager.php
+++ b/phpBB/includes/notification/manager.php
@@ -256,6 +256,7 @@ class phpbb_notification_manager
 			SET notification_read = 1
 			WHERE notification_time <= " . (int) $time .
 				(($item_type !== false) ? ' AND ' . (is_array($item_type) ? $this->db->sql_in_set('item_type', $item_type) : " item_type = '" . $this->db->sql_escape($item_type) . "'") : '') .
+				(($user_id !== false) ? ' AND ' . (is_array($user_id) ? $this->db->sql_in_set('user_id', $user_id) : 'user_id = ' . (int) $user_id) : '') .
 				(($item_id !== false) ? ' AND ' . (is_array($item_id) ? $this->db->sql_in_set('item_id', $item_id) : 'item_id = ' . (int) $item_id) : '');
 		$this->db->sql_query($sql);
 	}


### PR DESCRIPTION
The issue that was pointed out was that the $user_id parameter of phpbb_notification_manager::mark_notifications_read() was not being used.

After looking at it, the mark_notifications_read_by_parent() function also has a $user_id parameter, which is used in the SQL query. As such, implemented the $user_id variable into the query in mark_notifications_read() in much the same way.

Prior behavior appears to be that all notifications of the given type, from before the given time, from any user, and with the given item ID, would be marked read. Now, that behavior has been modified to ensure that the notifications are only marked read if they belong to the given user.

http://tracker.phpbb.com/browse/PHPBB3-11448
