### PR TITLE
[ticket/12217] Add more template events to viewtopic_body.html

### DIFF
--- a/phpBB/docs/events.md
+++ b/phpBB/docs/events.md
@@ -484,6 +484,30 @@ viewtopic_body_postrow_custom_fields_before
 * Purpose: Add data before the custom fields on the user profile when viewing
 a post
 
+viewtopic_body_postrow_post_after
+===
+* Locations:
+    + styles/prosilver/template/viewtopic_body.html
+    + styles/subsilver2/template/viewtopic_body.html
+* Since: 3.1.0-a4
+* Purpose: Add data after posts
+
+viewtopic_body_postrow_post_before
+===
+* Locations:
+    + styles/prosilver/template/viewtopic_body.html
+    + styles/subsilver2/template/viewtopic_body.html
+* Since: 3.1.0-a4
+* Purpose: Add data before posts
+
+viewtopic_body_topic_actions_before
+===
+* Locations:
+    + styles/prosilver/template/viewtopic_body.html
+    + styles/subsilver2/template/viewtopic_body.html
+* Since: 3.1.0-a4
+* Purpose: Add data before the topic actions buttons (after the posts sorting options)
+
 viewtopic_topic_title_prepend
 ===
 * Locations:

--- a/phpBB/styles/prosilver/template/viewtopic_body.html
+++ b/phpBB/styles/prosilver/template/viewtopic_body.html
@@ -107,12 +107,12 @@
 		{S_HIDDEN_FIELDS}
 	</div>
 
-
 	</form>
 	<hr />
 <!-- ENDIF -->
 
 <!-- BEGIN postrow -->
+	<!-- EVENT viewtopic_body_postrow_post_before -->
 	<!-- IF postrow.S_FIRST_UNREAD --><a id="unread"></a><!-- ENDIF -->
 	<div id="p{postrow.POST_ID}" class="post <!-- IF postrow.S_ROW_COUNT is odd -->bg1<!-- ELSE -->bg2<!-- ENDIF --><!-- IF postrow.S_UNREAD_POST --> unreadpost<!-- ENDIF --><!-- IF postrow.S_POST_REPORTED --> reported<!-- ENDIF --><!-- IF postrow.S_POST_DELETED --> deleted<!-- ENDIF --><!-- IF postrow.S_ONLINE and not postrow.S_POST_HIDDEN --> online<!-- ENDIF -->">
 		<div class="inner">
@@ -271,6 +271,7 @@
 	</div>
 
 	<hr class="divider" />
+	<!-- EVENT viewtopic_body_postrow_post_after -->
 <!-- END postrow -->
 <!-- IF S_QUICK_REPLY -->
 	<!-- INCLUDE quickreply_editor.html -->
@@ -292,6 +293,7 @@
 	<hr />
 <!-- ENDIF -->
 
+<!-- EVENT viewtopic_body_topic_actions_before -->
 <div class="topic-actions">
 	<div class="buttons">
 	<!-- IF not S_IS_BOT and S_DISPLAY_REPLY_INFO -->

--- a/phpBB/styles/subsilver2/template/viewtopic_body.html
+++ b/phpBB/styles/subsilver2/template/viewtopic_body.html
@@ -127,6 +127,7 @@
 	</table>
 
 <!-- BEGIN postrow -->
+	<!-- EVENT viewtopic_body_postrow_post_before -->
 	<table class="tablebg" width="100%" cellspacing="1">
 	<!-- IF postrow.S_FIRST_ROW -->
 		<tr>
@@ -338,6 +339,7 @@
 		<td class="spacer" colspan="2" height="1"><img src="images/spacer.gif" alt="" width="1" height="1" /></td>
 	</tr>
 	</table>
+	<!-- EVENT viewtopic_body_postrow_post_after -->
 <!-- END postrow -->
 
 	<!-- IF not S_IS_BOT -->
@@ -347,6 +349,8 @@
 	</tr>
 	</table>
 	<!-- ENDIF -->
+
+	<!-- EVENT viewtopic_body_topic_actions_before -->
 
 	<table width="100%" cellspacing="1">
 	<tr>


### PR DESCRIPTION
Add viewtopic template events before/after the posts,
after the sorting options to allow adding contents to
respective places (like advertisement and so on).

<a href="http://tracker.phpbb.com/browse/PHPBB3-12217">PHPBB3-12217</a>.
