### PR TITLE
[ticket/12498] Adds height-property for IE8 in tweaks.css

### DIFF
--- a/phpBB/styles/prosilver/theme/tweaks.css
+++ b/phpBB/styles/prosilver/theme/tweaks.css
@@ -66,3 +66,8 @@ dd.option {
 .icon-notification {
 	*z-index: 2;
 }
+
+/* Fixes header-avatar aspect-ratio in IE8 */
+.header-avatar img {
+	height: 25px;
+}


### PR DESCRIPTION
PHPBB3-12498

This fix adds a new "height"-property for the IE8 to keep the aspect-ratio of the header-avatar correct. In the moment the avatar is horizontally streched and this makes the header look ugly. (see picture in tracker-attachment) 

https://tracker.phpbb.com/browse/PHPBB3-12498
