### PR TITLE
[ticket/12392] Include $profile_fields in core.memberlist_view_profile

### DIFF
--- a/phpBB/memberlist.php
+++ b/phpBB/memberlist.php
@@ -558,8 +558,6 @@ switch ($mode)
 			$member['user_sig'] = generate_text_for_display($member['user_sig'], $member['user_sig_bbcode_uid'], $member['user_sig_bbcode_bitfield'], $parse_flags, true);
 		}
 
-		$poster_avatar = phpbb_get_user_avatar($member);
-
 		// We need to check if the modules 'zebra' ('friends' & 'foes' mode),  'notes' ('user_notes' mode) and  'warn' ('warn_user' mode) are accessible to decide if we can display appropriate links
 		$zebra_enabled = $friends_enabled = $foes_enabled = $user_notes_enabled = $warn_user_enabled = false;
 
@@ -650,7 +648,6 @@ switch ($mode)
 			'SIGNATURE'		=> $member['user_sig'],
 			'POSTS_IN_QUEUE'=> $member['posts_in_queue'],
 
-			'AVATAR_IMG'	=> $poster_avatar,
 			'PM_IMG'		=> $user->img('icon_contact_pm', $user->lang['SEND_PRIVATE_MESSAGE']),
 			'EMAIL_IMG'		=> $user->img('icon_contact_email', $user->lang['EMAIL']),
 			'JABBER_IMG'	=> $user->img('icon_contact_jabber', $user->lang['JABBER']),


### PR DESCRIPTION
The profile fields currently miss every event dispatch in place in the memberlist.

Also removed the double avatar assignment, which requested the user avatar twice, and was excluded from all the events.

PHPBB3-12392
