### PR TITLE
[ticket/13348] Fetch complete rowset and return data row by row

### DIFF
--- a/phpBB/phpbb/feed/base.php
+++ b/phpBB/phpbb/feed/base.php
@@ -68,7 +68,7 @@ abstract class base
 	var $separator_stats = "\xE2\x80\x94"; // &mdash;
 
 	/** @var array Feed database rows */
-	protected $feed_row;
+	protected $feed_rows;
 
 	/**
 	* Constructor
@@ -232,7 +232,7 @@ abstract class base
 
 	function get_item()
 	{
-		if (!is_array($this->feed_row))
+		if (!is_array($this->feed_rows))
 		{
 			if (!$this->get_sql())
 			{
@@ -242,11 +242,11 @@ abstract class base
 			// Query database
 			$sql = $this->db->sql_build_query('SELECT', $this->sql);
 			$result = $this->db->sql_query_limit($sql, $this->num_items);
-			$this->feed_row = $this->db->sql_fetchrowset($result);
+			$this->feed_rows = $this->db->sql_fetchrowset($result);
 			$this->db->sql_freeresult($result);
 		}
 
-		return array_shift($this->feed_row);
+		return array_shift($this->feed_rows);
 	}
 
 	function user_viewprofile($row)

--- a/phpBB/phpbb/feed/base.php
+++ b/phpBB/phpbb/feed/base.php
@@ -229,9 +229,9 @@ abstract class base
 
 	function get_item()
 	{
-		static $result;
+		static $feed_row;
 
-		if (!isset($result))
+		if (!isset($feed_row))
 		{
 			if (!$this->get_sql())
 			{
@@ -241,9 +241,11 @@ abstract class base
 			// Query database
 			$sql = $this->db->sql_build_query('SELECT', $this->sql);
 			$result = $this->db->sql_query_limit($sql, $this->num_items);
+			$feed_row = $this->db->sql_fetchrowset($result);
+			$this->db->sql_freeresult($result);
 		}
 
-		return $this->db->sql_fetchrow($result);
+		return array_shift($feed_row);
 	}
 
 	function user_viewprofile($row)

--- a/phpBB/phpbb/feed/base.php
+++ b/phpBB/phpbb/feed/base.php
@@ -67,8 +67,8 @@ abstract class base
 	*/
 	var $separator_stats = "\xE2\x80\x94"; // &mdash;
 
-	/** @var array Feed database rows */
-	protected $feed_rows;
+	/** @var mixed Query result handle */
+	protected $result;
 
 	/**
 	* Constructor
@@ -232,7 +232,7 @@ abstract class base
 
 	function get_item()
 	{
-		if (!is_array($this->feed_rows))
+		if (!isset($this->result))
 		{
 			if (!$this->get_sql())
 			{
@@ -241,12 +241,10 @@ abstract class base
 
 			// Query database
 			$sql = $this->db->sql_build_query('SELECT', $this->sql);
-			$result = $this->db->sql_query_limit($sql, $this->num_items);
-			$this->feed_rows = $this->db->sql_fetchrowset($result);
-			$this->db->sql_freeresult($result);
+			$this->result = $this->db->sql_query_limit($sql, $this->num_items);
 		}
 
-		return array_shift($this->feed_rows);
+		return $this->db->sql_fetchrow($this->result);
 	}
 
 	function user_viewprofile($row)

--- a/phpBB/phpbb/feed/base.php
+++ b/phpBB/phpbb/feed/base.php
@@ -67,6 +67,9 @@ abstract class base
 	*/
 	var $separator_stats = "\xE2\x80\x94"; // &mdash;
 
+	/** @var array Feed database rows */
+	var $feed_row;
+
 	/**
 	* Constructor
 	*
@@ -229,9 +232,7 @@ abstract class base
 
 	function get_item()
 	{
-		static $feed_row;
-
-		if (!isset($feed_row))
+		if (!isset($this->feed_row))
 		{
 			if (!$this->get_sql())
 			{
@@ -241,11 +242,11 @@ abstract class base
 			// Query database
 			$sql = $this->db->sql_build_query('SELECT', $this->sql);
 			$result = $this->db->sql_query_limit($sql, $this->num_items);
-			$feed_row = $this->db->sql_fetchrowset($result);
+			$this->feed_row = $this->db->sql_fetchrowset($result);
 			$this->db->sql_freeresult($result);
 		}
 
-		return array_shift($feed_row);
+		return array_shift($this->feed_row);
 	}
 
 	function user_viewprofile($row)

--- a/phpBB/phpbb/feed/base.php
+++ b/phpBB/phpbb/feed/base.php
@@ -68,7 +68,7 @@ abstract class base
 	var $separator_stats = "\xE2\x80\x94"; // &mdash;
 
 	/** @var array Feed database rows */
-	var $feed_row;
+	protected $feed_row;
 
 	/**
 	* Constructor
@@ -232,7 +232,7 @@ abstract class base
 
 	function get_item()
 	{
-		if (!isset($this->feed_row))
+		if (!is_array($this->feed_row))
 		{
 			if (!$this->get_sql())
 			{


### PR DESCRIPTION
Instead of keeping $result as a static pointer and calling sql_fetchrow()
on every iteration of get_time(), fetch the complete set ofrows upon querying
the database. Afterwards, return the rows one by one using array_shift().

Ticket: https://tracker.phpbb.com/browse/PHPBB3-13348