### PR TITLE
[ticket/11713] Do not remove module if it couldn't be deleted

### DIFF
--- a/phpBB/adm/style/ajax.js
+++ b/phpBB/adm/style/ajax.js
@@ -127,8 +127,10 @@ phpbb.addAjaxCallback('activate_deactivate', function(res) {
  * The removes the parent row of the link or form that triggered the callback,
  * and is good for stuff like the removal of forums.
  */
-phpbb.addAjaxCallback('row_delete', function() {
-	$(this).parents('tr').remove();
+phpbb.addAjaxCallback('row_delete', function(res) {
+	if (res.SUCCESS !== false) {
+		$(this).parents('tr').remove();
+	}
 });
 
 

--- a/phpBB/includes/acp/acp_modules.php
+++ b/phpBB/includes/acp/acp_modules.php
@@ -379,6 +379,7 @@ class acp_modules
 				$json_response->send(array(
 					'MESSAGE_TITLE'	=> $user->lang('ERROR'),
 					'MESSAGE_TEXT'	=> implode('<br />', $errors),
+					'SUCCESS'	=> false,
 				));
 			}
 


### PR DESCRIPTION
Up to now, the module or module category was always removed with jQuery,
even if there was an error. With this change, the modules will not be deleted
by jQuery if the return JSON array will have SUCCESS set to false.

Ticket: http://tracker.phpbb.com/browse/PHPBB3-11713

PHPBB3-11713
