### PR TITLE
[feature/sql-bool-builder] Extending DBAL query builder for boolean generation

### DIFF
--- a/phpBB/phpbb/db/driver/driver.php
+++ b/phpBB/phpbb/db/driver/driver.php
@@ -807,6 +807,8 @@ abstract class driver implements driver_interface
 
 	protected function _process_boolean_tree_first($operations_ary)
 	{
+		// In cases where an array exists but there is no head condition,
+		// it should be because there's only 1 WHERE clause. This seems the best way to deal with it.
 		if ($operations_ary[0] !== 'AND' &&
 			$operations_ary[0] !== 'OR')
 		{

--- a/phpBB/phpbb/db/driver/driver.php
+++ b/phpBB/phpbb/db/driver/driver.php
@@ -819,7 +819,7 @@ abstract class driver implements driver_interface
 	{
 		$operation = array_shift($operations_ary);
 
-		foreach ($operations_ary AS &$condition)
+		foreach ($operations_ary as &$condition)
 		{
 			switch ($condition[0])
 			{

--- a/phpBB/phpbb/db/driver/driver.php
+++ b/phpBB/phpbb/db/driver/driver.php
@@ -866,6 +866,24 @@ abstract class driver implements driver_interface
 
 								break;
 
+								case 'IS_NOT':
+
+									$condition[1] = 'IS NOT';
+
+								// no break
+								case 'IS':
+
+									// If the value is NULL, the string of it is the empty string ('') which is not the intended result.
+									// this should solve that
+									if ($condition[2] === null)
+									{
+										$condition[2] = 'NULL';
+									}
+
+									$condition = implode(' ', $condition);
+
+								break;
+
 								default:
 
 									$condition = implode(' ', $condition);

--- a/phpBB/phpbb/db/driver/driver.php
+++ b/phpBB/phpbb/db/driver/driver.php
@@ -831,7 +831,7 @@ abstract class driver implements driver_interface
 				break;
 				case 'NOT':
 
-					$condition = ' NOT ' . $this->_process_boolean_tree($condition);
+					$condition = ' NOT (' . $this->_process_boolean_tree($condition) . ') ';
 
 				break;
 

--- a/phpBB/phpbb/db/driver/driver.php
+++ b/phpBB/phpbb/db/driver/driver.php
@@ -792,11 +792,11 @@ abstract class driver implements driver_interface
 
 		return $sql;
 	}
-	
-	
+
+
 	protected function _process_boolean_tree_first($operations_ary)
 	{
-		if ($operations_ary[0] !== 'AND' && 
+		if ($operations_ary[0] !== 'AND' &&
 			$operations_ary[0] !== 'OR')
 		{
 			$operations_ary = array('AND', $operations_ary);
@@ -807,71 +807,71 @@ abstract class driver implements driver_interface
 	protected function _process_boolean_tree($operations_ary)
 	{
 		$operation = array_shift($operations_ary);
-		
+
 		foreach ($operations_ary AS &$condition)
 		{
 			switch ($condition[0])
 			{
 				case 'AND':
 				case 'OR':
-					
+
 					$condition = ' ( ' . $this->_process_boolean_tree($condition) . ') ';
-					
+
 				break;
 				case 'NOT':
-					
+
 					$condition = ' NOT ' . $this->_process_boolean_tree($condition);
-					
+
 				break;
-				
+
 				default:
-					
+
 					switch (sizeof($condition))
 					{
 						case 3:
-						
+
 							// Typical 3 element clause with {left hand} {operator} {right hand}
 							switch ($condition[1])
-							{	
+							{
 								case 'IN':
 								case 'NOT_IN':
-								
+
 									// As this is used with an IN, assume it is a set of elements for sql_in_set()
 									$condition = $this->sql_in_set($condition[0], $condition[2], $condition[1] === 'NOT_IN', true);
-									
+
 								break;
-								
+
 								default:
-								
+
 									$condition = implode(' ', $condition);
-									
+
 								break;
 							}
-							
+
 						break;
-						
+
 						case 5:
-						
+
 							// Subquery with {left hand} {operator} {compare kind} {SELECT Kind } {Sub Query}
-						
+
 							$condition = $condition[0] . ' ' . $condition[1] . ' ' . $condition[2] . ' ( ';
 							$condition .= $this->sql_build_query($condition[3], $condition[4]);
 							$condition .= ' )';
-							
+
 						break;
-						
+
 						default:
 							// This is an unpredicted clause setup. Just join all elements.
 							$condition = implode(' ', $condition);
-								
+
 						break;
 					}
-					
+
 				break;
 			}
-			
+
 		}
-		
+
 		if($operation === 'NOT')
 		{
 			$operations_ary =  implode("", $operations_ary);
@@ -880,10 +880,10 @@ abstract class driver implements driver_interface
 		{
 			$operations_ary = implode(" \n	$operation ", $operations_ary);
 		}
-		
+
 		return $operations_ary;
 	}
-	
+
 
 	/**
 	* {@inheritDoc}

--- a/phpBB/phpbb/db/driver/driver.php
+++ b/phpBB/phpbb/db/driver/driver.php
@@ -774,7 +774,18 @@ abstract class driver implements driver_interface
 
 				if (!empty($array['WHERE']))
 				{
-					$sql .= ' WHERE ' . $this->_sql_custom_build('WHERE', $array['WHERE']);
+					$sql .= ' WHERE ';
+
+					if (is_array($array['WHERE']))
+					{
+						$sql_where = $this->_process_boolean_tree_first($array['WHERE']);
+					}
+					else
+					{
+						$sql_where = $array['WHERE'];
+					}
+
+					$sql .= $this->_sql_custom_build('WHERE', $sql_where);
 				}
 
 				if (!empty($array['GROUP_BY']))

--- a/phpBB/phpbb/db/driver/driver.php
+++ b/phpBB/phpbb/db/driver/driver.php
@@ -792,6 +792,98 @@ abstract class driver implements driver_interface
 
 		return $sql;
 	}
+	
+	
+	protected function _process_boolean_tree_first($operations_ary)
+	{
+		if ($operations_ary[0] !== 'AND' && 
+			$operations_ary[0] !== 'OR')
+		{
+			$operations_ary = array('AND', $operations_ary);
+		}
+		return $this->_process_boolean_tree($operations_ary) . "\n";
+	}
+
+	protected function _process_boolean_tree($operations_ary)
+	{
+		$operation = array_shift($operations_ary);
+		
+		foreach ($operations_ary AS &$condition)
+		{
+			switch ($condition[0])
+			{
+				case 'AND':
+				case 'OR':
+					
+					$condition = ' ( ' . $this->_process_boolean_tree($condition) . ') ';
+					
+				break;
+				case 'NOT':
+					
+					$condition = ' NOT ' . $this->_process_boolean_tree($condition);
+					
+				break;
+				
+				default:
+					
+					switch (sizeof($condition))
+					{
+						case 3:
+						
+							// Typical 3 element clause with {left hand} {operator} {right hand}
+							switch ($condition[1])
+							{	
+								case 'IN':
+								case 'NOT_IN':
+								
+									// As this is used with an IN, assume it is a set of elements for sql_in_set()
+									$condition = $this->sql_in_set($condition[0], $condition[2], $condition[1] === 'NOT_IN', true);
+									
+								break;
+								
+								default:
+								
+									$condition = implode(' ', $condition);
+									
+								break;
+							}
+							
+						break;
+						
+						case 5:
+						
+							// Subquery with {left hand} {operator} {compare kind} {SELECT Kind } {Sub Query}
+						
+							$condition = $condition[0] . ' ' . $condition[1] . ' ' . $condition[2] . ' ( ';
+							$condition .= $this->sql_build_query($condition[3], $condition[4]);
+							$condition .= ' )';
+							
+						break;
+						
+						default:
+							// This is an unpredicted clause setup. Just join all elements.
+							$condition = implode(' ', $condition);
+								
+						break;
+					}
+					
+				break;
+			}
+			
+		}
+		
+		if($operation === 'NOT')
+		{
+			$operations_ary =  implode("", $operations_ary);
+		}
+		else
+		{
+			$operations_ary = implode(" \n	$operation ", $operations_ary);
+		}
+		
+		return $operations_ary;
+	}
+	
 
 	/**
 	* {@inheritDoc}

--- a/phpBB/phpbb/db/driver/driver.php
+++ b/phpBB/phpbb/db/driver/driver.php
@@ -854,6 +854,18 @@ abstract class driver implements driver_interface
 
 								break;
 
+								case 'LIKE':
+
+									$condition = $condition[0] . ' ' . $this->sql_like_expression($condition[2]) . ' ';
+
+								break;
+
+								case 'NOT_LIKE':
+
+									$condition = $condition[0] . ' ' . $this->sql_not_like_expression($condition[2]) . ' ';
+
+								break;
+
 								default:
 
 									$condition = implode(' ', $condition);

--- a/tests/dbal/boolean_processor_test.php
+++ b/tests/dbal/boolean_processor_test.php
@@ -1,0 +1,24 @@
+<?php
+/**
+*
+* This file is part of the phpBB Forum Software package.
+*
+* @copyright (c) phpBB Limited <https://www.phpbb.com>
+* @license GNU General Public License, version 2 (GPL-2.0)
+*
+* For full copyright and license information, please see
+* the docs/CREDITS.txt file.
+*
+*/
+
+require_once dirname(__FILE__) . '/../../phpBB/includes/functions.php';
+require_once dirname(__FILE__) . '/../../phpBB/includes/utf/utf_tools.php';
+
+class phpbb_boolean_processor_test extends phpbb_database_test_case
+{
+	public function getDataSet()
+	{
+		return $this->createXMLDataSet(dirname(__FILE__).'/fixtures/boolean_processor.xml');
+	}
+
+}

--- a/tests/dbal/boolean_processor_test.php
+++ b/tests/dbal/boolean_processor_test.php
@@ -45,7 +45,11 @@ class phpbb_boolean_processor_test extends phpbb_database_test_case
 			array('user_id' => '2'),
 			array('user_id' => '3'),
 			array('user_id' => '6'),
-			), $db->sql_fetchrowset($result));
+			), $db->sql_fetchrowset($result),
+				($result === false) ?
+				"SQL ERROR:<br>" . var_export($sql, true) . "<br>" . $db->sql_error() :
+				var_export($sql, true) . '   ' . var_export($result, true)
+			);
 	}
 
 	public function test_single_like()
@@ -70,7 +74,11 @@ class phpbb_boolean_processor_test extends phpbb_database_test_case
 		$this->assertEquals(array(
 			array('user_id' => '4'),
 			array('user_id' => '5'),
-			), $db->sql_fetchrowset($result));
+			), $db->sql_fetchrowset($result),
+				($result === false) ?
+				"SQL ERROR:<br>" . var_export($sql, true) . "<br>" . $db->sql_error() :
+				var_export($sql, true) . '   ' . var_export($result, true)
+			);
 	}
 
 	public function test_single_not_in()
@@ -96,7 +104,11 @@ class phpbb_boolean_processor_test extends phpbb_database_test_case
 			array('user_id' => '1'),
 			array('user_id' => '2'),
 			array('user_id' => '6'),
-			), $db->sql_fetchrowset($result));
+			), $db->sql_fetchrowset($result),
+				($result === false) ?
+				"SQL ERROR:<br>" . var_export($sql, true) . "<br>" . $db->sql_error() :
+				var_export($sql, true) . '   ' . var_export($result, true)
+			);
 	}
 
 	public function test_single_in()
