### PR TITLE
[ticket/11534] Check remote avatar content type if possible

### DIFF
--- a/phpBB/phpbb/avatar/driver/remote.php
+++ b/phpBB/phpbb/avatar/driver/remote.php
@@ -125,6 +125,37 @@ class remote extends \phpbb\avatar\driver\driver
 		$types = \fileupload::image_types();
 		$extension = strtolower(\filespec::get_extension($url));
 
+		// Check if this is actually an image
+		if ($file_stream = @fopen($url, 'r'))
+		{
+			// Timeout after 1 second
+			stream_set_timeout($file_stream, 1);
+			$meta = stream_get_meta_data($file_stream);
+			foreach ($meta['wrapper_data'] as $header)
+			{
+				$header = preg_split('/ /', $header, 2);
+				if (strtr(strtolower(trim($header[0], ':')), '_', '-') === 'content-type')
+				{
+					if (strpos($header[1], 'image/') !== 0)
+					{
+						$error[] = 'AVATAR_URL_INVALID';
+						fclose($file_stream);
+						return false;
+					}
+					else
+					{
+						fclose($file_stream);
+						break;
+					}
+				}
+			}
+		}
+		else
+		{
+			$error[] = 'AVATAR_URL_INVALID';
+			return false;
+		}
+
 		if (!empty($image_data) && (!isset($types[$image_data[2]]) || !in_array($extension, $types[$image_data[2]])))
 		{
 			if (!isset($types[$image_data[2]]))

--- a/tests/functional/avatar_acp_groups_test.php
+++ b/tests/functional/avatar_acp_groups_test.php
@@ -50,6 +50,15 @@ class phpbb_functional_avatar_acp_groups_test extends phpbb_functional_common_av
 					'avatar_delete'	=> array('tick', ''),
 				),
 			),
+			array(
+				'The URL you specified is invalid.',
+				'avatar_driver_remote',
+				array(
+					'avatar_remote_url'	=> 'https://www.phpbb.com/avatar/55502f40dc8b7c769880b10874abc9d0.jpg',
+					'avatar_remote_width'	=> 80,
+					'avatar_remote_height'	=> 80,
+				),
+			),
 		);
 	}
 


### PR DESCRIPTION
This should make sure that error pages like 404 or 503 pages are not treated
as remote avatar images.

Ticket: http://tracker.phpbb.com/browse/PHPBB3-11534

PHPBB3-11534
