### PR TITLE
[ticket/12913] Add more parameters to core.submit_post_end event

### DIFF
--- a/phpBB/includes/functions_posting.php
+++ b/phpBB/includes/functions_posting.php
@@ -2401,12 +2401,31 @@ function submit_post($mode, $subject, $username, $topic_type, &$poll, &$data, $u
 	* event is to modify the return URL ($url).
 	*
 	* @event core.submit_post_end
-	* @var	string		url						The "Return to topic" URL
-	* @var	array		data					Array of post data about the
-	*											submitted post
+	* @var	string	mode				Variable containing posting mode value
+	* @var	string	subject				Variable containing post subject value
+	* @var	string	username			Variable containing post author name
+	* @var	int		topic_type			Variable containing topic type value
+	* @var	array	poll				Array with the poll data for the post
+	* @var	array	data				Array with the data for the post
+	* @var	bool	update_message		Flag indicating if the post will be updated
+	* @var	bool	update_search_index	Flag indicating if the search index will be updated
+	* @var	string	url					The "Return to topic" URL
+	*
 	* @since 3.1.0-a3
+	* @change 3.1.0-RC3 Added vars mode, subject, username, topic_type,
+	*		poll, update_message, update_search_index
 	*/
-	$vars = array('url', 'data');
+	$vars = array(
+		'mode',
+		'subject',
+		'username',
+		'topic_type',
+		'poll',
+		'data',
+		'update_message',
+		'update_search_index',
+		'url',
+	);
 	extract($phpbb_dispatcher->trigger_event('core.submit_post_end', compact($vars)));
 
 	return $url;


### PR DESCRIPTION
As event core.modify_submit_post_data can modify any of the
function submit_post parameters, they may be needed to perform
actions directly after a post or topic has been submitted in
event core.submit_post_end (includes/functions_posting.php).

<a href="https://tracker.phpbb.com/browse/PHPBB3-12913">PHPBB3-12913</a>.
