### PR TITLE
[ticket/13066] Add search results core event to modify search title

### DIFF
--- a/phpBB/search.php
+++ b/phpBB/search.php
@@ -1149,6 +1149,20 @@ if ($keywords || $author || $author_id || $search_id || $submit)
 	}
 	unset($rowset);
 
+	/**
+	* Modify the title and/or load data for the search results page
+	*
+	* @event core.search_results_modify_search_title
+	* @var	int		author_id		ID of the author to search by
+	* @var	string	l_search_title	The title of the search page
+	* @var	string	search_id		Predefined search type name
+	* @var	string	show_results	Search results output mode - topics or posts
+	* @var	int		start			The starting id of the results
+	* @since 3.1.0-RC4
+	*/
+	$vars = array('author_id', 'l_search_title', 'search_id', 'show_results', 'start');
+	extract($phpbb_dispatcher->trigger_event('core.search_results_modify_search_title', compact($vars)));
+
 	page_header(($l_search_title) ? $l_search_title : $user->lang['SEARCH']);
 
 	$template->set_filenames(array(


### PR DESCRIPTION
search.php needs common search results event to be able to modify search title and probably perform some additional actions related to the search page rendering.

<a href="https://tracker.phpbb.com/browse/PHPBB3-13066">PHPBB3-13066</a>.
