### PR TITLE
[ticket/11476] Remove pass-by-reference from sql_mutli_insert

### DIFF
--- a/phpBB/includes/db/driver/driver.php
+++ b/phpBB/includes/db/driver/driver.php
@@ -568,12 +568,12 @@ class phpbb_db_driver
 	* Run more than one insert statement.
 	*
 	* @param string $table table name to run the statements on
-	* @param array &$sql_ary multi-dimensional array holding the statement data.
+	* @param array $sql_ary multi-dimensional array holding the statement data.
 	*
 	* @return bool false if no statements were executed.
 	* @access public
 	*/
-	function sql_multi_insert($table, &$sql_ary)
+	function sql_multi_insert($table, $sql_ary)
 	{
 		if (!sizeof($sql_ary))
 		{


### PR DESCRIPTION
The method never writes to the array passed by reference. So it can be
passed by value instead to avoid certain problems.

http://tracker.phpbb.com/browse/PHPBB3-11476
