### PR TITLE
[ticket/11442] Use correct button class for ajaxified confirm_box

### DIFF
--- a/phpBB/adm/style/confirm_body.html
+++ b/phpBB/adm/style/confirm_body.html
@@ -4,7 +4,7 @@
 	<p>{MESSAGE_TEXT}</p>
 
 	<fieldset class="submit-buttons">
-		<input type="button" name="confirm" value="{L_YES}" class="button2" />&nbsp;
+		<input type="button" name="confirm" value="{L_YES}" class="button1" />&nbsp;
 		<input type="button" name="cancel" value="{L_NO}" class="button2" />
 	</fieldset>
 


### PR DESCRIPTION
In commit 001572f the HTML code for the ajaxified confirm_box was moved
from overall_footer.html to confirm_body.html. While copying, the CSS
class of the "Yes" button was changed from button1 to button2. Due to the
fact that the phpbb.confirm() method uses the class button1 to check if
"Yes" was clicked, this broke the ajaxified confirm box in the ACP. With
this small patch the confirm boxes in the ACP should work properly again.

Ticket: http://tracker.phpbb.com/browse/PHPBB3-11442

PHPBB3-11442
