### PR TITLE
[ticket/12771] Bug in profilefield_base_migration when used in ext

### DIFF
--- a/phpBB/phpbb/db/migration/profilefield_base_migration.php
+++ b/phpBB/phpbb/db/migration/profilefield_base_migration.php
@@ -79,7 +79,7 @@ abstract class profilefield_base_migration extends \phpbb\db\migration\migration
 		$sql = 'SELECT lang_id
 			FROM ' . LANG_TABLE;
 		$result = $this->db->sql_query($sql);
-		$lang_name = (substr($this->profilefield_name, 6) == 'phpbb_') ? strtoupper(substr($this->profilefield_name, 6)) : strtoupper($this->profilefield_name);
+		$lang_name = (strpos($this->profilefield_name, 'phpbb_') === 0) ? strtoupper(substr($this->profilefield_name, 6)) : strtoupper($this->profilefield_name);
 		while ($lang_id = (int) $this->db->sql_fetchfield('lang_id'))
 		{
 			$insert_buffer->insert(array(


### PR DESCRIPTION
The base migration class should create lang entry for the new CPF
but it is supposed to strip it of phpbb_ prefix. As extensions
CPFs do not use phpbb_ prefix it will not create a lang entry.
This is as simple solution as it can be done.

PHPBB3-12771
