### PR TITLE
Make phpbb_wrapper_gmgetdate_test more reliable

### DIFF
--- a/tests/wrapper/gmgetdate_test.php
+++ b/tests/wrapper/gmgetdate_test.php
@@ -50,7 +50,18 @@ class phpbb_wrapper_gmgetdate_test extends phpbb_test_case
 			$date_array['year']
 		);
 
-		$this->assertEquals($expected, $actual);
+		// Calling second-granularity time functions twice isn't guaranteed to
+		// give the same results. As long as they're in the right order, allow
+		// a 1 second difference.
+		$this->assertTrue(
+			$actual >= $expected,
+			'Expected second time to be after (or equal to) the previous one'
+		);
+		$this->assertLessThanOrEqual(
+			1,
+			abs($actual - $expected),
+			'Expected '.$actual.' to be within 1 second of '.$expected.'.'
+		);
 
 		if (isset($current_timezone))
 		{


### PR DESCRIPTION
If you're unlucky, calling time() or similar twice in a row will
give you different results. Facebook runs these tests thousands of
times a day, so we occasionally have bogus failures.
