### PR TITLE
[ticket/11546] Fix is_absolute() throws E_NOTICE for empty string

### DIFF
--- a/phpBB/includes/functions.php
+++ b/phpBB/includes/functions.php
@@ -1005,7 +1005,7 @@ if (!function_exists('stripos'))
 */
 function is_absolute($path)
 {
-	return ($path[0] == '/' || (DIRECTORY_SEPARATOR == '\\' && preg_match('#^[a-z]:[/\\\]#i', $path))) ? true : false;
+	return (isset($path[0]) && $path[0] == '/' || (DIRECTORY_SEPARATOR == '\\' && preg_match('#^[a-z]:[/\\\]#i', $path))) ? true : false;
 }
 
 /**

--- a/tests/functions/is_absolute_test.php
+++ b/tests/functions/is_absolute_test.php
@@ -14,6 +14,7 @@ class phpbb_functions_is_absolute_test extends phpbb_test_case
 	static public function is_absolute_data()
 	{
 		return array(
+			array('', false),
 			array('/etc/phpbb', true),
 			array('etc/phpbb', false),
 


### PR DESCRIPTION
http://tracker.phpbb.com/browse/PHPBB3-11546
