### PR TITLE
[ticket/12910] Set get_name for Google+ fields

### DIFF
--- a/phpBB/phpbb/profilefields/type/type_googleplus.php
+++ b/phpBB/phpbb/profilefields/type/type_googleplus.php
@@ -18,6 +18,14 @@ class type_googleplus extends type_string
 	/**
 	* {@inheritDoc}
 	*/
+	public function get_name()
+	{
+		return $this->user->lang('FIELD_GOOGLEPLUS');
+	}
+
+	/**
+	* {@inheritDoc}
+	*/
 	public function get_service_name()
 	{
 		return 'profilefields.type.googleplus';


### PR DESCRIPTION
Using get_service name would confuse the ACP dropdowns while fetching the field's type's name, causing it to list 2 "Single text field". Instead specify the language name instead

[PHPBB3-12910](https://tracker.phpbb.com/browse/PHPBB3-12910)
