### PR TITLE
[ticket/12350] Instantiated mock phpbb_dispatcher so that test doesn't return non-object error

### DIFF
--- a/tests/extension/modules_test.php
+++ b/tests/extension/modules_test.php
@@ -227,7 +227,7 @@ class phpbb_extension_modules_test extends phpbb_test_case
 			)
 		);
 
-		$phpbb_dispatcher = phpbb_mock_event_dispatcher();
+		$phpbb_dispatcher = new phpbb_mock_event_dispatcher();
 
 		$this->assertEquals($expected, p_master::module_auth($module_auth, 0));
 	}


### PR DESCRIPTION
In modules_test.php::test_modules_auth() , `p_master::module_auth()` calls the static `module_auth` function, but module_auth references phpbb_dispatcher, which may not have been instantiated. This causes `Call to a member function trigger_event() on a non-object` as mentioned in #1943

Ran into this while running HHVM's test runner (which can run in parallel). Let me know if a more formal write-up is needed.
