### PR TITLE
[ticket/12410] Add Template events search_results_post_ b/a

### DIFF
--- a/phpBB/docs/events.md
+++ b/phpBB/docs/events.md
@@ -499,6 +499,22 @@ quickreply_editor_message_before
 * Since: 3.1.0-a4
 * Purpose: Add content before the quick reply textbox
 
+search_results_post_after
+===
+* Locations:
+    + styles/prosilver/template/search_results.html
+    + styles/subsilver2/template/search_results.html
+* Since: 3.1.0-b3
+* Purpose: Add data after search result posts
+
+search_results_post_before
+===
+* Locations:
+    + styles/prosilver/template/search_results.html
+    + styles/subsilver2/template/search_results.html
+* Since: 3.1.0-b3
+* Purpose: Add data before search result posts
+
 simple_footer_after
 ===
 * Locations:

--- a/phpBB/styles/prosilver/template/search_results.html
+++ b/phpBB/styles/prosilver/template/search_results.html
@@ -113,6 +113,7 @@
 <!-- ELSE -->
 
 	<!-- BEGIN searchresults -->
+		<!-- EVENT search_results_post_before -->
 		<div class="search post <!-- IF searchresults.S_ROW_COUNT is odd -->bg1<!-- ELSE -->bg2<!-- ENDIF --><!-- IF searchresults.S_POST_REPORTED --> reported<!-- ENDIF -->">
 			<div class="inner">
 
@@ -144,6 +145,7 @@
 
 			</div>
 		</div>
+		<!-- EVENT search_results_post_after -->
 	<!-- BEGINELSE -->
 		<div class="panel">
 			<div class="inner">

--- a/phpBB/styles/subsilver2/template/search_results.html
+++ b/phpBB/styles/subsilver2/template/search_results.html
@@ -91,6 +91,7 @@
 
 	<!-- BEGIN searchresults -->
 		<tr class="row2">
+		<!-- EVENT search_results_post_before -->
 		<!-- IF searchresults.S_IGNORE_POST -->
 			<td class="gensmall" colspan="2" height="25" align="center">{searchresults.L_IGNORE_POST}</td>
 		<!-- ELSE -->
@@ -126,6 +127,7 @@
 				</td>
 			</tr>
 		<!-- ENDIF -->
+		<!-- EVENT search_results_post_after -->
 		<tr>
 			<td class="spacer" colspan="2"><img src="images/spacer.gif" height="1" alt="" /></td>
 		</tr>


### PR DESCRIPTION
In viewtopic_body.html we have:

`<!-- EVENT viewtopic_body_postrow_post_before -->` and `<!-- EVENT viewtopic_body_postrow_post_after -->`

I propose:
`<!-- EVENT search_results_post_before -->` and `<!-- EVENT search_results_post_after -->`

This will allow us to do similar things with the search results.

https://tracker.phpbb.com/browse/PHPBB3-12410
PHPBB3-12410
