### PR TITLE
[Ticket/12701] Add events to user_add function

### DIFF
--- a/phpBB/includes/functions_user.php
+++ b/phpBB/includes/functions_user.php
@@ -264,7 +264,8 @@ function user_add($user_row, $cp_data = false)
 	* @var array	user_row		Array of user details submited to user_add
 	* @var array	cp_data			Array of Custom profile fields submited to user_add
 	* @var array	sql_ary		Array of data to be inserted when a user is added
-	* @since 3.1.0-b5
+	* @since 3.1.0-a1
+	* @change 3.1.0-b5
 	*/
 	$vars = array('user_row', 'cp_data', 'sql_ary');
 	extract($phpbb_dispatcher->trigger_event('core.user_add_modify_data', compact($vars)));


### PR DESCRIPTION
Add two new events to user_add function in ./includes/functions_user.php.

core.user_add_before - allow modification of submitted to function data.
Returns:
@var array $user_row - user_row array - User array
@var array $cp_data - cp_data array - CPF array

core.user_add_after - return user_id, user_row and cp_data after user registration
Returns:
@var int $user_id - user_id of the new user
@var array $user_row - user_row array - User array
@var array $cp_data - cp_data array - CPF array

Justification:
Allow extensions to parse data before and after creation of the user.

PHPBB3-12701
