### PR TITLE
[ticket/11558] Fix styling for notifications button

### DIFF
--- a/phpBB/styles/prosilver/template/overall_header.html
+++ b/phpBB/styles/prosilver/template/overall_header.html
@@ -137,8 +137,8 @@
 			<!-- IF not S_IS_BOT and S_USER_LOGGED_IN -->
 			<ul class="linklist leftside">
 				<!-- IF S_NOTIFICATIONS_DISPLAY -->
-				<li>
-					<a href="{U_VIEW_ALL_NOTIFICATIONS}" id="notification_list_button">{NOTIFICATIONS_COUNT}</a> &bull;
+				<li class="icon-notification">
+					<a href="{U_VIEW_ALL_NOTIFICATIONS}" id="notification_list_button">{NOTIFICATIONS_COUNT}</a>
 					<div id="notification_list" class="notification_list">
 						<div class="pointer"><div class="pointer_inner"></div></div>
 						<div class="header">

--- a/phpBB/styles/prosilver/theme/buttons.css
+++ b/phpBB/styles/prosilver/theme/buttons.css
@@ -97,20 +97,17 @@ a.sendemail {
 	padding: 1px 0 0 17px;
 }
 
-#notification_list_button:before, #notification_list_button:after {
+.icon-notification:before, .icon-notification:after {
 	display: inline;
 	font: inherit;
-	text-decoration: none;
 }
 
-#notification_list_button:before {
+.icon-notification:before {
 	content: '[';
-	padding-right: 4px;
 }
 
-#notification_list_button:after {
+.icon-notification:after {
 	content: ']';
-	padding-left: 4px;
 }
 
 /* Poster profile icons

--- a/phpBB/styles/prosilver/theme/colours.css
+++ b/phpBB/styles/prosilver/theme/colours.css
@@ -684,10 +684,6 @@ a.sendemail {
 	background-image: url("images/buttons.png");
 }
 
-#notification_list_button:before, #notification_list_button:after {
-	color: #536482;
-}
-
 /* Icon images
 ---------------------------------------- */
 .sitehome						{ background-image: url("./images/icon_home.gif"); }


### PR DESCRIPTION
Replaced [ and ] before and after notifications link in header with CSS styling. 

Works with IE8+ and modern browsers. IE7 users will not see [ and ], but link will look fine for them.

http://tracker.phpbb.com/browse/PHPBB3-11558
