### PR TITLE
[ticket/13182] Add posting.php core event to allow modifying the message text

### DIFF
--- a/phpBB/posting.php
+++ b/phpBB/posting.php
@@ -73,7 +73,6 @@ $current_time = time();
 * @var	bool	preview		Whether or not the post is being previewed
 * @var	bool	save		Whether or not a draft is being saved
 * @var	bool	load		Whether or not a draft is being loaded
-* @var	bool	delete		Whether or not the post is being deleted
 * @var	bool	cancel		Whether or not to cancel the form (returns to
 *							viewtopic or viewforum depending on if the user
 *							is posting a new topic or editing a post)
@@ -85,6 +84,7 @@ $current_time = time();
 *							NOTE: Should be actual language strings, NOT
 *							language keys.
 * @since 3.1.0-a1
+* @change 3.1.2-RC1			Removed 'delete' var as it does not exist
 */
 $vars = array(
 	'post_id',
@@ -96,7 +96,6 @@ $vars = array(
 	'preview',
 	'save',
 	'load',
-	'delete',
 	'cancel',
 	'refresh',
 	'mode',
@@ -869,6 +868,43 @@ if ($submit || $preview || $refresh)
 
 	// Parse Attachments - before checksum is calculated
 	$message_parser->parse_attachments('fileupload', $mode, $forum_id, $submit, $preview, $refresh);
+
+	/**
+	* This event allows you to modify message text before parsing
+	*
+	* @event core.posting_modify_message_text
+	* @var	array	post_data	Array with post data
+	* @var	string	mode		What action to take if the form is submitted
+	*				post|reply|quote|edit|delete|bump|smilies|popup
+	* @var	int	post_id		ID of the post
+	* @var	int	topic_id	ID of the topic
+	* @var	int	forum_id	ID of the forum
+	* @var	bool	submit		Whether or not the form has been submitted
+	* @var	bool	preview		Whether or not the post is being previewed
+	* @var	bool	save		Whether or not a draft is being saved
+	* @var	bool	load		Whether or not a draft is being loaded
+	* @var	bool	cancel		Whether or not to cancel the form (returns to
+	*				viewtopic or viewforum depending on if the user
+	*				is posting a new topic or editing a post)
+	* @var	bool	refresh		Whether or not to retain previously submitted data
+	* @var	object	message_parser	The message parser object
+	* @since 3.1.2-RC1
+	*/
+	$vars = array(
+		'post_data',
+		'mode',
+		'post_id',
+		'topic_id',
+		'forum_id',
+		'submit',
+		'preview',
+		'save',
+		'load',
+		'cancel',
+		'refresh',
+		'message_parser',
+	);
+	extract($phpbb_dispatcher->trigger_event('core.posting_modify_message_text', compact($vars)));
 
 	// Grab md5 'checksum' of new message
 	$message_md5 = md5($message_parser->message);
@@ -1727,7 +1763,6 @@ $page_data = array(
 * @var	bool	preview		Whether or not the post is being previewed
 * @var	bool	save		Whether or not a draft is being saved
 * @var	bool	load		Whether or not a draft is being loaded
-* @var	bool	delete		Whether or not the post is being deleted
 * @var	bool	cancel		Whether or not to cancel the form (returns to
 *				viewtopic or viewforum depending on if the user
 *				is posting a new topic or editing a post)
@@ -1744,6 +1779,7 @@ $page_data = array(
 *		s_topic_icons, form_enctype, s_action, s_hidden_fields,
 *		post_id, topic_id, forum_id, submit, preview, save, load,
 *		delete, cancel, refresh, error, page_data, message_parser
+* @change 3.1.2-RC1 Removed 'delete' var as it does not exist
 */
 $vars = array(
 	'post_data',
@@ -1761,7 +1797,6 @@ $vars = array(
 	'preview',
 	'save',
 	'load',
-	'delete',
 	'cancel',
 	'refresh',
 	'error',


### PR DESCRIPTION
posting.php core event to allow modifying the message before parsing
would be needed for some extensions, like for adding topic title to the
topic URL etc.

<a href="https://tracker.phpbb.com/browse/PHPBB3-13182">PHPBB3-13182</a>.
