### PR TITLE
[ticket/13674] Change MySQL native total search results calculation

### DIFF
--- a/phpBB/phpbb/search/fulltext_native.php
+++ b/phpBB/phpbb/search/fulltext_native.php
@@ -824,7 +824,7 @@ class fulltext_native extends \phpbb\search\base
 		}
 
 		// if using mysql and the total result count is not calculated yet, get it from the db
-		if(!$total_results && $is_mysql)
+		if (!$total_results && $is_mysql)
 		{
 			// Also count rows for the query as if there was not LIMIT. Add SQL_CALC_FOUND_ROWS to SQL
 			$sql_array['SELECT'] = 'SQL_CALC_FOUND_ROWS ' . $sql_array['SELECT'];

--- a/phpBB/phpbb/search/fulltext_native.php
+++ b/phpBB/phpbb/search/fulltext_native.php
@@ -823,6 +823,13 @@ class fulltext_native extends \phpbb\search\base
 			);
 		}
 
+		// if using mysql and the total result count is not calculated yet, get it from the db
+		if(!$total_results && $is_mysql)
+		{
+			// Also count rows for the query as if there was not LIMIT. Add SQL_CALC_FOUND_ROWS to SQL
+			$sql_array['SELECT'] = 'SQL_CALC_FOUND_ROWS ' . $sql_array['SELECT'];
+		}
+
 		$sql_array['WHERE'] = implode(' AND ', $sql_where);
 		$sql_array['GROUP_BY'] = ($group_by) ? (($type == 'posts') ? 'p.post_id' : 'p.topic_id') . ', ' . $sort_by_sql[$sort_key] : '';
 		$sql_array['ORDER_BY'] = $sql_sort;
@@ -838,19 +845,9 @@ class fulltext_native extends \phpbb\search\base
 		}
 		$this->db->sql_freeresult($result);
 
-		// if we use mysql and the total result count is not cached yet, retrieve it from the db
 		if (!$total_results && $is_mysql)
 		{
-			// Count rows for the executed queries. Replace $select within $sql with SQL_CALC_FOUND_ROWS, and run it
-			$sql_array_copy = $sql_array;
-			$sql_array_copy['SELECT'] = 'SQL_CALC_FOUND_ROWS p.post_id ';
-
-			$sql_calc = $this->db->sql_build_query('SELECT', $sql_array_copy);
-			unset($sql_array_copy);
-
-			$this->db->sql_query($sql_calc);
-			$this->db->sql_freeresult($result);
-
+			// Get the number of results as calculated by MySQL
 			$sql_count = 'SELECT FOUND_ROWS() as total_results';
 			$result = $this->db->sql_query($sql_count);
 			$total_results = (int) $this->db->sql_fetchfield('total_results');


### PR DESCRIPTION
This changes how the native FULLTEXT search calculates the total
match number for MySQL.
This should improve performance as there is one less query being made
and it is being searched using the technique mentioned in the manual

https://tracker.phpbb.com/browse/PHPBB3-13674