### PR TITLE
[ticket/12211] Do not run attachment file names twice through htmlspecialchars

### DIFF
--- a/phpBB/includes/functions_upload.php
+++ b/phpBB/includes/functions_upload.php
@@ -64,7 +64,7 @@ class filespec
 		$this->filename = $upload_ary['tmp_name'];
 		$this->filesize = $upload_ary['size'];
 		$name = (STRIP) ? stripslashes($upload_ary['name']) : $upload_ary['name'];
-		$name = trim(utf8_htmlspecialchars(utf8_basename($name)));
+		$name = trim(utf8_basename($name));
 		$this->realname = $this->uploadname = $name;
 		$this->mimetype = $upload_ary['type'];
 

--- a/tests/upload/filespec_test.php
+++ b/tests/upload/filespec_test.php
@@ -273,4 +273,18 @@ class phpbb_filespec_test extends phpbb_test_case
 
 		$phpEx = '';
 	}
+
+	/**
+	* @dataProvider clean_filename_variables
+	*/
+	public function test_uploadname($filename)
+	{
+		$type_cast_helper = new \phpbb\request\type_cast_helper();
+
+		$upload_name = '';
+		$type_cast_helper->set_var($upload_name, $filename, 'string', true, true);
+		$filespec = $this->get_filespec(array('name'=> $upload_name));
+
+		$this->assertSame(trim(utf8_basename(htmlspecialchars($filename))), $filespec->uploadname);
+	}
 }


### PR DESCRIPTION
Upload filenames are already processed via htmlspecialchars in the
type_cast_helper of the new request class. There is no need to run it through
htmlspecialchars() again in the filespec class.

Ticket: https://tracker.phpbb.com/browse/PHPBB3-12211

PHPBB3-12211
