### PR TITLE
[ticket/13549] Compare ORIG_PATH_INFO with SCRIPT_NAME for checking trailing paths

### DIFF
--- a/phpBB/includes/startup.php
+++ b/phpBB/includes/startup.php
@@ -104,8 +104,15 @@ function deregister_globals()
  */
 function phpbb_has_trailing_path($phpEx)
 {
+	// Check if web server is IIS
+	$is_iis = strpos(strtolower($_SERVER['SERVER_SOFTWARE']), 'microsoft-iis') !== false;
+
 	// Check if path_info is being used
-	if (!empty($_SERVER['PATH_INFO']) || !empty($_SERVER['ORIG_PATH_INFO']))
+	if (!empty($_SERVER['PATH_INFO']) || !empty($_SERVER['ORIG_PATH_INFO']) && !$is_iis)
+	{
+		return true;
+	}
+	else if ($is_iis && !empty($_SERVER['ORIG_PATH_INFO']) && str_replace($_SERVER['SCRIPT_NAME'], '', $_SERVER['ORIG_PATH_INFO']) !== '')
 	{
 		return true;
 	}

--- a/phpBB/includes/startup.php
+++ b/phpBB/includes/startup.php
@@ -108,11 +108,11 @@ function phpbb_has_trailing_path($phpEx)
 	$is_iis = strpos(strtolower($_SERVER['SERVER_SOFTWARE']), 'microsoft-iis') !== false;
 
 	// Check if path_info is being used
-	if (!empty($_SERVER['PATH_INFO']) || !empty($_SERVER['ORIG_PATH_INFO']) && !$is_iis)
+	if (!empty($_SERVER['PATH_INFO']) || (!empty($_SERVER['ORIG_PATH_INFO']) && !$is_iis))
 	{
 		return true;
 	}
-	else if ($is_iis && !empty($_SERVER['ORIG_PATH_INFO']) && str_replace($_SERVER['SCRIPT_NAME'], '', $_SERVER['ORIG_PATH_INFO']) !== '')
+	else if ($is_iis && !empty($_SERVER['ORIG_PATH_INFO']) && $_SERVER['SCRIPT_NAME'] != $_SERVER['ORIG_PATH_INFO'])
 	{
 		return true;
 	}

--- a/phpBB/includes/startup.php
+++ b/phpBB/includes/startup.php
@@ -104,15 +104,8 @@ function deregister_globals()
  */
 function phpbb_has_trailing_path($phpEx)
 {
-	// Check if web server is IIS
-	$is_iis = strpos(strtolower($_SERVER['SERVER_SOFTWARE']), 'microsoft-iis') !== false;
-
 	// Check if path_info is being used
-	if (!empty($_SERVER['PATH_INFO']) || (!empty($_SERVER['ORIG_PATH_INFO']) && !$is_iis))
-	{
-		return true;
-	}
-	else if ($is_iis && !empty($_SERVER['ORIG_PATH_INFO']) && $_SERVER['SCRIPT_NAME'] != $_SERVER['ORIG_PATH_INFO'])
+	if (!empty($_SERVER['PATH_INFO']) || (!empty($_SERVER['ORIG_PATH_INFO']) && $_SERVER['SCRIPT_NAME'] != $_SERVER['ORIG_PATH_INFO']))
 	{
 		return true;
 	}

--- a/tests/security/trailing_path_test.php
+++ b/tests/security/trailing_path_test.php
@@ -36,19 +36,28 @@ class phpbb_security_trailing_path_test extends phpbb_test_case
 			array(true, '', '', '/phpBB/index.php/?foo/a'),
 			array(true, '', '', '/projects/php.bb/phpBB/index.php/?a=5'),
 			array(false, '', '', '/projects/php.bb/phpBB/index.php?/a=5'),
+			array(false, '', '/phpBB/index.php', '/phpBB/index.php', '/phpBB/index.php', 'Microsoft-IIS/8.5'),
+			array(true, '', '/phpBB/index.php', '/phpBB/index.php'),
+			array(true, '', '/phpBB/index.php/', '/phpBB/index.php/', '/phpBB/index.php', 'Microsoft-IIS/8.5'),
+			array(true, '', '/phpBB/index.php/', '/phpBB/index.php/'),
 		);
 	}
 
 	/**
 	 * @dataProvider data_has_trailing_path
 	 */
-	public function test_has_trailing_path($expected, $path_info, $orig_path_info, $request_uri)
+	public function test_has_trailing_path($expected, $path_info, $orig_path_info, $request_uri, $script_name = '', $web_server = '')
 	{
 		global $phpEx;
 
 		$_SERVER['PATH_INFO'] = $path_info;
 		$_SERVER['ORIG_PATH_INFO'] = $orig_path_info;
 		$_SERVER['REQUEST_URI'] = $request_uri;
+		if (!empty($web_server))
+		{
+			$_SERVER['SERVER_SOFTWARE'] = $web_server;
+			$_SERVER['SCRIPT_NAME'] = $script_name;
+		}
 
 		$this->assertSame($expected, phpbb_has_trailing_path($phpEx));
 	}

--- a/tests/security/trailing_path_test.php
+++ b/tests/security/trailing_path_test.php
@@ -36,9 +36,9 @@ class phpbb_security_trailing_path_test extends phpbb_test_case
 			array(true, '', '', '/phpBB/index.php/?foo/a'),
 			array(true, '', '', '/projects/php.bb/phpBB/index.php/?a=5'),
 			array(false, '', '', '/projects/php.bb/phpBB/index.php?/a=5'),
-			array(false, '', '/phpBB/index.php', '/phpBB/index.php', '/phpBB/index.php', 'Microsoft-IIS/8.5'),
+			array(false, '', '/phpBB/index.php', '/phpBB/index.php', '/phpBB/index.php'),
 			array(true, '', '/phpBB/index.php', '/phpBB/index.php'),
-			array(true, '', '/phpBB/index.php/', '/phpBB/index.php/', '/phpBB/index.php', 'Microsoft-IIS/8.5'),
+			array(true, '', '/phpBB/index.php/', '/phpBB/index.php/', '/phpBB/index.php'),
 			array(true, '', '/phpBB/index.php/', '/phpBB/index.php/'),
 		);
 	}
@@ -46,18 +46,14 @@ class phpbb_security_trailing_path_test extends phpbb_test_case
 	/**
 	 * @dataProvider data_has_trailing_path
 	 */
-	public function test_has_trailing_path($expected, $path_info, $orig_path_info, $request_uri, $script_name = '', $web_server = '')
+	public function test_has_trailing_path($expected, $path_info, $orig_path_info, $request_uri, $script_name = '')
 	{
 		global $phpEx;
 
 		$_SERVER['PATH_INFO'] = $path_info;
 		$_SERVER['ORIG_PATH_INFO'] = $orig_path_info;
 		$_SERVER['REQUEST_URI'] = $request_uri;
-		if (!empty($web_server))
-		{
-			$_SERVER['SERVER_SOFTWARE'] = $web_server;
-			$_SERVER['SCRIPT_NAME'] = $script_name;
-		}
+		$_SERVER['SCRIPT_NAME'] = $script_name;
 
 		$this->assertSame($expected, phpbb_has_trailing_path($phpEx));
 	}


### PR DESCRIPTION
The ORIG_PATH_INFO on IIS also contains the script name. Only use that
for killing the script after removing the script name from ORIG_PATH_INFO.

Ticket: https://tracker.phpbb.com/browse/PHPBB3-13549