### PR TITLE
[ticket/13675] Add PHP and template events to ACP users profile

### DIFF
--- a/phpBB/adm/style/acp_users_profile.html
+++ b/phpBB/adm/style/acp_users_profile.html
@@ -2,6 +2,7 @@
 
 	<fieldset>
 		<legend>{L_USER_PROFILE}</legend>
+	<!-- EVENT acp_users_profile_before -->
 	<dl>
 		<dt><label for="jabber">{L_UCP_JABBER}{L_COLON}</label></dt>
 		<dd><input type="email" id="jabber" name="jabber" value="{JABBER}" /></dd>
@@ -10,6 +11,7 @@
 		<dt><label for="birthday">{L_BIRTHDAY}{L_COLON}</label><br /><span>{L_BIRTHDAY_EXPLAIN}</span></dt>
 		<dd>{L_DAY}{L_COLON} <select id="birthday" name="bday_day">{S_BIRTHDAY_DAY_OPTIONS}</select> {L_MONTH}{L_COLON} <select name="bday_month">{S_BIRTHDAY_MONTH_OPTIONS}</select> {L_YEAR}{L_COLON} <select name="bday_year">{S_BIRTHDAY_YEAR_OPTIONS}</select></dd>
 	</dl>
+	<!-- EVENT acp_users_profile_after -->
 	</fieldset>
 
 	<!-- IF .profile_fields -->
@@ -26,7 +28,7 @@
 		<!-- END profile_fields -->
 		</fieldset>
 	<!-- ENDIF -->
-
+	<!-- EVENT acp_users_profile_custom_after -->
 	<fieldset class="quick">
 		<input class="button1" type="submit" name="update" value="{L_SUBMIT}" />
 		{S_FORM_TOKEN}

--- a/phpBB/docs/events.md
+++ b/phpBB/docs/events.md
@@ -177,6 +177,27 @@ acp_ranks_list_header_before
 * Purpose: Add content after the last header-column (but before the action column)
 in the ranks list in the ACP
 
+acp_users_profile_before
+===
+* Locations:
+    + adm/style/acp_users_profile.html
+* Since: 3.1.4-RC1
+* Purpose: Add content before the profile details when editing a user in the ACP
+
+acp_users_profile_after
+===
+* Locations:
+    + adm/style/acp_users_profile.html
+* Since: 3.1.4-RC1
+* Purpose: Add content after the profile details but before the custom profile fields when editing a user in the ACP
+
+acp_users_profile_custom_after
+===
+* Locations:
+    + adm/style/acp_users_profile.html
+* Since: 3.1.4-RC1
+* Purpose: Add content after the the custom profile fields when editing a user in the ACP
+
 acp_simple_footer_after
 ===
 * Location: adm/style/simple_footer.html

--- a/phpBB/includes/acp/acp_users.php
+++ b/phpBB/includes/acp/acp_users.php
@@ -1380,13 +1380,15 @@ class acp_users
 				/**
 				* Modify user data on editing profile in ACP
 				*
-				* @event core.acp_users_modify_profile_info
+				* @event core.acp_users_modify_profile
 				* @var	array	data		Array with user profile data
 				* @var	bool	submit		Flag indicating if submit button has been pressed
+				* @var	int		user_id		The user id
+				* @var	array	user_row	Array with the full user data
 				* @since 3.1.4-RC1
 				*/
