### PR TITLE
[ticket/13189] Do not use confirm box for marking all notifications read

### DIFF
--- a/phpBB/includes/ucp/ucp_notifications.php
+++ b/phpBB/includes/ucp/ucp_notifications.php
@@ -95,35 +95,25 @@ class ucp_notifications
 			case 'notification_list':
 			default:
 				// Mark all items read
-				if ($request->variable('mark', '') == 'all' && (confirm_box(true) || check_link_hash($request->variable('token', ''), 'mark_all_notifications_read')))
+				if ($request->variable('mark', '') == 'all' && check_link_hash($request->variable('token', ''), 'mark_all_notifications_read'))
 				{
-					if (confirm_box(true))
+					$phpbb_notifications->mark_notifications_read(false, false, $user->data['user_id'], $form_time);
+
+					meta_refresh(3, $this->u_action);
+					$message = $user->lang['NOTIFICATIONS_MARK_ALL_READ_SUCCESS'];
+
+					if ($request->is_ajax())
 					{
-						$phpbb_notifications->mark_notifications_read(false, false, $user->data['user_id'], $form_time);
-
-						meta_refresh(3, $this->u_action);
-						$message = $user->lang['NOTIFICATIONS_MARK_ALL_READ_SUCCESS'];
-
-						if ($request->is_ajax())
-						{
-							$json_response = new \phpbb\json_response();
-							$json_response->send(array(
-								'MESSAGE_TITLE'	=> $user->lang['INFORMATION'],
-								'MESSAGE_TEXT'	=> $message,
-								'success'		=> true,
-							));
-						}
-						$message .= '<br /><br />' . $user->lang('RETURN_UCP', '<a href="' . $this->u_action . '">', '</a>');
-
-						trigger_error($message);
+						$json_response = new \phpbb\json_response();
+						$json_response->send(array(
+							'MESSAGE_TITLE'	=> $user->lang['INFORMATION'],
+							'MESSAGE_TEXT'	=> $message,
+							'success'		=> true,
+						));
 					}
-					else
-					{
-						confirm_box(false, 'NOTIFICATIONS_MARK_ALL_READ', build_hidden_fields(array(
-							'mark'		=> 'all',
-							'form_time'	=> $form_time,
-						)));
-					}
+					$message .= '<br /><br />' . $user->lang('RETURN_UCP', '<a href="' . $this->u_action . '">', '</a>');
+
+					trigger_error($message);
 				}
 
 				// Mark specific notifications read

--- a/tests/functional/notification_test.php
+++ b/tests/functional/notification_test.php
@@ -82,8 +82,6 @@ class phpbb_functional_notification_test extends phpbb_functional_test_case
 		// Get form token
 		$link = $crawler->selectLink($this->lang('NOTIFICATIONS_MARK_ALL_READ'))->link()->getUri();
 		$crawler = self::request('GET', substr($link, strpos($link, 'ucp.')));
-		$form = $crawler->selectButton($this->lang('YES'))->form();
-		$crawler = self::submit($form);
 		$this->assertEquals(0, $crawler->filter('#notification_list_button strong')->text());
 	}
 }


### PR DESCRIPTION
We already use a token for preventing CSRF when marking notifications read.
Making a user confirm the marking read action serves no real purpose. No
information will be lost by just marking the notifications read but it will
prevent users from always having to confirm this action.

Ticket: https://tracker.phpbb.com/browse/PHPBB3-13189
