### PR TITLE
[ticket/12823] Remove all trailing whitespace

### DIFF
--- a/phpBB/styles/prosilver/theme/bidi.css
+++ b/phpBB/styles/prosilver/theme/bidi.css
@@ -2,7 +2,7 @@
 ---------------------------------------- */
 
 /**
-* common.css 
+* common.css
 */
 .rtl h1 {
 	margin-right: 0;
@@ -189,7 +189,7 @@
 
 /* Misc layout styles
 ---------------------------------------- */
-/* column[1-2] styles are containers for two column layouts 
+/* column[1-2] styles are containers for two column layouts
    Also see tweaks.css */
 .rtl .column1 {
 	float: right;
@@ -1060,7 +1060,7 @@ ul.linklist li.small-icon > a, ul.linklist li.breadcrumbs span:first-child > a {
 	{
 		.rtl dl.details dt, .rtl dl.details dd {
 			float: none;
-			text-align: right;	
+			text-align: right;
 		}
 
 		.rtl dl.details dd {

--- a/phpBB/styles/prosilver/theme/colours.css
+++ b/phpBB/styles/prosilver/theme/colours.css
@@ -228,15 +228,15 @@ p.post-notice {
 	background-image: none;
 }
 
-p.post-notice.deleted:before { 
+p.post-notice.deleted:before {
 	background-image: url("./images/icon_topic_deleted.png");
 }
 
-p.post-notice.unapproved:before { 
+p.post-notice.unapproved:before {
 	background-image: url("./images/icon_topic_unapproved.gif");
 }
 
-p.post-notice.reported:before, p.post-notice.error:before { 
+p.post-notice.reported:before, p.post-notice.error:before {
 	background-image: url("./images/icon_topic_reported.gif");
 }
 

--- a/phpBB/styles/prosilver/theme/common.css
+++ b/phpBB/styles/prosilver/theme/common.css
@@ -432,7 +432,7 @@ ul.linklist.bulletin > li:before {
 	padding-right: 4px;
 }
 
-ul.linklist.bulletin > li:first-child:before, 
+ul.linklist.bulletin > li:first-child:before,
 ul.linklist.bulletin > li.rightside:last-child:before {
 	content: none;
 }

--- a/phpBB/styles/prosilver/theme/content.css
+++ b/phpBB/styles/prosilver/theme/content.css
@@ -458,7 +458,7 @@ blockquote {
 blockquote blockquote {
 	/* Nested quotes */
 	font-size: 1em;
-	margin: 0.5em 1px 0 15px;	
+	margin: 0.5em 1px 0 15px;
 }
 
 blockquote cite {
@@ -515,7 +515,7 @@ blockquote .codebox {
 ----------------------------------------*/
 .attachbox {
 	float: left;
-	width: auto; 
+	width: auto;
 	max-width: 100%;
 	margin: 5px 5px 5px 0;
 	padding: 6px;
@@ -592,7 +592,7 @@ dl.file dt {
 
 dl.file dd {
 	margin: 0;
-	padding: 0;	
+	padding: 0;
 }
 
 dl.thumbnail img {

--- a/phpBB/styles/prosilver/theme/cp.css
+++ b/phpBB/styles/prosilver/theme/cp.css
@@ -138,7 +138,7 @@ ul.cplist {
 	cursor: pointer;
 }
 
-/* CP tabbed menu 
+/* CP tabbed menu
 ----------------------------------------*/
 #tabs {
 	margin: 20px 0 0 7px;
@@ -321,7 +321,7 @@ ol.def-rules li {
 	border-right-color: transparent;
 }
 
-.pmlist li.pm_marked_colour, .pm_marked_colour, 
+.pmlist li.pm_marked_colour, .pm_marked_colour,
 .pmlist li.pm_replied_colour, .pm_replied_colour,
 .pmlist li.pm_friend_colour, .pm_friend_colour,
 .pmlist li.pm_foe_colour, .pm_foe_colour {
@@ -354,7 +354,7 @@ ol.def-rules li {
 @media only screen and (max-width: 900px), only screen and (max-device-width: 900px)
 {
 	.nojs #tabs a span, .nojs #minitabs a span {
-		max-width: 40px; 
+		max-width: 40px;
 		overflow: hidden;
 		text-overflow: ellipsis;
 		letter-spacing: -.5px;
@@ -366,8 +366,8 @@ ol.def-rules li {
 		margin: 0;
 	}
 
-	#navigation { 
-		padding: 0; 
+	#navigation {
+		padding: 0;
 		margin: 0 auto;
 		max-width: 320px;
 	}

--- a/phpBB/styles/prosilver/theme/forms.css
+++ b/phpBB/styles/prosilver/theme/forms.css
@@ -68,7 +68,7 @@ fieldset dl {
 }
 
 fieldset dt {
-	float: left;	
+	float: left;
 	width: 40%;
 	text-align: left;
 	display: block;
@@ -313,8 +313,8 @@ input.button3 {
 	font-variant: small-caps;
 }
 
-input[type="button"], input[type="submit"], input[type="reset"], input[type="checkbox"], input[type="radio"] { 
-	cursor: pointer; 
+input[type="button"], input[type="submit"], input[type="reset"], input[type="checkbox"], input[type="radio"] {
+	cursor: pointer;
 }
 
 /* Alternative button */

--- a/phpBB/styles/prosilver/theme/print.css
+++ b/phpBB/styles/prosilver/theme/print.css
@@ -91,11 +91,11 @@ hr {
 }
 
 /* Dont want to print url for names or titles in content area */
-.postbody .author a:link, .postbody .author a:visited, 
-html>body .postbody .author a:link:after, 
+.postbody .author a:link, .postbody .author a:visited,
+html>body .postbody .author a:link:after,
 html>body .postbody .author a:visited:after,
-.postquote .quote-by a:link, .postquote .quote-by a:visited, 
-html>body .postquote .quote-by a:link:after, 
+.postquote .quote-by a:link, .postquote .quote-by a:visited,
+html>body .postquote .quote-by a:link:after,
 html>body .postquote .quote-by a:visited:after,
 html>body .postbody h1 a:link:after, html>body .postbody h2 a:link:after {
 	text-decoration: none;
@@ -119,7 +119,7 @@ html>body .postbody h1 a:link:after, html>body .postbody h2 a:link:after {
 .postquote img { display: none; }
 .postquote span { display: block; }
 .postquote span .postquote { font-size: 100%; }
-.quote-by, blockquote cite { 
+.quote-by, blockquote cite {
 	color: black;
 	display : block;
 	font-weight: bold;

--- a/phpBB/styles/prosilver/theme/responsive.css
+++ b/phpBB/styles/prosilver/theme/responsive.css
@@ -118,11 +118,11 @@ ul.topiclist li.header dt .list-inner {
 	min-height: 0;
 }
 
-ul.topiclist dd { 
-	display: none; 
+ul.topiclist dd {
+	display: none;
 }
-ul.topiclist dd.mark { 
-	display: block; 
+ul.topiclist dd.mark {
+	display: block;
 }
 
 /* Forums and topics lists
@@ -366,7 +366,7 @@ fieldset.quick-login label[for="autologin"] {
 	dl.details dt, dl.details dd {
 		width: auto;
 		float: none;
-		text-align: left;	
+		text-align: left;
 	}
 
 	dl.details dd {

--- a/phpBB/styles/prosilver/theme/tweaks.css
+++ b/phpBB/styles/prosilver/theme/tweaks.css
@@ -1,6 +1,6 @@
 /* Style Sheet Tweaks
 
-These style definitions are IE 7 and 8 specific 
+These style definitions are IE 7 and 8 specific
 tweaks required due to its poor CSS support.
 -------------------------------------------------*/
 
@@ -14,9 +14,9 @@ ul.linklist {
 }
 
 /* Align checkboxes/radio buttons nicely */
-dd label input { 
-	vertical-align: text-bottom; 
-	*vertical-align: middle; 
+dd label input {
+	vertical-align: text-bottom;
+	*vertical-align: middle;
 }
 
 /* Simple fix so forum and topic lists always have a height set */


### PR DESCRIPTION
Almost all of the css files have aspects that contain trailing whitespace in the selector lines.
This is very annoying as any changes I make with my editor it automatically removes it which causes unnecessary changes to unaffected lines
There fore I have re-saved all of the files without editing them to remove all the trailing whitespace

Ticket: https://tracker.phpbb.com/browse/PHPBB3-12823

PHPBB3-12823
