### PR TITLE
[feature/editor-code-tabs] Allow tabs when typing code

### DIFF
--- a/phpBB/styles/prosilver/template/editor.js
+++ b/phpBB/styles/prosilver/template/editor.js
@@ -433,16 +433,14 @@ function getCaretPosition(txtarea) {
 
 			for (i = 0; i < startTags.length; i++) {
 				var tagLength = startTags[i].length;
-				if (start >= tagLength)
-				{
+				if (start >= tagLength) {
 					index = value.lastIndexOf(startTags[i], start - tagLength);
 					lastStart = Math.max(lastStart, index);
 				}
 			}
 			if (lastStart == -1) return false;
 
-			if (start > 0)
-			{
+			if (start > 0) {
 				for (i = 0; i < endTags.length; i++) {
 					index = value.lastIndexOf(endTags[i], start - 1);
 					lastEnd = Math.max(lastEnd, index);


### PR DESCRIPTION
Allow tabs when typing code in textarea.
Keep indentation when typing code in textarea.

It only works when user is typing inside [code] bbcode. If user is not typing code, behavior isn't changed.

Works with modern browsers and IE9+. Older browsers will see default behavior.

http://tracker.phpbb.com/browse/PHPBB3-11557
