### PR TITLE
[ticket/11538] Add admin as admins leader and moderator in memberlist_test

### DIFF
--- a/tests/functional/common_groups_test.php
+++ b/tests/functional/common_groups_test.php
@@ -30,12 +30,6 @@ abstract class phpbb_functional_common_groups_test extends phpbb_functional_test
 	*/
 	public function test_groups_manage($input, $expected)
 	{
-		$this->markTestIncomplete(
-			'Test fails on develop due to another test deleting the Administrators group.'
-		);
-		// See https://github.com/phpbb/phpbb3/pull/1407#issuecomment-18465480
-		// and https://gist.github.com/bantu/22dc4f6c6c0b8f9e0fa1
-
 		$this->login();
 		$this->admin_login();
 		$this->add_lang(array('ucp', 'acp/groups'));

--- a/tests/functional/memberlist_test.php
+++ b/tests/functional/memberlist_test.php
@@ -95,5 +95,17 @@ class phpbb_functional_memberlist_test extends phpbb_functional_test_case
 		$crawler = $this->get_memberlist_leaders_table_crawler();
 		$this->assertNotContains('memberlist-test-moderator', $crawler->eq(0)->text());
 		$this->assertContains('memberlist-test-moderator', $crawler->eq(1)->text());
+
+		// Add admin to moderators, should be visible as moderator
+		$this->add_user_group('GLOBAL_MODERATORS', array('admin'), true);
+		$crawler = $this->get_memberlist_leaders_table_crawler();
+		$this->assertNotContains('admin', $crawler->eq(0)->text());
+		$this->assertContains('admin', $crawler->eq(1)->text());
+
+		// Add admin to admins as leader, should be visible as admin, not moderator
+		$this->add_user_group('ADMINISTRATORS', array('admin'), true, true);
+		$crawler = $this->get_memberlist_leaders_table_crawler();
+		$this->assertContains('admin', $crawler->eq(0)->text());
+		$this->assertNotContains('admin', $crawler->eq(1)->text());
 	}
 }

--- a/tests/test_framework/phpbb_functional_test_case.php
+++ b/tests/test_framework/phpbb_functional_test_case.php
@@ -361,7 +361,7 @@ class phpbb_functional_test_case extends phpbb_test_case
 		return group_user_del($group_id, false, $usernames, $group_name);
 	}
 
-	protected function add_user_group($group_name, $usernames)
+	protected function add_user_group($group_name, $usernames, $default = false, $leader = false)
 	{
 		global $db, $cache, $auth, $config, $phpbb_dispatcher, $phpbb_log, $phpbb_container, $phpbb_root_path, $phpEx;
 
@@ -400,7 +400,7 @@ class phpbb_functional_test_case extends phpbb_test_case
 		$group_id = (int) $db->sql_fetchfield('group_id');
 		$db->sql_freeresult($result);
 
-		return group_user_add($group_id, false, $usernames, $group_name);
+		return group_user_add($group_id, false, $usernames, $group_name, $default, $leader);
 	}
 
 	protected function login($username = 'admin')


### PR DESCRIPTION
Removing the admin user from the admin and moderator group in memberlist_test
potentially breaks other tests, i.e. the ucp groups test.

Ticket: http://tracker.phpbb.com/browse/PHPBB3-11538

PHPBB3-11538
