### PR TITLE
[ticket/11116] Made ACP "extension not available" error message E_USER_WARNING

### DIFF
--- a/phpBB/includes/acp/acp_extensions.php
+++ b/phpBB/includes/acp/acp_extensions.php
@@ -81,7 +81,7 @@ class acp_extensions
 			case 'enable_pre':
 				if (!$md_manager->validate_enable())
 				{
-					trigger_error($user->lang['EXTENSION_NOT_AVAILABLE'] . adm_back_link($this->u_action));
+					trigger_error($user->lang['EXTENSION_NOT_AVAILABLE'] . adm_back_link($this->u_action), E_USER_WARNING);
 				}
 
 				if ($phpbb_extension_manager->enabled($ext_name))
@@ -100,7 +100,7 @@ class acp_extensions
 			case 'enable':
 				if (!$md_manager->validate_enable())
 				{
-					trigger_error($user->lang['EXTENSION_NOT_AVAILABLE'] . adm_back_link($this->u_action));
+					trigger_error($user->lang['EXTENSION_NOT_AVAILABLE'] . adm_back_link($this->u_action), E_USER_WARNING);
 				}
 
 				try


### PR DESCRIPTION
The error message generated when an administrator tries to enable an
incompatible extension used to be displayed in the green of the default
E_USER_NOTICE. Changed it to E_USER_WARNING to make it appear in red, as
requested in the ticket.

http://tracker.phpbb.com/browse/PHPBB3-11116
