### PR TITLE
[ticket/12871] Add PHPBB_DISPLAY_LOAD_TIME const to config.php on installation

### DIFF
--- a/phpBB/includes/functions_install.php
+++ b/phpBB/includes/functions_install.php
@@ -449,6 +449,7 @@ function phpbb_create_config_file_data($data, $dbms, $debug = false, $debug_cont
 	}
 
 	$config_data .= "\n@define('PHPBB_INSTALLED', true);\n";
+	$config_data .= "// @define('PHPBB_DISPLAY_LOAD_TIME', true);\n";
 
 	if ($debug)
 	{


### PR DESCRIPTION
To make it consistent with another config.php constants,
PHPBB_DISPLAY_LOAD_TIME is to be put in config.php during installation as well.

<a href="https://tracker.phpbb.com/browse/PHPBB3-12871">PHPBB3-12871</a>.
