### PR TITLE
[ticket/11857] Use passed service collection instead of container in manager

### DIFF
--- a/phpBB/config/services.yml
+++ b/phpBB/config/services.yml
@@ -22,7 +22,6 @@ services:
         arguments:
             - @config
             - @avatar.driver_collection
-            - @service_container
 
     cache:
         class: phpbb\cache\service

--- a/phpBB/phpbb/avatar/manager.php
+++ b/phpBB/phpbb/avatar/manager.php
@@ -42,12 +42,6 @@ class manager
 	protected $avatar_drivers;
 
 	/**
-	* Service container object
-	* @var object
-	*/
-	protected $container;
-
-	/**
 	* Default avatar data row
 	* @var array
 	*/
@@ -63,13 +57,27 @@ class manager
 	*
 	* @param \phpbb\config\config $config phpBB configuration
 	* @param array $avatar_drivers Avatar drivers passed via the service container
-	* @param object $container Container object
 	*/
-	public function __construct(\phpbb\config\config $config, $avatar_drivers, $container)
+	public function __construct(\phpbb\config\config $config, $avatar_drivers)
 	{
 		$this->config = $config;
-		$this->avatar_drivers = $avatar_drivers;
-		$this->container = $container;
+		$this->register_avatar_drivers($avatar_drivers);
+	}
+
+	/**
+	* Register avatar drivers
+	*
+	* @param array $avatar_drivers Service collection of avatar drivers
+	*/
+	protected function register_avatar_drivers($avatar_drivers)
+	{
+		if (!empty($avatar_drivers))
+		{
+			foreach ($avatar_drivers as $driver)
+			{
+				$this->avatar_drivers[$driver->get_name()] = $driver;
+			}
+		}
 	}
 
 	/**
@@ -112,7 +120,7 @@ class manager
 		* There is no need to handle invalid avatar types as the following code
 		* will cause a ServiceNotFoundException if the type does not exist
 		*/
-		$driver = $this->container->get($avatar_type);
+		$driver = $this->avatar_drivers[$avatar_type];
 
 		return $driver;
 	}

--- a/tests/avatar/manager_test.php
+++ b/tests/avatar/manager_test.php
@@ -112,7 +112,7 @@ class phpbb_avatar_manager_test extends PHPUnit_Framework_TestCase
 	public function test_get_driver_enabled($driver_name, $expected)
 	{
 		$driver = $this->manager->get_driver($driver_name);
-		$this->assertEquals($expected, $driver);
+		$this->assertEquals($expected, ($driver === null) ? null : $driver->get_name());
 	}
 
 	public function get_driver_data_all()
@@ -133,7 +133,7 @@ class phpbb_avatar_manager_test extends PHPUnit_Framework_TestCase
 	public function test_get_driver_all($driver_name, $expected)
 	{
 		$driver = $this->manager->get_driver($driver_name, false);
-		$this->assertEquals($expected, $driver);
+		$this->assertEquals($expected, ($driver === null) ? $driver : $driver->get_name());
 	}
 
 	public function test_get_avatar_settings()


### PR DESCRIPTION
The service collection that was already passed to the avatar manager should
be used in the avatar manager method get_driver() instead of the container
itself.

Ticket: http://tracker.phpbb.com/browse/PHPBB3-11857

PHPBB3-11857
