### PR TITLE
[ticket/10851] Set disallowed content to empty array if checking is disabled

### DIFF
--- a/phpBB/includes/functions_posting.php
+++ b/phpBB/includes/functions_posting.php
@@ -394,6 +394,10 @@ function upload_attachment($form_name, $forum_id, $local = false, $local_storage
 	{
 		$upload->set_disallowed_content(explode('|', $config['mime_triggers']));
 	}
+	else if (!$config['check_attachment_content'])
+	{
+		$upload->set_disallowed_content(array());
+	}
 
 	if (!$local)
 	{


### PR DESCRIPTION
The disallowed content defaults to a standard set of mimetype triggers by
default. If one doesn't want to check the attachments mimetype triggers then
we need to set the disallowed content to an empty array.

Ticket: http://tracker.phpbb.com/browse/PHPBB3-10851

Does not contain tests as test cases for fileupload do not exist in develop-olympus.
Tests are added for develop-ascraeus and develop in a seperate PR for those branches.
