### PR TITLE
[ticket/13059] Add core event to generate_page_link()

### DIFF
--- a/phpBB/config/services.yml
+++ b/phpBB/config/services.yml
@@ -288,6 +288,7 @@ services:
             - @template
             - @user
             - @controller.helper
+            - @dispatcher
 
     path_helper:
         class: phpbb\path_helper

--- a/tests/mock/event_dispatcher.php
+++ b/tests/mock/event_dispatcher.php
@@ -11,9 +11,18 @@
 *
 */
 
-class phpbb_mock_event_dispatcher
+class phpbb_mock_event_dispatcher extends \phpbb\event\dispatcher
 {
-	public function trigger_event($eventName, $data)
+	/**
+	* Constructor.
+	*
+	* Overwrite the constructor to get rid of ContainerInterface param instance
+	*/
+	public function __construct()
+	{
+	}
+
+	public function trigger_event($eventName, $data = array())
 	{
 		return array();
 	}

--- a/tests/pagination/pagination_test.php
+++ b/tests/pagination/pagination_test.php
@@ -28,7 +28,7 @@ class phpbb_pagination_pagination_test extends phpbb_template_template_test_case
 
 		global $phpbb_dispatcher;
 
-		$phpbb_dispatcher = new phpbb_mock_event_dispatcher;
+		$phpbb_dispatcher = new phpbb_mock_event_dispatcher();
 		$this->user = $this->getMock('\phpbb\user', array(), array('\phpbb\datetime'));
 		$this->user->expects($this->any())
 			->method('lang')
@@ -58,7 +58,7 @@ class phpbb_pagination_pagination_test extends phpbb_template_template_test_case
 		);
 
 		$this->helper = new phpbb_mock_controller_helper($this->template, $this->user, $this->config, $provider, $manager, $symfony_request, $filesystem, '', 'php', dirname(__FILE__) . '/');
-		$this->pagination = new \phpbb\pagination($this->template, $this->user, $this->helper);
+		$this->pagination = new \phpbb\pagination($this->template, $this->user, $this->helper, $phpbb_dispatcher);
 	}
 
 	public function generate_template_pagination_data()


### PR DESCRIPTION
Add core event to generate_page_link() to allow overriding/modifying pagination URLs.
Event request: http://area51.phpbb.com/phpBB/viewtopic.php?f=111&t=45905

https://tracker.phpbb.com/browse/PHPBB3-13059
