### PR TITLE
[ticket/13006] Add variables to the 'core.modify_quickmod_actions' event

### DIFF
--- a/phpBB/includes/mcp/mcp_main.php
+++ b/phpBB/includes/mcp/mcp_main.php
@@ -161,9 +161,13 @@ class mcp_main
 				* This event allows you to handle custom quickmod options
 				*
 				* @event core.modify_quickmod_actions
+				* @var	string	action		Topic quick moderation action name
+				* @var	bool	quickmod	Flag indicating whether MCP is in quick moderation mode
 				* @since 3.1.0-a4
+				* @change 3.1.0-RC4 Added variables: action, quickmod
 				*/
-				$phpbb_dispatcher->dispatch('core.modify_quickmod_actions');
+				$vars = array('action', 'quickmod');
+				extract($phpbb_dispatcher->trigger_event('core.modify_quickmod_actions', compact($vars)));
 			break;
 		}
 


### PR DESCRIPTION
Add $quickmod and $action variables
for the 'core.modify_quickmod_actions' event trigerring
to avoid of using global operator in corresponding extensions.

This PR is an addition to the PR https://github.com/phpbb/phpbb/pull/2045.

<a href="https://tracker.phpbb.com/browse/PHPBB3-13006">PHPBB3-13006</a>.