-				$vars = array('data', 'submit');
-				extract($phpbb_dispatcher->trigger_event('core.acp_users_modify_profile_info', compact($vars)));
+				$vars = array('data', 'submit', 'user_id', 'user_row');
+				extract($phpbb_dispatcher->trigger_event('core.acp_users_modify_profile', compact($vars)));
 
 				if ($submit)
 				{
@@ -1411,17 +1413,18 @@ class acp_users
 					{
 						$error[] = 'FORM_INVALID';
 					}
+
 					/**
-					* Validate user data on editing profile in ACP
+					* Validate profile data in ACP before submitting to the database
 					*
-					* @event core.acp_users_validate_profile_info
-					* @var	array 	data 	Array with user profile data
-					* @var	bool	submit	Flag indicating if submit button has been pressed
-					* @var array	error	Array of any generated errors
+					* @event core.acp_users_profile_validate
+					* @var	bool	submit		Flag indicating if submit button has been pressed
+					* @var	array	data		Array with user profile data
+					* @var	array	error		Array with the form errors
 					* @since 3.1.4-RC1
 					*/
-					$vars = array('data', 'submit', 'error');
-					extract($phpbb_dispatcher->trigger_event('core.acp_users_validate_profile_info', compact($vars)));
+					$vars = array('submit', 'data', 'error');
+					extract($phpbb_dispatcher->trigger_event('core.acp_users_profile_validate', compact($vars)));
 
 					if (!sizeof($error))
 					{
@@ -1433,14 +1436,15 @@ class acp_users
 						/**
 						* Modify profile data in ACP before submitting to the database
 						*
-						* @event core.acp_users_profile_info_sql_ary
+						* @event core.acp_users_profile_modify_sql_ary
 						* @var	array	cp_data		Array with the user custom profile fields data
 						* @var	array	data		Array with user profile data
-						* @var  array	sql_ary		user options data we update
+						* @var	int		user_id		The user id
+						* @var	array	user_row	Array with the full user data
 						* @since 3.1.4-RC1
 						*/
-						$vars = array('cp_data', 'data', 'sql_ary');
-						extract($phpbb_dispatcher->trigger_event('core.acp_users_profile_info_sql_ary', compact($vars)));
+						$vars = array('cp_data', 'data', 'user_id', 'user_row');
+						extract($phpbb_dispatcher->trigger_event('core.acp_users_profile_modify_sql_ary', compact($vars)));
 
 						$sql = 'UPDATE ' . USERS_TABLE . '
 							SET ' . $db->sql_build_array('UPDATE', $sql_ary) . "

--- a/phpBB/includes/acp/acp_users.php
+++ b/phpBB/includes/acp/acp_users.php
@@ -1441,9 +1441,10 @@ class acp_users
 						* @var	array	data		Array with user profile data
 						* @var	int		user_id		The user id
 						* @var	array	user_row	Array with the full user data
+						* @var	array	sql_ary		Array with sql data
 						* @since 3.1.4-RC1
 						*/
-						$vars = array('cp_data', 'data', 'user_id', 'user_row');
+						$vars = array('cp_data', 'data', 'user_id', 'user_row', 'sql_ary');
 						extract($phpbb_dispatcher->trigger_event('core.acp_users_profile_modify_sql_ary', compact($vars)));
 
 						$sql = 'UPDATE ' . USERS_TABLE . '

--- a/phpBB/includes/acp/acp_users.php
+++ b/phpBB/includes/acp/acp_users.php
@@ -1441,10 +1441,9 @@ class acp_users
 						* @var	array	data		Array with user profile data
 						* @var	int		user_id		The user id
 						* @var	array	user_row	Array with the full user data
-						* @var	array	sql_ary		Array with sql data
 						* @since 3.1.4-RC1
 						*/
-						$vars = array('cp_data', 'data', 'user_id', 'user_row', 'sql_ary');
+						$vars = array('cp_data', 'data', 'user_id', 'user_row');
 						extract($phpbb_dispatcher->trigger_event('core.acp_users_profile_modify_sql_ary', compact($vars)));
 
 						$sql = 'UPDATE ' . USERS_TABLE . '

--- a/phpBB/includes/acp/acp_users.php
+++ b/phpBB/includes/acp/acp_users.php
@@ -1380,15 +1380,13 @@ class acp_users
 				/**
 				* Modify user data on editing profile in ACP
 				*
-				* @event core.acp_users_modify_profile
+				* @event core.acp_users_modify_profile_info
 				* @var	array	data		Array with user profile data
 				* @var	bool	submit		Flag indicating if submit button has been pressed
-				* @var	int		user_id		The user id
-				* @var	array	user_row	Array with the full user data
 				* @since 3.1.4-RC1
 				*/
-				$vars = array('data', 'submit', 'user_id', 'user_row');
-				extract($phpbb_dispatcher->trigger_event('core.acp_users_modify_profile', compact($vars)));
+				$vars = array('data', 'submit');
+				extract($phpbb_dispatcher->trigger_event('core.acp_users_modify_profile_info', compact($vars)));
 
 				if ($submit)
 				{
@@ -1413,6 +1411,17 @@ class acp_users
 					{
 						$error[] = 'FORM_INVALID';
 					}
+					/**
+					* Validate user data on editing profile in ACP
+					*
+					* @event core.acp_users_validate_profile_info
+					* @var	array 	data 	Array with user profile data
+					* @var	bool	submit	Flag indicating if submit button has been pressed
+					* @var array	error	Array of any generated errors
+					* @since 3.1.4-RC1
+					*/
+					$vars = array('data', 'submit', 'error');
+					extract($phpbb_dispatcher->trigger_event('core.acp_users_validate_profile_info', compact($vars)));
 
 					if (!sizeof($error))
 					{
@@ -1424,15 +1433,14 @@ class acp_users
 						/**
 						* Modify profile data in ACP before submitting to the database
 						*
-						* @event core.acp_users_profile_modify_sql_ary
+						* @event core.acp_users_profile_info_sql_ary
 						* @var	array	cp_data		Array with the user custom profile fields data
 						* @var	array	data		Array with user profile data
-						* @var	int		user_id		The user id
-						* @var	array	user_row	Array with the full user data
+						* @var  array	sql_ary		user options data we update
 						* @since 3.1.4-RC1
 						*/
-						$vars = array('cp_data', 'data', 'user_id', 'user_row');
-						extract($phpbb_dispatcher->trigger_event('core.acp_users_profile_modify_sql_ary', compact($vars)));
+						$vars = array('cp_data', 'data', 'sql_ary');
+						extract($phpbb_dispatcher->trigger_event('core.acp_users_profile_info_sql_ary', compact($vars)));
 
 						$sql = 'UPDATE ' . USERS_TABLE . '
 							SET ' . $db->sql_build_array('UPDATE', $sql_ary) . "


### PR DESCRIPTION
There are PHP events in acp_users file but one can not validate the changes to the event.  Also allow the inclusion of html code within the adm style file

PHPBB3-13675