### PR TITLE
[ticket/12208] Remove file from upload queue if deleted before being uploaded.

### DIFF
--- a/phpBB/assets/javascript/plupload.js
+++ b/phpBB/assets/javascript/plupload.js
@@ -230,6 +230,9 @@ phpbb.plupload.updateHiddenData = function(row, attach, index) {
 phpbb.plupload.deleteFile = function(row, attachId) {
 	// If there's no attach id, then the file hasn't been uploaded. Simply delete the row.
 	if (typeof attachId === 'undefined') {
+		var file = uploader.getFile(row.attr('id'));
+		uploader.removeFile(file);
+
 		row.slideUp(100, function() {
 			row.remove();
 			phpbb.plupload.hideEmptyList();


### PR DESCRIPTION
The table row is removed, but the files aren't actually removed from the
upload queue, so they get uploaded either way.

http://tracker.phpbb.com/browse/PHPBB3-12208
