### PR TITLE
PHPBB3-13502 - controller resolver should handle callable functions and objects

### DIFF
--- a/phpBB/phpbb/controller/resolver.php
+++ b/phpBB/phpbb/controller/resolver.php
@@ -116,9 +116,18 @@ class resolver implements ControllerResolverInterface
 	*/
 	public function getArguments(Request $request, $controller)
 	{
-		// At this point, $controller contains the object and method name
-		list($object, $method) = $controller;
-		$mirror = new \ReflectionMethod($object, $method);
+		// At this point, $controller should be a callable
+		if (is_array($controller))
+		{
+			list($object, $method) = $controller;
+			$mirror = new \ReflectionMethod($object, $method);
+		} else if (is_object($controller) && !$controller instanceof \Closure)
+		{
+			$mirror = new \ReflectionObject($controller);
+			$mirror = $mirror->getMethod('__invoke');
+		} else {
+			$mirror = new \ReflectionFunction($controller);
+		}
 
 		$arguments = array();
 		$parameters = $mirror->getParameters();


### PR DESCRIPTION
This change follows what Symfony does, by allowing the controller to be any type of callable.