### PR TITLE
[ticket/12535] Make <a> adjust to the image width

### DIFF
--- a/phpBB/styles/prosilver/theme/content.css
+++ b/phpBB/styles/prosilver/theme/content.css
@@ -725,13 +725,13 @@ fieldset.polls dd div {
 }
 
 .postprofile .avatar {
-	display: block;
+	display: inline-block;
+	max-width: 90%;
 	border: none;
 	margin-bottom: 3px;
 }
 
 .postprofile .avatar img {
-	max-width: 90%;
 	height: auto !important;
 }
 

--- a/phpBB/styles/prosilver/theme/links.css
+++ b/phpBB/styles/prosilver/theme/links.css
@@ -121,6 +121,11 @@ a.lastsubject:hover {
 }
 
 /* Profile links */
+.postprofile a:link:before{
+	content:'';
+	display:block;
+}
+
 .postprofile a:link, .postprofile a:visited, .postprofile dt.author a {
 	font-weight: bold;
 	text-decoration: none;


### PR DESCRIPTION
No HTML changes made.

Changed so that the `<a>` that surrounds the `<img>` in viewtopic does not use
all width and, instead, have the same size as the image.
Additionally, I added a CSS pseudo-element to make the required forced
line break after the `<img>` happen.

Only limited testing made. Please test before merging.

PHPBB3-12535
