### PR TITLE
[ticket/12329] Add <div> container to index blocks (online-list, etc.)

### DIFF
--- a/phpBB/styles/prosilver/template/index_body.html
+++ b/phpBB/styles/prosilver/template/index_body.html
@@ -46,7 +46,7 @@
 <!-- EVENT index_body_stat_blocks_before -->
 
 <!-- IF S_DISPLAY_ONLINE_LIST -->
-	<div class="index-block online-list">
+	<div class="stat-block online-list">
 		<!-- IF U_VIEWONLINE --><h3><a href="{U_VIEWONLINE}">{L_WHO_IS_ONLINE}</a></h3><!-- ELSE --><h3>{L_WHO_IS_ONLINE}</h3><!-- ENDIF -->
 		<p>{TOTAL_USERS_ONLINE} ({L_ONLINE_EXPLAIN})<br />{RECORD_USERS}<br /> <br />{LOGGED_IN_USER_LIST}
 		<!-- IF LEGEND --><br /><em>{L_LEGEND}{L_COLON} {LEGEND}</em><!-- ENDIF --></p>
@@ -54,14 +54,14 @@
 <!-- ENDIF -->
 
 <!-- IF S_DISPLAY_BIRTHDAY_LIST -->
-	<div class="index-block birthday-list">
+	<div class="stat-block birthday-list">
 		<h3>{L_BIRTHDAYS}</h3>
 		<p><!-- IF .birthdays -->{L_CONGRATULATIONS}{L_COLON} <strong><!-- BEGIN birthdays -->{birthdays.USERNAME}<!-- IF birthdays.AGE !== '' --> ({birthdays.AGE})<!-- ENDIF --><!-- IF not birthdays.S_LAST_ROW -->, <!-- ENDIF --><!-- END birthdays --></strong><!-- ELSE -->{L_NO_BIRTHDAYS}<!-- ENDIF --></p>
 	</div>
 <!-- ENDIF -->
 
 <!-- IF NEWEST_USER -->
-	<div class="index-block statistics">
+	<div class="stat-block statistics">
 		<h3>{L_STATISTICS}</h3>
 		<p>{TOTAL_POSTS} &bull; {TOTAL_TOPICS} &bull; {TOTAL_USERS} &bull; {NEWEST_USER}</p>
 	</div>

--- a/phpBB/styles/prosilver/template/viewforum_body.html
+++ b/phpBB/styles/prosilver/template/viewforum_body.html
@@ -245,14 +245,14 @@
 <!-- INCLUDE jumpbox.html -->
 
 <!-- IF S_DISPLAY_ONLINE_LIST -->
-	<div class="misc-block online-list">
+	<div class="stat-block online-list">
 		<h3><!-- IF U_VIEWONLINE --><a href="{U_VIEWONLINE}">{L_WHO_IS_ONLINE}</a><!-- ELSE -->{L_WHO_IS_ONLINE}<!-- ENDIF --></h3>
 		<p>{LOGGED_IN_USER_LIST}</p>
 	</div>
 <!-- ENDIF -->
 
 <!-- IF S_DISPLAY_POST_INFO -->
-	<div class="misc-block permissions">
+	<div class="stat-block permissions">
 		<h3>{L_FORUM_PERMISSIONS}</h3>
 		<p><!-- BEGIN rules -->{rules.RULE}<br /><!-- END rules --></p>
 	</div>

--- a/phpBB/styles/prosilver/template/viewtopic_body.html
+++ b/phpBB/styles/prosilver/template/viewtopic_body.html
@@ -343,7 +343,7 @@
 <!-- ENDIF -->
 
 <!-- IF S_DISPLAY_ONLINE_LIST -->
-	<div class="misc-block online-list">
+	<div class="stat-block online-list">
 		<h3><!-- IF U_VIEWONLINE --><a href="{U_VIEWONLINE}">{L_WHO_IS_ONLINE}</a><!-- ELSE -->{L_WHO_IS_ONLINE}<!-- ENDIF --></h3>
 		<p>{LOGGED_IN_USER_LIST}</p>
 	</div>

--- a/phpBB/styles/subsilver2/template/index_body.html
+++ b/phpBB/styles/subsilver2/template/index_body.html
@@ -27,7 +27,7 @@
 <!-- IF S_DISPLAY_ONLINE_LIST -->
 	<br clear="all" />
 
-	<table class="tablebg online-list" width="100%" cellspacing="1">
+	<table class="tablebg stat-block online-list" width="100%" cellspacing="1">
 	<tr>
 		<td class="cat" colspan="2"><!-- IF U_VIEWONLINE --><h4><a href="{U_VIEWONLINE}">{L_WHO_IS_ONLINE}</a></h4><!-- ELSE --><h4>{L_WHO_IS_ONLINE}</h4><!-- ENDIF --></td>
 	</tr>
@@ -50,7 +50,7 @@
 <!-- IF S_DISPLAY_BIRTHDAY_LIST -->
 	<br clear="all" />
 
-	<table class="tablebg birthday-list" width="100%" cellspacing="1">
+	<table class="tablebg stat-block birthday-list" width="100%" cellspacing="1">
 	<tr>
 		<td class="cat" colspan="2"><h4>{L_BIRTHDAYS}</h4></td>
 	</tr>
@@ -63,7 +63,7 @@
 
 <br clear="all" />
 
-<table class="tablebg statistics" width="100%" cellspacing="1">
+<table class="tablebg stat-block statistics" width="100%" cellspacing="1">
 <tr>
 	<td class="cat" colspan="2"><h4>{L_STATISTICS}</h4></td>
 </tr>

--- a/phpBB/styles/subsilver2/template/viewforum_body.html
+++ b/phpBB/styles/subsilver2/template/viewforum_body.html
@@ -293,7 +293,7 @@
 <!-- IF S_DISPLAY_ONLINE_LIST -->
 	<br clear="all" />
 
-	<table class="tablebg online-list" width="100%" cellspacing="1">
+	<table class="tablebg stat-block online-list" width="100%" cellspacing="1">
 	<tr>
 		<td class="cat"><h4>{L_WHO_IS_ONLINE}</h4></td>
 	</tr>

--- a/phpBB/styles/subsilver2/template/viewtopic_body.html
+++ b/phpBB/styles/subsilver2/template/viewtopic_body.html
@@ -387,7 +387,7 @@
 <!-- IF S_DISPLAY_ONLINE_LIST -->
 	<br clear="all" />
 
-	<table class="tablebg online-list" width="100%" cellspacing="1">
+	<table class="tablebg stat-block online-list" width="100%" cellspacing="1">
 	<tr>
 		<td class="cat"><h4>{L_WHO_IS_ONLINE}</h4></td>
 	</tr>


### PR DESCRIPTION
Adding a container to the special index blocks gives us much better control over layout/styling. Currently this is very hard (since there are no suitable CSS selectors).

I decided to use the `index-block` class for index_body.html and `misc-block` for the others. I did this because permissions and stuff like that is categorized under "miscellaneous" in the proSilver CSS files.

PHPBB3-12329
