### PR TITLE
[ticket/11769-develop] Correctly supply the post author's username in posting.php - Develop

### DIFF
--- a/phpBB/includes/functions_posting.php
+++ b/phpBB/includes/functions_posting.php
@@ -2166,6 +2166,11 @@ function submit_post($mode, $subject, $username, $topic_type, &$poll, &$data, $u
 		update_forum_tracking_info($data['forum_id'], $forum_last_post_time, $f_mark_time, false);
 	}
 
+	// If a username was supplied or the poster is a guest, we will use the supplied username.
+	// Doing it this way we can use "...post by guest-username..." in notifications when
+	// "guest-username" is supplied or ommit the username if it is not.
+	$username = ($username !== '' || !$user->data['is_registered']) ? $username : $user->data['username'];
+
 	// Send Notifications
 	$notification_data = array_merge($data, array(
 		'topic_title'		=> (isset($data['topic_title'])) ? $data['topic_title'] : $subject,

--- a/phpBB/language/en/email/forum_notify.txt
+++ b/phpBB/language/en/email/forum_notify.txt
@@ -2,7 +2,7 @@ Subject: Forum post notification - "{FORUM_NAME}"
 
 Hello {USERNAME},
 
-You are receiving this notification because you are watching the forum "{FORUM_NAME}" at "{SITENAME}". This forum has received a new reply to the topic "{TOPIC_TITLE}"<!-- IF AUTHOR_NAME --> by {AUTHOR_NAME}<!-- ENDIF --> since your last visit. You can use the following link to view the last unread reply, no more notifications will be sent until you visit the topic.
+You are receiving this notification because you are watching the forum "{FORUM_NAME}" at "{SITENAME}". This forum has received a new reply to the topic "{TOPIC_TITLE}"<!-- IF AUTHOR_NAME !== '' --> by {AUTHOR_NAME}<!-- ENDIF --> since your last visit. You can use the following link to view the last unread reply, no more notifications will be sent until you visit the topic.
 
 {U_NEWEST_POST}
 

--- a/phpBB/language/en/email/newtopic_notify.txt
+++ b/phpBB/language/en/email/newtopic_notify.txt
@@ -2,7 +2,7 @@ Subject: New topic notification - "{FORUM_NAME}"
 
 Hello {USERNAME},
 
-You are receiving this notification because you are watching the forum "{FORUM_NAME}" at "{SITENAME}". This forum has received a new topic<!-- IF AUTHOR_NAME --> by {AUTHOR_NAME}<!-- ENDIF --> since your last visit, "{TOPIC_TITLE}". You can use the following link to view the forum, no more notifications will be sent until you visit the forum.
+You are receiving this notification because you are watching the forum "{FORUM_NAME}" at "{SITENAME}". This forum has received a new topic<!-- IF AUTHOR_NAME !== '' --> by {AUTHOR_NAME}<!-- ENDIF --> since your last visit, "{TOPIC_TITLE}". You can use the following link to view the forum, no more notifications will be sent until you visit the forum.
 
 {U_FORUM}
 

--- a/phpBB/language/en/email/topic_notify.txt
+++ b/phpBB/language/en/email/topic_notify.txt
@@ -2,7 +2,7 @@ Subject: Topic reply notification - "{TOPIC_TITLE}"
 
 Hello {USERNAME},
 
-You are receiving this notification because you are watching the topic "{TOPIC_TITLE}" at "{SITENAME}". This topic has received a reply<!-- IF AUTHOR_NAME --> by {AUTHOR_NAME}<!-- ENDIF --> since your last visit. You can use the following link to view the replies made, no more notifications will be sent until you visit the topic.
+You are receiving this notification because you are watching the topic "{TOPIC_TITLE}" at "{SITENAME}". This topic has received a reply<!-- IF AUTHOR_NAME !== '' --> by {AUTHOR_NAME}<!-- ENDIF --> since your last visit. You can use the following link to view the replies made, no more notifications will be sent until you visit the topic.
 
 If you want to view the newest post made since your last visit, click the following link:
 {U_NEWEST_POST}

--- a/phpBB/posting.php
+++ b/phpBB/posting.php
@@ -1152,8 +1152,14 @@ if ($submit || $preview || $refresh)
 				$data['topic_posts_softdeleted'] = $post_data['topic_posts_softdeleted'];
 			}
 
+			// Only return the username when it is either a guest posting or we are editing a post and
+			// the username was supplied; otherwise post_data might hold the data of the post that is
+			// being quoted (which could result in the username being returned being that of the quoted
+			// post's poster, not the poster of the current post). See: PHPBB3-11769 for more information.
+			$post_author_name = ((!$user->data['is_registered'] || $mode == 'edit') && $post_data['username'] !== '') ? $post_data['username'] : '';
+
 			// The last parameter tells submit_post if search indexer has to be run
-			$redirect_url = submit_post($mode, $post_data['post_subject'], $post_data['username'], $post_data['topic_type'], $poll, $data, $update_message, ($update_message || $update_subject) ? true : false);
+			$redirect_url = submit_post($mode, $post_data['post_subject'], $post_author_name, $post_data['topic_type'], $poll, $data, $update_message, ($update_message || $update_subject) ? true : false);
 
 			if ($config['enable_post_confirm'] && !$user->data['is_registered'] && (isset($captcha) && $captcha->is_solved() === true) && ($mode == 'post' || $mode == 'reply' || $mode == 'quote'))
 			{


### PR DESCRIPTION
Only supply the username, when it is a guest posting and it was supplied.
otherwise post_data might hold data of the post we quote, in which case
username is the original poster, not the current one.

http://tracker.phpbb.com/browse/PHPBB3-11769
