### PR TITLE
[ticket/12285] Fixes for extension multilingual support

### DIFF
--- a/phpBB/phpbb/user.php
+++ b/phpBB/phpbb/user.php
@@ -631,18 +631,20 @@ class user extends \phpbb\session
 				else if ($this->lang_name == basename($config['default_lang']))
 				{
 					// Fall back to the English Language
+					$reset_lang_name = $this->lang_name;
 					$this->lang_name = 'en';
 					$this->set_lang($lang, $help, $lang_file, $use_db, $use_help, $ext_name);
+					$this->lang_name = $reset_lang_name;
 				}
 				else if ($this->lang_name == $this->data['user_lang'])
 				{
 					// Fall back to the board default language
+					$reset_lang_name = $this->lang_name;
 					$this->lang_name = basename($config['default_lang']);
 					$this->set_lang($lang, $help, $lang_file, $use_db, $use_help, $ext_name);
+					$this->lang_name = $reset_lang_name;
 				}
 
-				// Reset the lang name
-				$this->lang_name = (file_exists($lang_path . $this->data['user_lang'] . "/common.$phpEx")) ? $this->data['user_lang'] : basename($config['default_lang']);
 				return;
 			}
 


### PR DESCRIPTION
By using just $lang_path, the lang_name could be reset based on the
presence of common.php inside individual extensions. So extensions that
do not support the additional languages on a board would fall back
permanently to the board’s default config language, preventing any other
extensions that load next from being able to use the user’s preferred
lang iso even if it were available in those later extensions.
http://tracker.phpbb.com/browse/PHPBB3-12285

PHPBB3-12285
