### PR TITLE
[ticket/12239] Move deprecated passwords functions to compatibility file

### DIFF
--- a/phpBB/includes/functions.php
+++ b/phpBB/includes/functions.php
@@ -368,41 +368,6 @@ function still_on_time($extra_time = 15)
 }
 
 /**
-* Hash the password
-*
-* @deprecated 3.1.0-a2 (To be removed: 3.3.0)
-*
-* @param string $password Password to be hashed
-*
-* @return string|bool Password hash or false if something went wrong during hashing
-*/
-function phpbb_hash($password)
-{
-	global $phpbb_container;
-
-	$passwords_manager = $phpbb_container->get('passwords.manager');
-	return $passwords_manager->hash($password);
-}
-
-/**
-* Check for correct password
-*
-* @deprecated 3.1.0-a2 (To be removed: 3.3.0)
-*
-* @param string $password The password in plain text
-* @param string $hash The stored password hash
-*
-* @return bool Returns true if the password is correct, false if not.
-*/
-function phpbb_check_hash($password, $hash)
-{
-	global $phpbb_container;
-
-	$passwords_manager = $phpbb_container->get('passwords.manager');
-	return $passwords_manager->check($password, $hash);
-}
-
-/**
 * Hashes an email address to a big integer
 *
 * @param string $email		Email address

--- a/phpBB/includes/functions_compatibility.php
+++ b/phpBB/includes/functions_compatibility.php
@@ -48,3 +48,38 @@ function get_user_avatar($avatar, $avatar_type, $avatar_width, $avatar_height, $
 
 	return phpbb_get_avatar($row, $alt, $ignore_config);
 }
+
+/**
+* Hash the password
+*
+* @deprecated 3.1.0-a2 (To be removed: 3.3.0)
+*
+* @param string $password Password to be hashed
+*
+* @return string|bool Password hash or false if something went wrong during hashing
+*/
+function phpbb_hash($password)
+{
+	global $phpbb_container;
+
+	$passwords_manager = $phpbb_container->get('passwords.manager');
+	return $passwords_manager->hash($password);
+}
+
+/**
+* Check for correct password
+*
+* @deprecated 3.1.0-a2 (To be removed: 3.3.0)
+*
+* @param string $password The password in plain text
+* @param string $hash The stored password hash
+*
+* @return bool Returns true if the password is correct, false if not.
+*/
+function phpbb_check_hash($password, $hash)
+{
+	global $phpbb_container;
+
+	$passwords_manager = $phpbb_container->get('passwords.manager');
+	return $passwords_manager->check($password, $hash);
+}

--- a/tests/security/hash_test.php
+++ b/tests/security/hash_test.php
@@ -7,7 +7,7 @@
 *
 */
 
-require_once dirname(__FILE__) . '/../../phpBB/includes/functions.php';
+require_once dirname(__FILE__) . '/../../phpBB/includes/functions_compatibility.php';
 
 class phpbb_security_hash_test extends phpbb_test_case
 {


### PR DESCRIPTION
The deprecated passwords functions are no longer used in the core and have
been replaced with the passwords manager. Therefore, the functions are
moved to the functions_compatibility file.

PHPBB3-12239

Ticket: http://tracker.phpbb.com/browse/PHPBB3-12239
