### PR TITLE
[ticket/13297] Add unicode modifier to url/email regular expression patterns

### DIFF
--- a/phpBB/includes/functions_content.php
+++ b/phpBB/includes/functions_content.php
@@ -712,7 +712,7 @@ function make_clickable_callback($type, $whitespace, $url, $relative_url, $class
 		break;
 	}
 
-	$short_url = (strlen($url) > 55) ? substr($url, 0, 39) . ' ... ' . substr($url, -10) : $url;
+	$short_url = (utf8_strlen($url) > 55) ? utf8_substr($url, 0, 39) . ' ... ' . utf8_substr($url, -10) : $url;
 
 	switch ($type)
 	{
@@ -788,28 +788,28 @@ function make_clickable($text, $server_url = false, $class = 'postlink')
 
 		// relative urls for this board
 		$magic_url_match_args[$server_url][] = array(
-			'#(^|[\n\t (>.])(' . preg_quote($server_url, '#') . ')/(' . get_preg_expression('relative_url_inline') . ')#i',
+			'#(^|[\n\t (>.])(' . preg_quote($server_url, '#') . ')/(' . get_preg_expression('relative_url_inline') . ')#iu',
 			MAGIC_URL_LOCAL,
 			$local_class,
 		);
 
 		// matches a xxxx://aaaaa.bbb.cccc. ...
 		$magic_url_match_args[$server_url][] = array(
-			'#(^|[\n\t (>.])(' . get_preg_expression('url_inline') . ')#i',
+			'#(^|[\n\t (>.])(' . get_preg_expression('url_inline') . ')#iu',
 			MAGIC_URL_FULL,
 			$class,
 		);
 
 		// matches a "www.xxxx.yyyy[/zzzz]" kinda lazy URL thing
 		$magic_url_match_args[$server_url][] = array(
-			'#(^|[\n\t (>])(' . get_preg_expression('www_url_inline') . ')#i',
+			'#(^|[\n\t (>])(' . get_preg_expression('www_url_inline') . ')#iu',
 			MAGIC_URL_WWW,
 			$class,
 		);
 
 		// matches an email@domain type address at the start of a line, or after a space or after what might be a BBCode.
 		$magic_url_match_args[$server_url][] = array(
-			'/(^|[\n\t (>])(' . get_preg_expression('email') . ')/i',
+			'/(^|[\n\t (>])(' . get_preg_expression('email') . ')/iu',
 			MAGIC_URL_EMAIL,
 			'',
 		);

--- a/phpBB/includes/message_parser.php
+++ b/phpBB/includes/message_parser.php
@@ -313,7 +313,7 @@ class bbcode_firstpass extends bbcode
 		$in = str_replace(' ', '%20', $in);
 
 		// Checking urls
-		if (!preg_match('#^' . get_preg_expression('url') . '$#i', $in) && !preg_match('#^' . get_preg_expression('www_url') . '$#i', $in))
+		if (!preg_match('#^' . get_preg_expression('url') . '$#i', $in) && !preg_match('#^' . get_preg_expression('www_url') . '$#iu', $in))
 		{
 			return '[img]' . $in . '[/img]';
 		}
@@ -381,8 +381,8 @@ class bbcode_firstpass extends bbcode
 		$in = str_replace(' ', '%20', $in);
 
 		// Make sure $in is a URL.
-		if (!preg_match('#^' . get_preg_expression('url') . '$#i', $in) &&
-			!preg_match('#^' . get_preg_expression('www_url') . '$#i', $in))
+		if (!preg_match('#^' . get_preg_expression('url') . '$#iu', $in) &&
+			!preg_match('#^' . get_preg_expression('www_url') . '$#iu', $in))
 		{
 			return '[flash=' . $width . ',' . $height . ']' . $in . '[/flash]';
 		}
@@ -973,9 +973,9 @@ class bbcode_firstpass extends bbcode
 		$url = str_replace(' ', '%20', $url);
 
 		// Checking urls
-		if (preg_match('#^' . get_preg_expression('url') . '$#i', $url) ||
-			preg_match('#^' . get_preg_expression('www_url') . '$#i', $url) ||
-			preg_match('#^' . preg_quote(generate_board_url(), '#') . get_preg_expression('relative_url') . '$#i', $url))
+		if (preg_match('#^' . get_preg_expression('url') . '$#iu', $url) ||
+			preg_match('#^' . get_preg_expression('www_url') . '$#iu', $url) ||
+			preg_match('#^' . preg_quote(generate_board_url(), '#') . get_preg_expression('relative_url') . '$#iu', $url))
 		{
 			$valid = true;
 		}

--- a/tests/functions/make_clickable_test.php
+++ b/tests/functions/make_clickable_test.php
@@ -1,0 +1,100 @@
+<?php
+/**
+*
+* This file is part of the phpBB Forum Software package.
+*
+* @copyright (c) phpBB Limited <https://www.phpbb.com>
+* @license GNU General Public License, version 2 (GPL-2.0)
+*
+* For full copyright and license information, please see
+* the docs/CREDITS.txt file.
+*
+*/
+
+require_once dirname(__FILE__) . '/../../phpBB/includes/functions.php';
+require_once dirname(__FILE__) . '/../../phpBB/includes/functions_content.php';
+
+class phpbb_functions_make_clickable_test extends phpbb_test_case
+{
+	/**
+	* Tags:
+	* 'm' - full URL like xxxx://aaaaa.bbb.cccc.
+	* 'l' - local relative board URL like http://domain.tld/path/to/board/index.php
+	* 'w' - URL without http/https protocol like www.xxxx.yyyy[/zzzz] aka 'lazy' URLs
+	* 'e' - email@domain type address
+	*
+	* Classes:
+	* "postlink-local" for 'l' URLs
+	* "postlink" for the rest of URLs
+	* empty for email addresses
+	**/
+	public function data_test_make_clickable_url_positive()
+	{
+		return array(
+			array(
+				'http://www.phpbb.com/community/',
+				'<!-- m --><a class="postlink" href="http://www.phpbb.com/community/">http://www.phpbb.com/community/</a><!-- m -->'
+			),
+			array(
+				'http://www.phpbb.com/path/file.ext#section',
+				'<!-- m --><a class="postlink" href="http://www.phpbb.com/path/file.ext#section">http://www.phpbb.com/path/file.ext#section</a><!-- m -->'
+			),
+			array(
+				'ftp://ftp.phpbb.com/',
+				'<!-- m --><a class="postlink" href="ftp://ftp.phpbb.com/">ftp://ftp.phpbb.com/</a><!-- m -->'
+			),
+			array(
+				'sip://bantu@phpbb.com',
+				'<!-- m --><a class="postlink" href="sip://bantu@phpbb.com">sip://bantu@phpbb.com</a><!-- m -->'
+			),
+			array(
+				'www.phpbb.com/community/',
+				'<!-- w --><a class="postlink" href="http://www.phpbb.com/community/">www.phpbb.com/community/</a><!-- w -->'
+			),
+			array(
+				'http://testhost/viewtopic.php?t=1',
+				'<!-- l --><a class="postlink-local" href="http://testhost/viewtopic.php?t=1">viewtopic.php?t=1</a><!-- l -->'
+			),
+			array(
+				'email@domain.com',
+				'<!-- e --><a href="mailto:email@domain.com">email@domain.com</a><!-- e -->'
+			),
+			// Test appending punctuation mark to the URL
+			array(
+				'http://testhost/viewtopic.php?t=1!',
+				'<!-- l --><a class="postlink-local" href="http://testhost/viewtopic.php?t=1">viewtopic.php?t=1</a><!-- l -->!'
+			),
+			array(
+				'www.phpbb.com/community/?',
+				'<!-- w --><a class="postlink" href="http://www.phpbb.com/community/">www.phpbb.com/community/</a><!-- w -->?'
+			),
+			// Test shortened text for URL > 55 characters long
+			// URL text should be turned into: first 39 chars + ' ... ' + last 10 chars
+			array(
+				'http://www.phpbb.com/community/path/to/long/url/file.ext#section',
+				'<!-- m --><a class="postlink" href="http://www.phpbb.com/community/path/to/long/url/file.ext#section">http://www.phpbb.com/community/path/to/ ... xt#section</a><!-- m -->'
+			),
+
+			// IDN is not parsed and returned as is
+			array('http://домен.рф', 'http://домен.рф'),
+			array('почта@домен.рф', 'почта@домен.рф'),
+		);
+	}
+
+	protected function setUp()
+	{
+		parent::setUp();
+
+		global $config, $user, $request;
+		$user = new phpbb_mock_user();
+		$request = new phpbb_mock_request();
+	}
+
+	/**
+	 * @dataProvider data_test_make_clickable_url_positive
+	 */
+	public function test_urls_matching_positive($url, $expected)
+	{
+		$this->assertSame($expected, make_clickable($url));
+	}
+}


### PR DESCRIPTION
Besides, some functions calls getting replaced with their utf8 forms to allow
extensions introducing international domain names and email addresses.

<a href="https://tracker.phpbb.com/browse/PHPBB3-13297">PHPBB3-13297</a>.
