### PR TITLE
Ticket/12643 Fixes deletion of columns that have the target column as a prefix

### DIFF
--- a/phpBB/phpbb/db/tools.php
+++ b/phpBB/phpbb/db/tools.php
@@ -2561,7 +2561,18 @@ class tools
 
 				foreach ($old_table_cols as $key => $declaration)
 				{
-					$entities = preg_split('#\s+#', trim($declaration));
+					$declaration = trim($declaration);
+
+					// Check for the beginning of the constraint section and stop
+					if (preg_match('/[^\(]*\s*PRIMARY KEY\s+\(/', $declaration) ||
+						preg_match('/[^\(]*\s*UNIQUE\s+\(/', $declaration) ||
+						preg_match('/[^\(]*\s*FOREIGN KEY\s+\(/', $declaration) ||
+						preg_match('/[^\(]*\s*CHECK\s+\(/', $declaration))
+					{
+						break;
+					}
+
+					$entities = preg_split('#\s+#', $declaration);
 					$column_list[] = $entities[0];
 					if ($entities[0] == $column_name)
 					{

--- a/tests/dbal/db_tools_test.php
+++ b/tests/dbal/db_tools_test.php
@@ -239,6 +239,24 @@ class phpbb_dbal_db_tools_test extends phpbb_database_test_case
 		$this->assertFalse($this->tools->sql_column_exists('prefix_table_name', 'c_bug_12012'));
 	}
 
+	public function test_column_change_with_composite_primary()
+	{
+		// Remove the old primary key
+		$this->assertTrue($this->tools->sql_column_remove('prefix_table_name', 'c_id'));
+		$this->assertTrue($this->tools->sql_column_add('prefix_table_name', 'c_id', array('UINT', 0)));
+
+		// Create a composite key
+		$this->assertTrue($this->tools->sql_create_primary_key('prefix_table_name', array('c_id', 'c_uint')));
+
+		// Create column
+		$this->assertFalse($this->tools->sql_column_exists('prefix_table_name', 'c_bug_12643'));
+		$this->assertTrue($this->tools->sql_column_add('prefix_table_name', 'c_bug_12643', array('DECIMAL', 0)));
+		$this->assertTrue($this->tools->sql_column_exists('prefix_table_name', 'c_bug_12643'));
+
+		// Change type from int to string
+		$this->assertTrue($this->tools->sql_column_change('prefix_table_name', 'c_bug_12643', array('VCHAR:100', '')));
+	}
+
 	public function test_column_remove()
 	{
 		$this->assertTrue($this->tools->sql_column_exists('prefix_table_name', 'c_int_size'));


### PR DESCRIPTION
https://tracker.phpbb.com/browse/PHPBB3-12643
Fixes deletion of columns that have the target column as a prefix (e.g. forum_posts and forum_posts_approved).
Fixes column changes when tables have certain constraints on them.
