### PR TITLE
Skip tests that require Fileinfo if it's not there

### DIFF
--- a/tests/mimetype/guesser_test.php
+++ b/tests/mimetype/guesser_test.php
@@ -123,8 +123,8 @@ class guesser_test extends \phpbb_test_case
 	}
 
 	/**
-	* @dataProvider data_content_guesser
 	* @requires function mime_content_type
+	* @dataProvider data_content_guesser
 	*/
 	public function test_content_guesser($expected, $guessers, $overload = false)
 	{


### PR DESCRIPTION
Test suite fails if Fileinfo isn't installed and mime_content_type() isn't available. I don't know whether this is a bug in the mimetype guesser or an oversight in the test suite. In the meantime, skipping tests lets the test suite finish.
