### PR TITLE
[ticket/13524]Local Gallery avatars split every 50 images. Subcategories in gallery

### DIFF
--- a/phpBB/adm/style/acp_groups.html
+++ b/phpBB/adm/style/acp_groups.html
@@ -124,8 +124,12 @@
 		</dl>
 		<!-- IF S_DISPLAY_GALLERY -->
 			<dl>
-				<dt><label>{L_AVATAR_GALLERY}:</label></dt>
-				<dd><input class="button2" type="submit" name="display_gallery" value="{L_DISPLAY_GALLERY}" /></dd>
+				<dt><label for="category">{L_AVATAR_CATEGORY}:</label></dt>
+				<dd><select name="category" id="category">{S_CAT_OPTIONS}</select>&nbsp;</dd>
+				<dt><label for="subcategory">{L_AVATAR_SUBCATEGORY}:</label></dt>
+				<dd><select name="subcategory" id="subcategory">{S_SUBCAT_OPTIONS}</select>&nbsp;</dd>
+				<dt><label for="subcategory">{L_AVATAR_PAGE}:</label></dt>
+				<dd><select name="page" id="page">{S_PAGE_OPTIONS}</select>&nbsp;<input class="button2" type="submit" value="{L_GO}" name="display_gallery" /></dd>
 			</dl>
 		<!-- ENDIF -->
 	<!-- ELSE -->

--- a/phpBB/adm/style/acp_users_avatar.html
+++ b/phpBB/adm/style/acp_users_avatar.html
@@ -43,7 +43,11 @@
 			<legend>{L_AVATAR_GALLERY}</legend>
 		<dl>
 			<dt><label for="category">{L_AVATAR_CATEGORY}:</label></dt>
-			<dd><select name="category" id="category">{S_CAT_OPTIONS}</select>&nbsp;<input class="button2" type="submit" value="{L_GO}" name="display_gallery" /></dd>
+			<dd><select name="category" id="category">{S_CAT_OPTIONS}</select>&nbsp;</dd>
+			<dt><label for="subcategory">{L_AVATAR_SUBCATEGORY}:</label></dt>
+			<dd><select name="subcategory" id="subcategory">{S_SUBCAT_OPTIONS}</select>&nbsp;</dd>
+			<dt><label for="subcategory">{L_AVATAR_PAGE}:</label></dt>
+			<dd><select name="page" id="page">{S_PAGE_OPTIONS}</select>&nbsp;<input class="button2" type="submit" value="{L_GO}" name="display_gallery" /></dd>
 		</dl>
 		<dl>
 			<table cellspacing="1">

--- a/phpBB/includes/acp/acp_users.php
+++ b/phpBB/includes/acp/acp_users.php
@@ -1742,10 +1742,13 @@ class acp_users
 				$display_gallery = (isset($_POST['display_gallery'])) ? true : false;
 				$avatar_select = basename(request_var('avatar_select', ''));
 				$category = basename(request_var('category', ''));
