### PR TITLE
[ticket/12656] Pass user object into all console commands for translation

### DIFF
--- a/phpBB/config/console.yml
+++ b/phpBB/config/console.yml
@@ -9,11 +9,11 @@ services:
     console.command.cache.purge:
         class: phpbb\console\command\cache\purge
         arguments:
+            - @user
             - @cache.driver
             - @dbal.conn
             - @auth
             - @log
-            - @user
             - @config
         tags:
             - { name: console.command }
@@ -21,6 +21,7 @@ services:
     console.command.config.delete:
         class: phpbb\console\command\config\delete
         arguments:
+            - @user
             - @config
         tags:
             - { name: console.command }
@@ -28,6 +29,7 @@ services:
     console.command.config.increment:
         class: phpbb\console\command\config\increment
         arguments:
+            - @user
             - @config
         tags:
             - { name: console.command }
@@ -35,6 +37,7 @@ services:
     console.command.config.get:
         class: phpbb\console\command\config\get
         arguments:
+            - @user
             - @config
         tags:
             - { name: console.command }
@@ -42,6 +45,7 @@ services:
     console.command.config.set:
         class: phpbb\console\command\config\set
         arguments:
+            - @user
             - @config
         tags:
             - { name: console.command }
@@ -49,6 +53,7 @@ services:
     console.command.config.set_atomic:
         class: phpbb\console\command\config\set_atomic
         arguments:
+            - @user
             - @config
         tags:
             - { name: console.command }
@@ -56,35 +61,36 @@ services:
     console.command.cron.list:
         class: phpbb\console\command\cron\cron_list
         arguments:
-            - @cron.manager
             - @user
+            - @cron.manager
         tags:
             - { name: console.command }
 
     console.command.cron.run:
         class: phpbb\console\command\cron\run
         arguments:
+            - @user
             - @cron.manager
             - @cron.lock_db
-            - @user
         tags:
             - { name: console.command }
 
     console.command.db.migrate:
         class: phpbb\console\command\db\migrate
         arguments:
+            - @user
             - @migrator
             - @ext.manager
             - @config
             - @cache
             - @log
-            - @user
         tags:
             - { name: console.command }
 
     console.command.dev.migration_tips:
         class: phpbb\console\command\dev\migration_tips
         arguments:
+            - @user
             - @ext.manager
         tags:
             - { name: console.command }
@@ -92,6 +98,7 @@ services:
     console.command.extension.disable:
         class: phpbb\console\command\extension\disable
         arguments:
+            - @user
             - @ext.manager
             - @log
         tags:
@@ -100,6 +107,7 @@ services:
     console.command.extension.enable:
         class: phpbb\console\command\extension\enable
         arguments:
+            - @user
             - @ext.manager
             - @log
         tags:
@@ -108,6 +116,7 @@ services:
     console.command.extension.purge:
         class: phpbb\console\command\extension\purge
         arguments:
+            - @user
             - @ext.manager
             - @log
         tags:
@@ -116,6 +125,7 @@ services:
     console.command.extension.show:
         class: phpbb\console\command\extension\show
         arguments:
+            - @user
             - @ext.manager
             - @log
         tags:
@@ -124,6 +134,7 @@ services:
     console.command.fixup.recalculate_email_hash:
         class: phpbb\console\command\fixup\recalculate_email_hash
         arguments:
+            - @user
             - @dbal.conn
         tags:
             - { name: console.command }

--- a/phpBB/phpbb/console/command/cache/purge.php
+++ b/phpBB/phpbb/console/command/cache/purge.php
@@ -29,31 +29,27 @@ class purge extends \phpbb\console\command\command
 	/** @var \phpbb\log\log */
 	protected $log;
 
-	/** @var \phpbb\user */
-	protected $user;
-
 	/** @var \phpbb\config\config */
 	protected $config;
 
 	/**
 	* Constructor
 	*
+	* @param \phpbb\user							$user	User instance
 	* @param \phpbb\cache\driver\driver_interface	$cache	Cache instance
 	* @param \phpbb\db\driver\driver_interface		$db		Database connection
 	* @param \phpbb\auth\auth						$auth	Auth instance
 	* @param \phpbb\log\log							$log	Logger instance
-	* @param \phpbb\user							$user	User instance
 	* @param \phpbb\config\config					$config	Config instance
 	*/
