### PR TITLE
[ticket/12906] Add rel="help" to FAQ link

### DIFF
--- a/phpBB/styles/subsilver2/template/overall_header.html
+++ b/phpBB/styles/subsilver2/template/overall_header.html
@@ -214,7 +214,7 @@ function marklist(id, name, state)
 			</td>
 			<td class="genmed" align="{S_CONTENT_FLOW_END}">
 				<!-- EVENT overall_header_navigation_prepend -->
-				<a href="{U_FAQ}" rel="help"><img src="{T_THEME_PATH}/images/icon_mini_faq.gif" width="12" height="13" alt="*" /> {L_FAQ}</a>
+				<a href="{U_FAQ}"><img src="{T_THEME_PATH}/images/icon_mini_faq.gif" width="12" height="13" alt="*" /> {L_FAQ}</a>
 				<!-- IF S_DISPLAY_SEARCH -->&nbsp; &nbsp;<a href="{U_SEARCH}"><img src="{T_THEME_PATH}/images/icon_mini_search.gif" width="12" height="13" alt="*" /> {L_SEARCH}</a><!-- ENDIF -->
 				<!-- IF not S_IS_BOT -->
 					<!-- IF S_DISPLAY_MEMBERLIST -->&nbsp; &nbsp;<a href="{U_MEMBERLIST}"><img src="{T_THEME_PATH}/images/icon_mini_members.gif" width="12" height="13" alt="*" /> {L_MEMBERLIST}</a><!-- ENDIF -->


### PR DESCRIPTION
The rel attribute specifies the relationship between the current document and the linked document.

By adding rel="help" to the FAQ's anchor, we are telling search engines that it is a link to a help document.
