### PR TITLE
[ticket/11578] Add missing underscore after 'validate' function prefix

### DIFF
--- a/phpBB/includes/functions_user.php
+++ b/phpBB/includes/functions_user.php
@@ -1247,7 +1247,7 @@ function validate_data($data, $val_ary)
 		{
 			$function = array_shift($validate);
 			array_unshift($validate, $data[$var]);
-			$function_prefix = (function_exists('phpbb_validate_' . $function)) ? 'phpbb_validate_' : 'validate';
+			$function_prefix = (function_exists('phpbb_validate_' . $function)) ? 'phpbb_validate_' : 'validate_';
 
 			if ($result = call_user_func_array($function_prefix . $function, $validate))
 			{


### PR DESCRIPTION
The underscore after the 'validate' function prefix for the older
functions was dropped by accident in PR #1407. This patch will add it
back.

Ticket: http://tracker.phpbb.com/browse/PHPBB3-11578

PHPBB3-11578
