### PR TITLE
[ticket/12969] Add template events around username link on composing pm

### DIFF
--- a/phpBB/docs/events.md
+++ b/phpBB/docs/events.md
@@ -732,6 +732,22 @@ posting_editor_subject_before
 * Since: 3.1.0-a2
 * Purpose: Add field (e.g. textbox) to the posting screen before the subject
 
+posting_pm_header_find_username_after
+===
+* Locations:
+    + styles/prosilver/template/posting_pm_header.html
+    + styles/subsilver2/template/ucp_header.html
+* Since: 3.1.0-RC4
+* Purpose: Add content after the find username link on composing pm
+
+posting_pm_header_find_username_before
+===
+* Locations:
+    + styles/prosilver/template/posting_pm_header.html
+    + styles/subsilver2/template/ucp_header.html
+* Since: 3.1.0-RC4
+* Purpose: Add content before the find username link on composing pm
+
 quickreply_editor_panel_after
 ===
 * Locations:

--- a/phpBB/styles/prosilver/template/posting_pm_header.html
+++ b/phpBB/styles/prosilver/template/posting_pm_header.html
@@ -15,7 +15,9 @@
 				<dd class="recipients">
 				<input type="submit" name="add_to" value="{L_ADD}" class="button2" tabindex="1" />
 				<input type="submit" name="add_bcc" value="{L_ADD_BCC}" class="button2" tabindex="1" />
+				<!-- EVENT posting_pm_header_find_username_before -->
 				<span><a href="{U_FIND_USERNAME}" onclick="find_username(this.href); return false;">{L_FIND_USERNAME}</a></span>
+				<!-- EVENT posting_pm_header_find_username_after -->
 				</dd>
 			</dl>
 			<!-- ENDIF -->

--- a/phpBB/styles/subsilver2/template/ucp_header.html
+++ b/phpBB/styles/subsilver2/template/ucp_header.html
@@ -25,11 +25,13 @@
 		<tr>
 			<td class="row1"><b class="genmed">{L_USERNAMES}{L_COLON}</b></td>
 		</tr>
+		<!-- EVENT posting_pm_header_find_username_before -->
 		<tr>
 			<td class="row2"><textarea name="username_list" rows="5" cols="22" tabindex="1"></textarea><br />
 				[ <a href="{U_FIND_USERNAME}" onclick="find_username(this.href); return false;">{L_FIND_USERNAME}</a> ]
 			</td>
 		</tr>
+		<!-- EVENT posting_pm_header_find_username_after -->
 	<!-- ENDIF -->
 	<!-- IF S_GROUP_OPTIONS -->
 		<tr>


### PR DESCRIPTION
Add template event before/after find username link on composing pm
to allow extensions perform additional actions on user finding.

<a href="https://tracker.phpbb.com/browse/PHPBB3-12969">PHPBB3-12969</a>·
