### PR TITLE
[ticket/13225] Use passwords manager instead of phpbb_hash in migration

### DIFF
--- a/phpBB/phpbb/db/migration/data/v30x/release_3_0_5_rc1.php
+++ b/phpBB/phpbb/db/migration/data/v30x/release_3_0_5_rc1.php
@@ -68,7 +68,7 @@ class release_3_0_5_rc1 extends \phpbb\db\migration\migration
 			if (strlen($row['user_password']) == 32)
 			{
 				$sql_ary = array(
-					'user_password'	=> $passwords_manager->hash($row['user_password'], 'passwords.driver.salted_md5'),
+					'user_password'	=> '$CP$' . $passwords_manager->hash($row['user_password'], 'passwords.driver.salted_md5'),
 				);
 
 				$this->sql_query('UPDATE ' . $this->table_prefix . 'users SET ' . $this->db->sql_build_array('UPDATE', $sql_ary) . ' WHERE user_id = ' . $row['user_id']);


### PR DESCRIPTION
Ticket: https://tracker.phpbb.com/browse/PHPBB3-13225
