### PR TITLE
[ticket/13658] add event before and after topics are deleted

### DIFF
--- a/phpBB/includes/functions_admin.php
+++ b/phpBB/includes/functions_admin.php
@@ -618,7 +618,7 @@ function move_posts($post_ids, $topic_id, $auto_sync = true)
 */
 function delete_topics($where_type, $where_ids, $auto_sync = true, $post_count_sync = true, $call_delete_posts = true)
 {
-	global $db, $config, $phpbb_container;
+	global $db, $config, $phpbb_container, $phpbb_dispatcher;
 
 	$approved_topics = 0;
 	$forum_ids = $topic_ids = array();
@@ -672,6 +672,18 @@ function delete_topics($where_type, $where_ids, $auto_sync = true, $post_count_s
 
 	$table_ary = array(BOOKMARKS_TABLE, TOPICS_TRACK_TABLE, TOPICS_POSTED_TABLE, POLL_VOTES_TABLE, POLL_OPTIONS_TABLE, TOPICS_WATCH_TABLE, TOPICS_TABLE);
 
+	/**
+	 * Perform additional actions before topic(s) deletion
+	 *
+	 * @event core.delete_topics_before
+	 * @var	array	topic_ids	Array of topic ids to delete
+	 * @since 3.1.4-RC1
+	 */
+	$vars = array(
+			'topic_ids',
+	);
+	extract($phpbb_dispatcher->trigger_event('core.delete_topics_before', compact($vars)));
+
 	foreach ($table_ary as $table)
 	{
 		$sql = "DELETE FROM $table
@@ -679,6 +691,18 @@ function delete_topics($where_type, $where_ids, $auto_sync = true, $post_count_s
 		$db->sql_query($sql);
 	}
 	unset($table_ary);
+
+	/**
+	 * Perform additional actions after topic(s) deletion
+	 *
+	 * @event core.delete_topics_after
+	 * @var	array	topic_ids	Array of topic ids that were deleted
+	 * @since 3.1.4-RC1
+	 */
+	$vars = array(
+			'topic_ids',
+	);
+	extract($phpbb_dispatcher->trigger_event('core.delete_topics_after', compact($vars)));
 
 	$moved_topic_ids = array();
 

--- a/phpBB/includes/functions_admin.php
+++ b/phpBB/includes/functions_admin.php
@@ -675,14 +675,16 @@ function delete_topics($where_type, $where_ids, $auto_sync = true, $post_count_s
 	/**
 	 * Perform additional actions before topic(s) deletion
 	 *
-	 * @event core.delete_topics_before
+	 * @event core.delete_topics_before_query
+	 * @var	array	table_ary	Array of tables from which all rows will be deleted that hold a topic_id occuring in topic_ids
 	 * @var	array	topic_ids	Array of topic ids to delete
 	 * @since 3.1.4-RC1
 	 */
 	$vars = array(
+			'table_ary',
 			'topic_ids',
 	);
-	extract($phpbb_dispatcher->trigger_event('core.delete_topics_before', compact($vars)));
+	extract($phpbb_dispatcher->trigger_event('core.delete_topics_before_query', compact($vars)));
 
 	foreach ($table_ary as $table)
 	{
@@ -695,14 +697,14 @@ function delete_topics($where_type, $where_ids, $auto_sync = true, $post_count_s
 	/**
 	 * Perform additional actions after topic(s) deletion
 	 *
-	 * @event core.delete_topics_after
+	 * @event core.delete_topics_after_query
 	 * @var	array	topic_ids	Array of topic ids that were deleted
 	 * @since 3.1.4-RC1
 	 */
 	$vars = array(
 			'topic_ids',
 	);
-	extract($phpbb_dispatcher->trigger_event('core.delete_topics_after', compact($vars)));
+	extract($phpbb_dispatcher->trigger_event('core.delete_topics_after_query', compact($vars)));
 
 	$moved_topic_ids = array();
 


### PR DESCRIPTION
Ticket: https://tracker.phpbb.com/browse/PHPBB3-13658
Event Request: http://area51.phpbb.com/phpBB/viewtopic.php?f=111&t=46255

Note: The old PR ( https://github.com/phpbb/phpbb/pull/3124 ) was not developed any further, so I made my own.