### PR TITLE
[ticket/12580] Remove :link pseudo from a tag

### DIFF
--- a/phpBB/styles/prosilver/theme/colours.css
+++ b/phpBB/styles/prosilver/theme/colours.css
@@ -250,7 +250,7 @@ p.post-notice.reported:before, p.post-notice.error:before {
 Colours and backgrounds for links.css
 -------------------------------------------------------------- */
 
-a:link	{ color: #105289; }
+a { color: #105289; }
 a:visited	{ color: #105289; }
 a:hover	{ color: #D31141; }
 a:active	{ color: #368AD2; }


### PR DESCRIPTION
[ticket/12580] Remove :link pseudo from a tag

removed the :link pseudo from a tag as due to specificity it prevents
classes from altering any properties set to it.

PHPBB3-12580 https://tracker.phpbb.com/browse/PHPBB3-12580?filter=-2
