### PR TITLE
[ticket/11725] Use new paths for phpbb_class_loader in file.php

### DIFF
--- a/phpBB/download/file.php
+++ b/phpBB/download/file.php
@@ -41,7 +41,7 @@ if (isset($_GET['avatar']))
 		exit;
 	}
 
-	require($phpbb_root_path . 'includes/class_loader.' . $phpEx);
+	require($phpbb_root_path . 'phpbb/class_loader.' . $phpEx);
 
 	require($phpbb_root_path . 'includes/constants.' . $phpEx);
 	require($phpbb_root_path . 'includes/functions.' . $phpEx);
@@ -50,7 +50,7 @@ if (isset($_GET['avatar']))
 	require($phpbb_root_path . 'includes/utf/utf_tools.' . $phpEx);
 
 	// Setup class loader first
-	$phpbb_class_loader = new phpbb_class_loader('phpbb_', "{$phpbb_root_path}includes/", $phpEx);
+	$phpbb_class_loader = new phpbb_class_loader('phpbb_', "{$phpbb_root_path}phpbb/", $phpEx);
 	$phpbb_class_loader->register();
 	$phpbb_class_loader_ext = new phpbb_class_loader('phpbb_ext_', "{$phpbb_root_path}ext/", $phpEx);
 	$phpbb_class_loader_ext->register();


### PR DESCRIPTION
In the PR #1559, the paths were changed from "{$phpbb_root_path}includes/" to
"{$phpbb_root_path}phpbb/" for the class loader. However, this was not changed
in all files that use it.

Ticket: http://tracker.phpbb.com/browse/PHPBB3-11725

PHPBB3-11725
