### PR TITLE
[ticket/13406] Add a space between the index name and columns list

### DIFF
--- a/phpBB/phpbb/db/tools.php
+++ b/phpBB/phpbb/db/tools.php
@@ -2175,7 +2175,7 @@ class tools
 				}
 			// no break
 			case 'mysql_41':
-				$statements[] = 'ALTER TABLE ' . $table_name . ' ADD INDEX ' . $index_name . '(' . implode(', ', $column) . ')';
+				$statements[] = 'ALTER TABLE ' . $table_name . ' ADD INDEX ' . $index_name . ' (' . implode(', ', $column) . ')';
 			break;
 
 			case 'mssql':


### PR DESCRIPTION
Currently there's no space between the index name and columns list
when generating ADD INDEX sql query for MySQL DBMSes. This may cause errors
on earlier MySQL versions like 3.23.

<a href="https://tracker.phpbb.com/browse/PHPBB3-13406">PHPBB3-13406</a>.