-	public function __construct(\phpbb\cache\driver\driver_interface $cache, \phpbb\db\driver\driver_interface $db, \phpbb\auth\auth $auth, \phpbb\log\log $log, \phpbb\user $user, \phpbb\config\config $config)
+	public function __construct(\phpbb\user $user, \phpbb\cache\driver\driver_interface $cache, \phpbb\db\driver\driver_interface $db, \phpbb\auth\auth $auth, \phpbb\log\log $log, \phpbb\config\config $config)
 	{
 		$this->cache = $cache;
 		$this->db = $db;
 		$this->auth = $auth;
 		$this->log = $log;
-		$this->user = $user;
 		$this->config = $config;
-		parent::__construct();
+		parent::__construct($user);
 	}
 
 	/**

--- a/phpBB/phpbb/console/command/command.php
+++ b/phpBB/phpbb/console/command/command.php
@@ -15,4 +15,17 @@ namespace phpbb\console\command;
 
 abstract class command extends \Symfony\Component\Console\Command\Command
 {
+	/** @var \phpbb\user */
+	protected $user;
+
+	/**
+	* Constructor
+	*
+	* @param \phpbb\user $user User instance (mostly for translation)
+	*/
+	public function __construct(\phpbb\user $user)
+	{
+		$this->user = $user;
+		parent::__construct();
+	}
 }

--- a/phpBB/phpbb/console/command/config/command.php
+++ b/phpBB/phpbb/console/command/config/command.php
@@ -17,10 +17,10 @@ abstract class command extends \phpbb\console\command\command
 	/** @var \phpbb\config\config */
 	protected $config;
 
-	function __construct(\phpbb\config\config $config)
+	function __construct(\phpbb\user $user, \phpbb\config\config $config)
 	{
 		$this->config = $config;
 
-		parent::__construct();
+		parent::__construct($user);
 	}
 }

--- a/phpBB/phpbb/console/command/cron/cron_list.php
+++ b/phpBB/phpbb/console/command/cron/cron_list.php
@@ -20,20 +20,16 @@ class cron_list extends \phpbb\console\command\command
 	/** @var \phpbb\cron\manager */
 	protected $cron_manager;
 
-	/** @var \phpbb\user */
-	protected $user;
-
 	/**
 	* Constructor
 	*
-	* @param \phpbb\cron\manager	$cron_manager	Cron manager
 	* @param \phpbb\user			$user			User instance
+	* @param \phpbb\cron\manager	$cron_manager	Cron manager
 	*/
-	public function __construct(\phpbb\cron\manager $cron_manager, \phpbb\user $user)
+	public function __construct(\phpbb\user $user, \phpbb\cron\manager $cron_manager)
 	{
 		$this->cron_manager = $cron_manager;
-		$this->user = $user;
-		parent::__construct();
+		parent::__construct($user);
 	}
 
 	/**

--- a/phpBB/phpbb/console/command/cron/run.php
+++ b/phpBB/phpbb/console/command/cron/run.php
@@ -25,23 +25,19 @@ class run extends \phpbb\console\command\command
 	/** @var \phpbb\lock\db */
 	protected $lock_db;
 
-	/** @var \phpbb\user */
-	protected $user;
-
 	/**
 	* Construct method
 	*
+	* @param \phpbb\user $user The user object (used to get language information)
 	* @param \phpbb\cron\manager $cron_manager The cron manager containing
 	*		the cron tasks to be executed.
 	* @param \phpbb\lock\db $lock_db The lock for accessing database.
-	* @param \phpbb\user $user The user object (used to get language information)
 	*/
-	public function __construct(\phpbb\cron\manager $cron_manager, \phpbb\lock\db $lock_db, \phpbb\user $user)
+	public function __construct(\phpbb\user $user, \phpbb\cron\manager $cron_manager, \phpbb\lock\db $lock_db)
 	{
 		$this->cron_manager = $cron_manager;
 		$this->lock_db = $lock_db;
-		$this->user = $user;
-		parent::__construct();
+		parent::__construct($user);
 	}
 
 	/**

--- a/phpBB/phpbb/console/command/db/migrate.php
+++ b/phpBB/phpbb/console/command/db/migrate.php
@@ -32,19 +32,15 @@ class migrate extends \phpbb\console\command\command
 	/** @var \phpbb\log\log */
 	protected $log;
 
