### PR TITLE
[ticket/8558] Add display name in emails from board

### DIFF
--- a/phpBB/includes/functions_messenger.php
+++ b/phpBB/includes/functions_messenger.php
@@ -486,14 +486,16 @@ class messenger
 			$use_queue = true;
 		}
 
+		$board_contact = '"' . mail_encode(htmlspecialchars($config['sitename'])) . '" <' . $config['board_contact'] . '>';
+
 		if (empty($this->replyto))
 		{
-			$this->replyto = '"' . $config['sitename'] . '" <' . $config['board_contact'] . '>';
+			$this->replyto = $board_contact;
 		}
 
 		if (empty($this->from))
 		{
-			$this->from = '"' . $config['sitename'] . '" <' . $config['board_contact'] . '>';
+			$this->from = $board_contact;
 		}
 
 		$encode_eol = ($config['smtp_delivery']) ? "\r\n" : $this->eol;


### PR DESCRIPTION
This PR replaces #1902 which was unfortunately not updated anymore by its author.

First I squashed his commits in only one commit and edited the commit message so it works. After that I removed the extra option in ACP because I thought that would be unnecessary. (Sitename should be enough) But since that reverted the changes he made in two files completely (and the changes would cause a conflict when merging in ascraeus) I squashed that change into his commit too.

After that I put that in one variable so `mail_encode` has to be called only once and added `htmlspecialchars`.

https://tracker.phpbb.com/browse/PHPBB3-8558
