### PR TITLE
[ticket/11962] Resize posted images to fit and give them a class

### DIFF
--- a/phpBB/includes/bbcode.php
+++ b/phpBB/includes/bbcode.php
@@ -404,7 +404,7 @@ class bbcode
 				'i_close'	=> '</span>',
 				'u_open'	=> '<span style="text-decoration: underline">',
 				'u_close'	=> '</span>',
-				'img'		=> '<img src="$1" alt="' . $user->lang['IMAGE'] . '" />',
+				'img'		=> '<img src="$1" class="postimage" alt="' . $user->lang['IMAGE'] . '" />',
 				'size'		=> '<span style="font-size: $1%; line-height: normal">$2</span>',
 				'color'		=> '<span style="color: $1">$2</span>',
 				'email'		=> '<a href="mailto:$1">$2</a>'

--- a/phpBB/styles/prosilver/template/attachment.html
+++ b/phpBB/styles/prosilver/template/attachment.html
@@ -6,7 +6,7 @@
 
 		<!-- IF _file.S_THUMBNAIL -->
 		<dl class="thumbnail">
-			<dt><a href="{_file.U_DOWNLOAD_LINK}"><img src="{_file.THUMB_IMAGE}" alt="{_file.DOWNLOAD_NAME}" title="{_file.DOWNLOAD_NAME} ({_file.FILESIZE} {_file.SIZE_LANG}) {_file.L_DOWNLOAD_COUNT}" /></a></dt>
+			<dt><a href="{_file.U_DOWNLOAD_LINK}"><img src="{_file.THUMB_IMAGE}" class="postimage" alt="{_file.DOWNLOAD_NAME}" title="{_file.DOWNLOAD_NAME} ({_file.FILESIZE} {_file.SIZE_LANG}) {_file.L_DOWNLOAD_COUNT}" /></a></dt>
 			<!-- IF _file.COMMENT --><dd> {_file.COMMENT}</dd><!-- ENDIF -->
 		</dl>
 		<!-- ENDIF -->
@@ -14,7 +14,7 @@
 
 		<!-- IF _file.S_IMAGE -->
 		<dl class="file">
-			<dt class="attach-image"><img src="{_file.U_INLINE_LINK}" alt="{_file.DOWNLOAD_NAME}" onclick="viewableArea(this);" /></dt>
+			<dt class="attach-image"><img src="{_file.U_INLINE_LINK}" class="postimage" alt="{_file.DOWNLOAD_NAME}" onclick="viewableArea(this);" /></dt>
 			<!-- IF _file.COMMENT --><dd><em>{_file.COMMENT}</em></dd><!-- ENDIF -->
 			<dd>{_file.DOWNLOAD_NAME} ({_file.FILESIZE} {_file.SIZE_LANG}) {_file.L_DOWNLOAD_COUNT}</dd>
 		</dl>

--- a/phpBB/styles/prosilver/template/bbcode.html
+++ b/phpBB/styles/prosilver/template/bbcode.html
@@ -31,7 +31,7 @@
 
 <!-- BEGIN size --><span style="font-size: {SIZE}%; line-height: 116%;">{TEXT}</span><!-- END size -->
 
-<!-- BEGIN img --><img src="{URL}" alt="{L_IMAGE}" /><!-- END img -->
+<!-- BEGIN img --><img src="{URL}" class="postimage" alt="{L_IMAGE}" /><!-- END img -->
 
 <!-- BEGIN url --><a href="{URL}" class="postlink">{DESCRIPTION}</a><!-- END url -->
 

--- a/phpBB/styles/prosilver/theme/content.css
+++ b/phpBB/styles/prosilver/theme/content.css
@@ -273,6 +273,10 @@ div[class].topic-actions {
 	overflow-x: auto;
 }
 
+.postbody img.postimage {
+	max-width: 99%;
+}
+
 .search .postbody {
 	width: 68%
 }

--- a/phpBB/styles/subsilver2/template/attachment.html
+++ b/phpBB/styles/subsilver2/template/attachment.html
@@ -10,12 +10,12 @@
 		<!-- ENDIF -->
 
 		<!-- IF _file.S_THUMBNAIL -->
-			<a href="{_file.U_DOWNLOAD_LINK}"><img src="{_file.THUMB_IMAGE}" alt="{_file.DOWNLOAD_NAME}" /></a><br />
+			<a href="{_file.U_DOWNLOAD_LINK}"><img src="{_file.THUMB_IMAGE}" class="postimage" alt="{_file.DOWNLOAD_NAME}" /></a><br />
 			<span class="gensmall">{_file.DOWNLOAD_NAME} [ {_file.FILESIZE} {_file.SIZE_LANG} | {_file.L_DOWNLOAD_COUNT} ]</span>
 		<!-- ENDIF -->
 
 		<!-- IF _file.S_IMAGE -->
-			<img src="{_file.U_INLINE_LINK}" alt="{_file.DOWNLOAD_NAME}" /><br />
+			<img src="{_file.U_INLINE_LINK}" class="postimage" alt="{_file.DOWNLOAD_NAME}" /><br />
 			<span class="gensmall">{_file.DOWNLOAD_NAME} [ {_file.FILESIZE} {_file.SIZE_LANG} | {_file.L_DOWNLOAD_COUNT} ]</span>
 		<!-- ENDIF -->
 

--- a/phpBB/styles/subsilver2/template/bbcode.html
+++ b/phpBB/styles/subsilver2/template/bbcode.html
@@ -50,7 +50,7 @@
 
 <!-- BEGIN size --><span style="font-size: {SIZE}%; line-height: normal">{TEXT}</span><!-- END size -->
 
-<!-- BEGIN img --><img src="{URL}" alt="{L_IMAGE}" /><!-- END img -->
+<!-- BEGIN img --><img src="{URL}" class="postimage" alt="{L_IMAGE}" /><!-- END img -->
 
 <!-- BEGIN url --><a href="{URL}" class="postlink">{DESCRIPTION}</a><!-- END url -->
 

--- a/phpBB/styles/subsilver2/theme/stylesheet.css
+++ b/phpBB/styles/subsilver2/theme/stylesheet.css
@@ -627,6 +627,10 @@ input:focus, select:focus, textarea:focus {
 	background-color: #FAFAFA;
 }
 
+.postimage {
+	max-width: 99%;
+}
+
 .syntaxbg {
 	color: #FFFFFF;
 }


### PR DESCRIPTION
http://tracker.phpbb.com/browse/PHPBB3-11962
Based on this ticket. Adding a resizer script from a 3rd party poses
potential issues, and may be best left for extensions. So this PR
aims to add a new class to all posted images that can be targeted
by future resizer scripts, and also we now prevent posted images
from exceeding the viewable area of the post content area. In other
words, phpBB can finally display large images without cropping them!
Also vastly improves the display of posted images on mobile devices.

PHPBB3-11962
