### PR TITLE
[ticket/11829] Use report_closed to determine status in MCP report_details

### DIFF
--- a/phpBB/includes/mcp/mcp_pm_reports.php
+++ b/phpBB/includes/mcp/mcp_pm_reports.php
@@ -161,6 +161,7 @@ class mcp_pm_reports
 					'S_CLOSE_ACTION'		=> append_sid("{$phpbb_root_path}mcp.$phpEx", 'i=pm_reports&amp;mode=pm_report_details&amp;r=' . $report_id),
 					'S_CAN_VIEWIP'			=> $auth->acl_getf_global('m_info'),
 					'S_POST_REPORTED'		=> $pm_info['message_reported'],
+					'S_REPORT_CLOSED'		=> $report['report_closed'],
 					'S_USER_NOTES'			=> true,
 
 					'U_MCP_REPORT'				=> append_sid("{$phpbb_root_path}mcp.$phpEx", 'i=pm_reports&amp;mode=pm_report_details&amp;r=' . $report_id),

--- a/phpBB/includes/mcp/mcp_reports.php
+++ b/phpBB/includes/mcp/mcp_reports.php
@@ -189,6 +189,7 @@ class mcp_reports
 					'S_POST_REPORTED'		=> $post_info['post_reported'],
 					'S_POST_UNAPPROVED'		=> ($post_info['post_visibility'] == ITEM_UNAPPROVED),
 					'S_POST_LOCKED'			=> $post_info['post_edit_locked'],
+					'S_REPORT_CLOSED'		=> $report['report_closed'],
 					'S_USER_NOTES'			=> true,
 
 					'U_EDIT'					=> ($auth->acl_get('m_edit', $post_info['forum_id'])) ? append_sid("{$phpbb_root_path}posting.$phpEx", "mode=edit&amp;f={$post_info['forum_id']}&amp;p={$post_info['post_id']}") : '',

--- a/phpBB/styles/prosilver/template/mcp_post.html
+++ b/phpBB/styles/prosilver/template/mcp_post.html
@@ -13,7 +13,7 @@
 		<div class="postbody">
 			<h3>{L_REPORT_REASON}{L_COLON} {REPORT_REASON_TITLE}</h3>
 			<p class="author">{L_REPORTED} {L_POST_BY_AUTHOR} {REPORTER_FULL} &laquo; {REPORT_DATE}</p>
-		<!-- IF not S_POST_REPORTED -->
+		<!-- IF S_REPORT_CLOSED -->
 			<p class="rules">{L_REPORT_CLOSED}</p>
 		<!-- ENDIF -->
 			<div class="content">
@@ -31,7 +31,7 @@
 	<form method="post" id="mcp_report" action="{S_CLOSE_ACTION}">
 
 	<fieldset class="submit-buttons">
-		<!-- IF S_POST_REPORTED -->
+		<!-- IF not S_REPORT_CLOSED -->
 			<input class="button1" type="submit" value="{L_CLOSE_REPORT}" name="action[close]" /> &nbsp;
 		<!-- ENDIF -->
 		<input class="button2" type="submit" value="{L_DELETE_REPORT}" name="action[delete]" />

--- a/phpBB/styles/subsilver2/template/mcp_post.html
+++ b/phpBB/styles/subsilver2/template/mcp_post.html
@@ -28,7 +28,7 @@
 		</tr>
 	<!-- ENDIF -->
 	<tr>
-		<td class="cat" align="center" colspan="2"><!-- IF S_POST_REPORTED --><input class="btnmain" type="submit" value="{L_CLOSE_REPORT}" name="action[close]" /><!-- ELSE -->{L_REPORT_CLOSED}<!-- ENDIF --> &nbsp; <input class="btnlite" type="submit" value="{L_DELETE_REPORT}" name="action[delete]" /></td>
+		<td class="cat" align="center" colspan="2"><!-- IF not S_REPORT_CLOSED --><input class="btnmain" type="submit" value="{L_CLOSE_REPORT}" name="action[close]" /><!-- ELSE -->{L_REPORT_CLOSED}<!-- ENDIF --> &nbsp; <input class="btnlite" type="submit" value="{L_DELETE_REPORT}" name="action[delete]" /></td>
 	</tr>
 	</table>
 


### PR DESCRIPTION
http://tracker.phpbb.com/browse/PHPBB3-11829

Instead of using post_reported of the post or message_reported of the pm, use
report_closed of the report itself to reliably determine whether this
particular report is closed or not in the report_details view of the MCP.
This fixes a bug where the report_details view would not show that the report
shown was closed and display a "Close report" button that had no effect.
