### PR TITLE
[ticket/11325] Check PHP 5.6 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ before_script:
   - sh -c "if [ '$DB' = 'postgres' ]; then psql -c 'DROP DATABASE IF EXISTS phpbb_tests;' -U postgres; fi"
   - sh -c "if [ '$DB' = 'postgres' ]; then psql -c 'create database phpbb_tests;' -U postgres; fi"
   - sh -c "if [ '$DB' = 'mariadb' ]; then travis/setup-mariadb.sh; fi"
+  - sh -c "if [ '$TRAVIS_PHP_VERSION' != 'hhvm' ]; then bash travis/setup-php-extensions.sh; fi"
   - sh -c "if [ '$TRAVIS_PHP_VERSION' = '5.3' -a '$DB' = 'mysql' ]; then mysql -e 'SET GLOBAL storage_engine=MyISAM;'; fi"
   - sh -c "if [ '$DB' = 'mysql' -o '$DB' = 'mariadb' ]; then mysql -e 'create database IF NOT EXISTS phpbb_tests;'; fi"
   - sh -c "if [ '$TRAVIS_PHP_VERSION' = '5.2' ]; then pear install --force phpunit/DbUnit; phpenv rehash; fi"

--- a/travis/setup-php-extensions.sh
+++ b/travis/setup-php-extensions.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+#
+# @copyright (c) 2014 phpBB Group
+# @license http://opensource.org/licenses/gpl-2.0.php GNU General Public License v2
+#
+set -e
+set -x
+
+function find_php_ini
+{
+	echo $(php --ini | grep "Loaded Configuration" | sed -e "s|.*:\s*||")
+}
+
+php_ini_file=$(find_php_ini)
+
+#mbstring
+if [ `php -r "echo (int) version_compare(PHP_VERSION, '5.6.0-a3', '>=');"` == "1" ]
+then
+	echo 'mbstring.http_input=pass' >> "$php_ini_file"
+	echo 'mbstring.http_output=pass' >> "$php_ini_file"
+fi


### PR DESCRIPTION
with php 5.6.0a3 the default configuration of mbstring changed from
'mbstring.http_input=pass' to 'mbstring.http_input=' so the new default
configuration use the value of 'output_encoding' which is empty by default
and so use the value of 'default_charset' which is 'UTF-8'.

PHPBB3-11325
