### PR TITLE
[ticket/12743] Make sure to use up-to-date schema with extensions

### DIFF
--- a/tests/test_framework/phpbb_database_test_case.php
+++ b/tests/test_framework/phpbb_database_test_case.php
@@ -84,6 +84,9 @@ abstract class phpbb_database_test_case extends PHPUnit_Extensions_Database_Test
 
 			copy(self::$install_schema_file, self::$phpbb_schema_copy);
 			copy(self::$schema_file, self::$install_schema_file);
+
+			// Make sure we load up to date schema
+			self::$already_connected = false;
 		}
 
 		parent::setUpBeforeClass();


### PR DESCRIPTION
The database test case will not load the schema again if the database is
already connected. If an extension adds schema changes and a database test
case without those is run before, the database schema will not contain tables
and columns the extension might add.

PHPBB3-12743

Ticket: https://tracker.phpbb.com/browse/PHPBB3-12743
