### PR TITLE
[ticket/11901] Pass empty string as relative_url for non-local magic URL...

### DIFF
--- a/phpBB/includes/functions_content.php
+++ b/phpBB/includes/functions_content.php
@@ -773,7 +773,8 @@ function make_clickable($text, $server_url = false, $class = 'postlink')
 		{
 			$text = preg_replace_callback($magic_args[0], function($matches) use ($magic_args)
 			{
-				return make_clickable_callback($magic_args[1], $matches[1], $matches[2], $matches[3], $magic_args[2]);
+				$relative_url = isset($matches[3]) ? $matches[3] : '';
+				return make_clickable_callback($magic_args[1], $matches[1], $matches[2], $relative_url, $magic_args[2]);
 			}, $text);
 		}
 	}


### PR DESCRIPTION
Only the regular expression for MAGIC_URL_LOCAL has three capturing groups. As
a result $matches[3] is only set in this case. Prior to PHPBB3-11606 an empty
string was passed to make_clickable_callback() as a replacement in case of less
than three capturing groups. This patch reintroduces the empty string.

Regression from 49c12ef4be229bf2223139298766ef441b075fbc.

PHPBB3-11901

http://tracker.phpbb.com/browse/PHPBB3-11901
