### PR TITLE
[ticket/12323] Template Event search_results_postprofile_before/after

### DIFF
--- a/phpBB/docs/events.md
+++ b/phpBB/docs/events.md
@@ -499,6 +499,20 @@ quickreply_editor_message_before
 * Since: 3.1.0-a4
 * Purpose: Add content before the quick reply textbox
 
+search_results_postprofile_after
+===
+* Locations:
+    + styles/prosilver/template/search_results.html
+* Since: 3.1.0-b3
+* Purpose: Add content after the post author and stats in search results (posts view mode)
+
+search_results_postprofile_before
+===
+* Locations:
+    + styles/prosilver/template/search_results.html
+* Since: 3.1.0-b3
+* Purpose: Add content directly before the post author in search results (posts view mode)
+
 simple_footer_after
 ===
 * Locations:

--- a/phpBB/styles/prosilver/template/search_results.html
+++ b/phpBB/styles/prosilver/template/search_results.html
@@ -122,12 +122,14 @@
 		</div>
 	<!-- ELSE -->
 		<dl class="postprofile">
+			<!-- EVENT search_results_postprofile_before -->
 			<dt class="author">{L_POST_BY_AUTHOR} {searchresults.POST_AUTHOR_FULL}</dt>
 			<dd class="search-result-date">{searchresults.POST_DATE}</dd>
 			<dd>{L_FORUM}{L_COLON} <a href="{searchresults.U_VIEW_FORUM}">{searchresults.FORUM_TITLE}</a></dd>
 			<dd>{L_TOPIC}{L_COLON} <a href="{searchresults.U_VIEW_TOPIC}">{searchresults.TOPIC_TITLE}</a></dd>
 			<dd>{L_REPLIES}{L_COLON} <strong>{searchresults.TOPIC_REPLIES}</strong></dd>
 			<dd>{L_VIEWS}{L_COLON} <strong>{searchresults.TOPIC_VIEWS}</strong></dd>
+			<!-- EVENT search_results_postprofile_after -->
 		</dl>
 
 		<div class="postbody">


### PR DESCRIPTION
For a more uniform user experience, it may be good to be able to show
user special content in search results (posts view).
This event will enable style designers to insert avatars or whatever in the same place as viewtopic_body.html

PHPBB3-12323
