### PR TITLE
[ticket/7580] Add test for IF {VAR} is defined in templates

### DIFF
--- a/tests/template/template_test.php
+++ b/tests/template/template_test.php
@@ -91,6 +91,13 @@ class phpbb_template_template_test extends phpbb_template_template_test_case
 				'03!false',
 			),
 			array(
+				'if.html',
+				array('VALUE_TEST' => 'value'),
+				array(),
+				array(),
+				'03!falsevalue',
+			),
+			array(
 				'loop.html',
 				array(),
 				array(),

--- a/tests/template/templates/if.html
+++ b/tests/template/templates/if.html
@@ -19,3 +19,7 @@ false
 <!-- IF S_TEST !== false -->
 !false
 <!-- ENDIF -->
+
+<!-- IF VALUE_TEST is defined -->
+{VALUE_TEST}
+<!-- ENDIF -->


### PR DESCRIPTION
http://tracker.phpbb.com/browse/PHPBB3-7580
This test demonstrates that is possible to test if a variable exists
and then use it if it does, similar to using isset(), but in 
template/twig syntax.
`<!— IF VAR is defined —>{VAR}<!— ENDIF —>`

PHPBB3-7580