+				$subcategory = basename(request_var('subcategory', ''));
+				$page = basename(request_var('page', ''));
+
 
 				if ($config['allow_avatar_local'] && $display_gallery)
 				{
-					avatar_gallery($category, $avatar_select, 4);
+					avatar_gallery($category, $subcategory, $page, $avatar_select, 4, 40);
 				}
 
 				$template->assign_vars(array(

--- a/phpBB/includes/functions_user.php
+++ b/phpBB/includes/functions_user.php
@@ -2173,11 +2173,6 @@ function avatar_gallery($category, $subcategory = '#NONE#', $page = 0, $avatar_s
 					{
 						if (preg_match('#^[^&\'"<>]+\.(?:gif|png|jpe?g)$#i', $sub_file))
 						{
-							if (($avatar_col_count * $avatar_row_count) == $avatars_per_page)
-							{
-								$avatar_page_count++;
-								$avatar_row_count = $avatar_col_count = 0;
-							}
 							$avatar_list[$file]['#NONE#'][$avatar_page_count][$avatar_row_count][$avatar_col_count] = array(
 								'file'		=> rawurlencode($file) . '/' . rawurlencode($sub_file),
 								'filename'	=> rawurlencode($sub_file),
@@ -2186,8 +2181,14 @@ function avatar_gallery($category, $subcategory = '#NONE#', $page = 0, $avatar_s
 							$avatar_col_count++;
 							if ($avatar_col_count == $items_per_column)
 							{
-								$avatar_row_count++;
-								$avatar_col_count = 0;
+								if (($avatar_col_count * ($avatar_row_count+1)) == $avatars_per_page)
+								{
+									$avatar_page_count++;
+									$avatar_row_count = $avatar_col_count = 0;
+								}else{
+									$avatar_row_count++;
+									$avatar_col_count = 0;
+								}
 							}
 						}
 						$sub_avatar_page_count = $sub_avatar_row_count = $sub_avatar_col_count = 0;
@@ -2200,11 +2201,6 @@ function avatar_gallery($category, $subcategory = '#NONE#', $page = 0, $avatar_s
 								{
 									if (preg_match('#^[^&\'"<>]+\.(?:gif|png|jpe?g)$#i', $sub_sub_file))
 									{
-										if (($sub_avatar_col_count * $sub_avatar_row_count) == $avatars_per_page)
-										{
-											$sub_avatar_page_count++;
-											$sub_avatar_row_count = $sub_avatar_col_count = 0;
-										}
 										$avatar_list[$file][$sub_file][$sub_avatar_page_count][$sub_avatar_row_count][$sub_avatar_col_count] = array(
 											'file'		=> rawurlencode($file) . '/' . rawurlencode($sub_file) . '/' . rawurlencode($sub_sub_file),
 											'filename'	=> rawurlencode($sub_sub_file),
@@ -2213,8 +2209,14 @@ function avatar_gallery($category, $subcategory = '#NONE#', $page = 0, $avatar_s
 										$sub_avatar_col_count++;
 										if ($sub_avatar_col_count == $items_per_column)
 										{
-											$sub_avatar_row_count++;
-											$sub_avatar_col_count = 0;
+											if (($avatar_col_count * ($avatar_row_count+1)) == $avatars_per_page)
+											{
+												$avatar_page_count++;
+												$avatar_row_count = $avatar_col_count = 0;
+											}else{
+												$avatar_row_count++;
+												$avatar_col_count = 0;
+											}
 										}
 									}
 								}

--- a/phpBB/includes/functions_user.php
+++ b/phpBB/includes/functions_user.php
@@ -2209,13 +2209,13 @@ function avatar_gallery($category, $subcategory = '#NONE#', $page = 0, $avatar_s
 										$sub_avatar_col_count++;
 										if ($sub_avatar_col_count == $items_per_column)
 										{
-											if (($avatar_col_count * ($avatar_row_count+1)) == $avatars_per_page)
+											if (($sub_avatar_col_count * ($sub_avatar_row_count+1)) == $avatars_per_page)
 											{
-												$avatar_page_count++;
-												$avatar_row_count = $avatar_col_count = 0;
+												$sub_avatar_page_count++;
+												$sub_avatar_row_count = $avatar_col_count = 0;
 											}else{
-												$avatar_row_count++;
-												$avatar_col_count = 0;
+												$sub_avatar_row_count++;
+												$sub_avatar_col_count = 0;
 											}
 										}
 									}

--- a/phpBB/includes/functions_user.php
+++ b/phpBB/includes/functions_user.php
@@ -2138,7 +2138,7 @@ function get_avatar_filename($avatar_entry)
 /**
 * Avatar Gallery
 */
-function avatar_gallery($category, $avatar_select, $items_per_column, $block_var = 'avatar_row')
+function avatar_gallery($category, $subcategory = '#NONE#', $page = 0, $avatar_select, $items_per_column, $avatars_per_page, $block_var = 'avatar_row')
 {
 	global $user, $cache, $template;
 	global $config, $phpbb_root_path;
@@ -2160,12 +2160,12 @@ function avatar_gallery($category, $avatar_select, $items_per_column, $block_var
 		{
 			return array($user->lang['NO_AVATAR_CATEGORY'] => array());
 		}
-
+		// Category
 		while (($file = readdir($dp)) !== false)
 		{
 			if ($file[0] != '.' && preg_match('#^[^&"\'<>]+$#i', $file) && is_dir("$path/$file"))
 			{
-				$avatar_row_count = $avatar_col_count = 0;
+				$avatar_page_count = $avatar_row_count = $avatar_col_count = 0;
 
 				if ($dp2 = @opendir("$path/$file"))
 				{
@@ -2173,7 +2173,12 @@ function avatar_gallery($category, $avatar_select, $items_per_column, $block_var
 					{
 						if (preg_match('#^[^&\'"<>]+\.(?:gif|png|jpe?g)$#i', $sub_file))
 						{
-							$avatar_list[$file][$avatar_row_count][$avatar_col_count] = array(
+							if (($avatar_col_count * $avatar_row_count) == $avatars_per_page)
+							{
+								$avatar_page_count++;
+								$avatar_row_count = $avatar_col_count = 0;
+							}
+							$avatar_list[$file]['#NONE#'][$avatar_page_count][$avatar_row_count][$avatar_col_count] = array(
 								'file'		=> rawurlencode($file) . '/' . rawurlencode($sub_file),
 								'filename'	=> rawurlencode($sub_file),
 								'name'		=> ucfirst(str_replace('_', ' ', preg_replace('#^(.*)\..*$#', '\1', $sub_file))),
@@ -2183,6 +2188,37 @@ function avatar_gallery($category, $avatar_select, $items_per_column, $block_var
 							{
 								$avatar_row_count++;
 								$avatar_col_count = 0;
+							}
+						}
+						$sub_avatar_page_count = $sub_avatar_row_count = $sub_avatar_col_count = 0;
+						// Subcategory
+						if ($sub_file[0] != '.' && preg_match('#^[^&"\'<>]+$#i', $sub_file) && is_dir("$path/$file/$sub_file"))
+						{
+							if ($dp3 = @opendir("$path/$file/$sub_file"))
+							{
+								while (($sub_sub_file = readdir($dp3)) !== false)
+								{
+									if (preg_match('#^[^&\'"<>]+\.(?:gif|png|jpe?g)$#i', $sub_sub_file))
+									{
+										if (($sub_avatar_col_count * $sub_avatar_row_count) == $avatars_per_page)
+										{
+											$sub_avatar_page_count++;
+											$sub_avatar_row_count = $sub_avatar_col_count = 0;
+										}
+										$avatar_list[$file][$sub_file][$sub_avatar_page_count][$sub_avatar_row_count][$sub_avatar_col_count] = array(
+											'file'		=> rawurlencode($file) . '/' . rawurlencode($sub_file) . '/' . rawurlencode($sub_sub_file),
+											'filename'	=> rawurlencode($sub_sub_file),
+											'name'		=> ucfirst(str_replace('_', ' ', preg_replace('#^(.*)\..*$#', '\1', $sub_sub_file))),
+										);
+										$sub_avatar_col_count++;
+										if ($sub_avatar_col_count == $items_per_column)
+										{
+											$sub_avatar_row_count++;
+											$sub_avatar_col_count = 0;
+										}
+									}
+								}
+								closedir($dp3);
 							}
 						}
 					}
@@ -2200,6 +2236,7 @@ function avatar_gallery($category, $avatar_select, $items_per_column, $block_var
 
 	@ksort($avatar_list);
 
+	// Generate Categories
 	$category = (!$category) ? key($avatar_list) : $category;
 	$avatar_categories = array_keys($avatar_list);
 
@@ -2208,15 +2245,41 @@ function avatar_gallery($category, $avatar_select, $items_per_column, $block_var
 	{
 		$s_category_options .= '<option value="' . $cat . '"' . (($cat == $category) ? ' selected="selected"' : '') . '>' . $cat . '</option>';
 	}
-
+	
+	$avatar_list = (isset($avatar_list[$category])) ? $avatar_list[$category] : array();
+	
+	// Generate Subcategories
+	$avatar_subcategories = array_keys($avatar_list);
+	
+	$s_subcategory_options = '';
+	foreach ($avatar_subcategories as $subcat)
+	{
+		$s_subcategory_options .= '<option value="' . $subcat . '"' . (($subcat == $subcategory) ? ' selected="selected"' : '') . '>' . $subcat . '</option>';
+	}
+	$subcategory = (!$subcategory) ? key($avatar_list) : $subcategory;
+	$avatar_list = (isset($avatar_list[$subcategory])) ? $avatar_list[$subcategory] : array();
+	
+	// Generate Pages
+	$avatar_pages = array_keys($avatar_list);
+	
+	$s_page_options = '';
+	foreach ($avatar_pages as $avatar_page)
+	{
+		$s_page_options .= '<option value="' . $avatar_page . '"' . (($avatar_page == $page) ? ' selected="selected"' : '') . '>' . $avatar_page . '</option>';
+	}
+	$page = (!$page) ? key($avatar_list) : $page;
+	
 	$template->assign_vars(array(
 		'S_AVATARS_ENABLED'		=> true,
 		'S_IN_AVATAR_GALLERY'	=> true,
-		'S_CAT_OPTIONS'			=> $s_category_options)
+		'S_CAT_OPTIONS'			=> $s_category_options,
+		'S_SUBCAT_OPTIONS'			=> $s_subcategory_options,
+		'S_PAGE_OPTIONS'			=> $s_page_options)
 	);
-
-	$avatar_list = (isset($avatar_list[$category])) ? $avatar_list[$category] : array();
-
+	
+	$avatar_list = (isset($avatar_list[$page])) ? $avatar_list[$page] : array();
+	
+	// Generate avatar rows and columns
 	foreach ($avatar_list as $avatar_row_ary)
 	{
 		$template->assign_block_vars($block_var, array());

--- a/phpBB/includes/ucp/ucp_groups.php
+++ b/phpBB/includes/ucp/ucp_groups.php
@@ -485,6 +485,8 @@ class ucp_groups
 
 						$avatar_select = basename(request_var('avatar_select', ''));
 						$category = basename(request_var('category', ''));
+						$subcategory = basename(request_var('subcategory', ''));
+						$page = basename(request_var('page', ''));
 
 						$can_upload = (file_exists($phpbb_root_path . $config['avatar_path']) && phpbb_is_writable($phpbb_root_path . $config['avatar_path']) && $file_uploads) ? true : false;
 
@@ -694,7 +696,7 @@ class ucp_groups
 
 						if ($config['allow_avatar'] && $config['allow_avatar_local'] && $display_gallery)
 						{
-							avatar_gallery($category, $avatar_select, 4);
+							avatar_gallery($category, $subcategory, $page, $avatar_select, 4, 40);
 						}
 
 						$avatars_enabled = ($config['allow_avatar'] && (($can_upload && ($config['allow_avatar_upload'] || $config['allow_avatar_remote_upload'])) || ($config['allow_avatar_local'] || $config['allow_avatar_remote']))) ? true : false;

--- a/phpBB/includes/ucp/ucp_profile.php
+++ b/phpBB/includes/ucp/ucp_profile.php
@@ -560,6 +560,8 @@ class ucp_profile
 				$display_gallery = request_var('display_gallery', '0');
 				$avatar_select = basename(request_var('avatar_select', ''));
 				$category = basename(request_var('category', ''));
+				$subcategory = basename(request_var('subcategory', ''));
+				$page = basename(request_var('page', ''));
 
 				$can_upload = (file_exists($phpbb_root_path . $config['avatar_path']) && phpbb_is_writable($phpbb_root_path . $config['avatar_path']) && $auth->acl_get('u_chgavatar') && (@ini_get('file_uploads') || strtolower(@ini_get('file_uploads')) == 'on')) ? true : false;
 
@@ -609,7 +611,7 @@ class ucp_profile
 
 				if ($config['allow_avatar'] && $display_gallery && $auth->acl_get('u_chgavatar') && $config['allow_avatar_local'])
 				{
-					avatar_gallery($category, $avatar_select, 4);
+					avatar_gallery($category, $subcategory, $page, $avatar_select, 4, 40);
 				}
 				else if ($config['allow_avatar'])
 				{

--- a/phpBB/language/en/ucp.php
+++ b/phpBB/language/en/ucp.php
@@ -89,6 +89,7 @@ $lang = array_merge($lang, array(
 	'ATTACHMENTS_DELETED'			=> 'Attachments successfully deleted.',
 	'ATTACHMENT_DELETED'			=> 'Attachment successfully deleted.',
 	'AVATAR_CATEGORY'				=> 'Category',
+	'AVATAR_SUBCATEGORY'			=> 'Subcategory',
 	'AVATAR_EXPLAIN'				=> 'Maximum dimensions; width: %1$d pixels, height: %2$d pixels, file size: %3$.2f KiB.',
 	'AVATAR_FEATURES_DISABLED'		=> 'The avatar functionality is currently disabled.',
 	'AVATAR_GALLERY'				=> 'Local gallery',

--- a/phpBB/styles/prosilver/template/ucp_avatar_options.html
+++ b/phpBB/styles/prosilver/template/ucp_avatar_options.html
@@ -53,6 +53,8 @@
 
 		<fieldset>
 			<label for="category">{L_AVATAR_CATEGORY}: <select name="category" id="category">{S_CAT_OPTIONS}</select></label>
+			<label for="subcategory">{L_AVATAR_SUBCATEGORY}: <select name="subcategory" id="subcategory">{S_SUBCAT_OPTIONS}</select></label>
+			<label for="page">{L_AVATAR_PAGE}: <select name="page" id="page">{S_PAGE_OPTIONS}</select></label>
 			<input type="submit" value="{L_GO}" name="display_gallery" class="button2" />
 			<input type="submit" name="cancel" value="{L_CANCEL}" class="button2" />
 		</fieldset>

--- a/phpBB/styles/subsilver2/template/ucp_profile_avatar.html
+++ b/phpBB/styles/subsilver2/template/ucp_profile_avatar.html
@@ -55,7 +55,7 @@
 		<th colspan="2">{L_AVATAR_GALLERY}</th>
 	</tr>
 	<tr> 
-		<td class="cat" colspan="2" align="center" valign="middle"><span class="genmed">{L_AVATAR_CATEGORY}: </span><select name="category">{S_CAT_OPTIONS}</select>&nbsp; <input class="btnlite" tabindex="0" type="submit" value="{L_GO}" name="display_gallery" /></td>
+		<td class="cat" colspan="2" align="center" valign="middle"><span class="genmed">{L_AVATAR_CATEGORY}: </span><select name="category">{S_CAT_OPTIONS}</select>&nbsp; <span class="genmed">{L_AVATAR_SUBCATEGORY}: </span><select name="subcategory">{S_SUBCAT_OPTIONS}</select>&nbsp; <span class="genmed">{L_AVATAR_PAGE}: </span><select name="page">{S_PAGE_OPTIONS}</select>&nbsp; <input class="btnlite" tabindex="0" type="submit" value="{L_GO}" name="display_gallery" /></td>
 	</tr>
 	<tr> 
 		<td class="row1" colspan="2" align="center">


### PR DESCRIPTION
Local Gallery avatars split every 50 images. 
(scratch 50 images we want it to look right so 40 images instead)
Helps fix long loading times when gallery contains a large amount of avatars.
Local gallery avatars can have folders that are inside of a folder in gallery.
Example:
sub categories under one category like
/images/avatars/gallery/toaru/index 
/images/avatars/gallery/toaru/misaka
instead of just 
/images/avatars/gallery/toaru/

PHPBB3-13524