### PR TITLE
[ticket/11613] Cookies does not work for netbios domain

### DIFF
--- a/phpBB/phpbb/session.php
+++ b/phpBB/phpbb/session.php
@@ -1052,7 +1052,7 @@ class session
 
 		$name_data = rawurlencode($config['cookie_name'] . '_' . $name) . '=' . rawurlencode($cookiedata);
 		$expire = gmdate('D, d-M-Y H:i:s \\G\\M\\T', $cookietime);
-		$domain = (!$config['cookie_domain'] || $config['cookie_domain'] == 'localhost' || $config['cookie_domain'] == '127.0.0.1') ? '' : '; domain=' . $config['cookie_domain'];
+		$domain = (!$config['cookie_domain'] || $config['cookie_domain'] == 'localhost' || $config['cookie_domain'] == '127.0.0.1' || strpos($config['cookie_domain'], '.') === FALSE) ? '' : '; domain=' . $config['cookie_domain'];
 
 		header('Set-Cookie: ' . $name_data . (($cookietime) ? '; expires=' . $expire : '') . '; path=' . $config['cookie_path'] . $domain . ((!$config['cookie_secure']) ? '' : '; secure') . '; HttpOnly', false);
 	}


### PR DESCRIPTION
If phpBB is installed on a local network, and his "domain" is only a
netbios name, cookies will not work.

http://tracker.phpbb.com/browse/PHPBB3-11613

PHPBB3-11613
