### PR TITLE
[ticket/12437] Clean up redundant "clear" & "corners" elements 

### DIFF
--- a/phpBB/styles/prosilver/template/faq_body.html
+++ b/phpBB/styles/prosilver/template/faq_body.html
@@ -24,10 +24,6 @@
 	</div>
 </div>
 
-
-
-<div class="clear"></div>
-
 <!-- BEGIN faq_block -->
 	<div class="panel <!-- IF faq_block.S_ROW_COUNT is odd -->bg1<!-- ELSE -->bg2<!-- ENDIF -->">
 		<div class="inner">

--- a/phpBB/styles/prosilver/template/mcp_footer.html
+++ b/phpBB/styles/prosilver/template/mcp_footer.html
@@ -1,9 +1,8 @@
 
 		</div>
-	<div class="clear"></div>
 
 	</div>
-	<span class="corners-bottom"><span></span></span></div>
+	</div>
 </div>
 
 <!-- INCLUDE overall_footer.html -->

--- a/phpBB/styles/prosilver/template/memberlist_view.html
+++ b/phpBB/styles/prosilver/template/memberlist_view.html
@@ -50,14 +50,14 @@
 		<!-- ENDIF -->
 	</dl>
 
-	<span class="clear"></span></div>
+	</div>
 </div>
 
 <!-- EVENT memberlist_view_contact_before -->
 <div class="panel bg2">
 	<div class="inner">
-	<div class="column1">
 
+	<div class="column1">
 		<h3>{L_CONTACT_USER} {USERNAME}</h3>
 
 		<dl class="details">
@@ -103,7 +103,8 @@
 			<!-- EVENT memberlist_view_user_statistics_after -->
 		</dl>
 	</div>
-	<span class="clear"></span></div>
+
+	</div>
 </div>
 <!-- EVENT memberlist_view_contact_after -->
 
@@ -115,7 +116,7 @@
 
 		<div class="postbody"><div class="signature standalone">{SIGNATURE}</div></div>
 
-	<span class="clear"></span></div>
+	</div>
 </div>
 <!-- ENDIF -->
 

--- a/phpBB/styles/prosilver/template/posting_pm_header.html
+++ b/phpBB/styles/prosilver/template/posting_pm_header.html
@@ -76,7 +76,6 @@
 			</dl>
 		</div>
 		<!-- ENDIF -->
-		
-		<div class="clear"></div>
+
 	<!-- ENDIF -->
 	</fieldset>

--- a/phpBB/styles/prosilver/template/ucp_footer.html
+++ b/phpBB/styles/prosilver/template/ucp_footer.html
@@ -1,9 +1,8 @@
 
 		</div>
-	<div class="clear"></div>
 
 	</div>
-	<span class="corners-bottom"><span></span></span></div>
+	</div>
 </div>
 <!-- IF S_COMPOSE_PM -->
 <div>{S_FORM_TOKEN}</div>


### PR DESCRIPTION
Since we are dropping IE6 & IE7 support, it would be nice to get rid of some redundant style elements like `<span class="clear"></span>`.

They don't add anything if they are inside container with a clearing rule like:
`.inner:after {
    clear: both;
    content: "";
    display: block;
}`

Since IE8 supports this method, we could simply remove these redundant elements.

Additionally, there are still remnants of old `corners-top` and `corners-bottom` code, which can easily be removed.

PHPBB3-12437
