### PR TITLE
[ticket/11346] Hide "Mark topics read" link when forum is empty.

### DIFF
--- a/phpBB/styles/prosilver/template/viewforum_body.html
+++ b/phpBB/styles/prosilver/template/viewforum_body.html
@@ -55,17 +55,15 @@
 		</div>
 	<!-- ENDIF -->
 
-	<!-- IF .pagination or TOTAL_POSTS or TOTAL_TOPICS -->
-		<div class="pagination">
-			<!-- IF not S_IS_BOT and U_MARK_TOPICS --><a href="{U_MARK_TOPICS}" accesskey="m" data-ajax="mark_topics_read" data-overlay="false">{L_MARK_TOPICS_READ}</a> &bull; <!-- ENDIF -->
-			<!-- IF TOTAL_TOPICS -->{TOTAL_TOPICS} &bull; <!-- ENDIF -->
-			<!-- IF .pagination -->
-				<!-- INCLUDE pagination.html -->
-			<!-- ELSE -->
-				{PAGE_NUMBER}
-			<!-- ENDIF -->
-		</div>
-	<!-- ENDIF -->
+	<div class="pagination">
+		<!-- IF not S_IS_BOT and U_MARK_TOPICS and .topicrow --><a href="{U_MARK_TOPICS}" accesskey="m" data-ajax="mark_topics_read" data-overlay="false">{L_MARK_TOPICS_READ}</a> &bull; <!-- ENDIF -->
+		{TOTAL_TOPICS} &bull; 
+		<!-- IF .pagination -->
+			<!-- INCLUDE pagination.html -->
+		<!-- ELSE -->
+			{PAGE_NUMBER}
+		<!-- ENDIF -->
+	</div>
 
 	</div>
 <!-- ENDIF -->
@@ -227,18 +225,15 @@
 		</div>
 		<!-- ENDIF -->
 
-		<!-- IF PAGE_NUMBER or TOTAL_POSTS or TOTAL_TOPICS -->
 		<div class="pagination">
-			<!-- IF TOTAL_TOPICS and not S_IS_BOT and U_MARK_TOPICS --><a href="{U_MARK_TOPICS}" data-ajax="mark_topics_read" data-overlay="false">{L_MARK_TOPICS_READ}</a> &bull;  <!-- ENDIF -->
-			<!-- IF TOTAL_POSTS and not NEWEST_USER --> {TOTAL_POSTS}<!-- ELSEIF TOTAL_TOPICS and not NEWEST_USER --> {TOTAL_TOPICS} &bull; <!-- ENDIF -->
-			<!-- IF TOTAL_USERS -->{TOTAL_USERS} &bull; <!-- ENDIF -->
+			<!-- IF not S_IS_BOT and U_MARK_TOPICS and .topicrow --><a href="{U_MARK_TOPICS}" data-ajax="mark_topics_read" data-overlay="false">{L_MARK_TOPICS_READ}</a> &bull; <!-- ENDIF -->
+			{TOTAL_TOPICS} &bull; 
 			<!-- IF .pagination -->
 				<!-- INCLUDE pagination.html -->
 			<!-- ELSE -->
 				{PAGE_NUMBER}
 			<!-- ENDIF -->
 		</div>
-		<!-- ENDIF -->
 	</div>
 <!-- ENDIF -->
 


### PR DESCRIPTION
See https://github.com/phpbb/phpbb/pull/919 for some background info.

The two blocks were already different when prosilver was initially commited: https://github.com/phpbb/phpbb/blob/f610ed82cbf0df2b5f8afd6ca3f88b9313281036/phpBB/styles/prosilver/template/viewforum_body.html

I see no reason for the bottom block to be different from the top one. TOTAL_POSTS and TOTAL_USERS are undefined in viewforum.php and simply do not make any sense in this context. I have removed the `<!-- IF .pagination or TOTAL_POSTS or TOTAL_TOPICS -->` check because it's not necessary. There is always content inside `<div class="pagination">` as TOTAL_TOPICS and PAGE_NUMBER will have a value even when the forum is empty. For this same reason `<!-- IF TOTAL_TOPICS -->` is also not needed.

http://tracker.phpbb.com/browse/PHPBB3-11346
