### PR TITLE
[ticket/11151] Initiate start index as non-negative 

### DIFF
--- a/phpBB/includes/functions.php
+++ b/phpBB/includes/functions.php
@@ -4347,6 +4347,21 @@ function phpbb_optionset($bit, $set, $data)
 }
 
 /**
+* Generate last valid page's starting parameter for paginating.
+*
+* @param int	$num_total	Maximum possible objects for paginating
+* @param int	$display_per_page	User configuration for pagination
+* @param int	$passed_index	Current index which may be out of bounds
+*
+* @return int	Minimum of last page number or $passed_index
+*/
+function phpbb_get_last_page_index($num_total, $display_per_page, $passed_index)
+{
+	$last_page = $num_total - ($num_total % $display_per_page);
+	return min($last_page, $passed_index);
+}
+
+/**
 * Login using http authenticate.
 *
 * @param array	$param		Parameter array, see $param_defaults array.

--- a/phpBB/memberlist.php
+++ b/phpBB/memberlist.php
@@ -1280,7 +1280,7 @@ switch ($mode)
 			$total_users = $config['num_users'];
 		}
 
-		$start = get_last_page_index($total_users, $config['topics_per_page'], $start);
+		$start = phpbb_get_last_page_index($total_users, $config['topics_per_page'], $start);
 
 		// Build a relevant pagination_url
 		$params = $sort_params = array();
@@ -1740,16 +1740,6 @@ function show_profile($data, $user_notes_enabled = false, $warn_user_enabled = f
 
 		'L_VIEWING_PROFILE'	=> sprintf($user->lang['VIEWING_PROFILE'], $username),
 	);
-}
-
-/**
-* Generate last valid page's starting parameter for paginating.
-*/
-
-function get_last_page_index($num_users, $display_per_page, $passed_index)
-{
-	$last_page = $num_users - ($num_users % $display_per_page);
-	return min($last_page, $passed_index);
 }
 
 function _sort_last_active($first, $second)


### PR DESCRIPTION
A negative value of `$start` displays wrong page numbers for memberlist.
Set it as zero if a negative or non-integer value is encountered.

http://tracker.phpbb.com/browse/PHPBB3-11151
