### PR TITLE
[ticket/12212] Encode the attachment file name before presenting to user.

### DIFF
--- a/phpBB/assets/javascript/plupload.js
+++ b/phpBB/assets/javascript/plupload.js
@@ -162,7 +162,7 @@ phpbb.plupload.insertRow = function(file) {
 	var row = $(phpbb.plupload.rowTpl);
 
 	row.attr('id', file.id);
-	row.find('.file-name').html(file.name);
+	row.find('.file-name').html(plupload.xmlEncode(file.name));
 	row.find('.file-size').html(plupload.formatSize(file.size));
 
 	if (phpbb.plupload.order == 'desc') {
@@ -496,6 +496,8 @@ $('#file-list').on('click', '.file-error', function(e) {
  * Fires when an error occurs.
  */
 uploader.bind('Error', function(up, error) {
+	error.file.name = plupload.xmlEncode(error.file.name);
+
 	// The error message that Plupload provides for these is vague, so we'll be more specific.
 	if (error.code === plupload.FILE_EXTENSION_ERROR) {
 		error.message = plupload.translate('Invalid file extension:') + ' ' + error.file.name;


### PR DESCRIPTION
The uploader inserts the file name directly into the page at the moment without handling any HTML special chars that may be in the name. This results in HTML that may be present getting rendered in error messages and the attachments list. This simply causes layout breakage for the user, since the backend takes care of sanitizing the name. Once phpBB returns the file data for the uploaded
file, the name in the attachment list gets replaced by the one that phpBB provides.

http://tracker.phpbb.com/browse/PHPBB3-12212
