### PR TITLE
[ticket/13337] Do not use SQL IN comparison with empty array

### DIFF
--- a/phpBB/phpbb/notification/manager.php
+++ b/phpBB/phpbb/notification/manager.php
@@ -292,7 +292,7 @@ class manager
 			WHERE notification_time <= " . (int) $time .
 				(($notification_type_name !== false) ? ' AND ' .
 					(is_array($notification_type_name) ? $this->db->sql_in_set('notification_type_id', $this->get_notification_type_ids($notification_type_name)) : 'notification_type_id = ' . $this->get_notification_type_id($notification_type_name)) : '') .
-				(($item_parent_id !== false) ? ' AND ' . (is_array($item_parent_id) ? $this->db->sql_in_set('item_parent_id', $item_parent_id) : 'item_parent_id = ' . (int) $item_parent_id) : '') .
+				(($item_parent_id !== false) ? ' AND ' . (is_array($item_parent_id) ? $this->db->sql_in_set('item_parent_id', $item_parent_id, false, true) : 'item_parent_id = ' . (int) $item_parent_id) : '') .
 				(($user_id !== false) ? ' AND ' . (is_array($user_id) ? $this->db->sql_in_set('user_id', $user_id) : 'user_id = ' . (int) $user_id) : '');
 		$this->db->sql_query($sql);
 	}


### PR DESCRIPTION
is_array() will evaluate to true even if the array is just an empty array.
Make sure we don't append anything to the sql query if the $item_parent_id
variable is an empty array.

https://tracker.phpbb.com/browse/PHPBB3-13337
