### PR TITLE
[ticket/11253] Fix auth for signature module for updating from installations installed prior to #1025 being merged

### DIFF
--- a/phpBB/includes/db/migration/data/310/signature_module_auth.php
+++ b/phpBB/includes/db/migration/data/310/signature_module_auth.php
@@ -15,8 +15,7 @@ class phpbb_db_migration_data_310_signature_module_auth extends phpbb_db_migrati
 			FROM ' . MODULES_TABLE . "
 			WHERE module_class = 'ucp'
 				AND module_basename = 'ucp_profile'
-				AND module_mode = 'signature'
-				AND module_auth = ''";
+				AND module_mode = 'signature'";
 		$result = $this->db->sql_query($sql);
 		$module_auth = $this->db_sql_fetchfield('module_auth');
 		$this->db->sql_freeresult($result);
@@ -45,7 +44,8 @@ class phpbb_db_migration_data_310_signature_module_auth extends phpbb_db_migrati
 			SET module_auth = 'acl_u_sig'
 			WHERE module_class = 'ucp'
 				AND module_basename = 'ucp_profile'
-				AND module_mode = 'signature'";
+				AND module_mode = 'signature'
+				AND module_auth = ''";
 		$this->db->sql_query($sql);
 	}
 }


### PR DESCRIPTION
That's a mouthful. It is better explained in the ticket, but basically the fix applied in #1025 only applies to 3.0.x updates, and 3.1-dev installs that occur after that patch was merged. This patch simply adds a migration to make sure that updating from a board running 3.1-dev from prior to #1025 (i.e. specifically, area51) gets the fix as well.

http://tracker.phpbb.com/browse/PHPBB3-11253
