### PR TITLE
[ticket/12309] Template Event quickreply_editor_panel_before/after

### DIFF
--- a/phpBB/docs/events.md
+++ b/phpBB/docs/events.md
@@ -319,6 +319,22 @@ posting_editor_subject_before
 * Since: 3.1.0-a2
 * Purpose: Add field (e.g. textbox) to the posting screen before the subject
 
+quickreply_editor_panel_after
+===
+* Locations:
+    + styles/prosilver/template/quickreply_editor.html
+    + styles/subsilver2/template/quickreply_editor.html
+* Since: 3.1.0-b2
+* Purpose: Add content after the quick reply panel (but inside the form)
+
+quickreply_editor_panel_before
+===
+* Locations:
+    + styles/prosilver/template/quickreply_editor.html
+    + styles/subsilver2/template/quickreply_editor.html
+* Since: 3.1.0-b2
+* Purpose: Add content before the quick reply panel (but inside the form)
+
 quickreply_editor_message_after
 ===
 * Locations:

--- a/phpBB/styles/prosilver/template/quickreply_editor.html
+++ b/phpBB/styles/prosilver/template/quickreply_editor.html
@@ -1,4 +1,5 @@
 <form method="post" action="{U_QR_ACTION}" id="qr_postform">
+<!-- EVENT quickreply_editor_panel_before -->
 	<div class="panel">
 		<div class="inner">
 				<h2>{L_QUICKREPLY}</h2>
@@ -21,4 +22,5 @@
 				</fieldset>
 		</div>
 	</div>
+<!-- EVENT quickreply_editor_panel_after -->
 </form>

--- a/phpBB/styles/subsilver2/template/quickreply_editor.html
+++ b/phpBB/styles/subsilver2/template/quickreply_editor.html
@@ -1,5 +1,5 @@
 <form method="post" action="{U_QR_ACTION}">
-
+<!-- EVENT quickreply_editor_panel_before -->
 	<table class="tablebg" width="100%" cellspacing="1">
 		<tr>
 			<th align="center" colspan="2">{L_QUICKREPLY}</th>
@@ -24,6 +24,6 @@
 			</td>
 		</tr>
 	</table>
-	
+<!-- EVENT quickreply_editor_panel_after -->
 </form>
 <br clear="all" />


### PR DESCRIPTION
Being able to wrap the quickreply editor can be handy (especially if we want to make a hide/show toggle button). And having an extra event inside the form itself can also be handy.
