### PR TITLE
[ticket/11424] Handle race condition properly

### DIFF
--- a/phpBB/includes/mcp/mcp_main.php
+++ b/phpBB/includes/mcp/mcp_main.php
@@ -213,8 +213,10 @@ class mcp_main
 						break;
 					}
 				}
+				
 				// Unhandled case. Set to E_USER_ERROR. Can be changed when new case is reported.
 				trigger_error('NO_MODE', E_USER_ERROR);
+				
 			break;
 		}
 	}


### PR DESCRIPTION
In circumstances when quickmod-race occur, `General Error` message will
instead be handled based on action taken. On allowed quickmod tools, 
display suitable error message with proper reasons.

PHPBB3-11424
