### PR TITLE
 [ticket/11488] Use correct base class in email notification method

### DIFF
--- a/phpBB/includes/notification/method/email.php
+++ b/phpBB/includes/notification/method/email.php
@@ -21,7 +21,7 @@ if (!defined('IN_PHPBB'))
 *
 * @package notifications
 */
-class phpbb_notification_method_email extends phpbb_notification_method_base
+class phpbb_notification_method_email extends phpbb_notification_method_messenger_base
 {
 	/**
 	* Get notification method name

--- a/phpBB/includes/notification/method/messenger_base.php
+++ b/phpBB/includes/notification/method/messenger_base.php
@@ -78,7 +78,7 @@ abstract class phpbb_notification_method_messenger_base extends phpbb_notificati
 				continue;
 			}
 
-			$messenger->template($email_template_base_dir . $notification->get_email_template(), $user['user_lang']);
+			$messenger->template($template_dir_prefix . $notification->get_email_template(), $user['user_lang']);
 
 			$messenger->to($user['user_email'], $user['username']);
 


### PR DESCRIPTION
In ticket/11451 this was not correctly changed to reflect the new class
phpbb_notifcation_method_messenger_base. Additionally, an undefined
variable error has been fixed in messenger_base.php (change should be
confirmed by bantu though).
The copyright year was changed according to Nils' remark in the previous PR #1300.

Ticket: http://tracker.phpbb.com/browse/PHPBB3-11488

PHPBB3-11488
