### PR TITLE
[ticket/13534] Set imagick path to empty string to prevent failing path ...

### DIFF
--- a/tests/functional/fileupload_form_test.php
+++ b/tests/functional/fileupload_form_test.php
@@ -93,23 +93,32 @@ class phpbb_functional_fileupload_form_test extends phpbb_functional_test_case
 		$this->login();
 		$this->admin_login();
 		$this->add_lang('ucp');
+
+		// Make sure check_attachment_content is set to false
 		$crawler = self::request('GET', 'adm/index.php?sid=' . $this->sid . '&i=acp_attachments&mode=attach');
 
-		$form = $crawler->selectButton('Submit')->form();
-		$values = $form->getValues();
-
-		$values["config[check_attachment_content]"] = 0;
-		$form->setValues($values);
-		$crawler = self::submit($form);
+		$form = $crawler->selectButton('Submit')->form(array(
+			'config[check_attachment_content]'	=> 0,
+			'config[img_imagick]'				=> '',
+		));
+		self::submit($form);
 
 		// Request index for correct URL
-		$crawler = self::request('GET', 'index.php?sid=' . $this->sid);
+		self::request('GET', 'index.php?sid=' . $this->sid);
 
 		$crawler = $this->upload_file('disallowed.jpg', 'image/jpeg');
 
 		// Hitting the UNABLE_GET_IMAGE_SIZE error means we passed the
 		// DISALLOWED_CONTENT check
 		$this->assertContainsLang('UNABLE_GET_IMAGE_SIZE', $crawler->text());
+
+		// Reset check_attachment_content to default (enabled)
+		$crawler = self::request('GET', 'adm/index.php?sid=' . $this->sid . '&i=acp_attachments&mode=attach');
+
+		$form = $crawler->selectButton('Submit')->form(array(
+			'config[check_attachment_content]'	=> 1,
+		));
+		self::submit($form);
 	}
 
 	public function test_too_large()


### PR DESCRIPTION
The imagick path defaults to /usr/bin. If it doesn't exist for some reason,
for example on travis, the form won't be submitted and the settings won't be
changed.

Ticket: https://tracker.phpbb.com/browse/PHPBB3-13534