### PR TITLE
Update colours.css

### DIFF
--- a/phpBB/styles/prosilver/theme/colours.css
+++ b/phpBB/styles/prosilver/theme/colours.css
@@ -656,7 +656,6 @@ Colours and backgrounds for buttons.css
 .icon-register				{ background-image: url("./images/icon_register.gif"); }
 .icon-search, .responsive-search a	{ background-image: url("./images/icon_search.gif"); }
 .icon-search-active			{ background-image: url("./images/subforum_read.gif"); }
-.icon-search-advanced		{ background-image: url("./images/icon_search_adv.gif"); }
 .icon-search-new			{ background-image: url("./images/subforum_unread.gif"); }
 .icon-search-self			{ background-image: url("./images/icon_topic_latest.gif"); }
 .icon-search-unanswered		{ background-image: url("./images/icon_post_target.gif"); }


### PR DESCRIPTION
The rule is a left over from development and it should be removed from colours.css

.icon-search-advanced	{ background-image: url("./images/icon_search_adv.gif"); }

Area21 ticket: https://area51.phpbb.com/phpBB/viewtopic.php?f=81&p=275166

PHPBB3-13639