### PR TITLE
[ticket/11536] Fixed incorrect removal of "install" in script_path

### DIFF
--- a/phpBB/install/install_install.php
+++ b/phpBB/install/install_install.php
@@ -1025,8 +1025,8 @@ class install_install extends module
 			}
 
 			// Replace backslashes and doubled slashes (could happen on some proxy setups)
-			$name = str_replace(array('\\', '//', '/install'), '/', $name);
-			$data['script_path'] = trim(dirname($name));
+			$name = str_replace(array('\\', '//'), '/', $name);
+			$data['script_path'] = trim(dirname(dirname($name)));
 		}
 
 		foreach ($this->advanced_config_options as $config_key => $vars)


### PR DESCRIPTION
Earlier the script would incorrectly remove the word "install"
from the script_path when trying to remove the last folder in the
path named "/install". This would lead to issues when the path
you are installing phpBB contained "install". For example
"/install_test/install" would become "/_test".

This change gets the parent folder instead of replacing all
"install". $name contains /install_test/install/index.php
from start and running dirname() gives /install_test/install.
Running dirname once more gives the parent folder of install,
/install_test.

Downside of this would be if the user would place the install folder into another folder, like "/install_test/something/install/" instead of "/install_test/install/". Do we need to take care of that?

http://tracker.phpbb.com/browse/PHPBB3-11536
