### PR TITLE
[ticket/12403] Add template events to acp_users_prefs.html

### DIFF
--- a/phpBB/adm/style/acp_users_prefs.html
+++ b/phpBB/adm/style/acp_users_prefs.html
@@ -5,9 +5,10 @@
 </script>
 
 	<form id="user_prefs" method="post" action="{U_ACTION}">
-
+	<!-- EVENT acp_users_prefs_prepend -->
 	<fieldset>
 		<legend>{L_UCP_PREFS_PERSONAL}</legend>
+	<!-- EVENT acp_users_prefs_personal_prepend -->
 	<dl> 
 		<dt><label for="viewemail">{L_SHOW_EMAIL}{L_COLON}</label></dt>
 		<dd><label><input type="radio" class="radio" name="viewemail" value="1"<!-- IF VIEW_EMAIL --> id="viewemail" checked="checked"<!-- ENDIF --> /> {L_YES}</label>
@@ -53,10 +54,12 @@
 		<dd><select name="dateoptions" id="dateoptions" onchange="if(this.value=='custom'){dE('custom_date',1);}else{dE('custom_date',-1);} if (this.value == 'custom') { document.getElementById('dateformat').value = default_dateformat; } else { document.getElementById('dateformat').value = this.value; }">{S_DATEFORMAT_OPTIONS}</select></dd>
 		<dd><div id="custom_date"<!-- IF not S_CUSTOM_DATEFORMAT --> style="display:none;"<!-- ENDIF -->><input type="text" name="dateformat" id="dateformat" value="{DATE_FORMAT}" maxlength="30" /></div></dd>
 	</dl>
+	<!-- EVENT acp_users_prefs_personal_append -->
 	</fieldset>
 
 	<fieldset>
 		<legend>{L_UCP_PREFS_POST}</legend>
+	<!-- EVENT acp_users_prefs_post_prepend -->
 	<dl> 
 		<dt><label for="bbcode">{L_DEFAULT_BBCODE}{L_COLON}</label></dt>
 		<dd><label><input type="radio" class="radio" name="bbcode" value="1"<!-- IF BBCODE --> id="bbcode" checked="checked"<!-- ENDIF --> /> {L_YES}</label>
@@ -77,10 +80,12 @@
 		<dd><label><input type="radio" class="radio" name="notify" value="1"<!-- IF NOTIFY --> id="notify" checked="checked"<!-- ENDIF --> /> {L_YES}</label>
 			<label><input type="radio" class="radio" name="notify" value="0"<!-- IF not NOTIFY --> id="notify" checked="checked"<!-- ENDIF --> /> {L_NO}</label></dd>
 	</dl>
+	<!-- EVENT acp_users_prefs_post_append -->
 	</fieldset>
 
 	<fieldset>
 		<legend>{L_UCP_PREFS_VIEW}</legend>
+	<!-- EVENT acp_users_prefs_view_prepend -->
 	<dl> 
 		<dt><label for="view_images">{L_VIEW_IMAGES}{L_COLON}</label></dt>
 		<dd><label><input type="radio" class="radio" name="view_images" value="1"<!-- IF VIEW_IMAGES --> id="view_images" checked="checked"<!-- ENDIF --> /> {L_YES}</label>
@@ -135,8 +140,9 @@
 		<dt><label>{L_VIEW_POSTS_DIR}{L_COLON}</label></dt>
 		<dd>{S_POST_SORT_DIR}</dd>
 	</dl>
+	<!-- EVENT acp_users_prefs_view_append -->
 	</fieldset>
-
+	<!-- EVENT acp_users_prefs_append -->
 	<fieldset class="quick">
 		<input class="button1" type="submit" name="update" value="{L_SUBMIT}" />
 		{S_FORM_TOKEN}

--- a/phpBB/docs/events.md
+++ b/phpBB/docs/events.md
@@ -76,6 +76,54 @@ acp_users_overview_options_append
 * Since: 3.1.0-a1
 * Purpose: Add options and settings on user overview page
 
+acp_users_prefs_append
+===
+* Location: adm/style/acp_users_prefs.html
+* Since: 3.1.0-b3
+* Purpose: Add user options fieldset to the bottom of ACP users prefs settings
+
+acp_users_prefs_prepend
+===
+* Location: adm/style/acp_users_prefs.html
+* Since: 3.1.0-b3
+* Purpose: Add user options fieldset to the top of ACP users prefs settings
+
+acp_users_prefs_personal_append
+===
+* Location: adm/style/acp_users_prefs.html
+* Since: 3.1.0-b3
+* Purpose: Add user options fieldset to the bottom of ACP users personal prefs settings
+
+acp_users_prefs_personal_prepend
+===
+* Location: adm/style/acp_users_prefs.html
+* Since: 3.1.0-b3
+* Purpose: Add user options fieldset to the top of ACP users personal prefs settings
+
+acp_users_prefs_post_append
+===
+* Location: adm/style/acp_users_prefs.html
+* Since: 3.1.0-b3
+* Purpose: Add user options fieldset to the bottom of ACP users post prefs settings
+
+acp_users_prefs_post_prepend
+===
+* Location: adm/style/acp_users_prefs.html
+* Since: 3.1.0-b3
+* Purpose: Add user options fieldset to the top of ACP users post prefs settings
+
+acp_users_prefs_view_append
+===
+* Location: adm/style/acp_users_prefs.html
+* Since: 3.1.0-b3
+* Purpose: Add user options fieldset to the bottom of ACP users view prefs settings
+
+acp_users_prefs_view_prepend
+===
+* Location: adm/style/acp_users_prefs.html
+* Since: 3.1.0-b3
+* Purpose: Add user options fieldset to the top of ACP users view prefs settings
+
 acp_users_signature_editor_buttons_after
 ===
 * Locations:


### PR DESCRIPTION
Since it is possible for extensions to add new user preferences to UCP,
it should be also possible to control it via ACP too
just like for build-in user preferences.
Thus, some prepend/append template events are added.

<a href="https://tracker.phpbb.com/browse/PHPBB3-12403">PHPBB3-12403</a>.
