### PR TITLE
[ticket/12472] Set fast_finish for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,3 +35,4 @@ matrix:
       env: DB=postgres
   allow_failures:
     - php: hhvm
+  fast_finish: true


### PR DESCRIPTION
Now, a build will finish as soon as a job has failed,
or when the only jobs left allow failures.
http://docs.travis-ci.com/user/build-configuration/#Fast-finishing

https://tracker.phpbb.com/browse/PHPBB3-12472
