### PR TITLE
[ticket/12028] Replace L_COLON with literal colon

### DIFF
--- a/phpBB/styles/prosilver/template/posting_buttons.html
+++ b/phpBB/styles/prosilver/template/posting_buttons.html
@@ -28,7 +28,7 @@
 		y: '{LA_BBCODE_Y_HELP}',
 		d: '{LA_BBCODE_D_HELP}'
 		<!-- BEGIN custom_tags -->
-			,cb_{custom_tags.BBCODE_ID}{L_COLON} '{custom_tags.A_BBCODE_HELPLINE}'
+			,cb_{custom_tags.BBCODE_ID}: '{custom_tags.A_BBCODE_HELPLINE}'
 		<!-- END custom_tags -->
 	}
 

--- a/phpBB/styles/subsilver2/template/posting_buttons.html
+++ b/phpBB/styles/subsilver2/template/posting_buttons.html
@@ -27,7 +27,7 @@
 			d: '{LA_BBCODE_D_HELP}',
 			tip: '{L_STYLES_TIP}'
 			<!-- BEGIN custom_tags -->
-				,cb_{custom_tags.BBCODE_ID}{L_COLON} '{custom_tags.A_BBCODE_HELPLINE}'
+				,cb_{custom_tags.BBCODE_ID}: '{custom_tags.A_BBCODE_HELPLINE}'
 			<!-- END custom_tags -->
 		}
 


### PR DESCRIPTION
If a translator were to define L_COLON as a fullwidth colon U+FF1A it would break the JavaScript.

http://tracker.phpbb.com/browse/PHPBB3-12028
