### PR TITLE
[ticket/11535] Correctly merge avatar_errors array into primary error array

### DIFF
--- a/phpBB/includes/acp/acp_groups.php
+++ b/phpBB/includes/acp/acp_groups.php
@@ -381,6 +381,9 @@ class acp_groups
 							$submit_ary['avatar_width'] = 0;
 							$submit_ary['avatar_height'] = 0;
 						}
+
+						// Merge any avatar errors into the primary error array
+						$error = array_merge($error, $phpbb_avatar_manager->localize_errors($user, $avatar_error));
 					}
 
 					// Validate the length of "Maximum number of allowed recipients per private message" setting.
@@ -570,8 +573,11 @@ class acp_groups
 
 				$avatar = phpbb_get_group_avatar($group_row, 'GROUP_AVATAR', true);
 
-				// Merge any avatar errors into the primary error array
-				$error = array_merge($error, $phpbb_avatar_manager->localize_errors($user, $avatar_error));
+				if (!$update)
+				{
+					// Merge any avatar errors into the primary error array
+					$error = array_merge($error, $phpbb_avatar_manager->localize_errors($user, $avatar_error));
+				}
 
 				$back_link = request_var('back_link', '');
 

--- a/phpBB/includes/ucp/ucp_groups.php
+++ b/phpBB/includes/ucp/ucp_groups.php
@@ -547,6 +547,9 @@ class ucp_groups
 									$submit_ary['avatar_width'] = 0;
 									$submit_ary['avatar_height'] = 0;
 								}
+
+								// Merge any avatars errors into the primary error array
+								$error = array_merge($error, $phpbb_avatar_manager->localize_errors($user, $avatar_error));
 							}
 
 							if (!check_form_key('ucp_groups'))
@@ -672,8 +675,11 @@ class ucp_groups
 							}
 						}
 
-						// Merge any avatars errors into the primary error array
-						$error = array_merge($error, $phpbb_avatar_manager->localize_errors($user, $avatar_error));
+						if (!$update)
+						{
+							// Merge any avatars errors into the primary error array
+							$error = array_merge($error, $phpbb_avatar_manager->localize_errors($user, $avatar_error));
+						}
 
 						$template->assign_vars(array(
 							'S_EDIT'			=> true,


### PR DESCRIPTION
The $avatar_errors array needs to be merged into the primary $error array
before the group settings get applied. This is currently not the case.
Functional tests for this will be provided by PR #1401.

This should be merged before PR #1401 so I can enable the tests in that PR that are currently marked as incomplete due to this bug.

Ticket: http://tracker.phpbb.com/browse/PHPBB3-11535

PHPBB3-11535
