### PR TITLE
[ticket/12318] Revert "Pin HHVM version to 3.0.0~precise."

### DIFF
--- a/travis/setup-webserver.sh
+++ b/travis/setup-webserver.sh
@@ -26,8 +26,7 @@ APP_SOCK=$(realpath "$DIR")/php-app.sock
 if [ "$TRAVIS_PHP_VERSION" = 'hhvm' ]
 then
 	# Upgrade to a recent stable version of HHVM
-	sudo apt-get -o Dpkg::Options::="--force-confnew" \
-		install -y hhvm=3.0.0~precise
+	sudo apt-get -o Dpkg::Options::="--force-confnew" install -y hhvm
 
 	# MySQLi is broken in HHVM 3.0.0~precise and still does not work for us in
 	# 2014.03.28~saucy, i.e. needs more work. Use MySQL extension for now.


### PR DESCRIPTION
This reverts commit f6614f2078740675ca0228b348500991888c2140 as the install
command started failing with "Version '3.0.0~precise' for 'hhvm' was not found"
in the meantime.

http://tracker.phpbb.com/browse/PHPBB3-12318
