### PR TITLE
[ticket/12350] Instantiate Mock Dispatcher for modules_test

### DIFF
--- a/tests/extension/modules_test.php
+++ b/tests/extension/modules_test.php
@@ -209,7 +209,7 @@ class phpbb_extension_modules_test extends phpbb_test_case
 	*/
 	public function test_modules_auth($module_auth, $expected)
 	{
-		global $phpbb_extension_manager;
+		global $phpbb_extension_manager, $phpbb_dispatcher;
 
 		$phpbb_extension_manager = $this->extension_manager = new phpbb_mock_extension_manager(
 			dirname(__FILE__) . '/',
@@ -226,6 +226,8 @@ class phpbb_extension_modules_test extends phpbb_test_case
 				),
 			)
 		);
+
+		$phpbb_dispatcher = new phpbb_mock_event_dispatcher();
 
 		$this->assertEquals($expected, p_master::module_auth($module_auth, 0));
 	}


### PR DESCRIPTION
As mentioned in #2232 , the test `modules_test.php::test_modules_auth()` calls `module_auth()` statically, and `phpbb_dispatcher` may not be initialized.

PHPBB3-12350
