### PR TITLE
Ticket/10388 Use Twig's Javascript escape filter instead of addslashes for LA_ keys

### DIFF
--- a/phpBB/phpbb/template/twig/extension.php
+++ b/phpBB/phpbb/template/twig/extension.php
@@ -71,7 +71,7 @@ class extension extends \Twig_Extension
 	{
 		return array(
 			new \Twig_SimpleFilter('subset', array($this, 'loop_subset'), array('needs_environment' => true)),
-			new \Twig_SimpleFilter('addslashes', 'addslashes'),
+			new \Twig_SimpleFilter('addslashes', 'addslashes'), // Deprecate addslashes in phpBB 3.1.4
 		);
 	}
 
@@ -177,7 +177,7 @@ class extension extends \Twig_Extension
 			return $context_vars['L_' . $key];
 		}
 
-		// LA_ is transformed into lang(\'$1\')|addslashes, so we should not
+		// LA_ is transformed into lang(\'$1\')|escape('js'), so we should not
 		// need to check for it
 
 		return call_user_func_array(array($this->user, 'lang'), $args);

--- a/phpBB/phpbb/template/twig/lexer.php
+++ b/phpBB/phpbb/template/twig/lexer.php
@@ -112,9 +112,9 @@ class lexer extends \Twig_Lexer
 		// Appends any filters after lang()
 		$code = preg_replace('#{L_([a-zA-Z0-9_\.]+)(\|[^}]+?)?}#', '{{ lang(\'$1\')$2 }}', $code);
 
-		// Replace all of our escaped language variables, {LA_VARNAME}, with Twig style, {{ lang('NAME')|addslashes }}
-		// Appends any filters after lang(), but before addslashes
-		$code = preg_replace('#{LA_([a-zA-Z0-9_\.]+)(\|[^}]+?)?}#', '{{ lang(\'$1\')$2|addslashes }}', $code);
+		// Replace all of our escaped language variables, {LA_VARNAME}, with Twig style, {{ lang('NAME')|escape('js') }}
+		// Appends any filters after lang(), but before escape('js')
+		$code = preg_replace('#{LA_([a-zA-Z0-9_\.]+)(\|[^}]+?)?}#', '{{ lang(\'$1\')$2|escape(\'js\') }}', $code);
 
 		// Replace all of our variables, {VARNAME}, with Twig style, {{ VARNAME }}
 		// Appends any filters

--- a/phpBB/styles/prosilver/template/captcha_recaptcha.html
+++ b/phpBB/styles/prosilver/template/captcha_recaptcha.html
@@ -29,7 +29,7 @@
 		</div>
 		</noscript>
 
-		<a href="http://www.google.com/intl/{LA_RECAPTCHA_LANG}/policies/" target="_blank" class="recaptcha-responsive" style="display: none"><img alt="" width="71" height="36" src="{RECAPTCHA_SERVER}/img/clean/logo.png"></a>
+		<a href="http://www.google.com/intl/{L_RECAPTCHA_LANG}/policies/" target="_blank" class="recaptcha-responsive" style="display: none"><img alt="" width="71" height="36" src="{RECAPTCHA_SERVER}/img/clean/logo.png"></a>
 	</dd>
 	</dl>
 <!-- ELSE -->

--- a/phpBB/styles/prosilver/template/memberlist_body.html
+++ b/phpBB/styles/prosilver/template/memberlist_body.html
@@ -25,7 +25,7 @@
 
 		<div class="action-bar top">
 			<div class="member-search panel">
-				<!-- IF U_FIND_MEMBER and not S_SEARCH_USER --><a href="{U_FIND_MEMBER}" id="member_search" data-alt-text="{LA_HIDE_MEMBER_SEARCH}">{L_FIND_USERNAME}</a> &bull; <!-- ELSEIF S_SEARCH_USER and U_HIDE_FIND_MEMBER and not S_IN_SEARCH_POPUP --><a href="{U_HIDE_FIND_MEMBER}" id="member_search" data-alt-text="{LA_FIND_USERNAME}">{L_HIDE_MEMBER_SEARCH}</a> &bull; <!-- ENDIF -->
+				<!-- IF U_FIND_MEMBER and not S_SEARCH_USER --><a href="{U_FIND_MEMBER}" id="member_search" data-alt-text="{L_HIDE_MEMBER_SEARCH}">{L_FIND_USERNAME}</a> &bull; <!-- ELSEIF S_SEARCH_USER and U_HIDE_FIND_MEMBER and not S_IN_SEARCH_POPUP --><a href="{U_HIDE_FIND_MEMBER}" id="member_search" data-alt-text="{L_FIND_USERNAME}">{L_HIDE_MEMBER_SEARCH}</a> &bull; <!-- ENDIF -->
 				<strong>
 				<!-- BEGIN first_char -->
 					<a href="{first_char.U_SORT}">{first_char.DESC}</a>&nbsp;

--- a/tests/template/template_test.php
+++ b/tests/template/template_test.php
@@ -286,7 +286,7 @@ class phpbb_template_template_test extends phpbb_template_template_test_case
 				array(),
 				array(),
 				array(),
-				"Value'\n1 O'Clock\nValue\'\n1 O\'Clock",
+				"Value'\n1 O'Clock\nValue\\x27\n1\\x20O\\x27Clock",
 				array('VARIABLE' => "Value'", '1_VARIABLE' => "1 O'Clock"),
 			),
 			array(


### PR DESCRIPTION
This applies twigs javascript escaping to lang vars that are used in JS. Only caveat is if an LA_KEY is accidentally used in HTML context, it renders the escaping (ie: Hello\x20World). I have corrected the instances I found where an LA_KEY was used outside of javascript in this PR. LA_KEYS should always be in javascript only,  anyways.

https://tracker.phpbb.com/browse/PHPBB3-10388

PHPBB3-10388