### PR TITLE
[ticket/12511] Add missing titles for profile fields in members group view

### DIFF
--- a/phpBB/styles/prosilver/template/memberlist_body.html
+++ b/phpBB/styles/prosilver/template/memberlist_body.html
@@ -96,10 +96,10 @@
 			<!-- IF U_SORT_ACTIVE --><th class="active"><a href="{U_SORT_ACTIVE}#memberlist">{L_LAST_ACTIVE}</a></th><!-- ENDIF -->
 	<!-- ELSEIF S_SHOW_GROUP -->
 		<th class="name">{L_GROUP_MEMBERS}</th>
-		<th class="posts">&nbsp;</th>
-		<th class="info">&nbsp;</th>
-		<th class="joined">&nbsp;</th>
-		<!-- IF U_SORT_ACTIVE --><th class="active">&nbsp;</th><!-- ENDIF -->
+		<th class="posts">{L_POSTS}</th>
+		<th class="info"><!-- BEGIN custom_fields --><!-- IF not custom_fields.S_FIRST_ROW -->{L_COMMA_SEPARATOR} <!-- ENDIF -->{custom_fields.PROFILE_FIELD_NAME}<!-- END custom_fields --></th>
+		<th class="joined">{L_JOINED}</th>
+		<!-- IF U_SORT_ACTIVE --><th class="active">{L_LAST_ACTIVE}</th><!-- ENDIF -->
 	<!-- ENDIF -->
 	</tr>
 	</thead>


### PR DESCRIPTION
For memberlist group view in cases the group is presented with the group leader
and group members, for members profile fields titles are missing: Posts,
Joined, Last active and custom profile fields titles.

<a href="https://tracker.phpbb.com/browse/PHPBB3-12511">PHPBB3-12511</a>.
