### PR TITLE
[ticket/12711] Fix contact form migration failing on MSSQL

### DIFF
--- a/phpBB/phpbb/config/db_text.php
+++ b/phpBB/phpbb/config/db_text.php
@@ -105,8 +105,8 @@ class db_text
 			if (!$this->db->sql_affectedrows($result))
 			{
 				$sql = 'INSERT INTO ' . $this->table . ' ' . $this->db->sql_build_array('INSERT', array(
-					'config_name'	=> $key,
-					'config_value'	=> $value,
+					'config_name'	=> (string) $key,
+					'config_value'	=> (string) $value,
 				));
 				$this->db->sql_query($sql);
 			}


### PR DESCRIPTION
Cast values to string such that they are quoted in SQL queries.

The value is stored in a text column and the key is stored in a varchar. Some
DBMSes do not like it when we insert integers into text columns. Cast both to
string to be on the safe side.

https://tracker.phpbb.com/browse/PHPBB3-12711
