### PR TITLE
[ticket/11144] Add missing {FORUM_NAME} variable

### DIFF
--- a/phpBB/includes/functions.php
+++ b/phpBB/includes/functions.php
@@ -3271,7 +3271,14 @@ function login_forum_box($forum_data)
 
 	page_header($user->lang['LOGIN'], false);
 
+	$forum_name = '';
+	if (isset($forum_data['forum_name']))
+	{
+		$forum_name = $forum_data['forum_name'];
+	}
+
 	$template->assign_vars(array(
+		'FORUM_NAME'			=> $forum_name,
 		'S_LOGIN_ACTION'		=> build_url(array('f')),
 		'S_HIDDEN_FIELDS'		=> build_hidden_fields(array('f' => $forum_data['forum_id'])))
 	);


### PR DESCRIPTION
The template variable {FORUM_NAME} was missing from the login page of a password protected forum

[PHPBB3-11144](http://tracker.phpbb.com/browse/PHPBB3-11144)
