### PR TITLE
[ticket/12355] Topic Tools not updated fully updated when subscribing/bookmarking

### DIFF
--- a/phpBB/assets/javascript/core.js
+++ b/phpBB/assets/javascript/core.js
@@ -549,11 +549,11 @@ phpbb.addAjaxCallback = function(id, callback) {
  * current text so that the process can be repeated.
  */
 phpbb.addAjaxCallback('alt_text', function() {
-	var el = $(this),
+	var el = $('[data-ajax="alt_text"]'),
 		altText;
 
 	altText = el.attr('data-alt-text');
-	el.attr('data-alt-text', el.text());
+	el.attr('data-alt-text', el.first().text());
 	el.attr('title', altText);
 	el.text(altText);
 });
@@ -568,7 +568,7 @@ phpbb.addAjaxCallback('alt_text', function() {
  * and changes the link itself.
  */
 phpbb.addAjaxCallback('toggle_link', function() {
-	var el = $(this),
+	var el = $('[data-ajax="toggle_link"]'),
 		toggleText,
 		toggleUrl,
 		toggleClass;
@@ -576,7 +576,7 @@ phpbb.addAjaxCallback('toggle_link', function() {
 	// Toggle link text
 
 	toggleText = el.attr('data-toggle-text');
-	el.attr('data-toggle-text', el.text());
+	el.attr('data-toggle-text', el.first().text());
 	el.attr('title', toggleText);
 	el.text(toggleText);
 


### PR DESCRIPTION
The Topic Tools menu appears at the top of a topic page and again at the
bottom of a topic page.
When you use the Topic Tools menu to Bookmark or Subscribe to a Topic, the
menu item you chose is updated to reflect that, by switching to say
Unsubscribe topic or Remove from Bookmarks.
However, this change is not mirrored in the other Topic Tools menu at the
other location on the page.
Both Topic Tools menus should be updated during the AJAX event, so that
they always show the same options to the user.

PHPBB3-12355
