### PR TITLE
[ticket/13512] Add template events before/after the post details

### DIFF
--- a/phpBB/docs/events.md
+++ b/phpBB/docs/events.md
@@ -1531,6 +1531,22 @@ viewtopic_body_postrow_post_content_footer
 * Since: 3.1.0-RC4
 * Purpose: Add data at the end of the posts.
 
+viewtopic_body_postrow_post_details_after
+===
+* Locations:
+    + styles/prosilver/template/viewtopic_body.html
+    + styles/subsilver2/template/viewtopic_body.html
+* Since: 3.1.4-RC1
+* Purpose: Add content after the post details
+
+viewtopic_body_postrow_post_details_before
+===
+* Locations:
+    + styles/prosilver/template/viewtopic_body.html
+    + styles/subsilver2/template/viewtopic_body.html
+* Since: 3.1.4-RC1
+* Purpose: Add content before the post details
+
 viewtopic_body_postrow_post_notices_after
 ===
 * Locations:

--- a/phpBB/styles/prosilver/template/viewtopic_body.html
+++ b/phpBB/styles/prosilver/template/viewtopic_body.html
@@ -249,7 +249,9 @@
 			<!-- ENDIF -->
 		<!-- ENDIF -->
 
+			<!-- EVENT viewtopic_body_postrow_post_details_before -->
 			<p class="author"><!-- IF S_IS_BOT -->{postrow.MINI_POST_IMG}<!-- ELSE --><a href="{postrow.U_MINI_POST}">{postrow.MINI_POST_IMG}</a><!-- ENDIF --><span class="responsive-hide">{L_POST_BY_AUTHOR} <strong>{postrow.POST_AUTHOR_FULL}</strong> &raquo; </span>{postrow.POST_DATE} </p>
+			<!-- EVENT viewtopic_body_postrow_post_details_after -->
 
 			<!-- IF postrow.S_POST_UNAPPROVED -->
 			<form method="post" class="mcp_approve" action="{postrow.U_APPROVE_ACTION}">

--- a/phpBB/styles/subsilver2/template/viewtopic_body.html
+++ b/phpBB/styles/subsilver2/template/viewtopic_body.html
@@ -167,6 +167,7 @@
 				<b class="postauthor"<!-- IF postrow.POST_AUTHOR_COLOUR --> style="color: {postrow.POST_AUTHOR_COLOUR}"<!-- ENDIF -->>{postrow.POST_AUTHOR}</b>
 				<!-- EVENT viewtopic_body_post_author_after -->
 			</td>
+			<!-- EVENT viewtopic_body_postrow_post_details_before -->
 			<td width="100%" height="25">
 				<table width="100%" cellspacing="0">
 				<tr>
@@ -177,6 +178,7 @@
 				</tr>
 				</table>
 			</td>
+			<!-- EVENT viewtopic_body_postrow_post_details_after -->
 		</tr>
 
 		<!-- IF postrow.S_ROW_COUNT is even --><tr class="row1"><!-- ELSE --><tr class="row2"><!-- ENDIF -->


### PR DESCRIPTION
Add template events to viewtopic_body.html to allow extensions adding content
before/after the post details.

<a href="https://tracker.phpbb.com/browse/PHPBB3-13512">PHPBB3-13512</a>.