### PR TITLE
[ticket/11466] Remove old database driver files from PHPUnit exclude

### DIFF
--- a/phpunit.xml.all
+++ b/phpunit.xml.all
@@ -24,15 +24,6 @@
         <whitelist>
             <directory suffix=".php">./phpBB/includes/</directory>
             <exclude>
-                <file>./phpBB/includes/db/firebird.php</file>
-                <file>./phpBB/includes/db/mysql.php</file>
-                <file>./phpBB/includes/db/mysqli.php</file>
-                <file>./phpBB/includes/db/mssql.php</file>
-                <file>./phpBB/includes/db/mssql_odbc.php</file>
-                <file>./phpBB/includes/db/mssqlnative.php</file>
-                <file>./phpBB/includes/db/oracle.php</file>
-                <file>./phpBB/includes/db/postgres.php</file>
-                <file>./phpBB/includes/db/sqlite.php</file>
                 <file>./phpBB/includes/search/fulltext_native.php</file>
                 <file>./phpBB/includes/search/fulltext_mysql.php</file>
                 <directory suffix=".php">./phpBB/includes/captcha/</directory>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -31,15 +31,6 @@
         <whitelist>
             <directory suffix=".php">./phpBB/includes/</directory>
             <exclude>
-                <file>./phpBB/includes/db/firebird.php</file>
-                <file>./phpBB/includes/db/mysql.php</file>
-                <file>./phpBB/includes/db/mysqli.php</file>
-                <file>./phpBB/includes/db/mssql.php</file>
-                <file>./phpBB/includes/db/mssql_odbc.php</file>
-                <file>./phpBB/includes/db/mssqlnative.php</file>
-                <file>./phpBB/includes/db/oracle.php</file>
-                <file>./phpBB/includes/db/postgres.php</file>
-                <file>./phpBB/includes/db/sqlite.php</file>
                 <file>./phpBB/includes/search/fulltext_native.php</file>
                 <file>./phpBB/includes/search/fulltext_mysql.php</file>
                 <directory suffix=".php">./phpBB/includes/captcha/</directory>

--- a/phpunit.xml.functional
+++ b/phpunit.xml.functional
@@ -30,15 +30,6 @@
         <whitelist>
             <directory suffix=".php">./phpBB/includes/</directory>
             <exclude>
-                <file>./phpBB/includes/db/firebird.php</file>
-                <file>./phpBB/includes/db/mysql.php</file>
-                <file>./phpBB/includes/db/mysqli.php</file>
-                <file>./phpBB/includes/db/mssql.php</file>
-                <file>./phpBB/includes/db/mssql_odbc.php</file>
-                <file>./phpBB/includes/db/mssqlnative.php</file>
-                <file>./phpBB/includes/db/oracle.php</file>
-                <file>./phpBB/includes/db/postgres.php</file>
-                <file>./phpBB/includes/db/sqlite.php</file>
                 <file>./phpBB/includes/search/fulltext_native.php</file>
                 <file>./phpBB/includes/search/fulltext_mysql.php</file>
                 <directory suffix=".php">./phpBB/includes/captcha/</directory>


### PR DESCRIPTION
As per the ticket comments, these can simply be removed, rather than having to
be renamed to the new file locations.

http://tracker.phpbb.com/browse/PHPBB3-11466
