### PR TITLE
[ticket/12604] Fix wrong padding when no notifications

### DIFF
--- a/phpBB/styles/prosilver/template/notification_dropdown.html
+++ b/phpBB/styles/prosilver/template/notification_dropdown.html
@@ -13,7 +13,7 @@
 
 		<ul>
 			<!-- IF not .notifications -->
-				<li>
+				<li class="no_notifications">
 					{L_NO_NOTIFICATIONS}
 				</li>
 			<!-- ENDIF -->

--- a/phpBB/styles/prosilver/theme/common.css
+++ b/phpBB/styles/prosilver/theme/common.css
@@ -1066,6 +1066,10 @@ form > p.post-notice strong {
 	position: relative;
 }
 
+.dropdown-extended ul li.no_notifications {
+	padding: 10px;
+}
+
 .dropdown-extended ul li:before, .dropdown-extended ul li:after {
 	display: none;
 }


### PR DESCRIPTION
Added a class to the <li> when the <li> represents that there's no
notifications (no_notifications) and
Added a CSS rule that matches the change to the HTML source for when
there's no notifications.

PHPBB3-12604
