### PR TITLE
[ticket/11537] Adjust error message on ucp group manage to fit rest of ucp

### DIFF
--- a/phpBB/styles/prosilver/template/ucp_groups_manage.html
+++ b/phpBB/styles/prosilver/template/ucp_groups_manage.html
@@ -6,19 +6,18 @@
 
 <div class="panel">
 	<div class="inner"><span class="corners-top"><span></span></span>
-	
+
+	<!-- IF S_ERROR -->
+	<fieldset>
+		<p class="error">{ERROR_MSG}</p>
+	</fieldset>
+	<!-- ENDIF -->
+
 	<p>{L_GROUPS_EXPLAIN}</p>
 
 	<!-- IF S_EDIT -->
 		<h3>{L_GROUP_DETAILS}</h3>
-	
-		<!-- IF S_ERROR -->
-		<div class="errorbox">
-			<h3>{L_WARNING}</h3>
-			<p>{ERROR_MSG}</p>
-		</div>
-		<!-- ENDIF -->
-	
+
 		<fieldset>
 		<dl>
 			<dt><label for="group_name">{L_GROUP_NAME}:</label></dt>


### PR DESCRIPTION
The current look highly differed from the rest of the UCP. Additionally,
this caused the error message to be hardly noticeable at all.

Ticket: http://tracker.phpbb.com/browse/PHPBB3-11537

PHPBB3-11537
