### PR TITLE
[ticket/12004] Support empty routes to app.php/ in path_helper

### DIFF
--- a/phpBB/phpbb/path_helper.php
+++ b/phpBB/phpbb/path_helper.php
@@ -149,6 +149,16 @@ class path_helper
 		$script_name = $this->symfony_request->getScriptName();
 
 		/*
+		* If the path info is empty but we're using app.php, then we
+		*	might be using an empty route like app.php/ which is
+		*	supported by symfony's routing
+		*/
+		if ($path_info === '/' && preg_match('/app\.' . $this->php_ext . '\/$/', $request_uri))
+		{
+			return $this->web_root_path = $this->phpbb_root_path . '../';
+		}
+
+		/*
 		* If the path info is empty (single /), then we're not using
 		*	a route like app.php/foo/bar
 		*/

--- a/tests/path_helper/web_root_path_test.php
+++ b/tests/path_helper/web_root_path_test.php
@@ -116,6 +116,13 @@ class phpbb_path_helper_web_root_path_test extends phpbb_test_case
 				'/phpbb3-fork/phpBB/foo/template',
 				'/phpbb3-fork/phpBB/app.php',
 			),
+			array(
+				$this->phpbb_root_path . 'test.php',
+				$this->phpbb_root_path . '../test.php',
+				'/',
+				'/phpbb3-fork/phpBB/app.php/',
+				'/phpbb3-fork/phpBB/app.php',
+			),
 		);
 	}
 


### PR DESCRIPTION
The symfony routing component allows us to use the path "/" for routes.
Therefore, we should be able to use example.com/app.php/ for controllers.
However, this currently does not properly work. The method get_web_root_path
incorrectly returns phpbb_root_path. Therefore, paths to images or files are
broken.

Ticket: http://tracker.phpbb.com/browse/PHPBB3-12004

PHPBB3-12004
