### PR TITLE
[ticket/11111] Prosilver posting textarea may only be resized vertically

### DIFF
--- a/phpBB/styles/prosilver/theme/forms.css
+++ b/phpBB/styles/prosilver/theme/forms.css
@@ -256,6 +256,7 @@ fieldset.submit-buttons input {
 	min-width: 100%;
 	max-width: 100%;
 	font-size: 1.2em;
+	resize: vertical;
 }
 
 /* Emoticons panel */


### PR DESCRIPTION
The resize element displays a mechanism for allowing the
user to resize the element. Setting this to vertical means it
may only be resized vertically. This does not affect the new
javascript auto-resize feature when typing large posts.

http://tracker.phpbb.com/browse/PHPBB3-11111

PHPBB3-11111
