### PR TITLE
[ticket/11366] Extension's version's check

### DIFF
--- a/phpBB/adm/style/acp_ext_details.html
+++ b/phpBB/adm/style/acp_ext_details.html
@@ -6,6 +6,19 @@
 
 	<h1>{L_EXTENSIONS_ADMIN}</h1>
 
+	<!-- IF S_VERSIONCHECK_FAIL -->
+	<div class="errorbox notice">
+		<p>{L_VERSIONCHECK_FAIL}</p>
+		<p>{VERSIONCHECK_FAIL_REASON}</p>
+		<p><a href="{U_VERSIONCHECK_FORCE}">{L_VERSIONCHECK_FORCE_UPDATE}</a></p>
+	</div>
+	<!-- ENDIF -->
+	<!-- IF S_VERSIONCHECK -->	
+	<div class="<!-- IF S_UP_TO_DATE -->successbox<!-- ELSE -->errorbox<!-- ENDIF -->">
+		<p>{UP_TO_DATE_MSG} - <a href="{U_VERSIONCHECK_FORCE}">{L_VERSIONCHECK_FORCE_UPDATE}</a></p>
+	</div>
+	<!-- ENDIF -->
+
 	<fieldset>
 		<legend>{L_EXT_DETAILS}</legend>
 		<!-- IF META_DISPLAY_NAME -->
@@ -45,6 +58,28 @@
 			<dd><span id="meta_license">{META_LICENSE}</span></dd>
 		</dl>
 	</fieldset>
+
+	<!-- IF S_VERSIONCHECK && not S_UP_TO_DATE -->
+	<fieldset>
+		<legend>{L_LATEST_VERSION}</legend>
+		<dl>
+			<dt><label>{L_VERSION}{L_COLON}</label></dt>
+			<dd><span id="latest_version">{LATEST_VERSION}</span></dd>
+		</dl>
+		<!-- IF LATEST_DOWNLOAD -->
+		<dl>
+			<dt><label>{L_DOWNLOAD_LATEST}</label></dt>
+			<dd><strong id="latest_download"><a href="{LATEST_DOWNLOAD}">{L_DOWNLOAD} {META_NAME} {LATEST_VERSION}</a></strong></dd>
+		</dl>
+		<!-- ENDIF -->
+		<!-- IF LATEST_ANNOUNCEMENT -->
+		<dl>
+			<dt><label>{L_ANNOUNCEMENT_TOPIC}</label></dt>
+			<dd><strong id="latest_announcement"><a href="{LATEST_ANNOUNCEMENT}">{L_RELEASE_ANNOUNCEMENT}</a></strong></dd>
+		</dl>
+		<!-- ENDIF -->
+	</fieldset>
+	<!-- ENDIF -->
 
 	<!-- IF META_REQUIRE_PHPBB || META_REQUIRE_PHP -->
 	<fieldset>

--- a/phpBB/adm/style/acp_ext_list.html
+++ b/phpBB/adm/style/acp_ext_list.html
@@ -7,22 +7,30 @@
 	<p>{L_EXTENSIONS_EXPLAIN}</p>
 
 	<table class="table1">
-		<col class="row1" ><col class="row2" ><col class="row2" >
+		<col class="row1" ><col class="row1" ><col class="row1" ><col class="row2" ><col class="row2" >
 	<thead>
 		<tr>
 			<th>{L_EXTENSION_NAME}</th>
-			<th>{L_EXTENSION_OPTIONS}</th>
-			<th>{L_EXTENSION_ACTIONS}</th>
+			<th width="10%">{L_CURRENT_VERSION}</th>
+			<th width="10%">{L_LATEST_VERSION}</th>
+			<th width="10%">{L_EXTENSION_OPTIONS}</th>
+			<th width="10%">{L_EXTENSION_ACTIONS}</th>
 		</tr>
 	</thead>
 	<tbody>
 		<!-- IF .enabled -->
 		<tr>
-			<td class="row3" colspan="3"><strong>{L_EXTENSIONS_ENABLED}</strong></td>
+			<td class="row3" colspan="5"><strong>{L_EXTENSIONS_ENABLED}</strong></td>
 		</tr>
 		<!-- BEGIN enabled -->
 		<tr class="ext_enabled">
 			<td><strong>{enabled.META_DISPLAY_NAME}</strong></td>
+			<td style="text-align: center;">{enabled.META_VERSION}</td>
+			<td style="text-align: center;">
+				<!-- IF enabled.S_VERSIONCHECK -->
+				<strong <!-- IF enabled.S_UP_TO_DATE -->style="color: #228822;"<!-- ELSE -->style="color: #BC2A4D;"<!-- ENDIF -->>{enabled.LATEST_VERSION}</strong> [&nbsp;<a href="{enabled.U_VERSIONCHECK_FORCE}">{L_VERSIONCHECK_FORCE_UPDATE}</a>&nbsp;]
+				<!-- ENDIF -->
+			</td>
 			<td style="text-align: center;"><a href="{enabled.U_DETAILS}">{L_DETAILS}</a></td>
 			<td style="text-align: center;">
 				<!-- BEGIN actions -->