@@ -122,7 +134,11 @@ class phpbb_boolean_processor_test extends phpbb_database_test_case
 			array('user_id' => '3'),
 			array('user_id' => '4'),
 			array('user_id' => '5'),
-			), $db->sql_fetchrowset($result));
+			), $db->sql_fetchrowset($result),
+				($result === false) ?
+				"SQL ERROR:<br>" . var_export($sql, true) . "<br>" . $db->sql_error() :
+				var_export($sql, true) . '   ' . var_export($result, true)
+			);
 	}
 
 	public function test_and_of_or_of_and()
@@ -168,7 +184,11 @@ class phpbb_boolean_processor_test extends phpbb_database_test_case
 		$this->assertEquals(array(
 			array('user_id' => '2'),
 			array('user_id' => '4'),
-			), $db->sql_fetchrowset($result));
+			), $db->sql_fetchrowset($result),
+				($result === false) ?
+				"SQL ERROR:<br>" . var_export($sql, true) . "<br>" . $db->sql_error() :
+				var_export($sql, true) . '   ' . var_export($result, true)
+			);
 	}
 
 	public function test_triple_and_with_in()
@@ -200,6 +220,11 @@ class phpbb_boolean_processor_test extends phpbb_database_test_case
 			array('user_id' => '2'),
 			array('user_id' => '3'),
 			), $db->sql_fetchrowset($result),
