### PR TITLE
Add event to acp_main.php to notice admin

### DIFF
--- a/phpBB/includes/acp/acp_main.php
+++ b/phpBB/includes/acp/acp_main.php
@@ -451,7 +451,7 @@ class acp_main
 		* @event core.acp_main_notice
 		* @since 3.1.0-RC3
 		*/
-		$phpbb_dispatcher->trigger_event('core.acp_main_notice');
+		$phpbb_dispatcher->dispatch('core.acp_main_notice');
 
 		// Get forum statistics
 		$total_posts = $config['num_posts'];


### PR DESCRIPTION
Like the notice on the main acp page, extensions should be able to generate their own notice for the admin. There is already a html event acp_main_notice_after so it should be able to do their own notice.

http://area51.phpbb.com/phpBB/viewtopic.php?f=111&t=45987
