### PR TITLE
[ticket/4412] Shorten long profile fields

### DIFF
--- a/phpBB/styles/prosilver/theme/common.css
+++ b/phpBB/styles/prosilver/theme/common.css
@@ -476,6 +476,8 @@ dl.details dd {
 	margin-bottom: 5px;
 	float: left;
 	width: 65%;
+	overflow: hidden;
+	text-overflow: ellipsis;
 }
 
 .clearfix, #tabs, #minitabs, fieldset dl, ul.topiclist dl, dl.polls {

--- a/phpBB/styles/prosilver/theme/content.css
+++ b/phpBB/styles/prosilver/theme/content.css
@@ -669,6 +669,11 @@ fieldset.polls dd div {
 	margin-left: 8px;
 }
 
+.postprofile dd {
+	overflow: hidden;
+	text-overflow: ellipsis;
+}
+
 .postprofile strong {
 	font-weight: normal;
 }


### PR DESCRIPTION
Shorten long profile fields using CSS

This solution makes browser hide part of long words that don't fit container. For example, "http://www.programmersworld.elementfx.com" value from website ticket example becomes "http://www.programmersworld...".

This fix works in all browsers, including IE8.

Related website ticket: https://www.phpbb.com/bugs/website/63355
Ticket: http://tracker.phpbb.com/browse/PHPBB3-4412
