### PR TITLE
[ticket/12457] Default to first category if none is selected in gallery avatar

### DIFF
--- a/phpBB/phpbb/avatar/driver/local.php
+++ b/phpBB/phpbb/avatar/driver/local.php
@@ -36,7 +36,7 @@ class local extends \phpbb\avatar\driver\driver
 	public function prepare_form($request, $template, $user, $row, &$error)
 	{
 		$avatar_list = $this->get_avatar_list($user);
-		$category = $request->variable('avatar_local_cat', '');
+		$category = $request->variable('avatar_local_cat', key($avatar_list));
 
 		foreach ($avatar_list as $cat => $null)
 		{


### PR DESCRIPTION
If any category exists, the key() function should always return the first
key of the $avatar_list array.

Ticket: https://tracker.phpbb.com/browse/PHPBB3-12457

PHPBB3-12457
