### PR TITLE
[Ticket/12699] Remove magic numbers in the message textarea keydown callback

### DIFF
--- a/phpBB/assets/javascript/core.js
+++ b/phpBB/assets/javascript/core.js
@@ -1202,10 +1202,10 @@ phpbb.applyCodeEditor = function(textarea) {
 		var key = event.keyCode || event.which;
 
 		// intercept tabs
-		if (key == 9		&&
-			!event.ctrlKey	&&
-			!event.shiftKey	&&
-			!event.altKey	&&
+		if (key == keymap.TAB	&&
+			!event.ctrlKey		&&
+			!event.shiftKey		&&
+			!event.altKey		&&
 			!event.metaKey) {
 			if (inTag()) {
 				appendText("\t");
@@ -1215,7 +1215,7 @@ phpbb.applyCodeEditor = function(textarea) {
 		}
 
 		// intercept new line characters
-		if (key == 13) {
+		if (key == keymap.ENTER) {
 			if (inTag()) {
 				var lastLine = getLastLine(true),
 					code = '' + /^\s*/g.exec(lastLine);


### PR DESCRIPTION
This replaces the magic numbers with parameters of the keymap object inside the phpBB core code block.

https://tracker.phpbb.com/browse/PHPBB3-12699
