### PR TITLE
[ticket/12690] Add core.submit_pm_after event

### DIFF
--- a/phpBB/includes/functions_privmsgs.php
+++ b/phpBB/includes/functions_privmsgs.php
@@ -1918,7 +1918,7 @@ function submit_pm($mode, $subject, &$data, $put_in_outbox = true)
 	*/
 	$vars = array('mode', 'subject', 'data', 'pm_data');
 	extract($phpbb_dispatcher->trigger_event('core.submit_pm_after', compact($vars)));
-	
+
 	return $data['msg_id'];
 }
 


### PR DESCRIPTION
Add core.submit_pm_after to funtion submit_pm.
Event will return just submited msg_id. It should be plased
just before return $data['msg_id'];

Justification:
Using only core.submit_pm_before does not allow to
follow up after message submission.
The message ID is recieved at DB submission.
Some times we need the MSG_ID as identifier

PHPBB3-12690
