### PR TITLE
[ticket/11983] Add missing argument to docblock in ucp_notifications

### DIFF
--- a/phpBB/includes/ucp/ucp_notifications.php
+++ b/phpBB/includes/ucp/ucp_notifications.php
@@ -162,6 +162,7 @@ class ucp_notifications
 	/**
 	* Output all the notification types to the template
 	*
+	* @param array $subscriptions Array containing global subscriptions
 	* @param \phpbb\notification\manager $phpbb_notifications
 	* @param \phpbb\template\template $template
 	* @param \phpbb\user $user


### PR DESCRIPTION
The argument $subscriptions was not documented in the docblock of the method
output_notification_types() until now.

Ticket: http://tracker.phpbb.com/browse/PHPBB3-11983

PHPBB3-11983
