### PR TITLE
[ticket/12333] Add Template Event overall_header_page_body_before

### DIFF
--- a/phpBB/docs/events.md
+++ b/phpBB/docs/events.md
@@ -223,14 +223,6 @@ overall_footer_copyright_prepend
 * Since: 3.1.0-a1
 * Purpose: Add content before the copyright line
 
-overall_header_body_after
-===
-* Locations:
-    + styles/prosilver/template/overall_header.html
-    + styles/subsilver2/template/overall_header.html
-* Since: 3.1.0-b3
-* Purpose: Add content after the header body
-
 overall_header_breadcrumb_append
 ===
 * Locations:
@@ -270,6 +262,14 @@ overall_header_navigation_prepend
     + styles/subsilver2/template/overall_header.html
 * Since: 3.1.0-a1
 * Purpose: Add links before the navigation links in the header
+
+overall_header_page_body_before
+===
+* Locations:
+    + styles/prosilver/template/overall_header.html
+    + styles/subsilver2/template/overall_header.html
+* Since: 3.1.0-b3
+* Purpose: Add content after the page-header, but before the page-body
 
 posting_editor_buttons_after
 ===

--- a/phpBB/styles/prosilver/template/overall_header.html
+++ b/phpBB/styles/prosilver/template/overall_header.html
@@ -176,7 +176,7 @@
 
 	</div>
 
-	<!-- EVENT overall_header_body_after -->
+	<!-- EVENT overall_header_page_body_before -->
 
 	<a id="start_here"></a>
 	<div id="page-body">

--- a/phpBB/styles/subsilver2/template/overall_header.html
+++ b/phpBB/styles/subsilver2/template/overall_header.html
@@ -222,7 +222,7 @@ function marklist(id, name, state)
 
 </div>
 
-<!-- EVENT overall_header_body_after -->
+<!-- EVENT overall_header_page_body_before -->
 
 <div id="wrapcentre">
 


### PR DESCRIPTION
Recently, the EVENT overall_header_body_before has been added.

I propose the EVENT overall_header_body_after.

Besides symmetry, it is useful to be able to insert code BETWEEN the <div id="page-header"> and <div id="page-body"> elements (this is currently not possible).

PHPBB3-12333
