### PR TITLE
[ticket/12407] Allow changing of post_data, etc. at end of posting.php

### DIFF
--- a/phpBB/posting.php
+++ b/phpBB/posting.php
@@ -1572,7 +1572,6 @@ $page_data = array(
 *				post|reply|quote|edit|delete|bump|smilies|popup
 * @var	string	page_title	Title of the mode page
 * @var	bool	s_topic_icons	Whether or not to show the topic icons
-<<<<<<< HEAD
 * @var	string	form_enctype	If attachments are allowed for this form
 *				"multipart/form-data" or empty string
 * @var	string	s_action	The URL to submit the POST data to


### PR DESCRIPTION
The current event core.posting_modify_template_vars is just ran using dispatch
but it doesn't pass any data from posting.php to the listener. Because of that,
it's not possible to know anything from posting.php and therefore limits the
use cases of this event. This will change it to allow similar actions as with
the event core.modify_posting_parameters.

Ticket: https://tracker.phpbb.com/browse/PHPBB3-12407

PHPBB3-12407
