### PR TITLE
[ticket/12376] Add template events viewtopic_body_polls

### DIFF
--- a/phpBB/docs/events.md
+++ b/phpBB/docs/events.md
@@ -693,22 +693,22 @@ viewtopic_body_footer_before
 and quick reply, directly before the jumpbox in Prosilver, breadcrumbs in
 Subsilver2.
 
-viewtopic_body_poll_fieldset_append
+viewtopic_body_poll_option_after
 ===
 * Locations:
     + styles/prosilver/template/viewtopic_body.html
     + styles/subsilver2/template/viewtopic_body.html
 * Since: 3.1.0-b3
-* Purpose: Add content before the items in the polls fieldset
+* Purpose: Add content after the poll option
 the list.
 
-viewtopic_body_poll_fieldset_prepend
+viewtopic_body_poll_option_before
 ===
 * Locations:
     + styles/prosilver/template/viewtopic_body.html
     + styles/subsilver2/template/viewtopic_body.html
 * Since: 3.1.0-b3
-* Purpose: Add content after the items in the polls fieldset
+* Purpose: Add content before the poll option
 the list.
 
 viewtopic_body_poll_question_append

--- a/phpBB/styles/prosilver/template/viewtopic_body.html
+++ b/phpBB/styles/prosilver/template/viewtopic_body.html
@@ -71,15 +71,15 @@
 			<p class="author">{L_POLL_LENGTH}<!-- IF S_CAN_VOTE and L_POLL_LENGTH --><br /><!-- ENDIF --><!-- IF S_CAN_VOTE --><span class="poll_max_votes">{L_MAX_VOTES}</span><!-- ENDIF --></p>
 
 			<fieldset class="polls">
-			<!-- EVENT viewtopic_body_poll_fieldset_prepend -->
-
 			<!-- BEGIN poll_option -->
+				<!-- EVENT viewtopic_body_poll_option_before -->
 				<dl class="<!-- IF poll_option.POLL_OPTION_VOTED -->voted<!-- ENDIF --><!-- IF poll_option.POLL_OPTION_MOST_VOTES --> most-votes<!-- ENDIF -->"<!-- IF poll_option.POLL_OPTION_VOTED --> title="{L_POLL_VOTED_OPTION}"<!-- ENDIF --> data-poll-option-id="{poll_option.POLL_OPTION_ID}">
 					<dt><!-- IF S_CAN_VOTE --><label for="vote_{poll_option.POLL_OPTION_ID}">{poll_option.POLL_OPTION_CAPTION}</label><!-- ELSE -->{poll_option.POLL_OPTION_CAPTION}<!-- ENDIF --></dt>
 					<!-- IF S_CAN_VOTE --><dd style="width: auto;" class="poll_option_select"><!-- IF S_IS_MULTI_CHOICE --><input type="checkbox" name="vote_id[]" id="vote_{poll_option.POLL_OPTION_ID}" value="{poll_option.POLL_OPTION_ID}"<!-- IF poll_option.POLL_OPTION_VOTED --> checked="checked"<!-- ENDIF --> /><!-- ELSE --><input type="radio" name="vote_id[]" id="vote_{poll_option.POLL_OPTION_ID}" value="{poll_option.POLL_OPTION_ID}"<!-- IF poll_option.POLL_OPTION_VOTED --> checked="checked"<!-- ENDIF --> /><!-- ENDIF --></dd><!-- ENDIF -->
 					<dd class="resultbar<!-- IF not S_DISPLAY_RESULTS --> hidden<!-- ENDIF -->"><div class="<!-- IF poll_option.POLL_OPTION_PCT < 20 -->pollbar1<!-- ELSEIF poll_option.POLL_OPTION_PCT < 40 -->pollbar2<!-- ELSEIF poll_option.POLL_OPTION_PCT < 60 -->pollbar3<!-- ELSEIF poll_option.POLL_OPTION_PCT < 80 -->pollbar4<!-- ELSE -->pollbar5<!-- ENDIF -->" style="width:{poll_option.POLL_OPTION_PERCENT_REL};">{poll_option.POLL_OPTION_RESULT}</div></dd>
 					<dd class="poll_option_percent<!-- IF not S_DISPLAY_RESULTS --> hidden<!-- ENDIF -->"><!-- IF poll_option.POLL_OPTION_RESULT == 0 -->{L_NO_VOTES}<!-- ELSE -->{poll_option.POLL_OPTION_PERCENT}<!-- ENDIF --></dd>
 				</dl>
+				<!-- EVENT viewtopic_body_poll_option_after -->
 			<!-- END poll_option -->
 
 				<dl class="poll_total_votes<!-- IF not S_DISPLAY_RESULTS --> hidden<!-- ENDIF -->">
@@ -100,8 +100,6 @@
 					<dd class="resultbar"><a href="{U_VIEW_RESULTS}">{L_VIEW_RESULTS}</a></dd>
 				</dl>
 			<!-- ENDIF -->
-
-			<!-- EVENT viewtopic_body_poll_fieldset_append -->
 			</fieldset>
 			<div class="vote-submitted hidden">{L_VOTE_SUBMITTED}</div>
 		</div>

--- a/phpBB/styles/subsilver2/template/viewtopic_body.html
+++ b/phpBB/styles/subsilver2/template/viewtopic_body.html
@@ -76,10 +76,10 @@
 			</tr>
 			<tr>
 				<td align="{S_CONTENT_FLOW_BEGIN}">
-				<!-- EVENT viewtopic_body_poll_fieldset_prepend -->
 					<table cellspacing="0" cellpadding="2" border="0">
 				<!-- BEGIN poll_option -->
 					<tr>
+					<!-- EVENT viewtopic_body_poll_option_before -->
 					<!-- IF S_CAN_VOTE -->
 						<td<!-- IF poll_option.POLL_OPTION_MOST_VOTES --> class="most-votes"<!-- ENDIF -->>
 							<!-- IF S_IS_MULTI_CHOICE -->
@@ -98,10 +98,10 @@
 								<td class="gensmall" valign="top"><b title="{L_POLL_VOTED_OPTION}">x</b></td>
 							<!-- ENDIF -->
 						<!-- ENDIF -->
+					<!-- EVENT viewtopic_body_poll_option_after -->
 					</tr>
 				<!-- END poll_option -->
 					</table>
-				<!-- EVENT viewtopic_body_poll_fieldset_append -->
 				</td>
 			</tr>
 		<!-- IF S_CAN_VOTE -->


### PR DESCRIPTION
I propose 3 template events:

1: `EVENT viewtopic_body_poll_question_prepend`

It would be the equivalent of `viewtopic_topic_title_prepend`, and will allow us to use prefixes, or better yet, icons. It will allow us to use code like:
`<h2><span class="<!-- IF S_CAN_VOTE and L_POLL_LENGTH -->poll-icon-timer<!-- ELSEIF S_CAN_VOTE -->poll-icon-open<!-- ELSE -->poll-icon-closed<!-- ENDIF -->">{L_VIEW_TOPIC_POLL}</span>....</h2>`

2: `EVENT viewtopic_body_poll_fieldset_prepend`
Having control of the poll fieldset can have advantages in case we want to add extra functionality, buttons or create wrapping containers.

3: `EVENT viewtopic_body_poll_fieldset_prepend`
The counter-part to the previous one

PHPBB3-12376
