### PR TITLE
[ticket/12572] Fix JS error when alert message title is undefined

### DIFF
--- a/phpBB/assets/javascript/core.js
+++ b/phpBB/assets/javascript/core.js
@@ -333,7 +333,9 @@ phpbb.ajaxify = function(options) {
 						// Hide the alert even if we refresh the page, in case the user
 						// presses the back button.
 						dark.fadeOut(phpbb.alertTime, function() {
-							alert.hide();
+							if (typeof alert !== 'undefined') {
+								alert.hide();
+							}
 						});
 					}, res.REFRESH_DATA.time * 1000); // Server specifies time in seconds
 				}


### PR DESCRIPTION
JS console reports error in core.js:
TypeError: alert is undefined
alert.hide()
when res.MESSAGE_TITLE is undefined.

<a href="https://tracker.phpbb.com/browse/PHPBB3-12572">PHPBB3-12572</a>.
