### PR TITLE
[ticket/12863] Add T_STYLES_PATH template var

### DIFF
--- a/phpBB/includes/functions.php
+++ b/phpBB/includes/functions.php
@@ -5020,6 +5020,7 @@ function page_header($page_title = '', $display_online_list = false, $item_id = 
 		'T_THEME_LANG_NAME'		=> $user->data['user_lang'],
 		'T_TEMPLATE_NAME'		=> $user->style['style_path'],
 		'T_SUPER_TEMPLATE_NAME'	=> rawurlencode((isset($user->style['style_parent_tree']) && $user->style['style_parent_tree']) ? $user->style['style_parent_tree'] : $user->style['style_path']),
+		'T_LANG_NAME'			=> $user->lang_name,
 		'T_IMAGES'				=> 'images',
 		'T_SMILIES'				=> $config['smilies_path'],
 		'T_AVATAR'				=> $config['avatar_path'],


### PR DESCRIPTION
Lets say you want to use template inheritance, but you also want to inherit some CSS or JS files from another template.

This isn't really possible since INCLUDEJS and INCLUDECSS don't have the same tree traversal properties as INCLUDE html.

So how do we load assets from another style?

By using T_STYLES_PATH, we could make it a bit easier to load assets, since we dont have to do all the ../../../other_style/ dir walking.

https://tracker.phpbb.com/browse/PHPBB3-12863
PHPBB3-12863
