### PR TITLE
[ticket/12533] Make <a> use all the container

### DIFF
--- a/phpBB/styles/prosilver/theme/colours.css
+++ b/phpBB/styles/prosilver/theme/colours.css
@@ -1161,7 +1161,6 @@ input.disabled {
 }
 
 .dropdown-extended .footer {
-	padding: 5px 0;
 	border-top-style: solid;
 	border-top-width: 1px;
 }

--- a/phpBB/styles/prosilver/theme/common.css
+++ b/phpBB/styles/prosilver/theme/common.css
@@ -1102,6 +1102,10 @@ form > p.post-notice strong {
 	padding: 10px;
 }
 
+.dropdown-extended .footer > a {
+	padding: 5px 0;
+}
+
 .dropdown-extended ul li a, .notification_list dt > a, .dropdown-extended .footer > a {
 	display: block;
 	text-decoration: none;


### PR DESCRIPTION
Changed padding CSS to the notifications' `<li>` and it's `<a>` (immediate child) so that the `<a>` block uses all it's container width and height.

To compensate that, I added the padding that was in the `<li>` to the `<a>`

PHPBB3-12533
