### PR TITLE
[ticket/13223] Fix USERNAME email template variable in notification

### DIFF
--- a/phpBB/phpbb/notification/type/admin_activate_user.php
+++ b/phpBB/phpbb/notification/type/admin_activate_user.php
@@ -131,7 +131,7 @@ class admin_activate_user extends \phpbb\notification\type\base
 	public function get_email_template_variables()
 	{
 		$board_url = generate_board_url();
-		$username = $this->user_loader->get_username($this->item_id, 'no_profile');
+		$username = $this->user_loader->get_username($this->item_id, 'username');
 
 		return array(
 			'USERNAME'			=> htmlspecialchars_decode($username),


### PR DESCRIPTION
admin_activate_user.php notification type is assigning username to email
template using user_loader->get_username() in 'no_profile' mode,
which in its turn calls get_username_string() function in 'no_profile' mode.
This causes HTML markup in emails for username colour.

<a href="https://tracker.phpbb.com/browse/PHPBB3-13223">PHPBB3-13223</a>.