@@ -36,11 +44,17 @@
 
 		<!-- IF .disabled -->
 		<tr>
-			<td class="row3" colspan="3"><strong>{L_EXTENSIONS_DISABLED}</strong></td>
+			<td class="row3" colspan="5"><strong>{L_EXTENSIONS_DISABLED}</strong></td>
 		</tr>
 		<!-- BEGIN disabled -->
 		<tr class="ext_disabled">
 			<td><strong>{disabled.META_DISPLAY_NAME}</strong></td>
+			<td style="text-align: center;">{disabled.META_VERSION}</td>
+			<td style="text-align: center;">
+				<!-- IF disabled.S_VERSIONCHECK -->
+				<strong <!-- IF disabled.S_UP_TO_DATE -->style="color: #228822;"<!-- ELSE -->style="color: #BC2A4D;"<!-- ENDIF -->>{disabled.LATEST_VERSION}</strong> [&nbsp;<a href="{U_VERSIONCHECK_FORCE}">{L_VERSIONCHECK_FORCE_UPDATE}</a>&nbsp;]
+				<!-- ENDIF -->
+			</td>
 			<td style="text-align: center;">
 				<!-- IF disabled.U_DETAILS --><a href="{disabled.U_DETAILS}">{L_DETAILS}</a><!-- ENDIF -->
 			</td>

--- a/phpBB/language/en/acp/extensions.php
+++ b/phpBB/language/en/acp/extensions.php
@@ -106,4 +106,11 @@ $lang = array_merge($lang, array(
 	'AUTHOR_EMAIL'			=> 'Email',
 	'AUTHOR_HOMEPAGE'		=> 'Homepage',
 	'AUTHOR_ROLE'			=> 'Role',
+
+	'NOT_UP_TO_DATE'			=> '%s is not up to date',
+	'UP_TO_DATE'			=> '%s is up to date',
+	'ANNOUNCEMENT_TOPIC'	=> 'Release Announcement',
+	'DOWNLOAD_LATEST'		=> 'Download Latest Version',
+	'NO_VERSIONCHECK'		=> 'No informations about how get the latest version.',
+//	'NO_INFO'					=> 'Version server could not be contacted',
 ));

