### PR TITLE
[ticket/11129] Added headers to empty subscription state

### DIFF
--- a/phpBB/styles/prosilver/template/ucp_main_subscribed.html
+++ b/phpBB/styles/prosilver/template/ucp_main_subscribed.html
@@ -43,6 +43,7 @@
     </ul>
 	<p><strong>{L_NO_WATCHED_FORUMS}</strong></p>
 <!-- ENDIF -->
+    <br />
 
 <!-- IF .topicrow -->
 	<ul class="topiclist">


### PR DESCRIPTION
There is a message: "You are not subscribed to any forums". Under the 'watched topics' section in the control panel.

While correct, could lead to confusion. What's missing is a header right above the message that says "Watched Topics" to match the "Watched Forums" header above. This will assert the idea that there are two separate watchable sections.
As is, it looks like that message is talking about the "Watched Forums" section, since it's listed under that header.

[before](http://tracker.phpbb.com/secure/attachment/12137/Screen%20shot%202012-10-02%20at%2014.41.36.jpg) & [after](http://tracker.phpbb.com/secure/attachment/12621/example2.png)

This now matches how subsilver2 displays these lists.

PHPBB3-11129
