### PR TITLE
[ticket/12841] Allow extensions to position new config vars

### DIFF
--- a/phpBB/includes/functions_acp.php
+++ b/phpBB/includes/functions_acp.php
@@ -665,14 +665,15 @@ function validate_range($value_ary, &$error)
 * @param array $add_config_vars An array of new config display vars
 * @param array $where Where to place the new config vars,
 *              before or after an exisiting config, as an array
-*              of the form: array('after' => 'config_name')
+*              of the form: array('after' => 'config_name') or
+*              array('before' => 'config_name').
 * @return array The array of config display vars
 */
 function phpbb_insert_config_array($display_vars, $add_config_vars, $where)
 {
 	if (is_array($where) && array_key_exists(current($where), $display_vars))
 	{
-		$position = array_search(current($where), array_keys($display_vars)) + ((key($where) == 'after') ? 1 : 0);
+		$position = array_search(current($where), array_keys($display_vars)) + ((key($where) == 'before') ? 0 : 1);
 		$display_vars = array_merge(
 			array_slice($display_vars, 0, $position),
 			$add_config_vars,

--- a/tests/functions/insert_config_array_test.php
+++ b/tests/functions/insert_config_array_test.php
@@ -92,13 +92,13 @@ class phpbb_functions_insert_config_array_test extends phpbb_test_case
 					'acp_config_5'	=> array(),
 				),
 			),
-			array( // When after|before is not used correctly (defaults to before)
+			array( // When after|before is not used correctly (defaults to after)
 				array('new_config_1' => array()),
 				array('foobar' => 'acp_config_1'),
 				array(
 					'legend1'		=> '',
-					'new_config_1'	=> array(),
 					'acp_config_1'	=> array(),
+					'new_config_1'	=> array(),
 					'acp_config_2'	=> array(),
 					'acp_config_3'	=> array(),
 					'acp_config_4'	=> array(),


### PR DESCRIPTION
https://tracker.phpbb.com/browse/PHPBB3-12841
This would be called by an extension using a command like:

``` php
$display_vars['vars'] = insert_config_array($display_vars['vars'], $custom_config_vars, array('after' => 'config_name'));
```

That would place their new $custom_config_vars array after core's existing "config_name" ACP config. They could also use 'before' if needed too.

PHPBB3-12841
