### PR TITLE
[ticket/13477] Update file cache driver for extension paths

### DIFF
--- a/phpBB/phpbb/cache/driver/file.php
+++ b/phpBB/phpbb/cache/driver/file.php
@@ -279,6 +279,7 @@ class file extends \phpbb\cache\driver\base
 		if ($var_name[0] == '_')
 		{
 			global $phpEx;
+			$var_name = str_replace('/', '_', $var_name);
 			return file_exists($this->cache_dir . 'data' . $var_name . ".$phpEx");
 		}
 		else
@@ -334,6 +335,7 @@ class file extends \phpbb\cache\driver\base
 	{
 		global $phpEx;
 
+		$filename = str_replace('/', '_', $filename);
 		$file = "{$this->cache_dir}$filename.$phpEx";
 
 		$type = substr($filename, 0, strpos($filename, '_'));
@@ -516,6 +518,7 @@ class file extends \phpbb\cache\driver\base
 	{
 		global $phpEx;
 
+		$filename = str_replace('/', '_', $filename);
 		$file = "{$this->cache_dir}$filename.$phpEx";
 
 		$lock = new \phpbb\lock\flock($file);


### PR DESCRIPTION
For the extension system's version check, the filename of a cache file contains slashes. This breaks the file cache. This change simply replaces the slashes with underscores, in the _exists(), _read(), and _write() methods.