### PR TITLE
[ticket/11593] initialize $is_expr as null before being passed to get_varref

### DIFF
--- a/phpBB/includes/template/filter.php
+++ b/phpBB/includes/template/filter.php
@@ -475,6 +475,7 @@ class phpbb_template_filter extends php_user_filter
 	*/
 	private function compile_var_tags(&$text_blocks)
 	{
+		$is_expr = null;
 		$text_blocks = $this->get_varref($text_blocks, $is_expr);
 		$lang_replaced = $this->compile_language_tags($text_blocks);
 


### PR DESCRIPTION
http://tracker.phpbb.com/browse/PHPBB3-11593
PHPBB3-11593
