### PR TITLE
[ticket/11602] Do not call localize_errors() if avatars are disabled

### DIFF
--- a/phpBB/includes/acp/acp_groups.php
+++ b/phpBB/includes/acp/acp_groups.php
@@ -591,7 +591,7 @@ class acp_groups
 
 				$avatar = phpbb_get_group_avatar($group_row, 'GROUP_AVATAR', true);
 
-				if (!$update)
+				if (isset($phpbb_avatar_manager) && !$update)
 				{
 					// Merge any avatar errors into the primary error array
 					$error = array_merge($error, $phpbb_avatar_manager->localize_errors($user, $avatar_error));

--- a/phpBB/includes/ucp/ucp_groups.php
+++ b/phpBB/includes/ucp/ucp_groups.php
@@ -691,7 +691,7 @@ class ucp_groups
 							}
 						}
 
-						if (!$update)
+						if (isset($phpbb_avatar_manager) && !$update)
 						{
 							// Merge any avatars errors into the primary error array
 							$error = array_merge($error, $phpbb_avatar_manager->localize_errors($user, $avatar_error));


### PR DESCRIPTION
The avatar manager's method localize_errors() shouldn't be called if
avatars are disabled in the config.

Ticket: http://tracker.phpbb.com/browse/PHPBB3-11602

PHPBB3-11602
