### PR TITLE
[ticket/12018] Use path_helper for admin style CSS in sql report

### DIFF
--- a/phpBB/phpbb/db/driver/driver.php
+++ b/phpBB/phpbb/db/driver/driver.php
@@ -816,7 +816,7 @@ class driver
 	*/
 	function sql_report($mode, $query = '')
 	{
-		global $cache, $starttime, $phpbb_root_path, $phpbb_admin_path, $user;
+		global $cache, $starttime, $phpbb_root_path, $phpbb_path_helper, $user;
 		global $request;
 
 		if (is_object($request) && !$request->variable('explain', false))
@@ -846,7 +846,7 @@ class driver
 					<head>
 						<meta charset="utf-8">
 						<title>SQL Report</title>
-						<link href="' . htmlspecialchars($phpbb_admin_path) . 'style/admin.css" rel="stylesheet" type="text/css" media="screen" />
+						<link href="' . htmlspecialchars($phpbb_path_helper->update_web_root_path($phpbb_root_path) . $phpbb_path_helper->get_adm_relative_path()) . 'style/admin.css" rel="stylesheet" type="text/css" media="screen" />
 					</head>
 					<body id="errorpage">
 					<div id="wrap">


### PR DESCRIPTION
The path to the admin style CSS is currently created with $phpbb_admin_path.
We should however use the path_helper to correctly link to this file in order
to have a correct link on pages like extensions.

Ticket: http://tracker.phpbb.com/browse/PHPBB3-12018

PHPBB3-12018
