### PR TITLE
[ticket/12524] Add search.php core event to modify search results rowset

### DIFF
--- a/phpBB/search.php
+++ b/phpBB/search.php
@@ -911,6 +911,30 @@ if ($keywords || $author || $author_id || $search_id || $submit)
 			$hilit = implode('|', $hilit_array);
 		}
 
+		/**
+		* Modify the rowset data
+		*
+		* @event core.search_modify_rowset
+		* @var	array	attachments				Array with posts attachments data
+		* @var	string	hilit					String to highlight
+		* @var	array	rowset					Array with the search results data
+		* @var	array	topic_tracking_info		Array with the topics tracking data
+		* @var	string	u_hilit					Highlight string to be injected into URL
+		* @var	string	view					Search results view mode
+		* @var	array	zebra					Array with zebra data for the current user
+		* @since 3.1.0-b4
+		*/
+		$vars = array(
+			'attachments',
+			'hilit',
+			'rowset',
+			'topic_tracking_info',
+			'u_hilit',
+			'view',
+			'zebra',
+		);
+		extract($phpbb_dispatcher->trigger_event('core.search_modify_rowset', compact($vars)));
+
 		foreach ($rowset as $row)
 		{
 			$forum_id = $row['forum_id'];


### PR DESCRIPTION
Currently it is possible to change search results within the search row scope,
but it should be possible to modify/unset every individual row
within the rowset.

<a href="https://tracker.phpbb.com/browse/PHPBB3-12524">PHPBB3-12524</a>.
