### PR TITLE
[ticket/11105] Add mandatory space to content part of meta http-equiv=re...

### DIFF
--- a/phpBB/includes/functions.php
+++ b/phpBB/includes/functions.php
@@ -2740,7 +2740,7 @@ function meta_refresh($time, $url, $disable_cd_check = false)
 
 	// For XHTML compatibility we change back & to &amp;
 	$template->assign_vars(array(
-		'META' => '<meta http-equiv="refresh" content="' . $time . ';url=' . $url . '" />')
+		'META' => '<meta http-equiv="refresh" content="' . $time . '; url=' . $url . '" />')
 	);
 
 	return $url;

--- a/phpBB/install/install_convert.php
+++ b/phpBB/install/install_convert.php
@@ -2087,7 +2087,7 @@ class install_convert extends module
 			// Because we should not rely on correct settings, we simply use the relative path here directly.
 			$template->assign_vars(array(
 				'S_REFRESH'	=> true,
-				'META'		=> '<meta http-equiv="refresh" content="5;url=' . $url . '" />')
+				'META'		=> '<meta http-equiv="refresh" content="5; url=' . $url . '" />')
 			);
 		}
 	}


### PR DESCRIPTION
...fresh.

There was no space between ; and the string "url=". But according to w3c, we
should have atleast one space between them. So, added space characters
accordingly.

PHPBB3-11105

https://tracker.phpbb.com/browse/PHPBB3-11105
