### PR TITLE
[ticket/13238] Do not drop indexes that do not exist from fulltext search

### DIFF
--- a/phpBB/phpbb/db/migration/data/v310/mysql_fulltext_drop.php
+++ b/phpBB/phpbb/db/migration/data/v310/mysql_fulltext_drop.php
@@ -15,10 +15,18 @@ namespace phpbb\db\migration\data\v310;
 
 class mysql_fulltext_drop extends \phpbb\db\migration\migration
 {
+	protected $indexes;
+
 	public function effectively_installed()
 	{
 		// This migration is irrelevant for all non-MySQL DBMSes.
-		return strpos($this->db->get_sql_layer(), 'mysql') === false;
+		if (strpos($this->db->get_sql_layer(), 'mysql') === false)
+		{
+			return true;
+		}
+
+		$this->find_indexes_to_drop();
+		return empty($this->indexes);
 	}
 
 	static public function depends_on()
@@ -30,6 +38,11 @@ class mysql_fulltext_drop extends \phpbb\db\migration\migration
 
 	public function update_schema()
 	{
+		if (empty($this->indexes))
+		{
+			return array();
+		}
+
 		/*
 		* Drop FULLTEXT indexes related to MySQL fulltext search.
 		* Doing so is equivalent to dropping the search index from the ACP.
@@ -40,12 +53,28 @@ class mysql_fulltext_drop extends \phpbb\db\migration\migration
 		*/
 		return array(
 			'drop_keys' => array(
-				$this->table_prefix . 'posts' => array(
-					'post_subject',
-					'post_text',
-					'post_content',
-				),
+				$this->table_prefix . 'posts' => $this->indexes,
 			),
 		);
+	}
+
+	public function find_indexes_to_drop()
+	{
+		if ($this->indexes !== null)
+		{
+			return $this->indexes;
+		}
+
+		$this->indexes = array();
+		$potential_keys = array('post_subject', 'post_text', 'post_content');
+		foreach ($potential_keys as $key)
+		{
+			if ($this->db_tools->sql_index_exists($this->table_prefix . 'posts', $key))
+			{
+				$this->indexes[] = $key;
+			}
+		}
+
+		return $this->indexes;
 	}
 }

--- a/phpBB/phpbb/db/migration/data/v310/postgres_fulltext_drop.php
+++ b/phpBB/phpbb/db/migration/data/v310/postgres_fulltext_drop.php
@@ -15,10 +15,18 @@ namespace phpbb\db\migration\data\v310;
 
 class postgres_fulltext_drop extends \phpbb\db\migration\migration
 {
+	protected $indexes;
+
 	public function effectively_installed()
 	{
 		// This migration is irrelevant for all non-PostgreSQL DBMSes.
-		return strpos($this->db->get_sql_layer(), 'postgres') === false;
+		if (strpos($this->db->get_sql_layer(), 'postgres') === false)
+		{
+			return true;
+		}
+
+		$this->find_indexes_to_drop();
+		return empty($this->indexes);
 	}
 
 	static public function depends_on()
@@ -30,6 +38,11 @@ class postgres_fulltext_drop extends \phpbb\db\migration\migration
 
 	public function update_schema()
 	{
+		if (empty($this->indexes))
+		{
+			return array();
+		}
+
 		/*
 		* Drop FULLTEXT indexes related to PostgreSQL fulltext search.
 		* Doing so is equivalent to dropping the search index from the ACP.
@@ -40,12 +53,28 @@ class postgres_fulltext_drop extends \phpbb\db\migration\migration
 		*/
 		return array(
 			'drop_keys' => array(
-				$this->table_prefix . 'posts' => array(
-					'post_subject',
-					'post_text',
-					'post_content',
-				),
+				$this->table_prefix . 'posts' => $this->indexes,
 			),
 		);
+	}
+
+	public function find_indexes_to_drop()
+	{
+		if ($this->indexes !== null)
+		{
+			return $this->indexes;
+		}
+
+		$this->indexes = array();
+		$potential_keys = array('post_subject', 'post_text', 'post_content');
+		foreach ($potential_keys as $key)
+		{
+			if ($this->db_tools->sql_index_exists($this->table_prefix . 'posts', $key))
+			{
+				$this->indexes[] = $key;
+			}
+		}
+
+		return $this->indexes;
 	}
 }


### PR DESCRIPTION
https://tracker.phpbb.com/browse/PHPBB3-13238

The reason why this one works, in opposite to #3092 is, because we only get the list of indexes in the `effectively_installed()`.
This method is not called when generating the schema. So the schema can still be generated with the wrong db object. For live boards this does not matter, because when the update is run, `effectively_installed()` is called, filling the array with the indexes that need to be deleted:
https://github.com/phpbb/phpbb/blob/develop/phpBB/phpbb/db/migrator.php#L254
https://github.com/phpbb/phpbb/blob/develop/phpBB/phpbb/db/migrator.php#L283