### PR TITLE
[ticket/12332] Fix plupload attachments with long names

### DIFF
--- a/phpBB/styles/prosilver/template/posting_attach_body.html
+++ b/phpBB/styles/prosilver/template/posting_attach_body.html
@@ -23,7 +23,7 @@
 
 	<div class="panel<!-- IF not .attach_row --> hidden<!-- ENDIF -->" id="file-list-container">
 		<div class="inner">
-			<table class="table1 zebra-list">
+			<table class="table1 zebra-list fixed-width-table">
 				<thead>
 					<tr>
 						<th class="attach-name">{L_PLUPLOAD_FILENAME}</th>

--- a/phpBB/styles/prosilver/theme/content.css
+++ b/phpBB/styles/prosilver/theme/content.css
@@ -803,6 +803,10 @@ div.dl_links {
 	white-space: nowrap;
 }
 
+table.fixed-width-table {
+	table-layout: fixed;
+}
+
 /* Show scrollbars for items with overflow on iOS devices
 ----------------------------------------*/
 .postbody .content::-webkit-scrollbar, #topicreview::-webkit-scrollbar, #post_details::-webkit-scrollbar, .codebox code::-webkit-scrollbar, .attachbox dd::-webkit-scrollbar, .attach-image::-webkit-scrollbar, .dropdown-extended ul::-webkit-scrollbar {


### PR DESCRIPTION
This issue has resurfaced for some reason. The attachments table for plupload needs to have its table layout set to fixed to keep the table from overflowing and ensure the plupload table stays within the confines of its enclosing element.
https://tracker.phpbb.com/browse/PHPBB3-12332

PHPBB3-12332
