### PR TITLE
[ticket/12238] Remove defunct confirmation box template code.

### DIFF
--- a/phpBB/styles/prosilver/template/mcp_header.html
+++ b/phpBB/styles/prosilver/template/mcp_header.html
@@ -47,19 +47,3 @@
 			<p><!-- BEGIN return_links -->{return_links.MESSAGE_LINK}<br /><br /><!-- END return_links --></p>
 		</div>
 		<!-- ENDIF -->
-
-		<!-- IF CONFIRM_MESSAGE -->
-			<form id="confirm" method="post" action="{S_CONFIRM_ACTION}"{S_FORM_ENCTYPE}>
-
-			<div class="content">
-				<h2>{L_PLEASE_CONFIRM}</h2>
-				<p>{CONFIRM_MESSAGE}</p>
-			
-				<fieldset class="submit-buttons">
-					{S_HIDDEN_FIELDS}<input class="button1" type="submit" name="submit" value="{L_YES}" />&nbsp; 
-					<input class="button2" type="cancel" value="{L_NO}" />
-				</fieldset>
-			</div>
-
-			</form>
-		<!-- ENDIF -->

--- a/phpBB/styles/subsilver2/template/mcp_header.html
+++ b/phpBB/styles/subsilver2/template/mcp_header.html
@@ -58,20 +58,3 @@
 
 			<br />
 		<!-- ENDIF -->
-
-		<!-- IF CONFIRM_MESSAGE -->
-			<form name="confirm" method="post" action="{S_CONFIRM_ACTION}">
-
-			<table class="tablebg" width="100%" cellspacing="1">
-			<tr>
-				<th>{L_PLEASE_CONFIRM}</th>
-			</tr>
-			<tr>
-				<td class="row1" align="center"><span class="gen"><br />{CONFIRM_MESSAGE}<br /><br />{S_HIDDEN_FIELDS}<input class="btnmain" type="submit" name="confirm" value="{L_YES}" />&nbsp;&nbsp;<input class="btnlite" type="submit" name="cancel" value="{L_NO}" /><br /><br /></span></td>
-			</tr>
-			</table>
-
-			</form>
-
-			<br />
-		<!-- ENDIF -->


### PR DESCRIPTION
Confirmation boxes are handled by confirm_body.html.

http://tracker.phpbb.com/browse/PHPBB3-12238
