### PR TITLE
[ticket/11615] Rename and remove magic number in session/init_test.php -> creation test.php

### DIFF
--- a/tests/session/creation_test.php
+++ b/tests/session/creation_test.php
@@ -35,7 +35,7 @@ class phpbb_session_creation_test extends phpbb_database_test_case
 		$this->assertSqlResultEquals(
 			array(array('session_user_id' => 3)),
 			$sql,
-			'Check if exacly one session for user id 3 was created'
+			'Check if exactly one session for user id 3 was created'
 		);
 
 		$one_year_in_seconds = 365 * 24 * 60 * 60;


### PR DESCRIPTION
These changes make the test easier to read for people who aren't previously familiar with the session test suite.
