### PR TITLE
[ticket/12772] Remove config_text parameter from message.form.topic

### DIFF
--- a/phpBB/config/services.yml
+++ b/phpBB/config/services.yml
@@ -255,7 +255,6 @@ services:
         arguments:
             - @auth
             - @config
-            - @config_text
             - @dbal.conn
             - @user
             - %core.root_path%


### PR DESCRIPTION
Broke Email topic since the topic_form class doesn't require this to be passed

[PHPBB3-12772](https://tracker.phpbb.com/browse/PHPBB3-12772)
