### PR TITLE
[ticket/11561] Specify used tables in notification fixture, so they are emptied

### DIFF
--- a/tests/notification/fixtures/notification.xml
+++ b/tests/notification/fixtures/notification.xml
@@ -1,5 +1,13 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <dataset>
+	<table name="phpbb_bookmarks">
+	</table>
 	<table name="phpbb_notifications">
+	</table>
+	<table name="phpbb_notification_types">
+	</table>
+	<table name="phpbb_topics_watch">
+	</table>
+	<table name="phpbb_user_notifications">
 	</table>
 </dataset>


### PR DESCRIPTION
http://tracker.phpbb.com/browse/PHPBB3-11561