+			($result === false) ?
+				"SQL ERROR:<br>" . var_export($sql, true) . "<br>" . $db->sql_error() :
+				var_export($sql, true) . '   ' . var_export($result, true)
+		);
+
 	}
 
 	public function test_double_and_with_not_of_or()
@@ -230,7 +255,11 @@ class phpbb_boolean_processor_test extends phpbb_database_test_case
 
 		$db->sql_return_on_error(false);
 
-		$this->assertEquals(array(), $db->sql_fetchrowset($result));
+		$this->assertEquals(array(), $db->sql_fetchrowset($result),
+				($result === false) ?
+				"SQL ERROR:<br>" . var_export($sql, true) . "<br>" . $db->sql_error() :
+				var_export($sql, true) . '   ' . var_export($result, true)
+			);
 	}
 
 	public function test_triple_and_with_is_null()
@@ -268,6 +297,10 @@ class phpbb_boolean_processor_test extends phpbb_database_test_case
 		$this->assertEquals(array(
 			array('username' => 'helper'),
 			array('username' => 'mass email'),
-			), $db->sql_fetchrowset($result));
+			), $db->sql_fetchrowset($result),
+				($result === false) ?
+				"SQL ERROR:<br>" . var_export($sql, true) . "<br>" . $db->sql_error() :
+				var_export($sql, true) . '   ' . var_export($result, true)
+			);
 	}
 }

