### PR TITLE
[Ticket/8700] Remove unused language strings from acp/styles

### DIFF
--- a/phpBB/adm/style/acp_styles.html
+++ b/phpBB/adm/style/acp_styles.html
@@ -24,7 +24,7 @@
 	</div>
 
 </fieldset>
-		
+
 </form>
 <!-- ELSE -->
 
@@ -44,7 +44,7 @@
 		<dd><input type="text" id="name" name="style_name" value="{STYLE_NAME}" /></dd>
 	</dl>
 	<dl>
-		<dt><label>{L_STYLE_PATH}</label></dt>
+		<dt><label>{L_STYLE_PATH}{L_COLON}</label></dt>
 		<dd><strong>{STYLE_PATH}</strong></dd>
 	</dl>
 	<dl>
@@ -117,7 +117,7 @@
 				<span class="error"><br />{styles_list.COMMENT}</span>
 			<!-- ENDIF -->
 			<!-- IF not styles_list.STYLE_ID and styles_list.COMMENT == '' -->
-				<span class="style-path"><br />{L_STYLE_PATH} {styles_list.STYLE_PATH_FULL}</span>
+				<span class="style-path"><br />{L_STYLE_PATH}{L_COLON} {styles_list.STYLE_PATH_FULL}</span>
 			<!-- ENDIF -->
 		</td>
 		<!-- IF not STYLES_LIST_HIDE_COUNT -->

--- a/phpBB/language/en/acp/styles.php
+++ b/phpBB/language/en/acp/styles.php
@@ -73,7 +73,7 @@ $lang = array_merge($lang, array(
 	'STYLE_INSTALLED_RETURN_UNINSTALLED'	=> '<a href="%s">Click here</a> to install more styles.',
 	'STYLE_NAME'				=> 'Style name',
 	'STYLE_NOT_INSTALLED'		=> 'Style "%s" was not installed.',
-	'STYLE_PATH'				=> 'Style path:',
+	'STYLE_PATH'				=> 'Style path',
 	'STYLE_UNINSTALL'			=> 'Uninstall',
 	'STYLE_UNINSTALL_DEPENDENT'	=> 'Style "%s" cannot be uninstalled because it has one or more child styles.',
 	'STYLE_UNINSTALLED'			=> 'Style "%s" uninstalled successfully.',


### PR DESCRIPTION
Most of the strings were obsoleted by the removal of:
- Imagesets
- Themes
- Templates
- Editor
- Exporter

I went through the affected files (php and html) by hand and couldn't find any problems afterwards

http://tracker.phpbb.com/browse/PHPBB3-8700
