### PR TITLE
[ticket/13341] Change coverage to whitelist to prevent errors with temp ...

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -32,8 +32,8 @@
     </groups>
 
     <filter>
-        <blacklist>
-            <directory>./tests</directory>
-        </blacklist>
+        <whitelist>
+            <directory suffix=".php">./phpBB/includes/</directory>
+        </whitelist>
     </filter>
 </phpunit>


### PR DESCRIPTION
...files.

b4f95deefc9d456c5a2d0f6338f6dcecc0829652 suggests that this can lead to issues
with classes having the same name. However, this does not seem to be a problem
with the current version of PHPUnit we are using.

Despite https://phpunit.de/manual/4.1/en/code-coverage-analysis.html saying
that addUncoveredFilesFromWhitelist="true" is optional, this seems to be on by
default in PHPUnit 4.1.0. As a result, all files are considered for code
coverage; which is what we want.

processUncoveredFilesFromWhitelist is however false (by default) and as such
even files that are considered for code coverage are not processed through PHP
when not used in actual tests. Since it is already impossible to test multiple
classes with the same name in the same test run (without process isolation),
because that would already lead to "cannot redeclare class" errors, it is also
impossible for "cannot redeclare class" errors to happen in test coverage.

PHPBB3-13341

https://tracker.phpbb.com/browse/PHPBB3-13341
