### PR TITLE
[ticket/12691] Add core.delete_pm to funtion delete_pm

### DIFF
--- a/phpBB/includes/functions_privmsgs.php
+++ b/phpBB/includes/functions_privmsgs.php
@@ -1013,7 +1013,7 @@ function delete_pm($user_id, $msg_ids, $folder_id)
 	}
 
 	/**
-	* Get all info for PM(s) that are to be deleted before deletion
+	* Get all info for PM(s) before they are deleted
 	*
 	* @event core.delete_pm_before
 	* @var	int	user_id	 ID of the user requested the message delete


### PR DESCRIPTION
Add core.delete_pm to funtion delete_pm.
Event will return:
int $user_id - ID of the user requested the message delete
array $msg_ids - array of all messages to be deleted
int $folder_id - ID of the user folder where the messages are stored
Justification:
Allow extensions to capture this event
and act as intended by ext author

PHPBB3-12691
