### PR TITLE
[ticket/11864] Do not call exit after display_progress_bar in acp_forums

### DIFF
--- a/phpBB/includes/acp/acp_forums.php
+++ b/phpBB/includes/acp/acp_forums.php
@@ -56,7 +56,6 @@ class acp_forums
 				$total = request_var('total', 0);
 
 				$this->display_progress_bar($start, $total);
-				exit;
 			break;
 
 			case 'delete':


### PR DESCRIPTION
The progress bar is called with the method display_progress_bar() in the
acp_forums files. This method then call adm_page_footer() which also calls
exit_handler(). Therefore, the exit; in acp_forums after
$this->display_progress_bar() is obsolete and shouldn't exist in the first
place.

PHPBB3-11864
