### PR TITLE
[ticket/12758] Add show_results var to core.search_modify_rowset

### DIFF
--- a/phpBB/search.php
+++ b/phpBB/search.php
@@ -929,6 +929,7 @@ if ($keywords || $author || $author_id || $search_id || $submit)
 		* @var	string	view					Search results view mode
 		* @var	array	zebra					Array with zebra data for the current user
 		* @since 3.1.0-b4
+		* @changed 3.1.0-b5 Added var show_results
 		*/
 		$vars = array(
 			'attachments',


### PR DESCRIPTION
It is currently impossible to distinguish between show_results == 'posts' and show_results == 'topics' in event core.search_modify_rowset.

This should be added to the dispatch vars.

PHPBB3-12758
