### PR TITLE
[ticket/12284] Improve readability of extension manager details

### DIFF
--- a/phpBB/adm/style/acp_ext_details.html
+++ b/phpBB/adm/style/acp_ext_details.html
@@ -21,12 +21,12 @@
 		<!-- IF META_DESCRIPTION -->
 		<dl>
 			<dt><label>{L_DESCRIPTION}{L_COLON}</label></dt>
-			<dd><p id="meta_description">{META_DESCRIPTION}</p></dd>
+			<dd><span id="meta_description">{META_DESCRIPTION}</span></dd>
 		</dl>
 		<!-- ENDIF -->
 		<dl>
 			<dt><label>{L_VERSION}{L_COLON}</label></dt>
-			<dd><p id="meta_version">{META_VERSION}</p></dd>
+			<dd><span id="meta_version">{META_VERSION}</span></dd>
 		</dl>
 		<!-- IF META_HOMEPAGE -->
 		<dl>
@@ -37,12 +37,12 @@
 		<!-- IF META_TIME -->
 		<dl>
 			<dt><label>{L_TIME}{L_COLON}</label></dt>
-			<dd><p id="meta_time">{META_TIME}</p></dd>
+			<dd><span id="meta_time">{META_TIME}</span></dd>
 		</dl>
 		<!-- ENDIF -->
 		<dl>
 			<dt><label>{L_LICENCE}{L_COLON}</label></dt>
-			<dd><p id="meta_license">{META_LICENCE}</p></dd>
+			<dd><span id="meta_license">{META_LICENCE}</span></dd>
 		</dl>
 	</fieldset>
 
@@ -52,13 +52,13 @@
 		<!-- IF META_REQUIRE_PHPBB -->
 		<dl<!-- IF META_REQUIRE_PHPBB_FAIL --> class="requirements_not_met"<!-- ENDIF -->>
 			<dt><label>{L_PHPBB_VERSION}{L_COLON}</label></dt>
-			<dd><p id="require_phpbb">{META_REQUIRE_PHPBB}</p></dd>
+			<dd><span id="require_phpbb">{META_REQUIRE_PHPBB}</span></dd>
 		</dl>
 		<!-- ENDIF -->
 		<!-- IF META_REQUIRE_PHP -->
 		<dl<!-- IF META_REQUIRE_PHP_FAIL --> class="requirements_not_met"<!-- ENDIF -->>
 			<dt><label>{L_PHP_VERSION}{L_COLON}</label></dt>
-			<dd><p id="require_php">{META_REQUIRE_PHP}</p></dd>
+			<dd><span id="require_php">{META_REQUIRE_PHP}</span></dd>
 		</dl>
 		<!-- ENDIF -->
 	</fieldset>


### PR DESCRIPTION
Use span tags like the rest of the ACP does, instead of P tags.
There is no semantic need to use P tags here. These are not
paragraphs. Screenshot comparisons posted in the ticket.
http://tracker.phpbb.com/browse/PHPBB3-12284

PHPBB3-12284
