### PR TITLE
[ticket/12207] Forum broken when error thrown

### DIFF
--- a/phpBB/styles/prosilver/theme/common.css
+++ b/phpBB/styles/prosilver/theme/common.css
@@ -747,7 +747,6 @@ dl.details dd {
 }
 
 .clearfix, fieldset dl, ul.topiclist dl, dl.polls {
-	height: 1%;
 	overflow: hidden;
 }
 
@@ -755,7 +754,6 @@ dl.details dd {
 /* Pagination
 ---------------------------------------- */
 .pagination {
-	height: 1%; /* IE tweak (holly hack) */
 	width: auto;
 	text-align: right;
 	margin-top: 5px;


### PR DESCRIPTION
Fix display of forum when error is outputted before &lt;html&gt; tag.

Similar to #2011

http://tracker.phpbb.com/browse/PHPBB3-12207
