### PR TITLE
[ticket/12845] Fix invalid ARIA role for breadcrumbs

### DIFF
--- a/phpBB/styles/prosilver/template/navbar_footer.html
+++ b/phpBB/styles/prosilver/template/navbar_footer.html
@@ -2,7 +2,7 @@
 	<div class="inner">
 
 	<ul id="nav-footer" class="linklist bulletin" role="menubar">
-		<li class="small-icon icon-home breadcrumbs" role="navigation">
+		<li class="small-icon icon-home breadcrumbs">
 			<!-- IF U_SITE_HOME --><span class="crumb"><a href="{U_SITE_HOME}" data-navbar-reference="home">{L_SITE_HOME}</a></span><!-- ENDIF -->
 			<span class="crumb"><a href="{U_INDEX}" data-navbar-reference="index">{L_INDEX}</a></span>
 			<!-- EVENT overall_footer_breadcrumb_append -->

--- a/phpBB/styles/prosilver/template/navbar_header.html
+++ b/phpBB/styles/prosilver/template/navbar_header.html
@@ -83,7 +83,7 @@
 
 	<ul id="nav-breadcrumbs" class="linklist navlinks" role="menubar">
 		<!-- DEFINE $MICRODATA = ' itemtype="http://data-vocabulary.org/Breadcrumb" itemscope=""' -->
-		<li class="small-icon icon-home breadcrumbs" role="navigation">
+		<li class="small-icon icon-home breadcrumbs">
 			<!-- IF U_SITE_HOME --><span class="crumb"><a href="{U_SITE_HOME}"{$MICRODATA} data-navbar-reference="home">{L_SITE_HOME}</a></span><!-- ENDIF -->
 			<span class="crumb"><a href="{U_INDEX}" accesskey="h"{$MICRODATA} data-navbar-reference="index">{L_INDEX}</a></span>
 			<!-- BEGIN navlinks -->


### PR DESCRIPTION
The current ARIA roles assigned to the breadcrumbs are invalid according to the HTML5 aria spec (not allowed on `li`). Since the navbar already has `role=menubar`, this should cover the functionality adequately for screen-readers (for now).

https://tracker.phpbb.com/browse/PHPBB3-12845
PHPBB3-12845
