### PR TITLE
[ticket/11486] Root path function created and existing code refactored

### DIFF
--- a/phpBB/includes/functions.php
+++ b/phpBB/includes/functions.php
@@ -5726,9 +5726,9 @@ function phpbb_create_symfony_request(phpbb_request $request)
 /**
  * Gets the url for the root board path
  *
- * @return The root path
+ * @return If use of the board path url is permitted, a board url will be returned. Otherwise the root path will be returned
  */
-function get_board_root_path()
+function phpbb_get_root_url_path()
 {
 	global $phpbb_root_path;
 	return (defined('PHPBB_USE_BOARD_URL_PATH') && PHPBB_USE_BOARD_URL_PATH) ? generate_board_url() . '/' : $phpbb_root_path;

--- a/phpBB/includes/functions_content.php
+++ b/phpBB/includes/functions_content.php
@@ -821,7 +821,7 @@ function smiley_text($text, $force_option = false)
 	}
 	else
 	{
-		$root_path = get_board_root_path();
+		$root_path = phpbb_get_root_url_path();
 		return preg_replace('#<!\-\- s(.*?) \-\-><img src="\{SMILIES_PATH\}\/(.*?) \/><!\-\- s\1 \-\->#', '<img class="smilies" src="' . $root_path . $config['smilies_path'] . '/\2 />', $text);
 	}
 }
@@ -929,7 +929,7 @@ function parse_attachments($forum_id, &$message, &$attachments, &$update_count, 
 		$block_array = array();
 
 		// Some basics...
-		$root_path = get_board_root_path();
+		$root_path = phpbb_get_root_url_path();
 		$attachment['extension'] = strtolower(trim($attachment['extension']));
 		$filename = $root_path . $config['upload_path'] . '/' . utf8_basename($attachment['physical_filename']);
 		$thumbnail_filename = $root_path . $config['upload_path'] . '/thumb_' . utf8_basename($attachment['physical_filename']);

--- a/phpBB/includes/ucp/ucp_pm_viewfolder.php
+++ b/phpBB/includes/ucp/ucp_pm_viewfolder.php
@@ -146,7 +146,7 @@ function view_folder($id, $mode, $folder_id, $folder)
 					}
 				}
 
-				$root_path = get_board_root_path();
+				$root_path = phpbb_get_root_url_path();
 				// Send vars to template
 				$template->assign_block_vars('messagerow', array(
 					'PM_CLASS'			=> ($row_indicator) ? 'pm_' . $row_indicator . '_colour' : '',


### PR DESCRIPTION
A method called get_board_root_path() was created to make getting the root
path easier. Existing uses of $root_path were updated to use this method

I ended up re-doing the ticket/11486 branch instead of fixing all of those bad commits.

PHPBB3-11486
