### PR TITLE
[ticket/12351] Add loading indicator to links that are missing it.

### DIFF
--- a/phpBB/adm/style/acp_forums.html
+++ b/phpBB/adm/style/acp_forums.html
@@ -467,9 +467,9 @@
 				</td>
 				<td class="actions">
 					<span class="up-disabled" style="display:none;">{ICON_MOVE_UP_DISABLED}</span>
-					<span class="up"><a href="{forums.U_MOVE_UP}" data-ajax="row_up" data-overlay="false">{ICON_MOVE_UP}</a></span>
+					<span class="up"><a href="{forums.U_MOVE_UP}" data-ajax="row_up">{ICON_MOVE_UP}</a></span>
 					<span class="down-disabled" style="display:none;">{ICON_MOVE_DOWN_DISABLED}</span>
-					<span class="down"><a href="{forums.U_MOVE_DOWN}" data-ajax="row_down" data-overlay="false">{ICON_MOVE_DOWN}</a></span>
+					<span class="down"><a href="{forums.U_MOVE_DOWN}" data-ajax="row_down">{ICON_MOVE_DOWN}</a></span>
 					<a href="{forums.U_EDIT}">{ICON_EDIT}</a>
 					<!-- IF not forums.S_FORUM_LINK -->
 						<a href="{forums.U_SYNC}" onclick="popup_progress_bar();">{ICON_SYNC}</a>

--- a/phpBB/adm/style/acp_groups_position.html
+++ b/phpBB/adm/style/acp_groups_position.html
@@ -43,9 +43,9 @@
 			<td style="text-align: center;">{legend.GROUP_TYPE}</td>
 			<td class="actions">
 				<span class="up-disabled" style="display: none;">{ICON_MOVE_UP_DISABLED}</span>
-				<span class="up"><a href="{legend.U_MOVE_UP}" data-ajax="row_up" data-overlay="false">{ICON_MOVE_UP}</a></span>
+				<span class="up"><a href="{legend.U_MOVE_UP}" data-ajax="row_up">{ICON_MOVE_UP}</a></span>
 				<span class="down-disabled" style="display:none;">{ICON_MOVE_DOWN_DISABLED}</span>
-				<span class="down"><a href="{legend.U_MOVE_DOWN}" data-ajax="row_down" data-overlay="false">{ICON_MOVE_DOWN}</a></span>
+				<span class="down"><a href="{legend.U_MOVE_DOWN}" data-ajax="row_down">{ICON_MOVE_DOWN}</a></span>
 				<a href="{legend.U_DELETE}">{ICON_DELETE}</a>
 			</td>
 		</tr>
@@ -129,9 +129,9 @@
 			</td></td>
 			<td class="actions">
 				<span class="up-disabled" style="display: none;">{ICON_MOVE_UP_DISABLED}</span>
-				<span class="up"><a href="{teampage.U_MOVE_UP}" data-ajax="row_up" data-overlay="false">{ICON_MOVE_UP}</a></span>
+				<span class="up"><a href="{teampage.U_MOVE_UP}" data-ajax="row_up">{ICON_MOVE_UP}</a></span>
 				<span class="down-disabled" style="display:none;">{ICON_MOVE_DOWN_DISABLED}</span>
-				<span class="down"><a href="{teampage.U_MOVE_DOWN}" data-ajax="row_down" data-overlay="false">{ICON_MOVE_DOWN}</a></span>
+				<span class="down"><a href="{teampage.U_MOVE_DOWN}" data-ajax="row_down">{ICON_MOVE_DOWN}</a></span>
 				<a href="{teampage.U_DELETE}">{ICON_DELETE}</a>
 			</td>
 		</tr>

--- a/phpBB/styles/prosilver/template/index_body.html
+++ b/phpBB/styles/prosilver/template/index_body.html
@@ -17,7 +17,7 @@
 		<!-- ENDIF -->
 		<li><a href="{U_SEARCH_ACTIVE_TOPICS}">{L_SEARCH_ACTIVE_TOPICS}</a></li>
 	<!-- ENDIF -->
-	<!-- IF not S_IS_BOT and U_MARK_FORUMS --><li class="rightside mark-read"><a href="{U_MARK_FORUMS}" accesskey="m" data-ajax="mark_forums_read" data-overlay="false">{L_MARK_FORUMS_READ}</a></li><!-- ENDIF -->
+	<!-- IF not S_IS_BOT and U_MARK_FORUMS --><li class="rightside mark-read"><a href="{U_MARK_FORUMS}" accesskey="m" data-ajax="mark_forums_read">{L_MARK_FORUMS_READ}</a></li><!-- ENDIF -->
 </ul>
 <!-- ENDIF -->
 

--- a/phpBB/styles/prosilver/template/viewforum_body.html
+++ b/phpBB/styles/prosilver/template/viewforum_body.html
@@ -28,7 +28,7 @@
 <!-- IF S_HAS_SUBFORUM -->
 <!-- IF not S_IS_BOT and U_MARK_FORUMS -->
 <ul class="linklist">
-	<li class="rightside mark-read"><a href="{U_MARK_FORUMS}" data-ajax="mark_forums_read" data-overlay="false">{L_MARK_SUBFORUMS_READ}</a></li>
+	<li class="rightside mark-read"><a href="{U_MARK_FORUMS}" data-ajax="mark_forums_read">{L_MARK_SUBFORUMS_READ}</a></li>
 </ul>
 <!-- ENDIF -->
 	<!-- INCLUDE forumlist_body.html -->
@@ -56,7 +56,7 @@
 	<!-- ENDIF -->
 
 	<div class="pagination">
-		<!-- IF not S_IS_BOT and U_MARK_TOPICS and .topicrow --><a href="{U_MARK_TOPICS}" accesskey="m" data-ajax="mark_topics_read" data-overlay="false">{L_MARK_TOPICS_READ}</a> &bull; <!-- ENDIF -->
+		<!-- IF not S_IS_BOT and U_MARK_TOPICS and .topicrow --><a href="{U_MARK_TOPICS}" accesskey="m" data-ajax="mark_topics_read">{L_MARK_TOPICS_READ}</a> &bull; <!-- ENDIF -->
 		{TOTAL_TOPICS} &bull; 
 		<!-- IF .pagination -->
 			<!-- INCLUDE pagination.html -->
@@ -227,7 +227,7 @@
 		<!-- ENDIF -->
 
 		<div class="pagination">
-			<!-- IF not S_IS_BOT and U_MARK_TOPICS and .topicrow --><a href="{U_MARK_TOPICS}" data-ajax="mark_topics_read" data-overlay="false">{L_MARK_TOPICS_READ}</a> &bull; <!-- ENDIF -->
+			<!-- IF not S_IS_BOT and U_MARK_TOPICS and .topicrow --><a href="{U_MARK_TOPICS}" data-ajax="mark_topics_read">{L_MARK_TOPICS_READ}</a> &bull; <!-- ENDIF -->
 			{TOTAL_TOPICS} &bull; 
 			<!-- IF .pagination -->
 				<!-- INCLUDE pagination.html -->


### PR DESCRIPTION
When you click on the link, the turning circle is missing, so you don't
know whether it is actually doing something or not, until the response is
served.

PHPBB3-12351
