### PR TITLE
[ticket/13050] Allow topic/forum subscription when email/jabber is off

### DIFF
--- a/phpBB/viewforum.php
+++ b/phpBB/viewforum.php
@@ -251,7 +251,7 @@ $s_watching_forum = array(
 	'is_watching'	=> false,
 );
 
-if (($config['email_enable'] || $config['jab_enable']) && $config['allow_forum_notify'] && $forum_data['forum_type'] == FORUM_POST && ($auth->acl_get('f_subscribe', $forum_id) || $user->data['user_id'] == ANONYMOUS))
+if ($config['allow_forum_notify'] && $forum_data['forum_type'] == FORUM_POST && ($auth->acl_get('f_subscribe', $forum_id) || $user->data['user_id'] == ANONYMOUS))
 {
 	$notify_status = (isset($forum_data['notify_status'])) ? $forum_data['notify_status'] : NULL;
 	watch_topic_forum('forum', $s_watching_forum, $user->data['user_id'], $forum_id, 0, $notify_status, $start, $forum_data['forum_name']);

--- a/phpBB/viewtopic.php
+++ b/phpBB/viewtopic.php
@@ -449,7 +449,7 @@ $s_watching_topic = array(
 	'is_watching'	=> false,
 );
 
-if (($config['email_enable'] || $config['jab_enable']) && $config['allow_topic_notify'])
+if ($config['allow_topic_notify'])
 {
 	$notify_status = (isset($topic_data['notify_status'])) ? $topic_data['notify_status'] : null;
 	watch_topic_forum('topic', $s_watching_topic, $user->data['user_id'], $forum_id, $topic_id, $notify_status, $start, $topic_data['topic_title']);


### PR DESCRIPTION
Currently, there's impossible to subscribe topic/forum if emails and/or jabber
is disabled. This seems to be a 3.0 leftover since 3.1 introduces new
notification system which handles this case and offers email/jabber-free
board notifications.

<a href="https://tracker.phpbb.com/browse/PHPBB3-13050">PHPBB3-13050</a>.
