### PR TITLE
[ticket/11690] Old module class names may get autoloaded by class_exists

### DIFF
--- a/phpBB/includes/acp/acp_modules.php
+++ b/phpBB/includes/acp/acp_modules.php
@@ -575,13 +575,20 @@ class acp_modules
 			// format. phpbb_acp_info_acp_foo needs to be turned into
 			// acp_foo_info and the respective file has to be included
 			// manually because it does not support auto loading
-			if (!class_exists($info_class))
+			$old_info_class_file = str_replace("phpbb_{$module_class}_info_", '', $cur_module);
+			$old_info_class = $old_info_class_file . '_info';
+
+			if (class_exists($old_info_class))
 			{
-				$info_class_file = str_replace("phpbb_{$module_class}_info_", '', $cur_module);
-				$info_class = $info_class_file . '_info';
-				if (!class_exists($info_class) && file_exists($directory . $info_class_file . '.' . $phpEx))
+				$info_class = $old_info_class;
+			}
+			else if (!class_exists($info_class))
+			{
+				$info_class = $old_info_class;
+				// need to check class exists again because previous checks triggered autoloading
+				if (!class_exists($info_class) && file_exists($directory . $old_info_class_file . '.' . $phpEx))
 				{
-					include($directory . $info_class_file . '.' . $phpEx);
+					include($directory . $old_info_class_file . '.' . $phpEx);
 				}
 			}
 


### PR DESCRIPTION
http://tracker.phpbb.com/browse/PHPBB3-11690
