### PR TITLE
[ticket/13679] Add template event overall_header_searchbox_before

### DIFF
--- a/phpBB/docs/events.md
+++ b/phpBB/docs/events.md
@@ -880,6 +880,13 @@ overall_header_page_body_before
 * Since: 3.1.0-b3
 * Purpose: Add content after the page-header, but before the page-body
 
+overall_header_searchbox_before
+===
+* Locations:
+    + styles/prosilver/template/overall_header.html
+* Since: 3.1.4-RC1
+* Purpose: Add content before the search box in the header
+
 overall_header_stylesheets_after
 ===
 * Locations:

--- a/phpBB/styles/prosilver/template/overall_header.html
+++ b/phpBB/styles/prosilver/template/overall_header.html
@@ -69,6 +69,7 @@
 				<p class="skiplink"><a href="#start_here">{L_SKIP}</a></p>
 			</div>
 
+			<!-- EVENT overall_header_searchbox_before -->
 			<!-- IF S_DISPLAY_SEARCH and not S_IN_SEARCH -->
 			<div id="search-box" class="search-box search-header">
 				<form action="{U_SEARCH}" method="get" id="search">


### PR DESCRIPTION
PHPBB3-13679

https://tracker.phpbb.com/browse/PHPBB3-13679
http://area51.phpbb.com/phpBB/viewtopic.php?f=111&t=47401

There is no search box in the header for subsilver2  therefore I didn't make any subsilver2 changes.
This event helps with the addition of social or other icons above or below the search box which is located in the prosilver header.
It is placed before the search box to make easier the placement of the icons when the search box is not shown, e.g. in the search page.