### PR TITLE
[ticket/12772] Do not pass db_text to \phpbb\message\topic_form

### DIFF
--- a/phpBB/config/services.yml
+++ b/phpBB/config/services.yml
@@ -255,7 +255,6 @@ services:
         arguments:
             - @auth
             - @config
-            - @config_text
             - @dbal.conn
             - @user
             - %core.root_path%


### PR DESCRIPTION
This was incorrectly added in a previous commit and causes a fatal error.

Ticket: https://tracker.phpbb.com/browse/PHPBB3-12772
