### PR TITLE
Fixed flakey tests

### DIFF
--- a/phpBB/includes/functions.php
+++ b/phpBB/includes/functions.php
@@ -124,6 +124,8 @@ function set_config($config_name, $config_value, $is_dynamic = false, \phpbb\con
 		}
 	}
 
+	if ($config === null)
+		return;
 	$config->set($config_name, $config_value, !$is_dynamic);
 }
 

--- a/tests/passwords/manager_test.php
+++ b/tests/passwords/manager_test.php
@@ -110,9 +110,11 @@ class phpbb_passwords_manager_test extends PHPUnit_Framework_TestCase
 	{
 		$password = $this->default_pw;
 		$time = microtime(true);
+		$is_tested = false;
 		// Limit each test to 1 second
-		while ((microtime(true) - $time) < 1)
+		while ((microtime(true) - $time) < 1 || !$is_tested)
 		{
+			$is_tested = true;
 			$hash = $this->manager->hash($password, $hash_type);
 			$this->assertEquals(true, $this->manager->check($password, $hash));
 			$password .= $this->pw_characters[mt_rand(0, 66)];


### PR DESCRIPTION
Assuming return value of time() and microtime() will increment by 1 when called every time, some issues will appear. (microtime(true) - $time will always greater than 1.) Also, $config is possible to be null when calling set_config.
