### PR TITLE
[ticket/12672] Make tab intercept; CB for keypress only react without key mods

### DIFF
--- a/phpBB/assets/javascript/core.js
+++ b/phpBB/assets/javascript/core.js
@@ -1201,7 +1201,11 @@ phpbb.applyCodeEditor = function(textarea) {
 		var key = event.keyCode || event.which;
 
 		// intercept tabs
-		if (key == 9) {
+		if (key == 9		&&
+			!event.ctrlKey	&&
+			!event.shiftKey	&&
+			!event.altKey	&&
+			!event.metaKey) {
 			if (inTag()) {
 				appendText("\t");
 				event.preventDefault();


### PR DESCRIPTION
Changed the callback of keypress inside the <textarea> for the posting
such that, if key 9 is pressed (tab character) and ctrl, shift, alt and meta
are not pressed the tab is placed. Otherwise, nothing is made and default is
not prevented.

https://tracker.phpbb.com/browse/PHPBB3-12672
