### PR TITLE
[ticket/12259] Reduce the size of our test matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,7 @@ php:
   - 5.6
 
 env:
-  - DB=mariadb
   - DB=mysql
-  - DB=postgres
 
 before_script:
   - sh -c "if [ '$DB' = 'postgres' ]; then psql -c 'DROP DATABASE IF EXISTS phpbb_tests;' -U postgres; fi"
@@ -26,3 +24,10 @@ before_script:
 script:
   - sh -c "if [ '$TRAVIS_PHP_VERSION' = '5.2' ]; then phpunit --configuration travis/phpunit-$DB-travis.xml; else phpBB/vendor/bin/phpunit --configuration travis/phpunit-$DB-travis.xml; fi"
   - sh -c "if [ '$TRAVIS_PHP_VERSION' = '5.5' -a '$DB' = 'mysql' -a '$TRAVIS_PULL_REQUEST' != 'false' ]; then git-tools/commit-msg-hook-range.sh origin/$TRAVIS_BRANCH..FETCH_HEAD; fi"
+
+matrix:
+  include:
+    - php: 5.4
+      env: DB=mariadb
+    - php: 5.4
+      env: DB=postgres


### PR DESCRIPTION
Only test MariaDB or PostgreSQL once on PHP 5.4. This reduces our build matrix
by 10 builds (over half).

http://tracker.phpbb.com/browse/PHPBB3-12259
