### PR TITLE
[ticket/12289] Add viewtopic template events for posts specific custom notices

### DIFF
--- a/phpBB/docs/events.md
+++ b/phpBB/docs/events.md
@@ -540,6 +540,22 @@ viewtopic_body_postrow_post_before
 * Since: 3.1.0-a4
 * Purpose: Add data before posts
 
+viewtopic_body_postrow_post_notices_after
+===
+* Locations:
+    + styles/prosilver/template/viewtopic_body.html
+    + styles/subsilver2/template/viewtopic_body.html
+* Since: 3.1.0-b2
+* Purpose: Add posts specific custom notices at the notices bottom.
+
+viewtopic_body_postrow_post_notices_before
+===
+* Locations:
+    + styles/prosilver/template/viewtopic_body.html
+    + styles/subsilver2/template/viewtopic_body.html
+* Since: 3.1.0-b2
+* Purpose: Add posts specific custom notices at the notices top.
+
 viewtopic_body_topic_actions_before
 ===
 * Locations:

--- a/phpBB/styles/prosilver/template/viewtopic_body.html
+++ b/phpBB/styles/prosilver/template/viewtopic_body.html
@@ -252,6 +252,7 @@
 				</dl>
 			<!-- ENDIF -->
 
+			<!-- EVENT viewtopic_body_postrow_post_notices_before -->
 			<!-- IF postrow.S_DISPLAY_NOTICE --><div class="rules">{L_DOWNLOAD_NOTICE}</div><!-- ENDIF -->
 			<!-- IF postrow.DELETED_MESSAGE or postrow.DELETE_REASON -->
 				<div class="notice post_deleted_msg">
@@ -266,6 +267,7 @@
 			<!-- ENDIF -->
 
 			<!-- IF postrow.BUMPED_MESSAGE --><div class="notice"><br /><br />{postrow.BUMPED_MESSAGE}</div><!-- ENDIF -->
+			<!-- EVENT viewtopic_body_postrow_post_notices_after -->
 			<!-- IF postrow.SIGNATURE --><div id="sig{postrow.POST_ID}" class="signature">{postrow.SIGNATURE}</div><!-- ENDIF -->
 			</div>
 

--- a/phpBB/styles/subsilver2/template/viewtopic_body.html
+++ b/phpBB/styles/subsilver2/template/viewtopic_body.html
@@ -260,6 +260,7 @@
 						<div class="postbody"><br />_________________<br />{postrow.SIGNATURE}</div>
 					<!-- ENDIF -->
 
+					<!-- EVENT viewtopic_body_postrow_post_notices_before -->
 					<!-- IF postrow.DELETED_MESSAGE or postrow.DELETE_REASON -->
 						<!-- IF postrow.DELETE_REASON -->
 							<br /><br />
@@ -295,6 +296,7 @@
 					<!-- IF postrow.BUMPED_MESSAGE -->
 						<span class="gensmall"><br /><br />{postrow.BUMPED_MESSAGE}</span>
 					<!-- ENDIF -->
+					<!-- EVENT viewtopic_body_postrow_post_notices_after -->
 
 					<!-- IF not postrow.S_HAS_ATTACHMENTS --><br clear="all" /><br /><!-- ENDIF -->
 


### PR DESCRIPTION
These events allow extensions to add own posts specific notices-alike info.

<a href="http://tracker.phpbb.com/browse/PHPBB3-12289">PHPBB3-12289</a>.
