### PR TITLE
[ticket/12764] Properly handle errors upon connecting to MySQLi database

### DIFF
--- a/phpBB/phpbb/db/driver/mysqli.php
+++ b/phpBB/phpbb/db/driver/mysqli.php
@@ -61,7 +61,11 @@ class mysqli extends \phpbb\db\driver\mysql_base
 		}
 
 		$this->db_connect_id = mysqli_init();
-		@mysqli_real_connect($this->db_connect_id, $this->server, $this->user, $sqlpassword, $this->dbname, $port, $socket, MYSQLI_CLIENT_FOUND_ROWS);
+
+		if (!@mysqli_real_connect($this->db_connect_id, $this->server, $this->user, $sqlpassword, $this->dbname, $port, $socket, MYSQLI_CLIENT_FOUND_ROWS))
+		{
+			$this->db_connect_id = '';
+		}
 
 		if ($this->db_connect_id && $this->dbname != '')
 		{


### PR DESCRIPTION
As the db_connect_id gets set up by mysql_init(), the db_connect_id will be an
object with empty settings instead of just empty. Even if mysql_real_connect()
encounters an error upon connecting, the db_connect_id is still set. This
will result in trying to just access the database which obviously does
nothing.
By setting db_connect_id to an empty string, the script will not try to query
th database and properly handle any errors that occur upon connecting.

Ticket: https://tracker.phpbb.com/browse/PHPBB3-12764
