### PR TITLE
[ticket/12326] Error while updating from b1 to b2 because of incomplete update files

### DIFF
--- a/build/package.php
+++ b/build/package.php
@@ -276,29 +276,23 @@ $update_info = array(
 
 		if (sizeof($file_contents['all']))
 		{
-			$index_contents .= '\'files\'		=> array(\'' . implode("',\n\t'", $file_contents['all']) . '\'),
-';
+			$index_contents .= "\t'files'		=> array(\n\t\t'" . implode("',\n\t\t'", $file_contents['all']) . "',\n\t),\n";
 		}
 		else
 		{
-			$index_contents .= '\'files\'		=> array(),
-';
+			$index_contents .= "\t'files'		=> array(),\n";
 		}
 
 		if (sizeof($file_contents['binary']))
 		{
-			$index_contents .= '\'binary\'		=> array(\'' . implode("',\n\t'", $file_contents['binary']) . '\'),
-';
+			$index_contents .= "\t'binary'		=> array(\n\t\t'" . implode("',\n\t\t'", $file_contents['binary']) . "',\n\t),\n";
 		}
 		else
 		{
-			$index_contents .= '\'binary\'		=> array(),
-';
+			$index_contents .= "\t'binary'		=> array(),\n";
 		}
 
-		$index_contents .= ');
-
-?' . '>';
+		$index_contents .= ");\n";
 
 		$fp = fopen($dest_filename_dir . '/install/update/index.php', 'wt');
 		fwrite($fp, $index_contents);


### PR DESCRIPTION
The patch removes files from the changed file list instead of just ignoring them while building the package.
Otherwise we run into an error about an incomplete update package when trying to run the file update.

http://tracker.phpbb.com/browse/PHPBB3-12326
