### PR TITLE
[ticket/11789] Remove inline color in memberlist_view

### DIFF
--- a/phpBB/styles/subsilver2/template/memberlist_view.html
+++ b/phpBB/styles/subsilver2/template/memberlist_view.html
@@ -18,7 +18,7 @@
 			<table cellspacing="1" cellpadding="2" border="0">
 			<!-- IF S_USER_INACTIVE -->
 			<tr>
-				<td align="center" style="color: red;"><b class="gen">{L_USER_IS_INACTIVE}</b><br />{L_INACTIVE_REASON}: {USER_INACTIVE_REASON}<br /><br /></td>
+				<td align="center"><b class="gen inactive">{L_USER_IS_INACTIVE}</b><br />{L_INACTIVE_REASON}: {USER_INACTIVE_REASON}<br /><br /></td>
 			</tr>
 			<!-- ENDIF -->
 			<tr>

--- a/phpBB/styles/subsilver2/theme/stylesheet.css
+++ b/phpBB/styles/subsilver2/theme/stylesheet.css
@@ -296,7 +296,7 @@ p.topicdetails {
 	color: green;
 }
 
-.offline, .error {
+.offline, .error, .inactive {
 	color: red;
 }
 


### PR DESCRIPTION
http://tracker.phpbb.com/browse/PHPBB3-11789

Missed one entry. Also red color is now used only for message, not whole table cell.
