### PR TITLE
[ticket/11697] author_search() used incorrect parameter

### DIFF
--- a/phpBB/phpbb/search/fulltext_mysql.php
+++ b/phpBB/phpbb/search/fulltext_mysql.php
@@ -542,7 +542,7 @@ class phpbb_search_fulltext_mysql extends phpbb_search_base
 	* @param	int			$per_page			number of ids each page is supposed to contain
 	* @return	boolean|int						total number of results
 	*/
-	public function author_search($type, $firstpost_only, $sort_by_sql, $sort_key, $sort_dir, $sort_days, $ex_fid_ary, $m_approve_fid_ary, $topic_id, $author_ary, $author_name, &$id_ary, &$start, $per_page)
+	public function author_search($type, $firstpost_only, $sort_by_sql, $sort_key, $sort_dir, $sort_days, $ex_fid_ary, $post_visibility, $topic_id, $author_ary, $author_name, &$id_ary, &$start, $per_page)
 	{
 		// No author? No posts
 		if (!sizeof($author_ary))


### PR DESCRIPTION
The author_search() function in fulltext_mysql.php had an argument
$m_approve_fid_ary parameter but it was changed in the Docblock
and code to $post_visibility. This change renames that argument
according to the docblock, the code and to mirror the other classes.

http://tracker.phpbb.com/browse/PHPBB3-11697

PHPBB3-11697
