### PR TITLE
[ticket/12213] Add MCP events for custom quick moderation options

### DIFF
--- a/phpBB/includes/mcp/mcp_main.php
+++ b/phpBB/includes/mcp/mcp_main.php
@@ -34,6 +34,7 @@ class mcp_main
 	{
 		global $auth, $db, $user, $template, $action;
 		global $config, $phpbb_root_path, $phpEx, $request;
+		global $phpbb_dispatcher;
 
 		$quickmod = ($mode == 'quickmod') ? true : false;
 
@@ -150,6 +151,16 @@ class mcp_main
 				}
 
 				mcp_restore_topic($topic_ids);
+			break;
+
+			default:
+				/**
+				* This event allows you to handle custom quickmod options
+				*
+				* @event core.modify_quickmod_actions
+				* @since 3.1.0-a4
+				*/
+				$phpbb_dispatcher->dispatch('core.modify_quickmod_actions');
 			break;
 		}
 

--- a/phpBB/mcp.php
+++ b/phpBB/mcp.php
@@ -183,7 +183,26 @@ if ($quickmod)
 		break;
 
 		default:
-			trigger_error($user->lang('QUICKMOD_ACTION_NOT_ALLOWED', $action), E_USER_ERROR);
+			// If needed, the flag can be set to true within event listener
+			// to indicate that the action was handled properly
+			// and to pass by the trigger_error() call below
+			$break = false;
+
+			/**
+			* This event allows you to add custom quickmod options
+			*
+			* @event core.modify_quickmod_options
+			* @var	object	module			Instance of module system class
+			* @var	string	action			Quickmod option
+			* @var	bool	break			Flag indicating if the action was handled properly
+			* @since 3.1.0-a4
+			*/
+			extract($phpbb_dispatcher->trigger_event('core.modify_quickmod_options', compact(array('module', 'action', 'break'))));
+
+			if (!$break)
+			{
+				trigger_error($user->lang('QUICKMOD_ACTION_NOT_ALLOWED', $action), E_USER_ERROR);
+			}
 		break;
 	}
 }


### PR DESCRIPTION
Add core events to mcp.php and mcp_main.php. This allows
extensions to add and to handle custom quick moderation options.

<a href="http://tracker.phpbb.com/browse/PHPBB3-12213">PHPBB3-12213</a>.
