### PR TITLE
[ticket/7187] Quote smilies error

### DIFF
--- a/phpBB/posting.php
+++ b/phpBB/posting.php
@@ -1337,7 +1337,7 @@ if ($mode == 'quote' && !$submit && !$preview && !$refresh)
 {
 	if ($config['allow_bbcode'])
 	{
-		$message_parser->message = '[quote=&quot;' . $post_data['quote_username'] . '&quot;]' . censor_text(trim($message_parser->message)) . "[/quote]\n";
+		$message_parser->message = '[quote=&quot;' . $post_data['quote_username'] . '&quot;]' . ' '.censor_text(trim($message_parser->message)) . "[/quote]\n";
 	}
 	else
 	{


### PR DESCRIPTION
If similes is quoted, no space is there. So now added space. PHPBB3-7187