--- a/tests/dbal/boolean_processor_test.php
+++ b/tests/dbal/boolean_processor_test.php
@@ -153,7 +153,7 @@ class phpbb_boolean_processor_test extends phpbb_database_test_case
 					),
 					array('AND',
 						array('ug.group_id', '=', 1),
-						array('b.ban_id', 'IS NOT', NULL),
+						array('b.ban_id', 'IS_NOT', NULL),
 					),
 				),
 				array('u.user_id', '=', 'ug.user_id'),

--- a/tests/dbal/boolean_processor_test.php
+++ b/tests/dbal/boolean_processor_test.php
@@ -21,6 +21,37 @@ class phpbb_boolean_processor_test extends phpbb_database_test_case
 		return $this->createXMLDataSet(dirname(__FILE__).'/fixtures/boolean_processor.xml');
 	}
 
+	public function test_double_and_with_not_of_or()
+	{
+		$db = $this->new_dbal();
+
+		$db->sql_return_on_error(true);
+
+		$sql_ary = array(
+			'SELECT'	=> 'u.user_id',
+			'FROM'		=> array(
+				'phpbb_users'		=> 'u',
+				'phpbb_user_group'	=> 'ug',
+			),
+			'WHERE'		=> array('AND',
+				array('NOT',
+					array('OR',
+						array('ug.group_id', '=', 1),
+						array('ug.group_id', '=', 2),
+					),
+				),
+				array('u.user_id', '=', 'ug.user_id'),
+			),
+			'ORDER_BY'	=> 'u.user_id',
+		);
+		$sql = $db->sql_build_query('SELECT', $sql_ary);
+		$result = $db->sql_query($sql);
+
+		$db->sql_return_on_error(false);
+
+		$this->assertEquals(array(), $db->sql_fetchrowset($result));
+	}
+
 	public function test_triple_and_with_is_null()
 	{
 		$db = $this->new_dbal();

--- a/tests/dbal/boolean_processor_test.php
+++ b/tests/dbal/boolean_processor_test.php
@@ -21,6 +21,32 @@ class phpbb_boolean_processor_test extends phpbb_database_test_case
 		return $this->createXMLDataSet(dirname(__FILE__).'/fixtures/boolean_processor.xml');
 	}
 
