### PR TITLE
[ticket/13342] Fix invalid resetting of CAPTCHA plugin when using Recaptcha

### DIFF
--- a/phpBB/phpbb/db/migration/data/v310/captcha_plugins.php
+++ b/phpBB/phpbb/db/migration/data/v310/captcha_plugins.php
@@ -25,9 +25,13 @@ class captcha_plugins extends \phpbb\db\migration\migration
 	public function update_data()
 	{
 		$captcha_plugin = $this->config['captcha_plugin'];
-		if (strpos($this->config['captcha_plugin'], 'phpbb_captcha_') === 0)
+		if (strpos($captcha_plugin, 'phpbb_captcha_') === 0)
 		{
-			$captcha_plugin = substr($this->config['captcha_plugin'], strlen('phpbb_captcha_'));
+			$captcha_plugin = substr($captcha_plugin, strlen('phpbb_captcha_'));
+		}
+		else if (strpos($captcha_plugin, 'phpbb_') === 0)
+		{
+			$captcha_plugin = substr($captcha_plugin, strlen('phpbb_'));
 		}
 
 		return array(


### PR DESCRIPTION
The Recaptcha plugin class name does not follow the phpbb_captcha_ prefix convention as all others. Instead it simply uses phpbb_, hence the check for its existence under phpbb/captcha/plugins/ fails.

Depends on https://github.com/phpbb/phpbb/pull/3148

[PHPBB3-13342](https://tracker.phpbb.com/browse/PHPBB3-13342)
