### PR TITLE
[ticket/10687] Improve error message if unable to get image dimensions

### DIFF
--- a/phpBB/language/en/common.php
+++ b/phpBB/language/en/common.php
@@ -654,7 +654,7 @@ $lang = array_merge($lang, array(
 	'TOTAL_USERS_ZERO'	=> 'Total members <strong>0</strong>',
 	'TRACKED_PHP_ERROR'	=> 'Tracked PHP errors: %s',
 
-	'UNABLE_GET_IMAGE_SIZE'	=> 'It was not possible to determine the dimensions of the image.',
+	'UNABLE_GET_IMAGE_SIZE'	=> 'It was not possible to determine the dimensions of the image. Please verify that the URL you entered is correct.',
 	'UNABLE_TO_DELIVER_FILE'=> 'Unable to deliver file.',
 	'UNKNOWN_BROWSER'		=> 'Unknown browser',
 	'UNMARK_ALL'			=> 'Unmark all',


### PR DESCRIPTION
The error message that is presented if getimagesize() was unable to determine
an image's dimensions now additionally states that this might be caused by an
incorrect URL.

Ticket: http://tracker.phpbb.com/browse/PHPBB3-10687

PHPBB3-10687