+	public function test_single_in()
+	{
+		$db = $this->new_dbal();
+
+		$db->sql_return_on_error(true);
+
+		$sql_ary = array(
+			'SELECT'	=> 'u.user_id',
+			'FROM'		=> array(
+				'phpbb_users'		=> 'u',
+			),
+			'WHERE'		=> array('u.user_id', 'IN', array(3,4,5)),
+			'ORDER_BY'	=> 'u.user_id',
+		);
+		$sql = $db->sql_build_query('SELECT', $sql_ary);
+		$result = $db->sql_query($sql);
+
+		$db->sql_return_on_error(false);
+
+		$this->assertEquals(array(
+			array('user_id' => '3'),
+			array('user_id' => '4'),
+			array('user_id' => '5'),
+			), $db->sql_fetchrowset($result));
+	}
+
 	public function test_and_of_or_of_and()
 	{
 		$db = $this->new_dbal();

--- a/tests/dbal/boolean_processor_test.php
+++ b/tests/dbal/boolean_processor_test.php
@@ -21,4 +21,41 @@ class phpbb_boolean_processor_test extends phpbb_database_test_case
 		return $this->createXMLDataSet(dirname(__FILE__).'/fixtures/boolean_processor.xml');
 	}
 
+	public function test_triple_and_with_is_null()
+	{
+		$db = $this->new_dbal();
+
+		$db->sql_return_on_error(true);
+
+		$sql_ary = array(
+			'SELECT'	=> 'u.username',
+			'FROM'		=> array(
+				'phpbb_users'		=> 'u',
+				'phpbb_user_group'	=> 'ug',
+			),
+			'LEFT_JOIN'	=> array(
+				array(
+					'FROM'	=> array(
+						'phpbb_banlist'	=> 'b',
+					),
+					'ON'	=> 'u.user_id = b.ban_userid',
+				),
+			),
+			'WHERE'		=> array('AND',
+				array('ug.group_id', '=', 1),
+				array('u.user_id', '=', 'ug.user_id'),
+				array('b.ban_id', 'IS', NULL),
+			),
+			'ORDER_BY'	=> 'u.username',
+		);
+		$sql = $db->sql_build_query('SELECT', $sql_ary);
+		$result = $db->sql_query($sql);
+
+		$db->sql_return_on_error(false);
+
+		$this->assertEquals(array(
+			array('username' => 'helper'),
+			array('username' => 'mass email'),
+			), $db->sql_fetchrowset($result));
+	}
 }

--- a/tests/dbal/boolean_processor_test.php
+++ b/tests/dbal/boolean_processor_test.php
@@ -21,6 +21,37 @@ class phpbb_boolean_processor_test extends phpbb_database_test_case
 		return $this->createXMLDataSet(dirname(__FILE__).'/fixtures/boolean_processor.xml');
 	}
 
