### PR TITLE
[ticket/12562] Add max-width to proSilver

### DIFF
--- a/phpBB/styles/prosilver/theme/common.css
+++ b/phpBB/styles/prosilver/theme/common.css
@@ -59,7 +59,7 @@ body {
 	font-size: 10px;
 	line-height: normal;
 	margin: 0;
-	padding: 12px 0;
+	padding: 0;
 	word-wrap: break-word;
 }
 
@@ -175,8 +175,10 @@ ol ol ul, ol ul ul, ul ol ul, ul ul ul {
 /* Main blocks
 ---------------------------------------- */
 #wrap {
-	padding: 0 20px;
 	min-width: 650px;
+	max-width: 1152px;
+	margin: 0 auto;
+	padding: 12px;
 }
 
 #simple-wrap {

--- a/phpBB/styles/prosilver/theme/responsive.css
+++ b/phpBB/styles/prosilver/theme/responsive.css
@@ -13,12 +13,12 @@ html {
 }
 
 body {
-	padding: 0 5px;
+	padding: 0;
 }
 
 #wrap {
 	min-width: 300px;
-	padding: 0;
+	padding: 0 5px;
 }
 
 /* Common block wrappers


### PR DESCRIPTION
Don't kill me just yet. There are (many) valid reasons to have a max-width. Legibility, style consistency, and a default for extensions. I'm obviously not saying that A51 should use it, but having a default instead of "unlimited" for releases is worth considering.

I'm just submitting this so we know what we're looking at.
![fx](https://cloud.githubusercontent.com/assets/3015760/3237328/23044a26-f0e7-11e3-83f6-801c07163939.png)

Discussion: https://tracker.phpbb.com/browse/PHPBB3-12562
