### PR TITLE
[ticket/12199] Move deprecated functions to functions_compatibility.php

### DIFF
--- a/phpBB/includes/functions.php
+++ b/phpBB/includes/functions.php
@@ -1005,24 +1005,6 @@ function phpbb_get_timezone_identifiers($selected_timezone)
 }
 
 /**
-* Pick a timezone
-*
-* @param	string		$default			A timezone to select
-* @param	boolean		$truncate			Shall we truncate the options text
-*
-* @return		string		Returns the options for timezone selector only
-*
-* @deprecated
-*/
-function tz_select($default = '', $truncate = false)
-{
-	global $user;
-
-	$timezone_select = phpbb_timezone_select($user, $default, $truncate);
-	return $timezone_select['tz_select'];
-}
-
-/**
 * Options to pick a timezone and date/time
 *
 * @param	\phpbb\user	$user				Object of the current user

--- a/phpBB/includes/functions_admin.php
+++ b/phpBB/includes/functions_admin.php
@@ -2581,20 +2581,6 @@ function phpbb_cache_moderators($db, $cache, $auth)
 }
 
 /**
-* Cache moderators. Called whenever permissions are changed
-* via admin_permissions. Changes of usernames and group names
-* must be carried through for the moderators table.
-*
-* @deprecated 3.1
-* @return null
-*/
-function cache_moderators()
-{
-	global $db, $cache, $auth;
-	return phpbb_cache_moderators($db, $cache, $auth);
-}
-
-/**
 * View log
 *
 * @param	string	$mode			The mode defines which log_type is used and from which log the entry is retrieved
@@ -2741,20 +2727,6 @@ function phpbb_update_foes($db, $auth, $group_id = false, $user_id = false)
 		$db->sql_query($sql);
 	}
 	unset($perms);
-}
-
-/**
-* Removes moderators and administrators from foe lists.
-*
-* @deprecated 3.1
-* @param array|bool $group_id If an array, remove all members of this group from foe lists, or false to ignore
-* @param array|bool $user_id If an array, remove this user from foe lists, or false to ignore
-* @return null
-*/
-function update_foes($group_id = false, $user_id = false)
-{
-	global $db, $auth;
-	return phpbb_update_foes($db, $auth, $group_id, $user_id);
 }
 
 /**

--- a/phpBB/includes/functions_compatibility.php
+++ b/phpBB/includes/functions_compatibility.php
@@ -116,3 +116,49 @@ function phpbb_clean_path($path)
 
 	return $phpbb_path_helper->clean_path($path);
 }
+
+/**
+* Pick a timezone
+*
+* @param	string		$default			A timezone to select
+* @param	boolean		$truncate			Shall we truncate the options text
+*
+* @return		string		Returns the options for timezone selector only
+*
+* @deprecated
+*/
+function tz_select($default = '', $truncate = false)
+{
+	global $user;
+
+	$timezone_select = phpbb_timezone_select($user, $default, $truncate);
+	return $timezone_select['tz_select'];
+}
+
+/**
+* Cache moderators. Called whenever permissions are changed
+* via admin_permissions. Changes of usernames and group names
+* must be carried through for the moderators table.
+*
+* @deprecated 3.1
+* @return null
+*/
+function cache_moderators()
+{
+	global $db, $cache, $auth;
+	return phpbb_cache_moderators($db, $cache, $auth);
+}
+
+/**
+* Removes moderators and administrators from foe lists.
+*
+* @deprecated 3.1
+* @param array|bool $group_id If an array, remove all members of this group from foe lists, or false to ignore
+* @param array|bool $user_id If an array, remove this user from foe lists, or false to ignore
+* @return null
+*/
+function update_foes($group_id = false, $user_id = false)
+{
+	global $db, $auth;
+	return phpbb_update_foes($db, $auth, $group_id, $user_id);
+}


### PR DESCRIPTION
_Currently 13 functions are marked as deprecated:_
**functions.php:**
- function set_var()
- function request_var()
- function set_config()
- function set_config_count()
- function tz_select()
- function add_log()

**functions_admin:**
- function cache_moderators()
- function update_foes()

**functions_compatibility:**
- function get_user_avatar()
- function phpbb_hash()
- function phpbb_check_hash()
- function phpbb_clean_path()

**functions_install:**
- function get_tables()

_8 of them are still used in the core:_
- add_log              Used in many places (~198 calls)
- get_tables           Used in install\install_convert::get_convert_settings and functions_install.php\connect_check_db
- get_user_avatar      Used in phpbb\user_loader:get_avatar
- phpbb_hash           Used in phpbb\db\migration\data\v30x\release_3_0_5_rc1
- request_var          Used quite everywhere (~997 calls)
- set_config           Used in many places (~129 calls)
- set_config_count     Used in a few places (~37 calls)
- set_var              Used by phpbb_http_login and phpbb\auth\provider\apache::autologin

https://tracker.phpbb.com/browse/PHPBB3-12199

PHPBB3-12199
