### PR TITLE
Add core events on mcp_queue for approval and disapproval

### DIFF
--- a/phpBB/includes/mcp/mcp_queue.php
+++ b/phpBB/includes/mcp/mcp_queue.php
@@ -616,7 +616,7 @@ class mcp_queue
 	*/
 	static public function approve_posts($action, $post_id_list, $id, $mode)
 	{
-		global $db, $template, $user, $config, $request, $phpbb_container;
+		global $db, $template, $user, $config, $request, $phpbb_container, $phpbb_dispatcher;
 		global $phpEx, $phpbb_root_path;
 
 		if (!phpbb_check_ids($post_id_list, POSTS_TABLE, 'post_id', array('m_approve')))
@@ -764,6 +764,30 @@ class mcp_queue
 				$success_msg = (sizeof($post_info) == 1) ? 'POST_' . strtoupper($action) . 'D_SUCCESS' : 'POSTS_' . strtoupper($action) . 'D_SUCCESS';
 			}
 
+			/**
+			 * Perform additional actions during post(s) approval
+			 *
+			 * @event core.approve_posts_after
+			 * @var	string	action				Variable containing the action we perform on the posts ('approve' or 'restore')
+			 * @var	array	post_info			Array containing info for all posts being approved
+			 * @var	array	topic_info			Array containing info for all parent topics of the posts
+			 * @var	int		num_topics			Variable containing number of topics
+			 * @var bool	notify_poster		Variable telling if the post should be notified or not
+			 * @var	string	success_msg			Variable containing the language key for the success message
+			 * @var string	redirect			Variable containing the redirect url
+			 * @since 3.1.4-RC1
+			 */
+			$vars = array(
+				'action',
+				'post_info',
+				'topic_info',
+				'num_topics',
+				'notify_poster',
+				'success_msg',
+				'redirect',
+			);
+			extract($phpbb_dispatcher->trigger_event('core.approve_posts_after', compact($vars)));
+
 			meta_refresh(3, $redirect);
 			$message = $user->lang[$success_msg];
 
@@ -840,7 +864,7 @@ class mcp_queue
 	static public function approve_topics($action, $topic_id_list, $id, $mode)
 	{
 		global $db, $template, $user, $config;
-		global $phpEx, $phpbb_root_path, $request, $phpbb_container;
+		global $phpEx, $phpbb_root_path, $request, $phpbb_container, $phpbb_dispatcher;
 
 		if (!phpbb_check_ids($topic_id_list, TOPICS_TABLE, 'topic_id', array('m_approve')))
 		{
@@ -945,6 +969,28 @@ class mcp_queue
 				}
 			}
 
+			/**
+			 * Perform additional actions during topics(s) approval
+			 *
+			 * @event core.approve_topics_after
+			 * @var	string	action				Variable containing the action we perform on the posts ('approve' or 'restore')
+			 * @var	mixed	topic_info			Array containing info for all topics being approved
+			 * @var	array	first_post_ids		Array containing ids of all first posts
+			 * @var bool	notify_poster		Variable telling if the poster should be notified or not
+			 * @var	string	success_msg			Variable containing the language key for the success message
+			 * @var string	redirect			Variable containing the redirect url
+			 * @since 3.1.4-RC1
+			 */
+			$vars = array(
+				'action',
+				'topic_info',
+				'first_post_ids',
+				'notify_poster',
+				'success_msg',
+				'redirect',
+			);
+			extract($phpbb_dispatcher->trigger_event('core.approve_topics_after', compact($vars)));
+
 			meta_refresh(3, $redirect);
 			$message = $user->lang[$success_msg];
 
@@ -1008,7 +1054,7 @@ class mcp_queue
 	*/
 	static public function disapprove_posts($post_id_list, $id, $mode)
 	{
-		global $db, $template, $user, $config, $phpbb_container;
+		global $db, $template, $user, $config, $phpbb_container, $phpbb_dispatcher;
 		global $phpEx, $phpbb_root_path, $request;
 
 		if (!phpbb_check_ids($post_id_list, POSTS_TABLE, 'post_id', array('m_approve')))
@@ -1239,8 +1285,6 @@ class mcp_queue
 				}
 			}
 
-			unset($lang_reasons, $post_info, $disapprove_reason, $disapprove_reason_lang);
-
 			if ($num_disapproved_topics)
 			{
 				$success_msg = ($num_disapproved_topics == 1) ? 'TOPIC' : 'TOPICS';
@@ -1274,6 +1318,44 @@ class mcp_queue
 					$redirect = append_sid($phpbb_root_path . 'viewforum.' . $phpEx, 'f=' . $request->variable('f', 0));
 				}
 			}
+
+			/**
+			 * Perform additional actions during post(s) disapproval
+			 *
+			 * @event core.disapprove_posts_after
+			 * @var	array	post_info					Array containing info for all posts being disapproved
+			 * @var	array	topic_information			Array containing information for the topics
+			 * @var	array	topic_posts_unapproved		Array containing list of topic ids and the count of disapproved posts in them
+			 * @var	array	post_disapprove_list		Array containing list of posts and their topic id
+			 * @var	int		num_disapproved_topics		Variable containing the number of disapproved topics
+			 * @var	int		num_disapproved_posts		Variable containing the number of disapproved posts
+			 * @var array	lang_reasons				Array containing the language keys for reasons
+			 * @var	string	disapprove_reason			Variable containing the language key for the success message
+			 * @var	string	disapprove_reason_lang		Variable containing the language key for the success message
+			 * @var bool	is_disapproving				Variable telling if anything is going to be disapproved
+			 * @var bool	notify_poster				Variable telling if the post should be notified or not
+			 * @var	string	success_msg					Variable containing the language key for the success message
+			 * @var string	redirect					Variable containing the redirect url
+			 * @since 3.1.4-RC1
+			 */
+			$vars = array(
+				'post_info',
+				'topic_information',
+				'topic_posts_unapproved',
+				'post_disapprove_list',
+				'num_disapproved_topics',
+				'num_disapproved_posts',
+				'lang_reasons',
+				'disapprove_reason',
+				'disapprove_reason_lang',
+				'is_disapproving',
+				'notify_poster',
+				'success_msg',
+				'redirect',
+			);
+			extract($phpbb_dispatcher->trigger_event('core.disapprove_posts_after', compact($vars)));
+
+			unset($lang_reasons, $post_info, $disapprove_reason, $disapprove_reason_lang);
 
 			meta_refresh(3, $redirect);
 			$message = $user->lang[$success_msg];


### PR DESCRIPTION
Events added for the functions approve_posts(), approve_topics()
and disapprove_posts() in mcp_queue.php, so that you can send notifications
during approval and disapproval.

PHPBB3-13537