### PR TITLE
[ticket/13194] BBCode isn't parsed when issuing a warning for a post

### DIFF
--- a/phpBB/includes/mcp/mcp_warn.php
+++ b/phpBB/includes/mcp/mcp_warn.php
@@ -332,7 +332,7 @@ class mcp_warn
 
 		// We want to make the message available here as a reminder
 		// Parse the message and subject
-		$parse_flags = OPTION_FLAG_SMILIES | ($row['bbcode_bitfield'] ? OPTION_FLAG_BBCODE : 0);
+		$parse_flags = OPTION_FLAG_SMILIES | ($user_row['bbcode_bitfield'] ? OPTION_FLAG_BBCODE : 0);
 		$message = generate_text_for_display($user_row['post_text'], $user_row['bbcode_uid'], $user_row['bbcode_bitfield'], $parse_flags, true);
 
 		// Generate the appropriate user information for the user we are looking at


### PR DESCRIPTION
[PHPBB3-13194](https://tracker.phpbb.com/browse/PHPBB3-13194)
