### PR TITLE
[ticket/11551] Fix error in system tab if get_remote_file returns empty string

### DIFF
--- a/phpBB/includes/acp/acp_update.php
+++ b/phpBB/includes/acp/acp_update.php
@@ -39,7 +39,7 @@ class acp_update
 
 		$info = obtain_latest_version_info(request_var('versioncheck_force', false));
 
-		if ($info === false)
+		if (empty($info))
 		{
 			trigger_error('VERSIONCHECK_FAIL', E_USER_WARNING);
 		}

--- a/phpBB/includes/functions_admin.php
+++ b/phpBB/includes/functions_admin.php
@@ -3319,7 +3319,7 @@ function obtain_latest_version_info($force_update = false, $warn_fail = false, $
 		$info = get_remote_file('version.phpbb.com', '/phpbb',
 				((defined('PHPBB_QA')) ? '30x_qa.txt' : '30x.txt'), $errstr, $errno);
 
-		if ($info === false)
+		if (empty($info))
 		{
 			$cache->destroy('versioncheck');
 			if ($warn_fail)


### PR DESCRIPTION
Currently a debug error is thrown. With this patch, it fails without keeping
the admin from being able to access the rest of the System modules by showing
a nicer error "Failed to obtain latest version information."

PHPBB3-11551