-	/** @var \phpbb\user */
-	protected $user;
-
-	function __construct(\phpbb\db\migrator $migrator, \phpbb\extension\manager $extension_manager, \phpbb\config\config $config, \phpbb\cache\service $cache, \phpbb\log\log $log, \phpbb\user $user)
+	function __construct(\phpbb\user $user, \phpbb\db\migrator $migrator, \phpbb\extension\manager $extension_manager, \phpbb\config\config $config, \phpbb\cache\service $cache, \phpbb\log\log $log)
 	{
 		$this->migrator = $migrator;
 		$this->extension_manager = $extension_manager;
 		$this->config = $config;
 		$this->cache = $cache;
 		$this->log = $log;
-		$this->user = $user;
+		parent::__construct($user);
 		$this->user->add_lang(array('common', 'install', 'migrator'));
-		parent::__construct();
 	}
 
 	protected function configure()

--- a/phpBB/phpbb/console/command/dev/migration_tips.php
+++ b/phpBB/phpbb/console/command/dev/migration_tips.php
@@ -20,10 +20,10 @@ class migration_tips extends \phpbb\console\command\command
 	/** @var \phpbb\extension\manager */
 	protected $extension_manager;
 
-	function __construct(\phpbb\extension\manager $extension_manager)
+	function __construct(\phpbb\user $user, \phpbb\extension\manager $extension_manager)
 	{
 		$this->extension_manager = $extension_manager;
-		parent::__construct();
+		parent::__construct($user);
 	}
 
 	protected function configure()

--- a/phpBB/phpbb/console/command/extension/command.php
+++ b/phpBB/phpbb/console/command/extension/command.php
@@ -20,11 +20,11 @@ abstract class command extends \phpbb\console\command\command
 	/** @var \phpbb\log\log */
 	protected $log;
 
-	public function __construct(\phpbb\extension\manager $manager, \phpbb\log\log $log)
+	public function __construct(\phpbb\user $user, \phpbb\extension\manager $manager, \phpbb\log\log $log)
 	{
 		$this->manager = $manager;
 		$this->log = $log;
 
-		parent::__construct();
+		parent::__construct($user);
 	}
 }

--- a/phpBB/phpbb/console/command/fixup/recalculate_email_hash.php
+++ b/phpBB/phpbb/console/command/fixup/recalculate_email_hash.php
@@ -20,11 +20,11 @@ class recalculate_email_hash extends \phpbb\console\command\command
 	/** @var \phpbb\db\driver\driver_interface */
 	protected $db;
 
-	function __construct(\phpbb\db\driver\driver_interface $db)
+	function __construct(\phpbb\user $user, \phpbb\db\driver\driver_interface $db)
 	{
 		$this->db = $db;
 
-		parent::__construct();
+		parent::__construct($user);
 	}
 
 	protected function configure()

--- a/tests/console/cron/cron_list_test.php
+++ b/tests/console/cron/cron_list_test.php
@@ -75,7 +75,7 @@ class phpbb_console_command_cron_list_test extends phpbb_test_case
 	public function get_command_tester()
 	{
 		$application = new Application();
-		$application->add(new cron_list($this->cron_manager, $this->user));
+		$application->add(new cron_list($this->user, $this->cron_manager));
 
 		$command = $application->find('cron:list');
 		$this->command_name = $command->getName();

--- a/tests/console/cron/run_test.php
+++ b/tests/console/cron/run_test.php
@@ -148,7 +148,7 @@ class phpbb_console_command_cron_run_test extends phpbb_database_test_case
 	public function get_command_tester()
 	{
 		$application = new Application();
-		$application->add(new run($this->cron_manager, $this->lock, $this->user));
+		$application->add(new run($this->user, $this->cron_manager, $this->lock));
 
 		$command = $application->find('cron:run');
 		$this->command_name = $command->getName();


### PR DESCRIPTION
Base patch for https://tracker.phpbb.com/browse/PHPBB3-12656
- The user object is a property of the abstract phpbb console command class
- The user object is always passed as the first parameter
