### PR TITLE
[ticket/13315] Fix loss of CAPTCHA plugin config value.

### DIFF
--- a/phpBB/phpbb/db/migration/data/v310/reset_missing_captcha_plugin.php
+++ b/phpBB/phpbb/db/migration/data/v310/reset_missing_captcha_plugin.php
@@ -29,7 +29,7 @@ class reset_missing_captcha_plugin extends \phpbb\db\migration\migration
 	{
 		return array(
 			array('if', array(
-				(!is_dir($this->phpbb_root_path . 'phpbb/captcha/plugins/') &&
+				(is_dir($this->phpbb_root_path . 'includes/captcha/plugins/') &&
 				!is_file($this->phpbb_root_path . "includes/captcha/plugins/{$this->config['captcha_plugin']}_plugin." . $this->php_ext)),
 				array('config.update', array('captcha_plugin', 'phpbb_captcha_nogd')),
 			)),


### PR DESCRIPTION
The plugins were moved to phpbb/captcha/plugins/ after this migration was created, thus the check is no longer valid and ends up resetting the value prematurely. We check for the existence of the phpbb/captcha/plugins directory, in case the user fails to remove the includes/captcha/plugins/ directory.

[PHPBB3-13315](https://tracker.phpbb.com/browse/PHPBB3-13315)
