### PR TITLE
[ticket/12519] Restore m_approve language description

### DIFF
--- a/phpBB/language/en/acp/permissions_phpbb.php
+++ b/phpBB/language/en/acp/permissions_phpbb.php
@@ -142,7 +142,7 @@ $lang = array_merge($lang, array(
 	'ACL_M_EDIT'		=> 'Can edit posts',
 	'ACL_M_DELETE'		=> 'Can permanently delete posts',
 	'ACL_M_SOFTDELETE'	=> 'Can soft delete posts<br /><em>Moderators, who have the approve posts permission, can restore soft deleted posts.</em>',
-	'ACL_M_APPROVE'		=> 'Can approve posts',
+	'ACL_M_APPROVE'		=> 'Can approve and restore posts',
 	'ACL_M_REPORT'		=> 'Can close and delete reports',
 	'ACL_M_CHGPOSTER'	=> 'Can change post author',
 


### PR DESCRIPTION
Restore acl_m_approve language description to:
"Can approve and restore posts"

PHPBB3-12519
