### PR TITLE
[ticket/13015] Allow adding multiple notifications per user about the same item

### DIFF
--- a/phpBB/phpbb/notification/manager.php
+++ b/phpBB/phpbb/notification/manager.php
@@ -381,21 +381,6 @@ class manager
 		// Never send notifications to the anonymous user!
 		unset($notify_users[ANONYMOUS]);
 
-		// Make sure not to send new notifications to users who've already been notified about this item
-		// This may happen when an item was added, but now new users are able to see the item
-		$sql = 'SELECT n.user_id
-			FROM ' . $this->notifications_table . ' n, ' . $this->notification_types_table . ' nt
-			WHERE n.notification_type_id = ' . (int) $notification_type_id . '
-				AND n.item_id = ' . (int) $item_id . '
-				AND nt.notification_type_id = n.notification_type_id
-				AND nt.notification_type_enabled = 1';
-		$result = $this->db->sql_query($sql);
-		while ($row = $this->db->sql_fetchrow($result))
-		{
-			unset($notify_users[$row['user_id']]);
-		}
-		$this->db->sql_freeresult($result);
-
 		if (!sizeof($notify_users))
 		{
 			return;

--- a/phpBB/phpbb/notification/type/admin_activate_user.php
+++ b/phpBB/phpbb/notification/type/admin_activate_user.php
@@ -72,6 +72,7 @@ class admin_activate_user extends \phpbb\notification\type\base
 	{
 		$options = array_merge(array(
 			'ignore_users'	=> array(),
+			'item_id'			=> $this->get_item_id($user),
 		), $options);
 
 		// Grab admins that have permission to administer users.
@@ -95,6 +96,7 @@ class admin_activate_user extends \phpbb\notification\type\base
 			return array();
 		}
 		$users = array_unique($users);
+		$users = $this->filter_item_notified_users($users, $options);
 
 		return $this->check_user_notification_options($users, $options);
 	}

