### PR TITLE
[ticket/11668] Run lint test at the end of the test suite

### DIFF
--- a/phpunit.xml.all
+++ b/phpunit.xml.all
@@ -15,6 +15,10 @@
         <testsuite name="phpBB Test Suite">
             <directory suffix="_test.php">./tests/</directory>
             <exclude>./tests/functional</exclude>
+            <exclude>tests/lint_test.php</exclude>
+        </testsuite>
+        <testsuite name="phpBB Lint Test">
+            <file>tests/lint_test.php</file>
         </testsuite>
         <testsuite name="phpBB Functional Tests">
             <directory suffix="_test.php" phpVersion="5.3.0" phpVersionOperator=">=">./tests/functional</directory>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -15,6 +15,10 @@
         <testsuite name="phpBB Test Suite">
             <directory suffix="_test.php">./tests/</directory>
             <exclude>./tests/functional</exclude>
+            <exclude>tests/lint_test.php</exclude>
+        </testsuite>
+        <testsuite name="phpBB Lint Test">
+            <file>tests/lint_test.php</file>
         </testsuite>
         <testsuite name="phpBB Functional Tests">
             <directory suffix="_test.php" phpVersion="5.3.0" phpVersionOperator=">=">./tests/functional</directory>

--- a/phpunit.xml.functional
+++ b/phpunit.xml.functional
@@ -15,6 +15,10 @@
         <testsuite name="phpBB Test Suite">
             <directory suffix="_test.php">./tests/</directory>
             <exclude>./tests/functional</exclude>
+            <exclude>tests/lint_test.php</exclude>
+        </testsuite>
+        <testsuite name="phpBB Lint Test">
+            <file>tests/lint_test.php</file>
         </testsuite>
         <testsuite name="phpBB Functional Tests">
             <directory suffix="_test.php" phpVersion="5.3.0" phpVersionOperator=">=">./tests/functional</directory>


### PR DESCRIPTION
The lint test is very slow. Running it at the end should speed up the development cycle.

This will have some conflicts when merging into develop, so resolve them properly.

[PHPBB3-11668](http://tracker.phpbb.com/browse/PHPBB3-11668)
