### PR TITLE
[ticket/11437] add an extra condition to if statement

### DIFF
--- a/phpBB/includes/search/fulltext_sphinx.php
+++ b/phpBB/includes/search/fulltext_sphinx.php
@@ -611,7 +611,7 @@ class phpbb_search_fulltext_sphinx
 
 		$result_count = $result['total_found'];
 
-		if ($start >= $result_count)
+		if ($result_count && $start >= $result_count)
 		{
 			$start = floor(($result_count - 1) / $per_page) * $per_page;
 


### PR DESCRIPTION
When search returns no results there is no need to go inside the if
statement. Since $result_count becomes zero, $start becomes negative
which leads to failed assertion.
http://tracker.phpbb.com/browse/PHPBB3-11437

Todo: Functional tests for this incorrect behavior

PHPBB3-11437
