### PR TITLE
[ticket/12741] Functional tests on Travis fail since php update last night

### DIFF
--- a/travis/setup-webserver.sh
+++ b/travis/setup-webserver.sh
@@ -48,6 +48,7 @@ else
 		user = $USER
 		group = $USER
 		listen = $APP_SOCK
+		listen.mode = 0666
 		pm = static
 		pm.max_children = 2
 


### PR DESCRIPTION
Since php 5.4.29, by default, php-fpm creates the socket with the 0600 mode instead of
0666.

https://tracker.phpbb.com/browse/PHPBB3-12741

PHPBB3-12741
