### PR TITLE
[ticket/10917] Fix issue which was created of my previous pull request and removed variable

### DIFF
--- a/phpBB/install/install_update.php
+++ b/phpBB/install/install_update.php
@@ -58,7 +58,6 @@ class install_update extends module
 	var $new_location;
 	var $latest_version;
 	var $current_version;
-	var $unequal_version;
 
 	var $update_to_version;
 
@@ -76,7 +75,6 @@ class install_update extends module
 
 		$this->tpl_name = 'install_update';
 		$this->page_title = 'UPDATE_INSTALLATION';
-		$this->unequal_version = false;
 
 		$this->old_location = $phpbb_root_path . 'install/update/old/';
 		$this->new_location = $phpbb_root_path . 'install/update/new/';
@@ -195,8 +193,6 @@ class install_update extends module
 		// Check if the update files are actually meant to update from the current version
 		if ($this->current_version != $this->update_info['version']['from'])
 		{
-			$this->unequal_version = true;
-
 			$template->assign_vars(array(
 				'S_ERROR'	=> true,
 				'ERROR_MSG'	=> sprintf($user->lang['INCOMPATIBLE_UPDATE_FILES'], $this->current_version, $this->update_info['version']['from'], $this->update_info['version']['to']),
@@ -206,8 +202,6 @@ class install_update extends module
 		// Check if the update files stored are for the latest version...
 		if (version_compare(strtolower($this->latest_version), strtolower($this->update_info['version']['to']), '>'))
 		{
-			$this->unequal_version = true;
-
 			$template->assign_vars(array(
 				'S_WARNING'		=> true,
 				'WARNING_MSG'	=> sprintf($user->lang['OLD_UPDATE_FILES'], $this->update_info['version']['from'], $this->update_info['version']['to'], $this->latest_version))
@@ -294,7 +288,7 @@ class install_update extends module
 				);
 
 				// Print out version the update package updates to
-				if ($this->unequal_version)
+				if ($this->latest_version != $this->update_info['version']['to'])
 				{
 					$template->assign_var('PACKAGE_VERSION', $this->update_info['version']['to']);
 				}


### PR DESCRIPTION
Unfortunately my previous pull request "created" an issue which
made it impossible to update from a version which was released
before 3.0.10. Further it wasn't noticed until the pull request was
merged.

bantu mentioned that this changes the semantics of
`$this->unequal_version`. So instead of changing the name
I decided to remove it because it was only used once and makes
only sense in the second if statement and not in the first where it
just cheks if the current package is meant to update from the
current version.

http://tracker.phpbb.com/browse/PHPBB3-10917
