### PR TITLE
Fix reliability issue in flock test

### DIFF
--- a/tests/lock/flock_test.php
+++ b/tests/lock/flock_test.php
@@ -83,9 +83,9 @@ class phpbb_lock_flock_test extends phpbb_test_case
 			sleep(1);
 
 			$lock = new \phpbb\lock\flock($path);
-			$start = time();
+			$start = microtime(true);
 			$ok = $lock->acquire();
-			$delta = time() - $start;
+			$delta = microtime(true) - $start;
 			$this->assertTrue($ok);
 			$this->assertTrue($lock->owns_lock());
 			$this->assertGreaterThan(0.5, $delta, 'First lock acquired too soon');
@@ -94,9 +94,9 @@ class phpbb_lock_flock_test extends phpbb_test_case
 			$this->assertFalse($lock->owns_lock());
 
 			// acquire again, this should be instantaneous
-			$start = time();
+			$start = microtime(true);
 			$ok = $lock->acquire();
-			$delta = time() - $start;
+			$delta = microtime(true) - $start;
 			$this->assertTrue($ok);
 			$this->assertTrue($lock->owns_lock());
 			$this->assertLessThan(0.1, $delta, 'Second lock not acquired instantaneously');


### PR DESCRIPTION
$delta was always an int - so, this test would sometimes fail if you
happened to call time() /very/ close to a 1s boundary.

Found by HHVM's continuous testing.
