### PR TITLE
[ticket/12359] Remove inline width styling on UCP birthday fields

### DIFF
--- a/phpBB/styles/prosilver/template/ucp_profile_profile_info.html
+++ b/phpBB/styles/prosilver/template/ucp_profile_profile_info.html
@@ -50,9 +50,9 @@
 		<dl>
 			<dt><label for="bday_day">{L_BIRTHDAY}:</label><br /><span>{L_BIRTHDAY_EXPLAIN}</span></dt>
 			<dd>
-				<label for="bday_day">{L_DAY}: <select name="bday_day" id="bday_day" style="width: 4em;">{S_BIRTHDAY_DAY_OPTIONS}</select></label> 
-				<label for="bday_month">{L_MONTH}: <select name="bday_month" id="bday_month" style="width: 4em;">{S_BIRTHDAY_MONTH_OPTIONS}</select></label> 
-				<label for="bday_year">{L_YEAR}: <select name="bday_year" id="bday_year" style="width: 6em;">{S_BIRTHDAY_YEAR_OPTIONS}</select></label>
+				<label for="bday_day">{L_DAY}: <select name="bday_day" id="bday_day">{S_BIRTHDAY_DAY_OPTIONS}</select></label> 
+				<label for="bday_month">{L_MONTH}: <select name="bday_month" id="bday_month">{S_BIRTHDAY_MONTH_OPTIONS}</select></label> 
+				<label for="bday_year">{L_YEAR}: <select name="bday_year" id="bday_year">{S_BIRTHDAY_YEAR_OPTIONS}</select></label>
 			</dd>
 		</dl>
 	<!-- ENDIF -->


### PR DESCRIPTION
This issue presents itself in Chrome in both olympus and ascraeus.
In olympus, double digit numbers are slightly cropped. In ascraeus
double digit number are stacked vertically. There is no actual need
for inline style settings here, as these fields already have a width
of "auto" assigned to them by prosilver's CSS.
http://tracker.phpbb.com/browse/PHPBB3-12359

PHPBB3-12359
