### PR TITLE
[ticket/11978] Text field for topic-search too narrow

### DIFF
--- a/phpBB/styles/prosilver/theme/forms.css
+++ b/phpBB/styles/prosilver/theme/forms.css
@@ -283,7 +283,7 @@ fieldset.submit-buttons input {
 input.inputbox	{ width: 85%; }
 input.medium	{ width: 50%; }
 input.narrow	{ width: 25%; }
-input.tiny		{ width: 125px; }
+input.tiny		{ width: 128px; }
 
 textarea.inputbox {
 	width: 85%;


### PR DESCRIPTION
Text field for topic-search too narrow for German language. It is made
little broader extending width to 128px in forms.css

http://tracker.phpbb.com/browse/PHPBB3-11978

PHPBB3-11978