+	public function test_triple_and_with_in()
+	{
+		$db = $this->new_dbal();
+
+		$db->sql_return_on_error(true);
+
+		$sql_ary = array(
+			'SELECT'	=> 'u.user_id',
+			'FROM'		=> array(
+				'phpbb_users'		=> 'u',
+				'phpbb_user_group'	=> 'ug',
+			),
+			'WHERE'		=> array('AND',
+				array('ug.user_id', 'IN', array(1, 2, 3, 4)),
+				array('ug.group_id', '=', 1),
+				array('u.user_id', '=', 'ug.user_id'),
+			),
+			'ORDER_BY'	=> 'u.user_id',
+		);
+		$sql = $db->sql_build_query('SELECT', $sql_ary);
+		$result = $db->sql_query($sql);
+
+		$db->sql_return_on_error(false);
+
+		$this->assertEquals(array(
+			array('user_id' => '1'),
+			array('user_id' => '2'),
+			array('user_id' => '3'),
+			), $db->sql_fetchrowset($result),
+	}
+
 	public function test_double_and_with_not_of_or()
 	{
 		$db = $this->new_dbal();

--- a/tests/dbal/boolean_processor_test.php
+++ b/tests/dbal/boolean_processor_test.php
@@ -21,6 +21,32 @@ class phpbb_boolean_processor_test extends phpbb_database_test_case
 		return $this->createXMLDataSet(dirname(__FILE__).'/fixtures/boolean_processor.xml');
 	}
 
+	public function test_single_not_in()
+	{
+		$db = $this->new_dbal();
+
+		$db->sql_return_on_error(true);
+
+		$sql_ary = array(
+			'SELECT'	=> 'u.user_id',
+			'FROM'		=> array(
+				'phpbb_users'		=> 'u',
+			),
+			'WHERE'		=> array('u.user_id', 'NOT_IN', array(3,4,5)),
+			'ORDER_BY'	=> 'u.user_id',
+		);
+		$sql = $db->sql_build_query('SELECT', $sql_ary);
+		$result = $db->sql_query($sql);
+
+		$db->sql_return_on_error(false);
+
+		$this->assertEquals(array(
+			array('user_id' => '1'),
+			array('user_id' => '2'),
+			array('user_id' => '6'),
+			), $db->sql_fetchrowset($result));
+	}
+
 	public function test_single_in()
 	{
 		$db = $this->new_dbal();

--- a/tests/dbal/boolean_processor_test.php
+++ b/tests/dbal/boolean_processor_test.php
@@ -21,6 +21,31 @@ class phpbb_boolean_processor_test extends phpbb_database_test_case
 		return $this->createXMLDataSet(dirname(__FILE__).'/fixtures/boolean_processor.xml');
 	}
 
+	public function test_single_like()
+	{
+		$db = $this->new_dbal();
+
+		$db->sql_return_on_error(true);
+
+		$sql_ary = array(
+			'SELECT'	=> 'u.user_id',
+			'FROM'		=> array(
+				'phpbb_users'		=> 'u',
+			),
+			'WHERE'		=> array('u.username_clean', 'LIKE', 'gr' . $db->get_any_char()),
+			'ORDER_BY'	=> 'u.user_id',
+		);
+		$sql = $db->sql_build_query('SELECT', $sql_ary);
+		$result = $db->sql_query($sql);
+
+		$db->sql_return_on_error(false);
+
+		$this->assertEquals(array(
+			array('user_id' => '4'),
+			array('user_id' => '5'),
+			), $db->sql_fetchrowset($result));
+	}
+
 	public function test_single_not_in()
 	{
 		$db = $this->new_dbal();

--- a/tests/dbal/boolean_processor_test.php
+++ b/tests/dbal/boolean_processor_test.php
@@ -21,6 +21,33 @@ class phpbb_boolean_processor_test extends phpbb_database_test_case
 		return $this->createXMLDataSet(dirname(__FILE__).'/fixtures/boolean_processor.xml');
 	}
 
+	public function test_single_not_like()
+	{
+		$db = $this->new_dbal();
+
+		$db->sql_return_on_error(true);
+
+		$sql_ary = array(
+			'SELECT'	=> 'u.user_id',
+			'FROM'		=> array(
+				'phpbb_users'		=> 'u',
+			),
+			'WHERE'		=> array('u.username_clean', 'NOT_LIKE', 'gr' . $db->get_any_char()),
+			'ORDER_BY'	=> 'u.user_id',
+		);
+		$sql = $db->sql_build_query('SELECT', $sql_ary);
+		$result = $db->sql_query($sql);
+
+		$db->sql_return_on_error(false);
+
+		$this->assertEquals(array(
+			array('user_id' => '1'),
+			array('user_id' => '2'),
+			array('user_id' => '3'),
+			array('user_id' => '6'),
+			), $db->sql_fetchrowset($result));
+	}
+
 	public function test_single_like()
 	{
 		$db = $this->new_dbal();

--- a/tests/dbal/fixtures/boolean_processor.xml
+++ b/tests/dbal/fixtures/boolean_processor.xml
@@ -1,0 +1,84 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<dataset>
+	<table name="phpbb_banlist">
+		<column>ban_id</column>
+		<column>ban_userid</column>
+		<row>
+			<value>1</value>
+			<value>2</value>
+		</row>
+	</table>
+	<table name="phpbb_users">
+		<column>user_id</column>
+		<column>username</column>
+		<column>username_clean</column>
+		<column>user_permissions</column>
+		<column>user_sig</column>
+		<row>
+			<value>1</value>
+			<value>mass email</value>
+			<value>mass email</value>
+			<value></value>
+			<value></value>
+		</row>
+		<row>
+			<value>2</value>
+			<value>banned</value>
+			<value>banned</value>
+			<value></value>
+			<value></value>
+		</row>
+		<row>
+			<value>3</value>
+			<value>helper</value>
+			<value>helper</value>
+			<value></value>
+			<value></value>
+		</row>
+		<row>
+			<value>4</value>
+			<value>GroupBPal</value>
+			<value>groupbpal</value>
+			<value></value>
+			<value></value>
+		</row>
+		<row>
+			<value>5</value>
+			<value>GroupBPal2</value>
+			<value>groupBPal2</value>
+			<value></value>
+			<value></value>
+		</row>
+		<row>
+			<value>6</value>
+			<value>not in group</value>
+			<value>not in group</value>
+			<value></value>
+			<value></value>
+		</row>
+	</table>
+	<table name="phpbb_user_group">
+		<column>user_id</column>
+		<column>group_id</column>
+		<row>
+			<value>1</value>
+			<value>1</value>
+		</row>
+		<row>
+			<value>2</value>
+			<value>1</value>
+		</row>
+		<row>
+			<value>3</value>
+			<value>1</value>
+		</row>
+		<row>
+			<value>4</value>
+			<value>2</value>
+		</row>
+		<row>
+			<value>5</value>
+			<value>2</value>
+		</row>
+	</table>
+</dataset>


### PR DESCRIPTION
Improve DBAL's query builder by adding a boolean query builder using a structured stack of arrays.

This can be used everywhere in an SQL query where boolean operations are used.
Currently, this can only be used in the WHERE and the JOINs' ON clause.

The main and general use-cases are:
To flexibly the build of the WHERE clause in SQL queries
To ease, simplify and prevent errors when doing SQL query editing by phpBB's extensions

Topic: https://area51.phpbb.com/phpBB/viewtopic.php?f=81&t=47306
https://tracker.phpbb.com/browse/PHPBB3-13652

Documentation: https://github.com/phpbb/documentation/pull/51

PHPBB3-13652