### PR TITLE
[ticket/11809] Ensure code.js is first script included after jQuery

### DIFF
--- a/phpBB/styles/prosilver/template/overall_footer.html
+++ b/phpBB/styles/prosilver/template/overall_footer.html
@@ -58,8 +58,8 @@
 
 <script type="text/javascript" src="{T_JQUERY_LINK}"></script>
 <!-- IF S_JQUERY_FALLBACK --><script type="text/javascript">window.jQuery || document.write(unescape('%3Cscript src="{T_ASSETS_PATH}/javascript/jquery.js?assets_version={T_ASSETS_VERSION}" type="text/javascript"%3E%3C/script%3E'));</script><!-- ENDIF -->
+<script type="text/javascript" src="{T_ASSETS_PATH}/javascript/core.js?assets_version={T_ASSETS_VERSION}"></script>
 <!-- INCLUDEJS forum_fn.js -->
-<!-- INCLUDEJS {T_ASSETS_PATH}/javascript/core.js -->
 <!-- INCLUDEJS ajax.js -->
 
 <!-- EVENT overall_footer_after -->

--- a/phpBB/styles/subsilver2/template/overall_footer.html
+++ b/phpBB/styles/subsilver2/template/overall_footer.html
@@ -13,7 +13,7 @@
 
 <script type="text/javascript" src="{T_JQUERY_LINK}"></script>
 <!-- IF S_JQUERY_FALLBACK --><script type="text/javascript">window.jQuery || document.write(unescape('%3Cscript src="{T_ASSETS_PATH}/javascript/jquery.js?assets_version={T_ASSETS_VERSION}" type="text/javascript"%3E%3C/script%3E'));</script><!-- ENDIF -->
-<!-- INCLUDEJS {T_ASSETS_PATH}/javascript/core.js -->
+<script type="text/javascript" src="{T_ASSETS_PATH}/javascript/core.js?assets_version={T_ASSETS_VERSION}"></script>
 
 <!-- EVENT overall_footer_after -->
 


### PR DESCRIPTION
The file core.js sets up most of the AJAX and jQuery related framework for
phpBB. Due to this, it needs to be included before any other javascript file
in order to ensure that subsequent files can use the phpBB variables and
functions. Currently, it is however loaded with INCLUDEJS in overall_footer
which causes it to be loaded after every other javascript file except for the
style specific ajax.js. This causes every javascript file that is included
before core.js and is using the phpBB AJAX functions or variables to break.

Ticket: http://tracker.phpbb.com/browse/PHPBB3-11809

PHPBB3-11809
