### PR TITLE
[ticket/12232] Remove excessive calls to sizeof() in assign_block_vars() method.

### DIFF
--- a/phpBB/phpbb/template/context.php
+++ b/phpBB/phpbb/template/context.php
@@ -155,11 +155,12 @@ class context
 			// We're adding a new iteration to this block with the given
 			// variable assignments.
 			$str[$blocks[$blockcount]][] = $vararray;
+			$s_num_rows = sizeof($str[$blocks[$blockcount]]);
 
 			// Set S_NUM_ROWS
 			foreach ($str[$blocks[$blockcount]] as &$mod_block)
 			{
-				$mod_block['S_NUM_ROWS'] = sizeof($str[$blocks[$blockcount]]);
+				$mod_block['S_NUM_ROWS'] = $s_num_rows;
 			}
 		}
 		else


### PR DESCRIPTION
The size of the template block array is calculated within a foreach loop iterating through the array, which is unnecessary. It only needs to be done once. In a block of 1000 rows, this results in 500,500 calls ((1000 \* 1001) / 2) to sizeof() in this location. With this change, that's reduced to 1000.

In the case of the ban page, there are three blocks assigned for each banned user... which means 1,501,500 calls to sizeof(). Fun.

Total execution time for ban page:
Current: 81.463s
New: 0.798s

http://tracker.phpbb.com/browse/PHPBB3-12232
