### PR TITLE
[ticket/12728] Enforce box model sizing on image attachment thumbnails

### DIFF
--- a/phpBB/styles/prosilver/theme/content.css
+++ b/phpBB/styles/prosilver/theme/content.css
@@ -267,7 +267,7 @@ dd.option {
 }
 
 .postbody img.postimage {
-	max-width: 99%;
+	max-width: 100%;
 }
 
 .search .postbody {

--- a/phpBB/styles/subsilver2/theme/stylesheet.css
+++ b/phpBB/styles/subsilver2/theme/stylesheet.css
@@ -632,7 +632,7 @@ input:focus, select:focus, textarea:focus {
 }
 
 .postimage {
-	max-width: 99%;
+	max-width: 100%;
 }
 
 .syntaxbg {


### PR DESCRIPTION
This PR fixes horizontal scrollbars that appear inside attachment boxes for attached images when they are viewed on mobile phones.

Basically, because the image is scaled to a %, at small responsive layout sizes, the image and the padding and borders around it become enough to overflow the confines of the attachment box. Enforcing box model sizing on it keeps everything at true proportion at any responsive layout size.

https://tracker.phpbb.com/browse/PHPBB3-12728

PHPBB3-12728
