### PR TITLE
[ticket/11991] Fix incorrect class name for report_post_closed notification.

### DIFF
--- a/phpBB/config/notifications.yml
+++ b/phpBB/config/notifications.yml
@@ -266,7 +266,7 @@ services:
             - { name: notification.type }
 
     notification.type.report_post_closed:
-        class: phpbb\notification\type\report_post
+        class: phpbb\notification\type\report_post_closed
         scope: prototype # scope MUST be prototype for this to work!
         arguments:
             - @user_loader


### PR DESCRIPTION
http://tracker.phpbb.com/browse/PHPBB3-11991
