### PR TITLE
[ticket/13549] Do not exit when ORIG_PATH_INFO just contains SCRIPT_NAME...

### DIFF
--- a/phpBB/includes/startup.php
+++ b/phpBB/includes/startup.php
@@ -105,7 +105,7 @@ function deregister_globals()
 function phpbb_has_trailing_path($phpEx)
 {
 	// Check if path_info is being used
-	if (!empty($_SERVER['PATH_INFO']) || !empty($_SERVER['ORIG_PATH_INFO']))
+	if (!empty($_SERVER['PATH_INFO']) || (!empty($_SERVER['ORIG_PATH_INFO']) && $_SERVER['SCRIPT_NAME'] != $_SERVER['ORIG_PATH_INFO']))
 	{
 		return true;
 	}

--- a/tests/security/trailing_path_test.php
+++ b/tests/security/trailing_path_test.php
@@ -36,19 +36,24 @@ class phpbb_security_trailing_path_test extends phpbb_test_case
 			array(true, '', '', '/phpBB/index.php/?foo/a'),
 			array(true, '', '', '/projects/php.bb/phpBB/index.php/?a=5'),
 			array(false, '', '', '/projects/php.bb/phpBB/index.php?/a=5'),
+			array(false, '', '/phpBB/index.php', '/phpBB/index.php', '/phpBB/index.php'),
+			array(true, '', '/phpBB/index.php', '/phpBB/index.php'),
+			array(true, '', '/phpBB/index.php/', '/phpBB/index.php/', '/phpBB/index.php'),
+			array(true, '', '/phpBB/index.php/', '/phpBB/index.php/'),
 		);
 	}
 
 	/**
 	 * @dataProvider data_has_trailing_path
 	 */
-	public function test_has_trailing_path($expected, $path_info, $orig_path_info, $request_uri)
+	public function test_has_trailing_path($expected, $path_info, $orig_path_info, $request_uri, $script_name = '')
 	{
 		global $phpEx;
 
 		$_SERVER['PATH_INFO'] = $path_info;
 		$_SERVER['ORIG_PATH_INFO'] = $orig_path_info;
 		$_SERVER['REQUEST_URI'] = $request_uri;
+		$_SERVER['SCRIPT_NAME'] = $script_name;
 
 		$this->assertSame($expected, phpbb_has_trailing_path($phpEx));
 	}


### PR DESCRIPTION
The ORIG_PATH_INFO on IIS also contains the script name. Only use that
for killing the script after removing the script name from ORIG_PATH_INFO.

https://tracker.phpbb.com/browse/PHPBB3-13549

Replaced #3342