### PR TITLE
[ticket/11512] Changed the messages for language en

### DIFF
--- a/phpBB/language/en/ucp.php
+++ b/phpBB/language/en/ucp.php
@@ -272,9 +272,9 @@ $lang = array_merge($lang, array(
 	'LOGIN_EXPLAIN_UCP'			=> 'Please login in order to access the User Control Panel.',
 	'LOGIN_KEY'					=> 'Login Key',
 	'LOGIN_TIME'				=> 'Login Time',
-	'LOGIN_REDIRECT'			=> 'You have been successfully logged in.',
+	'LOGIN_REDIRECT'			=> 'You have been successfully logged in and will now be redirected to the index page.',
 	'LOGOUT_FAILED'				=> 'You were not logged out, as the request did not match your session. Please contact the board administrator if you continue to experience problems.',
-	'LOGOUT_REDIRECT'			=> 'You have been successfully logged out.',
+	'LOGOUT_REDIRECT'			=> 'You have been successfully logged out and will now be redirected to the index page.',
 
 	'MARK_IMPORTANT'				=> 'Mark/Unmark as important',
 	'MARKED_MESSAGE'				=> 'Marked message',


### PR DESCRIPTION
Earlier user was not informed before being redirected after successful login/logout.
So, modified the messages to state that the user is being redirected to
the index page, after successful login/logout (for language en).

PHPBB3-11512
