### PR TITLE
[ticket/12364] Add template identifier var to all missing pages

### DIFF
--- a/phpBB/faq.php
+++ b/phpBB/faq.php
@@ -74,6 +74,7 @@ $template->assign_vars(array(
 	'L_BACK_TO_TOP'				=> $user->lang['BACK_TO_TOP'],
 
 	'SWITCH_COLUMN_MANUALLY'	=> (!$found_switch) ? true : false,
+	'S_IN_FAQ'					=> true,
 ));
 
 page_header($l_title);

--- a/phpBB/index.php
+++ b/phpBB/index.php
@@ -175,6 +175,7 @@ $template->assign_vars(array(
 	'S_LOGIN_ACTION'			=> append_sid("{$phpbb_root_path}ucp.$phpEx", 'mode=login'),
 	'U_SEND_PASSWORD'           => ($config['email_enable']) ? append_sid("{$phpbb_root_path}ucp.$phpEx", 'mode=sendpassword') : '',
 	'S_DISPLAY_BIRTHDAY_LIST'	=> ($config['load_birthdays']) ? true : false,
+	'S_INDEX'					=> true,
 
 	'U_MARK_FORUMS'		=> ($user->data['is_registered'] || $config['load_anon_lastread']) ? append_sid("{$phpbb_root_path}index.$phpEx", 'hash=' . generate_link_hash('global') . '&amp;mark=forums&amp;mark_time=' . time()) : '',
 	'U_MCP'				=> ($auth->acl_get('m_') || $auth->acl_getf_global('m_')) ? append_sid("{$phpbb_root_path}mcp.$phpEx", 'i=main&amp;mode=front', true, $user->session_id) : '')

--- a/phpBB/memberlist.php
+++ b/phpBB/memberlist.php
@@ -21,6 +21,9 @@ $user->session_begin();
 $auth->acl($user->data);
 $user->setup(array('memberlist', 'groups'));
 
+// Setting a variable to let the style designer know where he is...
+$template->assign_var('S_IN_MEMBERLIST', true);
+
 // Grab data
 $mode		= request_var('mode', '');
 $action		= request_var('action', '');

--- a/phpBB/posting.php
+++ b/phpBB/posting.php
@@ -1544,6 +1544,7 @@ $template->assign_vars(array(
 	'S_POST_ACTION'			=> $s_action,
 	'S_HIDDEN_FIELDS'		=> $s_hidden_fields,
 	'S_ATTACH_DATA'			=> json_encode($message_parser->attachment_data),
+	'S_IN_POSTING'			=> true,
 ));
 
 /**

--- a/phpBB/report.php
+++ b/phpBB/report.php
@@ -301,8 +301,9 @@ $template->assign_vars(array(
 	'S_HIDDEN_FIELDS'	=> (sizeof($s_hidden_fields)) ? $s_hidden_fields : null,
 
 	'S_NOTIFY'			=> $user_notify,
-	'S_CAN_NOTIFY'		=> ($user->data['is_registered']) ? true : false)
-);
+	'S_CAN_NOTIFY'		=> ($user->data['is_registered']) ? true : false,
+	'S_IN_REPORT'		=> true,
+));
 
 generate_forum_nav($forum_data);
 

--- a/phpBB/viewonline.php
+++ b/phpBB/viewonline.php
@@ -437,8 +437,9 @@ $template->assign_vars(array(
 
 	'U_SWITCH_GUEST_DISPLAY'	=> append_sid("{$phpbb_root_path}viewonline.$phpEx", 'sg=' . ((int) !$show_guests)),
 	'L_SWITCH_GUEST_DISPLAY'	=> ($show_guests) ? $user->lang['HIDE_GUESTS'] : $user->lang['DISPLAY_GUESTS'],
-	'S_SWITCH_GUEST_DISPLAY'	=> ($config['load_online_guests']) ? true : false)
-);
+	'S_SWITCH_GUEST_DISPLAY'	=> ($config['load_online_guests']) ? true : false,
+	'S_VIEWONLINE'				=> true,
+));
 
 // We do not need to load the who is online box here. ;)
 $config['load_online'] = false;


### PR DESCRIPTION
viewtopic.php has `S_VIEWTOPIC`
viewforum.php has `S_VIEWFORUM`
search.php has `S_IN_SEARCH`
ucp.php has `S_IN_UCP`
mcp.php has `S_IN_MCP`

It would be good to have `index.php`, `viewonline.php`, `faq.php`, `memberlist.php`, `posting.php` and `report.php` use this method too.

Why? The only other guaranteed method to get the correct page type is using the `{SCRIPT_NAME}` variable, which is unreliable.

PHPBB3-12364
