### PR TITLE
[ticket/12417] Revert "No longer allow Travis CI HHVM environment to fai...

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,3 +33,5 @@ matrix:
       env: DB=mariadb
     - php: 5.4
       env: DB=postgres
+  allow_failures:
+    - php: hhvm


### PR DESCRIPTION
...l."

hhvm-nightly 2014.04.16~precise introduced "Attempted to serialize
unserializable builtin class DOMElement" errors when running functional tests.

This reverts commit ff7cc77f9db66b7fddacd77f215d85cf0243b2fa.

PHPBB3-12417
