### PR TITLE
[ticket/12704] Improve the load time information in the footer when enabled

### DIFF
--- a/phpBB/includes/functions.php
+++ b/phpBB/includes/functions.php
@@ -5064,10 +5064,10 @@ function phpbb_generate_debug_output(phpbb\db\driver\driver_interface $db, \phpb
 		if (isset($GLOBALS['starttime']))
 		{
 			$totaltime = microtime(true) - $GLOBALS['starttime'];
-			$debug_info[] = sprintf('Time: %.3fs', $totaltime);
+			$debug_info[] = sprintf('<abbr title="SQL time: %.3fs / PHP time: %.3fs">Time: %.3fs</abbr>', $db->sql_time, ($totaltime - $db->sql_time), $totaltime);
 		}
 
-		$debug_info[] = $db->sql_num_queries() . ' Queries (' . $db->sql_num_queries(true) . ' cached)';
+		$debug_info[] = sprintf('<abbr title="Cached: %d">Queries: %d</abbr>', $db->sql_num_queries(true), $db->sql_num_queries());
 
 		$memory_usage = memory_get_peak_usage();
 		if ($memory_usage)

--- a/phpBB/phpbb/db/driver/firebird.php
+++ b/phpBB/phpbb/db/driver/firebird.php
@@ -140,6 +140,10 @@ class firebird extends \phpbb\db\driver\driver
 			{
 				$this->sql_report('start', $query);
 			}
+			else if (defined('PHPBB_DISPLAY_LOAD_TIME'))
+			{
+				$this->curtime = microtime(true);
+			}
 
 			$this->last_query_text = $query;
 			$this->query_result = ($cache && $cache_ttl) ? $cache->sql_load($query) : false;
@@ -240,6 +244,10 @@ class firebird extends \phpbb\db\driver\driver
 				if (defined('DEBUG'))
 				{
 					$this->sql_report('stop', $query);
+				}
+				else if (defined('PHPBB_DISPLAY_LOAD_TIME'))
+				{
+					$this->sql_time += microtime(true) - $this->curtime;
 				}
 
 				if (!$this->transaction)

--- a/phpBB/phpbb/db/driver/mssql.php
+++ b/phpBB/phpbb/db/driver/mssql.php
@@ -137,6 +137,10 @@ class mssql extends \phpbb\db\driver\driver
 			{
 				$this->sql_report('start', $query);
 			}
+			else if (defined('PHPBB_DISPLAY_LOAD_TIME'))
+			{
+				$this->curtime = microtime(true);
+			}
 
 			$this->query_result = ($cache && $cache_ttl) ? $cache->sql_load($query) : false;
 			$this->sql_add_num_queries($this->query_result);
@@ -151,6 +155,10 @@ class mssql extends \phpbb\db\driver\driver
 				if (defined('DEBUG'))
 				{
 					$this->sql_report('stop', $query);
+				}
+				else if (defined('PHPBB_DISPLAY_LOAD_TIME'))
+				{
+					$this->sql_time += microtime(true) - $this->curtime;
 				}
 
 				if ($cache && $cache_ttl)

--- a/phpBB/phpbb/db/driver/mssql_odbc.php
+++ b/phpBB/phpbb/db/driver/mssql_odbc.php
@@ -156,6 +156,10 @@ class mssql_odbc extends \phpbb\db\driver\mssql_base
 			{
 				$this->sql_report('start', $query);
 			}
+			else if (defined('PHPBB_DISPLAY_LOAD_TIME'))
+			{
+				$this->curtime = microtime(true);
+			}
 
 			$this->last_query_text = $query;
 			$this->query_result = ($cache && $cache_ttl) ? $cache->sql_load($query) : false;
@@ -171,6 +175,10 @@ class mssql_odbc extends \phpbb\db\driver\mssql_base
 				if (defined('DEBUG'))
 				{
 					$this->sql_report('stop', $query);
+				}
+				else if (defined('PHPBB_DISPLAY_LOAD_TIME'))
+				{
+					$this->sql_time += microtime(true) - $this->curtime;
 				}
 
 				if ($cache && $cache_ttl)

--- a/phpBB/phpbb/db/driver/mssqlnative.php
+++ b/phpBB/phpbb/db/driver/mssqlnative.php
@@ -127,6 +127,10 @@ class mssqlnative extends \phpbb\db\driver\mssql_base
 			{
 				$this->sql_report('start', $query);
 			}
+			else if (defined('PHPBB_DISPLAY_LOAD_TIME'))
+			{
+				$this->curtime = microtime(true);
+			}
 
 			$this->last_query_text = $query;
 			$this->query_result = ($cache && $cache_ttl) ? $cache->sql_load($query) : false;
@@ -144,6 +148,10 @@ class mssqlnative extends \phpbb\db\driver\mssql_base
 				if (defined('DEBUG'))
 				{
 					$this->sql_report('stop', $query);
+				}
+				else if (defined('PHPBB_DISPLAY_LOAD_TIME'))
+				{
+					$this->sql_time += microtime(true) - $this->curtime;
 				}
 
 				if ($cache && $cache_ttl)

--- a/phpBB/phpbb/db/driver/mysql.php
+++ b/phpBB/phpbb/db/driver/mysql.php
@@ -166,6 +166,10 @@ class mysql extends \phpbb\db\driver\mysql_base
 			{
 				$this->sql_report('start', $query);
 			}
+			else if (defined('PHPBB_DISPLAY_LOAD_TIME'))
+			{
+				$this->curtime = microtime(true);
+			}
 
 			$this->query_result = ($cache && $cache_ttl) ? $cache->sql_load($query) : false;
 			$this->sql_add_num_queries($this->query_result);
@@ -180,6 +184,10 @@ class mysql extends \phpbb\db\driver\mysql_base
 				if (defined('DEBUG'))
 				{
 					$this->sql_report('stop', $query);
+				}
+				else if (defined('PHPBB_DISPLAY_LOAD_TIME'))
+				{
+					$this->sql_time += microtime(true) - $this->curtime;
 				}
 
 				if ($cache && $cache_ttl)

--- a/phpBB/phpbb/db/driver/mysqli.php
+++ b/phpBB/phpbb/db/driver/mysqli.php
@@ -165,6 +165,10 @@ class mysqli extends \phpbb\db\driver\mysql_base
 			{
 				$this->sql_report('start', $query);
 			}
+			else if (defined('PHPBB_DISPLAY_LOAD_TIME'))
+			{
+				$this->curtime = microtime(true);
+			}
 
 			$this->query_result = ($cache && $cache_ttl) ? $cache->sql_load($query) : false;
 			$this->sql_add_num_queries($this->query_result);
@@ -179,6 +183,10 @@ class mysqli extends \phpbb\db\driver\mysql_base
 				if (defined('DEBUG'))
 				{
 					$this->sql_report('stop', $query);
+				}
+				else if (defined('PHPBB_DISPLAY_LOAD_TIME'))
+				{
+					$this->sql_time += microtime(true) - $this->curtime;
 				}
 
 				if ($cache && $cache_ttl)

--- a/phpBB/phpbb/db/driver/oracle.php
+++ b/phpBB/phpbb/db/driver/oracle.php
@@ -253,6 +253,10 @@ class oracle extends \phpbb\db\driver\driver
 			{
 				$this->sql_report('start', $query);
 			}
+			else if (defined('PHPBB_DISPLAY_LOAD_TIME'))
+			{
+				$this->curtime = microtime(true);
+			}
 
 			$this->last_query_text = $query;
 			$this->query_result = ($cache && $cache_ttl) ? $cache->sql_load($query) : false;
@@ -429,6 +433,10 @@ class oracle extends \phpbb\db\driver\driver
 				if (defined('DEBUG'))
 				{
 					$this->sql_report('stop', $query);
+				}
+				else if (defined('PHPBB_DISPLAY_LOAD_TIME'))
+				{
+					$this->sql_time += microtime(true) - $this->curtime;
 				}
 
 				if ($cache && $cache_ttl)

--- a/phpBB/phpbb/db/driver/postgres.php
+++ b/phpBB/phpbb/db/driver/postgres.php
@@ -179,6 +179,10 @@ class postgres extends \phpbb\db\driver\driver
 			{
 				$this->sql_report('start', $query);
 			}
+			else if (defined('PHPBB_DISPLAY_LOAD_TIME'))
+			{
+				$this->curtime = microtime(true);
+			}
 
 			$this->last_query_text = $query;
 			$this->query_result = ($cache && $cache_ttl) ? $cache->sql_load($query) : false;
@@ -194,6 +198,10 @@ class postgres extends \phpbb\db\driver\driver
 				if (defined('DEBUG'))
 				{
 					$this->sql_report('stop', $query);
+				}
+				else if (defined('PHPBB_DISPLAY_LOAD_TIME'))
+				{
+					$this->sql_time += microtime(true) - $this->curtime;
 				}
 
 				if ($cache && $cache_ttl)

--- a/phpBB/phpbb/db/driver/sqlite.php
+++ b/phpBB/phpbb/db/driver/sqlite.php
@@ -121,6 +121,10 @@ class sqlite extends \phpbb\db\driver\driver
 			{
 				$this->sql_report('start', $query);
 			}
+			else if (defined('PHPBB_DISPLAY_LOAD_TIME'))
+			{
+				$this->curtime = microtime(true);
+			}
 
 			$this->query_result = ($cache && $cache_ttl) ? $cache->sql_load($query) : false;
 			$this->sql_add_num_queries($this->query_result);
@@ -135,6 +139,10 @@ class sqlite extends \phpbb\db\driver\driver
 				if (defined('DEBUG'))
 				{
 					$this->sql_report('stop', $query);
+				}
+				else if (defined('PHPBB_DISPLAY_LOAD_TIME'))
+				{
+					$this->sql_time += microtime(true) - $this->curtime;
 				}
 
 				if ($cache && $cache_ttl)

--- a/phpBB/phpbb/db/driver/sqlite3.php
+++ b/phpBB/phpbb/db/driver/sqlite3.php
@@ -121,6 +121,10 @@ class sqlite3 extends \phpbb\db\driver\driver
 			{
 				$this->sql_report('start', $query);
 			}
+			else if (defined('PHPBB_DISPLAY_LOAD_TIME'))
+			{
+				$this->curtime = microtime(true);
+			}
 
 			$this->last_query_text = $query;
 			$this->query_result = ($cache && $cache_ttl) ? $cache->sql_load($query) : false;
@@ -136,6 +140,10 @@ class sqlite3 extends \phpbb\db\driver\driver
 				if (defined('DEBUG'))
 				{
 					$this->sql_report('stop', $query);
+				}
+				else if (defined('PHPBB_DISPLAY_LOAD_TIME'))
+				{
+					$this->sql_time += microtime(true) - $this->curtime;
 				}
 
 				if ($cache && $cache_ttl)


### PR DESCRIPTION
PR #2570 has added new constant to display load time information without
debug mode is being on (https://tracker.phpbb.com/browse/PHPBB3-12687).
This patch expands the total load time info with SQL/PHP load times,
while hiding the additional info with <abbr> element.

<a href="https://tracker.phpbb.com/browse/PHPBB3-12704">PHPBB3-12704</a>.
