### PR TITLE
[ticket/12811] Fix padding/margin bug affecting bottom layout

### DIFF
--- a/phpBB/styles/prosilver/theme/common.css
+++ b/phpBB/styles/prosilver/theme/common.css
@@ -185,7 +185,7 @@ ol ol ul, ol ul ul, ul ol ul, ul ul ul {
 
 @media only screen and (max-width: 1220px), only screen and (max-device-width: 1220px) {
 	#wrap {
-		margin: 12px;
+		margin: 0 12px;
 	}
 }
 

--- a/phpBB/styles/prosilver/theme/responsive.css
+++ b/phpBB/styles/prosilver/theme/responsive.css
@@ -12,6 +12,10 @@ html {
 	height: auto;
 }
 
+body {
+	padding: 0;
+}
+
 #wrap {
 	border: none;
 	border-radius: 0;


### PR DESCRIPTION
This reverts the top/bottom spacing of 12px on the body tag back to padding, which how it was always done prior to the [recent change](https://github.com/phpbb/phpbb/pull/2682/files) that moved it to the margins of the wrap tag, which do not work for all browsers.

https://tracker.phpbb.com/browse/PHPBB3-12811

PHPBB3-12811
