### PR TITLE
[ticket/12003] ACP broken when error thrown

### DIFF
--- a/phpBB/adm/style/admin.css
+++ b/phpBB/adm/style/admin.css
@@ -1860,7 +1860,6 @@ li.pagination ul {
 }*/
 
 .clearfix, .row, #content, fieldset dl, #page-body {
-	height: 1%;
 	overflow: hidden;
 }
 


### PR DESCRIPTION
Fix display of ACP when error is outputted before &lt;html&gt; tag.

PHPBB3-12003
