### PR TITLE
[ticket/13524]Local Gallery avatars split every 50 images. Subcategories in gallery

### DIFF
--- a/phpBB/adm/style/acp_groups.html
+++ b/phpBB/adm/style/acp_groups.html
@@ -124,8 +124,12 @@
 		</dl>
 		<!-- IF S_DISPLAY_GALLERY -->
 			<dl>
-				<dt><label>{L_AVATAR_GALLERY}:</label></dt>
-				<dd><input class="button2" type="submit" name="display_gallery" value="{L_DISPLAY_GALLERY}" /></dd>
+				<dt><label for="category">{L_AVATAR_CATEGORY}:</label></dt>
+				<dd><select name="category" id="category">{S_CAT_OPTIONS}</select>&nbsp;</dd>
+				<dt><label for="subcategory">{L_AVATAR_SUBCATEGORY}:</label></dt>
+				<dd><select name="subcategory" id="subcategory">{S_SUBCAT_OPTIONS}</select>&nbsp;</dd>
+				<dt><label for="subcategory">{L_AVATAR_PAGE}:</label></dt>
+				<dd><select name="page" id="page">{S_PAGE_OPTIONS}</select>&nbsp;<input class="button2" type="submit" value="{L_GO}" name="display_gallery" /></dd>
 			</dl>
 		<!-- ENDIF -->
 	<!-- ELSE -->

--- a/phpBB/adm/style/acp_users_avatar.html
+++ b/phpBB/adm/style/acp_users_avatar.html
@@ -43,7 +43,11 @@
 			<legend>{L_AVATAR_GALLERY}</legend>
 		<dl>
 			<dt><label for="category">{L_AVATAR_CATEGORY}:</label></dt>
-			<dd><select name="category" id="category">{S_CAT_OPTIONS}</select>&nbsp;<input class="button2" type="submit" value="{L_GO}" name="display_gallery" /></dd>
+			<dd><select name="category" id="category">{S_CAT_OPTIONS}</select>&nbsp;</dd>
+			<dt><label for="subcategory">{L_AVATAR_SUBCATEGORY}:</label></dt>
+			<dd><select name="subcategory" id="subcategory">{S_SUBCAT_OPTIONS}</select>&nbsp;</dd>
+			<dt><label for="subcategory">{L_AVATAR_PAGE}:</label></dt>
+			<dd><select name="page" id="page">{S_PAGE_OPTIONS}</select>&nbsp;<input class="button2" type="submit" value="{L_GO}" name="display_gallery" /></dd>
 		</dl>
 		<dl>
 			<table cellspacing="1">

--- a/phpBB/includes/acp/acp_users.php
+++ b/phpBB/includes/acp/acp_users.php
@@ -1742,10 +1742,13 @@ class acp_users
 				$display_gallery = (isset($_POST['display_gallery'])) ? true : false;
 				$avatar_select = basename(request_var('avatar_select', ''));
 				$category = basename(request_var('category', ''));
+				$subcategory = basename(request_var('subcategory', ''));
+				$page = basename(request_var('page', ''));
+
 
 				if ($config['allow_avatar_local'] && $display_gallery)
 				{
-					avatar_gallery($category, $avatar_select, 4);
+					avatar_gallery($category, $subcategory, $page, $avatar_select, 4, 40);
 				}
 
 				$template->assign_vars(array(

--- a/phpBB/language/en/ucp.php
+++ b/phpBB/language/en/ucp.php
@@ -89,6 +89,7 @@ $lang = array_merge($lang, array(
 	'ATTACHMENTS_DELETED'			=> 'Attachments successfully deleted.',
 	'ATTACHMENT_DELETED'			=> 'Attachment successfully deleted.',
 	'AVATAR_CATEGORY'				=> 'Category',
+	'AVATAR_SUBCATEGORY'			=> 'Subcategory',
 	'AVATAR_EXPLAIN'				=> 'Maximum dimensions; width: %1$d pixels, height: %2$d pixels, file size: %3$.2f KiB.',
 	'AVATAR_FEATURES_DISABLED'		=> 'The avatar functionality is currently disabled.',
 	'AVATAR_GALLERY'				=> 'Local gallery',

--- a/phpBB/styles/prosilver/template/ucp_avatar_options.html
+++ b/phpBB/styles/prosilver/template/ucp_avatar_options.html
@@ -53,6 +53,8 @@
 
 		<fieldset>
 			<label for="category">{L_AVATAR_CATEGORY}: <select name="category" id="category">{S_CAT_OPTIONS}</select></label>
+			<label for="subcategory">{L_AVATAR_SUBCATEGORY}: <select name="subcategory" id="subcategory">{S_SUBCAT_OPTIONS}</select></label>
+			<label for="page">{L_AVATAR_PAGE}: <select name="page" id="page">{S_PAGE_OPTIONS}</select></label>
 			<input type="submit" value="{L_GO}" name="display_gallery" class="button2" />
 			<input type="submit" name="cancel" value="{L_CANCEL}" class="button2" />
 		</fieldset>

--- a/phpBB/styles/subsilver2/template/ucp_profile_avatar.html
+++ b/phpBB/styles/subsilver2/template/ucp_profile_avatar.html
@@ -55,7 +55,7 @@
 		<th colspan="2">{L_AVATAR_GALLERY}</th>
 	</tr>
 	<tr> 
-		<td class="cat" colspan="2" align="center" valign="middle"><span class="genmed">{L_AVATAR_CATEGORY}: </span><select name="category">{S_CAT_OPTIONS}</select>&nbsp; <input class="btnlite" tabindex="0" type="submit" value="{L_GO}" name="display_gallery" /></td>
+		<td class="cat" colspan="2" align="center" valign="middle"><span class="genmed">{L_AVATAR_CATEGORY}: </span><select name="category">{S_CAT_OPTIONS}</select>&nbsp; <span class="genmed">{L_AVATAR_SUBCATEGORY}: </span><select name="subcategory">{S_SUBCAT_OPTIONS}</select>&nbsp; <span class="genmed">{L_AVATAR_PAGE}: </span><select name="page">{S_PAGE_OPTIONS}</select>&nbsp; <input class="btnlite" tabindex="0" type="submit" value="{L_GO}" name="display_gallery" /></td>
 	</tr>
 	<tr> 
 		<td class="row1" colspan="2" align="center">


### PR DESCRIPTION
[ticket/13524]Local Gallery avatars split every 50 images. Subcategories in gallery

Local Gallery avatars split every 50 images. 
(scratch 50 images we want it to look right so 40 images instead)
Helps fix long loading times when gallery contains a large amount of avatars.
Local gallery avatars can have folders that are inside of a folder in gallery.
Example:
sub categories under one category like
/images/avatars/gallery/toaru/index 
/images/avatars/gallery/toaru/misaka
instead of just 
/images/avatars/gallery/toaru/

PHPBB3-13524