### PR TITLE
[ticket/12379] Remove duplicate labels in attachment uploader when responsive.

### DIFF
--- a/phpBB/styles/prosilver/template/posting_attach_body.html
+++ b/phpBB/styles/prosilver/template/posting_attach_body.html
@@ -35,7 +35,6 @@
 				<tbody class="responsive-skip-empty" id="file-list">
 					<tr class="attach-row" id="attach-row-tpl">
 							<td class="attach-name">
-								<dfn style="display: none;">{L_PLUPLOAD_FILENAME}</dfn>
 								<span class="file-name"></span>
 								<span class="attach-controls">
 									<input type="button" value="{L_PLACE_INLINE}" class="button2 hidden file-inline-bbcode" />&nbsp;
@@ -44,15 +43,12 @@
 								<span class="clear"></span>
 							</td>
 							<td class="attach-comment">
-								<dfn style="display: none;">{L_FILE_COMMENT}</dfn>
 								<textarea rows="1" cols="30" class="inputbox"></textarea>
 							</td>
 							<td class="attach-filesize">
-								<dfn style="display: none;">{L_PLUPLOAD_SIZE}</dfn>
 								<span class="file-size"></span>
 							</td>
 							<td class="attach-status">
-								<dfn style="display: none;">{L_PLUPLOAD_STATUS}</dfn>
 								<span class="file-progress">
 									<span class="file-progress-bar"></span>
 								</span>


### PR DESCRIPTION
https://tracker.phpbb.com/browse/PHPBB3-12379