--- a/phpBB/phpbb/notification/type/approve_post.php
+++ b/phpBB/phpbb/notification/type/approve_post.php
@@ -76,10 +76,12 @@ class approve_post extends \phpbb\notification\type\post
 	{
 		$options = array_merge(array(
 			'ignore_users'		=> array(),
+			'item_id'			=> $this->get_item_id($post),
 		), $options);
 
 		$users = array();
 		$users[$post['poster_id']] = array('');
+		$users = $this->filter_item_notified_users($users, $options);
 
 		return $this->get_authorised_recipients(array_keys($users), $post['forum_id'], array_merge($options, array(
 			'item_type'		=> self::$notification_option['id'],

--- a/phpBB/phpbb/notification/type/approve_topic.php
+++ b/phpBB/phpbb/notification/type/approve_topic.php
@@ -76,10 +76,12 @@ class approve_topic extends \phpbb\notification\type\topic
 	{
 		$options = array_merge(array(
 			'ignore_users'		=> array(),
+			'item_id'			=> $this->get_item_id($post),
 		), $options);
 
 		$users = array();
 		$users[$post['poster_id']] = array('');
+		$users = $this->filter_item_notified_users($users, $options);
 
 		return $this->get_authorised_recipients(array_keys($users), $post['forum_id'], array_merge($options, array(
 			'item_type'		=> self::$notification_option['id'],

--- a/phpBB/phpbb/notification/type/bookmark.php
+++ b/phpBB/phpbb/notification/type/bookmark.php
@@ -68,6 +68,7 @@ class bookmark extends \phpbb\notification\type\post
 	{
 		$options = array_merge(array(
 			'ignore_users'		=> array(),
+			'item_id'			=> $this->get_item_id($post),
 		), $options);
 
 		$users = array();
@@ -116,6 +117,8 @@ class bookmark extends \phpbb\notification\type\post
 			}
 		}
 		$this->db->sql_freeresult($result);
+
+		$notify_users = $this->filter_item_notified_users($notify_users, $options);
 
 		return $notify_users;
 	}

--- a/phpBB/phpbb/notification/type/group_request.php
+++ b/phpBB/phpbb/notification/type/group_request.php
@@ -71,6 +71,7 @@ class group_request extends \phpbb\notification\type\base
 	{
 		$options = array_merge(array(
 			'ignore_users'		=> array(),
+			'item_id'			=> $this->get_item_id($group),
 		), $options);
 
 		$sql = 'SELECT user_id
@@ -87,6 +88,7 @@ class group_request extends \phpbb\notification\type\base
 		$this->db->sql_freeresult($result);
 
 		$this->user_loader->load_users($user_ids);
+		$user_ids = $this->filter_item_notified_users($user_ids, $options);
 
 		return $this->check_user_notification_options($user_ids, $options);
 	}

--- a/phpBB/phpbb/notification/type/group_request_approved.php
+++ b/phpBB/phpbb/notification/type/group_request_approved.php
@@ -52,6 +52,10 @@ class group_request_approved extends \phpbb\notification\type\base
 	*/
 	public function find_users_for_notification($group, $options = array())
 	{
+		$options = array_merge(array(
+			'item_id'			=> $this->get_item_id($group),
+		), $options);
+
 		$users = array();
 
 		$group['user_ids'] = (!is_array($group['user_ids'])) ? array($group['user_ids']) : $group['user_ids'];
@@ -60,6 +64,7 @@ class group_request_approved extends \phpbb\notification\type\base
 		{
 			$users[$user_id] = array('');
 		}
+		$users = $this->filter_item_notified_users($users, $options);
 
 		return $users;
 	}

--- a/phpBB/phpbb/notification/type/pm.php
+++ b/phpBB/phpbb/notification/type/pm.php
@@ -81,6 +81,7 @@ class pm extends \phpbb\notification\type\base
 	{
 		$options = array_merge(array(
 			'ignore_users'		=> array(),
+			'item_id'			=> $this->get_item_id($pm),
 		), $options);
 
 		if (!sizeof($pm['recipients']))
@@ -89,6 +90,7 @@ class pm extends \phpbb\notification\type\base
 		}
 
 		unset($pm['recipients'][$pm['from_user_id']]);
+		$pm['recipients'] = $this->filter_item_notified_users($pm['recipients'], $options);
 
 		$this->user_loader->load_users(array_keys($pm['recipients']));
 

--- a/phpBB/phpbb/notification/type/post.php
+++ b/phpBB/phpbb/notification/type/post.php
@@ -95,6 +95,7 @@ class post extends \phpbb\notification\type\base
 	{
 		$options = array_merge(array(
 			'ignore_users'		=> array(),
+			'item_id'			=> $this->get_item_id($post),
 		), $options);
 
 		$users = array();
@@ -156,6 +157,8 @@ class post extends \phpbb\notification\type\base
 			}
 		}
 		$this->db->sql_freeresult($result);
+
+		$notify_users = $this->filter_item_notified_users($notify_users, $options);
 
 		return $notify_users;
 	}

--- a/phpBB/phpbb/notification/type/post_in_queue.php
+++ b/phpBB/phpbb/notification/type/post_in_queue.php
@@ -78,6 +78,7 @@ class post_in_queue extends \phpbb\notification\type\post
 	{
 		$options = array_merge(array(
 			'ignore_users'		=> array(),
+			'item_id'			=> $this->get_item_id($post),
 		), $options);
 
 		// 0 is for global moderator permissions
@@ -106,6 +107,8 @@ class post_in_queue extends \phpbb\notification\type\post
 		{
 			return array();
 		}
+
+		$auth_read[$post['forum_id']]['f_read'] = $this->filter_item_notified_users($auth_read[$post['forum_id']]['f_read'], $options);
 
 		return $this->check_user_notification_options($auth_read[$post['forum_id']]['f_read'], array_merge($options, array(
 			'item_type'		=> self::$notification_option['id'],

--- a/phpBB/phpbb/notification/type/quote.php
+++ b/phpBB/phpbb/notification/type/quote.php
@@ -75,6 +75,7 @@ class quote extends \phpbb\notification\type\post
 	{
 		$options = array_merge(array(
 			'ignore_users'		=> array(),
+			'item_id'			=> $this->get_item_id($post),
 		), $options);
 
 		$usernames = false;
@@ -101,6 +102,8 @@ class quote extends \phpbb\notification\type\post
 			$users[] = (int) $row['user_id'];
 		}
 		$this->db->sql_freeresult($result);
+
+		$users = $this->filter_item_notified_users($users, $options);
 
 		return $this->get_authorised_recipients($users, $post['forum_id'], $options, true);
 	}

--- a/phpBB/phpbb/notification/type/report_pm.php
+++ b/phpBB/phpbb/notification/type/report_pm.php
@@ -102,6 +102,7 @@ class report_pm extends \phpbb\notification\type\pm
 	{
 		$options = array_merge(array(
 			'ignore_users'		=> array(),
+			'item_id'			=> $this->get_item_id($post),
 		), $options);
 
 		// Global
@@ -118,6 +119,8 @@ class report_pm extends \phpbb\notification\type\pm
 		{
 			unset($auth_approve[$post['forum_id']][$this->permission][$key]);
 		}
+
+		$auth_approve[$post['forum_id']][$this->permission] = $this->filter_item_notified_users($auth_approve[$post['forum_id']][$this->permission], $options);
 
 		return $this->check_user_notification_options($auth_approve[$post['forum_id']][$this->permission], array_merge($options, array(
 			'item_type'		=> self::$notification_option['id'],

--- a/phpBB/phpbb/notification/type/report_pm_closed.php
+++ b/phpBB/phpbb/notification/type/report_pm_closed.php
@@ -59,12 +59,19 @@ class report_pm_closed extends \phpbb\notification\type\pm
 	*/
 	public function find_users_for_notification($pm, $options = array())
 	{
+		$options = array_merge(array(
+			'item_id'			=> $this->get_item_id($pm),
+		), $options);
+
 		if ($pm['reporter'] == $this->user->data['user_id'])
 		{
 			return array();
 		}
 
-		return array($pm['reporter'] => array(''));
+		$users = array($pm['reporter'] => array(''));
+		$users = $this->filter_item_notified_users($users, $options);
+
+		return $users;
 	}
 
 	/**

--- a/phpBB/phpbb/notification/type/report_post_closed.php
+++ b/phpBB/phpbb/notification/type/report_post_closed.php
@@ -66,12 +66,19 @@ class report_post_closed extends \phpbb\notification\type\post
 	*/
 	public function find_users_for_notification($post, $options = array())
 	{
+		$options = array_merge(array(
+			'item_id'			=> $this->get_item_id($post),
+		), $options);
+
 		if ($post['reporter'] == $this->user->data['user_id'])
 		{
 			return array();
 		}
 
-		return array($post['reporter'] => array(''));
+		$users = array($post['reporter'] => array(''));
+		$users = $this->filter_item_notified_users($users, $options);
+
+		return $users;
 	}
 
 	/**

--- a/phpBB/phpbb/notification/type/topic.php
+++ b/phpBB/phpbb/notification/type/topic.php
@@ -95,6 +95,7 @@ class topic extends \phpbb\notification\type\base
 	{
 		$options = array_merge(array(
 			'ignore_users'			=> array(),
+			'item_id'			=> $this->get_item_id($topic),
 		), $options);
 
 		$users = array();
@@ -110,6 +111,8 @@ class topic extends \phpbb\notification\type\base
 			$users[] = (int) $row['user_id'];
 		}
 		$this->db->sql_freeresult($result);
+
+		$users = $this->filter_item_notified_users($users, $options);
 
 		return $this->get_authorised_recipients($users, $topic['forum_id'], $options);
 	}

--- a/phpBB/phpbb/notification/type/topic_in_queue.php
+++ b/phpBB/phpbb/notification/type/topic_in_queue.php
@@ -78,6 +78,7 @@ class topic_in_queue extends \phpbb\notification\type\topic
 	{
 		$options = array_merge(array(
 			'ignore_users'		=> array(),
+			'item_id'			=> $this->get_item_id($topic),
 		), $options);
 
 		// 0 is for global moderator permissions
@@ -106,6 +107,8 @@ class topic_in_queue extends \phpbb\notification\type\topic
 		{
 			return array();
 		}
+
+		$auth_read[$topic['forum_id']]['f_read'] = $this->filter_item_notified_users($auth_read[$topic['forum_id']]['f_read'], $options);
 
 		return $this->check_user_notification_options($auth_read[$topic['forum_id']]['f_read'], array_merge($options, array(
 			'item_type'		=> self::$notification_option['id'],


### PR DESCRIPTION
It is impossible to send notification to user about item user already has been
notified. The limitation is hardcoded in notifications manager class.
To allow adding multiple notifications per user about the same item,
move the limitation to the notification type class to be able to set
corresponding notifications behavior on per-type notification basis.

<a href="https://tracker.phpbb.com/browse/PHPBB3-13015">PHPBB3-13015</a>.
