### PR TITLE
[ticket/11545] Remove DIRECTORY_SEPARATOR dependency from is_absolute

### DIFF
--- a/phpBB/includes/functions.php
+++ b/phpBB/includes/functions.php
@@ -1005,7 +1005,7 @@ if (!function_exists('stripos'))
 */
 function is_absolute($path)
 {
-	return (isset($path[0]) && $path[0] == '/' || (DIRECTORY_SEPARATOR == '\\' && preg_match('#^[a-z]:[/\\\]#i', $path))) ? true : false;
+	return (isset($path[0]) && $path[0] == '/' || preg_match('#^[a-z]:[/\\\]#i', $path)) ? true : false;
 }
 
 /**

--- a/tests/functions/is_absolute_test.php
+++ b/tests/functions/is_absolute_test.php
@@ -14,14 +14,35 @@ class phpbb_functions_is_absolute_test extends phpbb_test_case
 	static public function is_absolute_data()
 	{
 		return array(
+			// Empty
 			array('', false),
-			array('/etc/phpbb', true),
-			array('etc/phpbb', false),
 
-			// Until we got DIRECTORY_SEPARATOR replaced in that function,
-			// test results vary on OS.
-			array('c:\windows', DIRECTORY_SEPARATOR == '\\'),
-			array('C:\Windows', DIRECTORY_SEPARATOR == '\\'),
+			// Absolute unix style
+			array('/etc/phpbb', true),
+			// Unix does not support \ so that is not an absolute path
+			array('\etc\phpbb', false),
+
+			// Absolute windows style
+			array('c:\windows', true),
+			array('C:\Windows', true),
+			array('c:/windows', true),
+			array('C:/Windows', true),
+
+			// Executable
+			array('etc/phpbb', false),
+			array('explorer.exe', false),
+
+			// Relative subdir
+			array('Windows\System32', false),
+			array('Windows\System32\explorer.exe', false),
+			array('Windows/System32', false),
+			array('Windows/System32/explorer.exe', false),
+
+			// Relative updir
+			array('..\Windows\System32', false),
+			array('..\Windows\System32\explorer.exe', false),
+			array('../Windows/System32', false),
+			array('../Windows/System32/explorer.exe', false),
 		);
 	}
 


### PR DESCRIPTION
The given path is an absolute path in general, just not on our current system.

http://tracker.phpbb.com/browse/PHPBB3-11545
