### PR TITLE
[ticket/13069] Fix timezone location filtering.

### DIFF
--- a/phpBB/assets/javascript/core.js
+++ b/phpBB/assets/javascript/core.js
@@ -782,12 +782,7 @@ phpbb.timezoneSwitchDate = function(keepSelection) {
 			.insertAfter('#timezone');
 	} else {
 		// Copy the content of our backup, so we can remove all unneeded options
-		var $replacement = $timezoneCopy.clone();
-		$replacement.attr('id', 'timezone')
-			.css('display', 'block')
-			.attr('name', 'tz');
-
-		$timezone.replaceWith($replacement);
+		$timezone.html($timezoneCopy.html());
 	}
 
 	if ($tzDate.val() !== '') {


### PR DESCRIPTION
$timezone contains the original jQuery object, therefore the subsequent
removal of the optgroup children while filtering has no effect on the
$replacement object - the one that's now visible to the user. We'll simplify
and fix this by injecting the content of the copy instead of going through the
trouble of cloning it.

[PHPBB3-13069](https://tracker.phpbb.com/browse/PHPBB3-13069)
