### PR TITLE
[ticket/12397] Fix sql_unique_index_exists doc block

### DIFF
--- a/phpBB/includes/db/db_tools.php
+++ b/phpBB/includes/db/db_tools.php
@@ -875,7 +875,7 @@ class phpbb_db_tools
 			}
 		}
 
-		// Add unqiue indexes?
+		// Add unique indexes?
 		if (!empty($schema_changes['add_unique_index']))
 		{
 			foreach ($schema_changes['add_unique_index'] as $table => $index_array)
@@ -1286,7 +1286,7 @@ class phpbb_db_tools
 	}
 
 	/**
-	* Check if a specified index exists in table. Does not return PRIMARY KEY and UNIQUE indexes.
+	* Check if a specified index exists in table. Does not return PRIMARY KEY indexes.
 	*
 	* @param string	$table_name		Table to check the index at
 	* @param string	$index_name		The index name to check


### PR DESCRIPTION
db_tools::sql_unique_index_exists() searches also for unique indexes but not
primary keys.

PHPBB3-12397
