### PR TITLE
[ticket/13110] Add core event to the page_footer() function

### DIFF
--- a/phpBB/includes/functions.php
+++ b/phpBB/includes/functions.php
@@ -5278,6 +5278,18 @@ function page_footer($run_cron = true, $display_template = true, $exit_handler =
 		}
 	}
 
+	/**
+	* Execute code and/or modify output before displaying the template.
+	*
+	* @event core.page_footer_after
+	* @var	bool display_template	Whether or not to display the template
+	* @var	bool exit_handler		Whether or not to run the exit_handler()
+	*
+	* @since 3.1.0-RC5
+	*/
+	$vars = array('display_template', 'exit_handler');
+	extract($phpbb_dispatcher->trigger_event('core.page_footer_after', compact($vars)));
+
 	if ($display_template)
 	{
 		$template->display('body');


### PR DESCRIPTION
Add core event to the page_footer() in includes/functions.php to allow
extensions handling overall page output before its displaying.

<a href="https://tracker.phpbb.com/browse/PHPBB3-13110">PHPBB3-13110</a>.
