### PR TITLE
[task/github-readme/travis] Fix Travis-Badge and link

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ Find support and lots more on [phpBB.com](http://www.phpbb.com)! Discuss the dev
 ## AUTOMATED TESTING
 
 We have unit and functional tests in order to prevent regressions. You can view the bamboo continuous integration [here](http://bamboo.phpbb.com) or check our travis build below.
-develop - [![Build Status](https://secure.travis-ci.org/phpbb/phpbb3.png?branch=develop)](http://travis-ci.org/phpbb/phpbb3)
-develop-olympus - [![Build Status](https://secure.travis-ci.org/phpbb/phpbb3.png?branch=develop-olympus)](http://travis-ci.org/phpbb/phpbb3)
+develop - [![Build Status](https://secure.travis-ci.org/phpbb/phpbb.png?branch=develop)](http://travis-ci.org/phpbb/phpbb)
+develop-olympus - [![Build Status](https://secure.travis-ci.org/phpbb/phpbb.png?branch=develop-olympus)](http://travis-ci.org/phpbb/phpbb)
 
 ## LICENSE
 


### PR DESCRIPTION
restore the travis badge and point to the status-page
