### PR TITLE
[ticket/11803] Revert POLL_MAX_OPTIONS min HTML attribute's value to 0

### DIFF
--- a/phpBB/styles/prosilver/template/posting_poll_body.html
+++ b/phpBB/styles/prosilver/template/posting_poll_body.html
@@ -26,7 +26,7 @@
 
 		<dl>
 			<dt><label for="poll_max_options">{L_POLL_MAX_OPTIONS}{L_COLON}</label></dt>
-			<dd><input type="number" min="1" max="999" name="poll_max_options" id="poll_max_options" size="3" maxlength="3" value="{POLL_MAX_OPTIONS}" class="inputbox autowidth" /></dd>
+			<dd><input type="number" min="0" max="999" name="poll_max_options" id="poll_max_options" size="3" maxlength="3" value="{POLL_MAX_OPTIONS}" class="inputbox autowidth" /></dd>
 			<dd>{L_POLL_MAX_OPTIONS_EXPLAIN}</dd>
 		</dl>
 		<dl>


### PR DESCRIPTION
When it was made the min number of options allowed to a user was 1 but 0 can also be used as it means unlimited.

PHPBB3-11803
