### PR TITLE
[ticket/11663] Make generate_text_for_storage return the errors.

### DIFF
--- a/phpBB/includes/functions_content.php
+++ b/phpBB/includes/functions_content.php
@@ -481,6 +481,14 @@ function generate_text_for_display($text, $uid, $bitfield, $flags, $censor_text 
 * For parsing custom parsed text to be stored within the database.
 * This function additionally returns the uid and bitfield that needs to be stored.
 * Expects $text to be the value directly from request_var() and in it's non-parsed form
+* 
+* @param string $text The text to be replaced with the parsed one
+* @param string $uid The BBCode uid for this parse
+* @param string $bitfield The BBCode bitfield for this parse
+* @param int $flags The allow_bbcode, allow_urls and allow_smilies compiled into a single integer.
+* @param bool $allow_bbcode If BBCode is allowed (i.e. if BBCode is parsed)
+* @param bool $allow_urls If urls is allowed
+* @param bool $allow_smilies If smilies are allowed
 *
 * @return array	An array of string with the errors that occurred while parsing
 */


### PR DESCRIPTION
generate_text_for_storage does not return anything, all returned values are outputted using the parameters so this uses the returned value with the same idea as many C language functions where the returned value is if all went well or not and if it didn't what went wrong.

PHPBB3-11663
