### PR TITLE
[ticket/12931] Fix general error on user registration

### DIFF
--- a/phpBB/includes/functions_messenger.php
+++ b/phpBB/includes/functions_messenger.php
@@ -402,17 +402,9 @@ class messenger
 	*/
 	function generate_message_id()
 	{
-		global $config;
+		global $config, $request;
 
-		$domain = 'phpbb.generated';
-		if ($config['server_name'])
-		{
-			$domain = $config['server_name'];
-		}
-		else if (!empty($_SERVER['SERVER_NAME']))
-		{
-			$domain = $_SERVER['SERVER_NAME'];
-		}
+		$domain = ($config['server_name']) ?: $request->server('SERVER_NAME', 'phpbb.generated');
 
 		return md5(unique_id(time())) . '@' . $domain;
 	}


### PR DESCRIPTION
Fix "Illegal use of $_SERVER" general error on user registration
when $config['server_name'] is not set.

<a href="https://tracker.phpbb.com/browse/PHPBB3-12931">PHPBB3-12931</a>.
