### PR TITLE
[ticket/11949] Do not prepend leading backslash to cache class name

### DIFF
--- a/phpBB/phpbb/di/extension/config.php
+++ b/phpBB/phpbb/di/extension/config.php
@@ -70,7 +70,7 @@ class config extends Extension
 	{
 		if (preg_match('#^[a-z]+$#', $acm_type))
 		{
-			return '\\phpbb\cache\driver\\'.$acm_type;
+			return 'phpbb\\cache\\driver\\' . $acm_type;
 		}
 
 		return $acm_type;


### PR DESCRIPTION
The container seems to prepend the leading `\` itself, so we get an
`InvalidArgumentException with message '"'\\phpbb\\cache\\driver\\file'" is
not a valid class name for the "cache.driver" service.'`

http://tracker.phpbb.com/browse/PHPBB3-11949
