### PR TITLE
[ticket/11927] Correctly add new files on update

### DIFF
--- a/phpBB/includes/functions_install.php
+++ b/phpBB/includes/functions_install.php
@@ -546,7 +546,7 @@ function phpbb_create_config_file_data($data, $dbms, $debug = false, $debug_test
 * @param	string	$file				File including path from phpbb root
 * @return	bool		Should we ignore the new file or add it to the board?
 */
-function ignore_new_file_on_update($phpbb_root_path, $file)
+function phpbb_ignore_new_file_on_update($phpbb_root_path, $file)
 {
 	$ignore_new_file = false;
 

--- a/phpBB/install/install_update.php
+++ b/phpBB/install/install_update.php
@@ -1311,7 +1311,7 @@ class install_update extends module
 					}
 				}*/
 
-				if (!ignore_new_file_on_update($phpbb_root_path, $file))
+				if (!phpbb_ignore_new_file_on_update($phpbb_root_path, $file))
 				{
 					$this->get_custom_info($update_list['new'], $file);
 					$update_list['new'][] = array('filename' => $file, 'custom' => false);

--- a/tests/functions_install/ignore_new_file_on_update_test.php
+++ b/tests/functions_install/ignore_new_file_on_update_test.php
@@ -34,6 +34,6 @@ class phpbb_functions_install_ignore_new_file_on_update_test extends phpbb_test_
 	public function test_ignore_new_file_on_update($file, $expected)
 	{
 		global $phpbb_root_path;
-		$this->assertEquals($expected, ignore_new_file_on_update($phpbb_root_path, $file));
+		$this->assertEquals($expected, phpbb_ignore_new_file_on_update($phpbb_root_path, $file));
 	}
 }


### PR DESCRIPTION
Currently we ignore language and style files when the directory where they
go to do not exist. However in 3.1 we introduce some new sub directories:
- language/en/email/short/
- styles/prosilver/theme/en/

So we need to change our check to look whether the language or style exist,
rather then the parent directory.

http://tracker.phpbb.com/browse/PHPBB3-11927
