### PR TITLE
[ticket/12853] Change navbar ACP from skip- to last-responsive

### DIFF
--- a/phpBB/styles/prosilver/template/navbar_header.html
+++ b/phpBB/styles/prosilver/template/navbar_header.html
@@ -34,7 +34,7 @@
 		<!-- EVENT overall_header_navigation_prepend -->
 		<li class="small-icon icon-faq" <!-- IF not S_USER_LOGGED_IN -->data-skip-responsive="true"<!-- ELSE -->data-last-responsive="true"<!-- ENDIF -->><a href="{U_FAQ}" title="{L_FAQ_EXPLAIN}" role="menuitem">{L_FAQ}</a></li>
 		<!-- EVENT overall_header_navigation_append -->
-		<!-- IF U_ACP --><li class="small-icon icon-acp" data-skip-responsive="true"><a href="{U_ACP}" title="{L_ACP}" role="menuitem">{L_ACP_SHORT}</a></li><!-- ENDIF -->
+		<!-- IF U_ACP --><li class="small-icon icon-acp" data-last-responsive="true"><a href="{U_ACP}" title="{L_ACP}" role="menuitem">{L_ACP_SHORT}</a></li><!-- ENDIF -->
 		<!-- IF U_MCP --><li class="small-icon icon-mcp" data-skip-responsive="true"><a href="{U_MCP}" title="{L_MCP}" role="menuitem">{L_MCP_SHORT}</a></li><!-- ENDIF -->
 
 	<!-- IF S_REGISTERED_USER -->


### PR DESCRIPTION
One small problem with this is that we recently moved the ACP/MCP to the end of the list (in order to prevent the links from jumping when MCP is not available on certain pages). See: https://tracker.phpbb.com/browse/PHPBB3-12824

So when we change ACP to responsive-last, it will be handled like other links, and placed in the dropdown in the same order. The result will be that it will be placed between FAQ and the other quick-links.

I don't suppose we want this.

If this is indeed unacceptable, we basically have 2 options. [1] Move the ACP back to the front of the list, or [2] use JS to detect the ACP and move it to the top of the list.

https://tracker.phpbb.com/browse/PHPBB3-12853
PHPBB3-12853
