### PR TITLE
[ticket/12247] Add ['username'] to mcp_queue.php's user_notification()

### DIFF
--- a/phpBB/includes/mcp/mcp_queue.php
+++ b/phpBB/includes/mcp/mcp_queue.php
@@ -660,15 +660,17 @@ function approve_post($post_id_list, $id, $mode)
 
 		foreach ($post_info as $post_id => $post_data)
 		{
+			$username = ($post_data['post_username']) ? $post_data['post_username'] : $post_data['username'];
+
 			if ($post_id == $post_data['topic_first_post_id'] && $post_id == $post_data['topic_last_post_id'])
 			{
 				// Forum Notifications
-				user_notification('post', $post_data['topic_title'], $post_data['topic_title'], $post_data['forum_name'], $post_data['forum_id'], $post_data['topic_id'], $post_id, $post_data['username']);
+				user_notification('post', $post_data['topic_title'], $post_data['topic_title'], $post_data['forum_name'], $post_data['forum_id'], $post_data['topic_id'], $post_id, $username);
 			}
 			else
 			{
 				// Topic Notifications
-				user_notification('reply', $post_data['post_subject'], $post_data['topic_title'], $post_data['forum_name'], $post_data['forum_id'], $post_data['topic_id'], $post_id, $post_data['username']);
+				user_notification('reply', $post_data['post_subject'], $post_data['topic_title'], $post_data['forum_name'], $post_data['forum_id'], $post_data['topic_id'], $post_id, $username);
 			}
 		}
 


### PR DESCRIPTION
It includes the poster's username in the email notifications of
posts that get approved by moderators.

This is done by adding the username to every user_notification()
function located in /phpBB/includes/mcp/mcp_queue.php.

http://tracker.phpbb.com/browse/PHPBB3-12247
