### PR TITLE
[ticket/12220] Fix division by zero in search page with no results.

### DIFF
--- a/phpBB/search.php
+++ b/phpBB/search.php
@@ -602,7 +602,6 @@ if ($keywords || $author || $author_id || $search_id || $submit)
 		'SEARCH_WORDS'		=> $keywords,
 		'SEARCHED_QUERY'	=> $search->get_search_query(),
 		'IGNORED_WORDS'		=> (sizeof($common_words)) ? implode(' ', $common_words) : '',
-		'PAGE_NUMBER'		=> $pagination->on_page($u_search, $total_match_count, $per_page, $start),
 
 		'PHRASE_SEARCH_DISABLED'		=> $phrase_search_disabled,
 


### PR DESCRIPTION
The page url parameter no longer exists in the pagination.on_page() method, therefore the page url passed is being divided by 0 - the total number of items. Since PAGE_NUMBER is assigned in pagination.generate_template_pagination(), this separate assignment is no longer needed.

http://tracker.phpbb.com/browse/PHPBB3-12220
