### PR TITLE
[ticket/13370] Allow calling class method in convertor framework directly

### DIFF
--- a/phpBB/install/install_convert.php
+++ b/phpBB/install/install_convert.php
@@ -2014,7 +2014,7 @@ class install_convert extends module
 					{
 						$value = $fields[1][$firstkey];
 					}
-					else if (is_array($fields[2]))
+					else if (is_array($fields[2]) && !is_callable($fields[2]))
 					{
 						// Execute complex function/eval/typecast
 						$value = $fields[1];


### PR DESCRIPTION
This change allows the usage of `array($class, 'method'))` directly instead of
having to use the functionX syntax as follows: `array('function1' => array($class, 'method')))`

[PHPBB3-13370](https://tracker.phpbb.com/browse/PHPBB3-13370)
