### PR TITLE
[ticket/12354] Assert same instead of equal where necessary in passwords tests

### DIFF
--- a/tests/passwords/drivers_test.php
+++ b/tests/passwords/drivers_test.php
@@ -38,7 +38,7 @@ class phpbb_passwords_helper_test extends PHPUnit_Framework_TestCase
 	public function test_helper_encode64($input, $length, $output)
 	{
 		$return = $this->driver_helper->hash_encode64($input, $length);
-		$this->assertEquals($output, $return);
+		$this->assertSame($output, $return);
 	}
 
 	public function data_get_random_salt()
@@ -61,8 +61,8 @@ class phpbb_passwords_helper_test extends PHPUnit_Framework_TestCase
 		while ((microtime(true) - $start) < 1)
 		{
 			$urandom_string = (empty($rand_seed)) ? $this->driver_helper->get_random_salt($length) : $this->driver_helper->get_random_salt($length, $rand_seed);
-			$this->assertEquals($length, strlen($urandom_string));
-			$this->assertNotEquals($rand_string, $urandom_string);
+			$this->assertSame($length, strlen($urandom_string));
+			$this->assertNotSame($rand_string, $urandom_string);
 		}
 	}
 

--- a/tests/passwords/manager_test.php
+++ b/tests/passwords/manager_test.php
@@ -273,7 +273,7 @@ class phpbb_passwords_manager_test extends PHPUnit_Framework_TestCase
 		// Limit test to 1 second
 		while ((microtime(true) - $time) < 1)
 		{
-			$this->assertNotEquals($first_id, $this->driver_helper->unique_id());
+			$this->assertNotSame($first_id, $this->driver_helper->unique_id());
 		}
 	}
 


### PR DESCRIPTION
In some tests we try to make sure that we do not get the same output in a limited timeframe.
These tests should use assertSame/NotSame instead of assertEqual/NotEqual.

Ticket: http://tracker.phpbb.com/browse/PHPBB3-12354
