### PR TITLE
[ticket/12093] Check that document.selection is supported.

### DIFF
--- a/phpBB/adm/style/editor.js
+++ b/phpBB/adm/style/editor.js
@@ -292,7 +292,7 @@ function mozWrap(txtarea, open, close)
 */
 function storeCaret(textEl)
 {
-	if (textEl.createTextRange)
+	if (textEl.createTextRange && document.selection)
 	{
 		textEl.caretPos = document.selection.createRange().duplicate();
 	}

--- a/phpBB/styles/prosilver/template/editor.js
+++ b/phpBB/styles/prosilver/template/editor.js
@@ -347,7 +347,7 @@ function mozWrap(txtarea, open, close)
 */
 function storeCaret(textEl)
 {
-	if (textEl.createTextRange)
+	if (textEl.createTextRange && document.selection)
 	{
 		textEl.caretPos = document.selection.createRange().duplicate();
 	}

--- a/phpBB/styles/subsilver2/template/editor.js
+++ b/phpBB/styles/subsilver2/template/editor.js
@@ -351,7 +351,7 @@ function mozWrap(txtarea, open, close)
 */
 function storeCaret(textEl)
 {
-	if (textEl.createTextRange)
+	if (textEl.createTextRange && document.selection)
 	{
 		textEl.caretPos = document.selection.createRange().duplicate();
 	}


### PR DESCRIPTION
Inserting text at the caret position in IE11 now works as in other browsers (storeCaret() isn't executed when inserting bbcode/smilies or a quote) - setting textEl.caretPos is no longer necessary, so simply checking that document.selection is supported should suffice.

http://tracker.phpbb.com/browse/PHPBB3-12093