--- a/phpBB/phpbb/extension/version_helper.php
+++ b/phpBB/phpbb/extension/version_helper.php
@@ -1,0 +1,257 @@
+<?php
+/**
+*
+* @package extension
+* @copyright (c) 2014 phpBB Group
+* @license http://opensource.org/licenses/gpl-2.0.php GNU General Public License v2
+*
+*/
+
+namespace phpbb\extension;
+
+/**
+ * Class to handle version checking and comparison for the extensions
+ */
+class version_helper
+{
+	/**
+	 * @var string Host
+	 */
+	protected $host = '';
+
+	/**
+	 * @var string Path to file
+	 */
+	protected $path = '';
+
+	/**
+	 * @var string File name
+	 */
+	protected $file = '';
+
+	/**
+	 * @var string Extension name
+	 */
+	protected $extension = '';
+
+	/**
+	 * @var string Current version installed
+	 */
+	protected $current_version = '';
+
+	/** @var \phpbb\cache\service */
+	protected $cache;
+
+	/** @var \phpbb\user */
+	protected $user;
+
+	/**
+	 * @var array Metadata of the latest versio
+	 */
+	protected $latest_version_metadata;
+
+	/**
+	 * Constructor
+	 *
+	 * @param \phpbb\cache\service $cache
+	 * @param \phpbb\user $user
+	 */
+	public function __construct(\phpbb\cache\service $cache, \phpbb\user $user)
+	{
+		$this->cache = $cache;
+		$this->user = $user;
+	}
+
+	/**
+	 * Set the informations concerning the current version from the metadata
+	 *
+	 * @param array $metadata
+	 * @throws \RuntimeException
+	 */
+	public function set_metadata($metadata)
+	{
+		if (! isset($metadata['extra']['version-check']))
+		{
+			throw new \RuntimeException($this->user->lang('NO_VERSIONCHECK'));
+		}
+
+		$meta_vc = $metadata['extra']['version-check'];
+		
+		$this->set_file_location($meta_vc['host'], $meta_vc['directory'], $meta_vc['filename']);
+		$this->set_extension($metadata['name']);
+		$this->set_current_version($metadata['version']);
+	}
+
+	/**
+	 * Set the name of the extention
+	 *
+	 * @param string Name of the extension
+	 * @return version_helper
+	 */
+	public function set_extension($extension)
+	{
+		$this->extension = $extension;
+
+		return $this;
+	}
+
+	/**
+	 * Set location to the file
+	 *
+	 * @param string $host Host (e.g. version.phpbb.com)
+	 * @param string $path Path to file (e.g. /phpbb)
+	 * @param string $file File name (Default: composer.json)
+	 * @return version_helper
+	 */
+	public function set_file_location($host, $path, $file = 'composer.json')
+	{
+		$this->host = $host;
+		$this->path = $path;
+		$this->file = $file;
+
+		return $this;
+	}
+
+	/**
+	 * Set current version
+	 *
+	 * @param string $version The current version
+	 * @return version_helper
+	 */
+	public function set_current_version($version)
+	{
+		$this->current_version = $version;
+
+		return $this;
+	}
+
+	/**
+	 * Wrapper for version_compare() that allows using uppercase A and B
+	 * for alpha and beta releases.
+	 *
+	 * See http://www.php.net/manual/en/function.version-compare.php
+	 *
+	 * @param string $version1		First version number
+	 * @param string $version2		Second version number
+	 * @param string $operator		Comparison operator (optional)
+	 *
+	 * @return mixed				Boolean (true, false) if comparison operator is specified.
+	 *								Integer (-1, 0, 1) otherwise.
+	 */
+	public function compare($version1, $version2, $operator = null)
+	{
+		return phpbb_version_compare($version1, $version2, $operator);
+	}
+
+	/**
+	 * Say if the extension is up to date or not
+	 *
+	 * The informations about the lastest version are retrieved if needed
+	 * 
+	 * @return bool true if the version is up to date
+	 * @throws \RuntimeException
+	 */
+	public function is_uptodate()
+	{
+		if (empty($this->latest_version_metadata))
+		{
+			$this->get_version();
+		}
+
+		return $this->compare($this->current_version, $this->latest_version_metadata['version'], '>=');
+	}
+
+	/**
+	 * Return the latest version number
+	 *
+	 * @return The latest version number ready to be displayed.
+	 */
+	public function get_latest_version() {
+		if (empty($this->latest_version_metadata))
+		{
+			$this->get_version();
+		}
+		
+		return htmlspecialchars($this->latest_version_metadata['version']);
+	}
+
+	/**
+	 * Return the latest download link
+	 *
+	 * @return The latest download link if existed, an empty string otherwise.
+	 */
+	public function get_latest_download_link() {
+		if (empty($this->latest_version_metadata))
+		{
+			$this->get_version();
+		}
+		
+		return isset($this->latest_version_metadata['extra']['download']) ? $this->latest_version_metadata['extra']['download']: '';
+	}
+
+	/**
+	 * Return the latest announcement link
+	 *
+	 * @return The latest announcement link if existed, an empty string otherwise.
+	 */
+	public function get_latest_announcement_link() {
+		if (empty($this->latest_version_metadata))
+		{
+			$this->get_version();
+		}
+		
+		return isset($this->latest_version_metadata['extra']['announcement']) ? $this->latest_version_metadata['extra']['announcement']: '';
+	}
+
+	/**
+	 * Obtains the latest version information
+	 *
+	 * @param bool $force_update Ignores cached data. Defaults to false.
+	 * @return string Version info
+	 * @throws \RuntimeException
+	 */
+	public function get_version($force_update = false)
+	{
+echo 'Force : ' . $force_update;
+		$cache_file = 'versioncheck_ext_' . $this->extension . ':' . $this->host . $this->path . $this->file;
+
+		$info = $this->cache->get($cache_file);
+
+		if ($info === false || $force_update)
+		{
+			$errstr = $errno = '';
+			$info = get_remote_file($this->host, $this->path, $this->file, $errstr, $errno);
+
+			if (!empty($errstr))
+			{
+				throw new \RuntimeException($errstr);
+			}
+			
+			$info = json_decode($info, true);
+
+			if (empty($info['version']))
+			{
+				$this->user->add_lang('acp/common');
+
+				throw new \RuntimeException($this->user->lang('VERSIONCHECK_FAIL'));
+			}
+
+			// Replace & with &amp; on announcement and download links
+			if (isset($info['extra']['announcement'])) 
+			{
+				$info['extra']['announcement'] = str_replace('&', '&amp;', $info['extra']['announcement']);
+			}
+			
+			if (isset($info['extra']['download'])) 
+			{
+				$info['extra']['download'] = str_replace('&', '&amp;', $info['extra']['download']);
+			}
+			
+			$this->cache->put($cache_file, $info, 86400); // 24 hours
+		}
+
+		$this->latest_version_metadata = $info;
+
+		return $info;
+	}
+}


### PR DESCRIPTION
Add a feature to check automatically the version of the installed
extensions. The informations are cached for 24 hours (like for the
global update check on the main page of the acp).

The informations about the versions are display both on the global list
and on the detailled page.

To do this the developper has to to let the composer.json of the latest
version available and add some informations into it :

```
"extra": {
    "version-check": {
        "host": "<the host>",
        "directory": "<the directory containing the file>",
        "filename": "<the composer.json of the latest version>"
    }
}
```

He can also add two extra informations which will be displayed if a new
version is available :

```
"extra": {
    "download": "<download link>",
    "annoucement": "<announcement link>",
}
```

Currently a notice is displayed when the "extra.version-check"
informations are
missing.

Ticket: https://tracker.phpbb.com/browse/PHPBB3-11366

Signed-off-by: Nicofuma github@nicofuma.fr

PHPBB3-11366
