### PR TITLE
[ticket/12210] dbtools::sql_create_table incorrectly throws error

### DIFF
--- a/phpBB/includes/db/db_tools.php
+++ b/phpBB/includes/db/db_tools.php
@@ -477,7 +477,7 @@ class phpbb_db_tools
 			// here lies an array, filled with information compiled on the column's data
 			$prepared_column = $this->sql_prepare_column_data($table_name, $column_name, $column_data);
 
-			if (isset($prepared_column['auto_increment']) && strlen($column_name) > 26) // "${column_name}_gen"
+			if (isset($prepared_column['auto_increment']) && $prepared_column['auto_increment'] && strlen($column_name) > 26) // "${column_name}_gen"
 			{
 				trigger_error("Index name '${column_name}_gen' on table '$table_name' is too long. The maximum auto increment column length is 26 characters.", E_USER_ERROR);
 			}


### PR DESCRIPTION
related to auto-increment length on non auto-increment fields

http://tracker.phpbb.com/browse/PHPBB3-12210

Develop: https://github.com/phpbb/phpbb/pull/2042
