### PR TITLE
Escape values in SQL queries

### DIFF
--- a/phpBB/phpbb/user.php
+++ b/phpBB/phpbb/user.php
@@ -234,7 +234,7 @@ class user extends \phpbb\session
 
 		$sql = 'SELECT *
 			FROM ' . STYLES_TABLE . " s
-			WHERE s.style_id = $style_id";
+			WHERE s.style_id = '{$db->sql_escape($style_id)}'";
 		$result = $db->sql_query($sql, 3600);
 		$this->style = $db->sql_fetchrow($result);
 		$db->sql_freeresult($result);
@@ -246,7 +246,7 @@ class user extends \phpbb\session
 
 			$sql = 'SELECT *
 				FROM ' . STYLES_TABLE . " s
-				WHERE s.style_id = $style_id";
+				WHERE s.style_id = '{$db->sql_escape($style_id)}'";
 			$result = $db->sql_query($sql, 3600);
 			$this->style = $db->sql_fetchrow($result);
 			$db->sql_freeresult($result);
@@ -259,12 +259,12 @@ class user extends \phpbb\session
 
 			$sql = 'UPDATE ' . USERS_TABLE . "
 				SET user_style = $style_id
-				WHERE user_id = {$this->data['user_id']}";
+				WHERE user_id = '{$db->sql_escape($this->data['user_id'])}'";
 			$db->sql_query($sql);
 
 			$sql = 'SELECT *
 				FROM ' . STYLES_TABLE . " s
-				WHERE s.style_id = $style_id";
+				WHERE s.style_id = '{$db->sql_escape($style_id)}'";
 			$result = $db->sql_query($sql, 3600);
 			$this->style = $db->sql_fetchrow($result);
 			$db->sql_freeresult($result);
@@ -793,7 +793,8 @@ class user extends \phpbb\session
 
 		$sql = 'SELECT *
 			FROM ' . PROFILE_FIELDS_DATA_TABLE . "
-			WHERE user_id = $user_id";
+			WHERE user_id = '{$db->sql_escape($user_id)}'";
+
 		$result = $db->sql_query_limit($sql, 1);
 		$this->profile_fields = (!($row = $db->sql_fetchrow($result))) ? array() : $row;
 		$db->sql_freeresult($result);


### PR DESCRIPTION
This adds `$db->escape_sql()` to potentially unsafe database queries.

There seem to be quite a few places remaining where this would be appropriate. I'm happy to send in a few more PRs for it.
