### PR TITLE
[ticket/12304] Add CSS class to rules-link container

### DIFF
--- a/phpBB/styles/prosilver/template/posting_layout.html
+++ b/phpBB/styles/prosilver/template/posting_layout.html
@@ -7,7 +7,7 @@
  <!-- ENDIF -->
 
 <!-- IF S_FORUM_RULES -->
-	<div class="rules">
+	<div class="rules<!-- IF U_FORUM_RULES --> rules-link<!-- ENDIF -->">
 		<div class="inner">
 		
 		<!-- IF U_FORUM_RULES -->

--- a/phpBB/styles/prosilver/template/viewforum_body.html
+++ b/phpBB/styles/prosilver/template/viewforum_body.html
@@ -11,7 +11,7 @@
 <!-- ENDIF -->
 
 <!-- IF S_FORUM_RULES -->
-	<div class="rules">
+	<div class="rules<!-- IF U_FORUM_RULES --> rules-link<!-- ENDIF -->">
 		<div class="inner">
 
 		<!-- IF U_FORUM_RULES -->

--- a/phpBB/styles/prosilver/template/viewtopic_body.html
+++ b/phpBB/styles/prosilver/template/viewtopic_body.html
@@ -11,7 +11,7 @@
 <!-- ENDIF -->
 
 <!-- IF S_FORUM_RULES -->
-	<div class="rules">
+	<div class="rules<!-- IF U_FORUM_RULES --> rules-link<!-- ENDIF -->">
 		<div class="inner">
 
 		<!-- IF U_FORUM_RULES -->

--- a/phpBB/styles/subsilver2/template/posting_body.html
+++ b/phpBB/styles/subsilver2/template/posting_body.html
@@ -5,7 +5,7 @@
 <!-- ENDIF -->
 
 <!-- IF S_FORUM_RULES -->
-	<div class="forumrules">
+	<div class="forumrules<!-- IF U_FORUM_RULES --> rules-link<!-- ENDIF -->">
 		<!-- IF U_FORUM_RULES -->
 			<h3>{L_FORUM_RULES}</h3><br />
 			<a href="{U_FORUM_RULES}"><b>{L_FORUM_RULES_LINK}</b></a>

--- a/phpBB/styles/subsilver2/template/viewforum_body.html
+++ b/phpBB/styles/subsilver2/template/viewforum_body.html
@@ -1,7 +1,7 @@
 <!-- INCLUDE overall_header.html -->
 
 <!-- IF S_FORUM_RULES -->
-	<div class="forumrules">
+	<div class="forumrules<!-- IF U_FORUM_RULES --> rules-link<!-- ENDIF -->">
 		<!-- IF U_FORUM_RULES -->
 			<h3>{L_FORUM_RULES}</h3><br />
 			<a href="{U_FORUM_RULES}"><b>{L_FORUM_RULES_LINK}</b></a>

--- a/phpBB/styles/subsilver2/template/viewtopic_body.html
+++ b/phpBB/styles/subsilver2/template/viewtopic_body.html
@@ -1,7 +1,7 @@
 <!-- INCLUDE overall_header.html -->
 
 <!-- IF S_FORUM_RULES -->
-	<div class="forumrules">
+	<div class="forumrules<!-- IF U_FORUM_RULES --> rules-link<!-- ENDIF -->">
 		<!-- IF U_FORUM_RULES -->
 			<h3>{L_FORUM_RULES}</h3><br />
 			<a href="{U_FORUM_RULES}"><b>{L_FORUM_RULES_LINK}</b></a>


### PR DESCRIPTION
When a forum has a forum-rules link instead of forum-rules text, there
is no way to distinguish in the styling of the container (or the button)
it will have.

It should be possible to style the <div class="rules"> container
differently if there is only a link (no text).

http://tracker.phpbb.com/browse/PHPBB3-12304
