### PR TITLE
[ticket/11547] Test fixtures do not support utf8 characters

### DIFF
--- a/tests/dbal/fixtures/utf8_fixture.xml
+++ b/tests/dbal/fixtures/utf8_fixture.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<dataset>
+	<table name="phpbb_config">
+		<column>config_name</column>
+		<column>config_value</column>
+		<column>is_dynamic</column>
+		<row>
+			<value>Belarusian</value>
+			<value>Беларуская</value>
+			<value>0</value>
+		</row>
+		<row>
+			<value>Arabic</value>
+			<value>العربية</value>
+			<value>0</value>
+		</row>
+		<row>
+			<value>Czech</value>
+			<value>Čeština</value>
+			<value>0</value>
+		</row>
+		<row>
+			<value>German</value>
+			<value>Deutsch öäüß</value>
+			<value>0</value>
+		</row>
+	</table>
+</dataset>

--- a/tests/dbal/utf8_test.php
+++ b/tests/dbal/utf8_test.php
@@ -1,0 +1,45 @@
+<?php
+/**
+*
+* @package testing
+* @copyright (c) 2013 phpBB Group
+* @license http://opensource.org/licenses/gpl-2.0.php GNU General Public License v2
+*
+*/
+
+
+class phpbb_dbal_utf8_test extends phpbb_database_test_case
+{
+	public function getDataSet()
+	{
+		return $this->createXMLDataSet(dirname(__FILE__).'/fixtures/utf8_fixture.xml');
+	}
+
+	static public function utf8_data_fixture_data()
+	{
+		return array(
+			array('Belarusian', 'Беларуская'),
+			array('Arabic', 'العربية'),
+			array('Czech', 'Čeština'),
+			array('German', 'Deutsch öäüß'),
+		);
+	}
+
+	/**
+	* @dataProvider utf8_data_fixture_data
+	*/
+	public function test_utf8_data_fixture($english, $local)
+	{
+		$this->markTestIncomplete('Currently UTF8 characters can not be part of fixtures, see PHPBB3-11547');
+
+		$db = $this->new_dbal();
+
+		$sql = "SELECT config_value
+			FROM phpbb_config
+			WHERE config_name = '" . $db->sql_escape($english) . "'";
+		$result = $db->sql_query($sql);
+
+		$this->assertEquals($local, $db->sql_fetchfield('config_value'));
+		$db->sql_freeresult($result);
+	}
+}


### PR DESCRIPTION
Adding incomplete tests for now, until the issue is fixed.

http://tracker.phpbb.com/browse/PHPBB3-11547
