### PR TITLE
[ticket/12677] Remove comment about ‘thread’, replace with ‘topic’

### DIFF
--- a/phpBB/includes/functions_display.php
+++ b/phpBB/includes/functions_display.php
@@ -1157,7 +1157,7 @@ function watch_topic_forum($mode, &$s_watching, $user_id, $forum_id, $topic_id, 
 	$u_url .= ($mode == 'forum') ? '&amp;f' : '&amp;f=' . $forum_id . '&amp;t';
 	$is_watching = 0;
 
-	// Is user watching this thread?
+	// Is user watching this topic?
 	if ($user_id != ANONYMOUS)
 	{
 		$can_watch = true;


### PR DESCRIPTION
[phpbb:develop-ascraeus]

Tidy up one comment in file ‘phpBB/includes/functions_display.php’ to remove reference about ‘thread’ and replace this comment with ‘topic’, as there are no ‘threads’ in phpBB3.

PHPBB3-12677
