### PR TITLE
[ticket/12642] Ensure CPF type specific options are set when editing booleans.

### DIFF
--- a/phpBB/phpbb/profilefields/type/type_bool.php
+++ b/phpBB/phpbb/profilefields/type/type_bool.php
@@ -367,29 +367,29 @@ class type_bool extends type_base
 	*/
 	public function prepare_hidden_fields($step, $key, $action, &$field_data)
 	{
-		if ($key == 'l_lang_options' && $this->request->is_set('l_lang_options'))
+		if ($key == 'field_default_value')
 		{
-			return $this->request->variable($key, array(array('')), true);
+			$field_length = $this->request->variable('field_length', 0);
+
+			// Do a simple is set check if using checkbox.
+			if ($field_length == 2)
+			{
+				return $this->request->is_set($key);
+			}
+			return $this->request->variable($key, $field_data[$key], true);
 		}
-		else if ($key == 'field_default_value')
+
+		$default_lang_options = array(
+			'l_lang_options'	=> array(0 => array('')),
+			'lang_options'		=> array(0 => ''),
+		);
+
+		if (isset($default_lang_options[$key]) && $this->request->is_set($key))
 		{
-			return $this->request->variable($key, $field_data[$key]);
+			return $this->request->variable($key, $default_lang_options[$key], true);
 		}
-		else
-		{
-			if (!$this->request->is_set($key))
-			{
-				return false;
-			}
-			else if ($key == 'field_ident' && isset($field_data[$key]))
-			{
-				return $field_data[$key];
-			}
-			else
-			{
-				return ($key == 'lang_options') ? $this->request->variable($key, array(''), true) : $this->request->variable($key, '', true);
-			}
-		}
+
+		return parent::prepare_hidden_fields($step, $key, $action, $field_data);
 	}
 
 	/**


### PR DESCRIPTION
prepare_hidden_fields is expected to return null if the option is not sent
in the request. The boolean method returns false instead, which results in
the options being set as false in hidden fields when accessing the first edit
step.

When checking the "Default value" option, there is also a failure to check
whether the "Field type" option is set to checkbox, thus resulting in this
option getting lost as well.

[PHPBB3-12642](https://tracker.phpbb.com/browse/PHPBB3-12642)