### PR TITLE
[ticket/11577] Correct over-sized Topic Rows

### DIFF
--- a/phpBB/styles/prosilver/theme/content.css
+++ b/phpBB/styles/prosilver/theme/content.css
@@ -159,7 +159,7 @@ dl.icon dt .list-inner {
 }
 
 dl.icon dt, dl.icon dd {
-	min-height: 30px;
+	min-height: 35px;
 }
 
 dd.posts, dd.topics, dd.views, dd.extra, dd.mark {


### PR DESCRIPTION
Fixes a change made in PR 1331 that oversized topic rows.
Icons in topic rows, in Prosilver, are only 27px high, so we do not need
a min-height as high as 40px. Setting it to 35px is still conservative
and restores the original height of topic rows from before PR 1331.
http://tracker.phpbb.com/browse/PHPBB3-11577

PHPBB3-11577
