### PR TITLE
[ticket/12505] Remove outdated media handling in attachments

### DIFF
--- a/phpBB/includes/acp/acp_attachments.php
+++ b/phpBB/includes/acp/acp_attachments.php
@@ -620,10 +620,7 @@ class acp_attachments
 				$cat_lang = array(
 					ATTACHMENT_CATEGORY_NONE		=> $user->lang['NO_FILE_CAT'],
 					ATTACHMENT_CATEGORY_IMAGE		=> $user->lang['CAT_IMAGES'],
-					ATTACHMENT_CATEGORY_WM			=> $user->lang['CAT_WM_FILES'],
-					ATTACHMENT_CATEGORY_RM			=> $user->lang['CAT_RM_FILES'],
 					ATTACHMENT_CATEGORY_FLASH		=> $user->lang['CAT_FLASH_FILES'],
-					ATTACHMENT_CATEGORY_QUICKTIME	=> $user->lang['CAT_QUICKTIME_FILES'],
 				);
 
 				$group_id = $request->variable('g', 0);
@@ -1371,10 +1368,7 @@ class acp_attachments
 		$types = array(
 			ATTACHMENT_CATEGORY_NONE		=> $user->lang['NO_FILE_CAT'],
 			ATTACHMENT_CATEGORY_IMAGE		=> $user->lang['CAT_IMAGES'],
-			ATTACHMENT_CATEGORY_WM			=> $user->lang['CAT_WM_FILES'],
-			ATTACHMENT_CATEGORY_RM			=> $user->lang['CAT_RM_FILES'],
 			ATTACHMENT_CATEGORY_FLASH		=> $user->lang['CAT_FLASH_FILES'],
-			ATTACHMENT_CATEGORY_QUICKTIME	=> $user->lang['CAT_QUICKTIME_FILES'],
 		);
 
 		if ($group_id)

--- a/phpBB/includes/constants.php
+++ b/phpBB/includes/constants.php
@@ -171,11 +171,11 @@ define('CONFIRM_REPORT', 4);
 // Categories - Attachments
 define('ATTACHMENT_CATEGORY_NONE', 0);
 define('ATTACHMENT_CATEGORY_IMAGE', 1); // Inline Images
-define('ATTACHMENT_CATEGORY_WM', 2); // Windows Media Files - Streaming
-define('ATTACHMENT_CATEGORY_RM', 3); // Real Media Files - Streaming
+define('ATTACHMENT_CATEGORY_WM', 2); // Windows Media Files - Streaming - @deprecated 3.1
+define('ATTACHMENT_CATEGORY_RM', 3); // Real Media Files - Streaming - @deprecated 3.1
 define('ATTACHMENT_CATEGORY_THUMB', 4); // Not used within the database, only while displaying posts
 define('ATTACHMENT_CATEGORY_FLASH', 5); // Flash/SWF files
-define('ATTACHMENT_CATEGORY_QUICKTIME', 6); // Quicktime/Mov files
+define('ATTACHMENT_CATEGORY_QUICKTIME', 6); // Quicktime/Mov files - @deprecated 3.1
 
 // BBCode UID length
 define('BBCODE_UID_LEN', 8);

--- a/phpBB/includes/constants.php
+++ b/phpBB/includes/constants.php
@@ -171,11 +171,11 @@ define('CONFIRM_REPORT', 4);
 // Categories - Attachments
 define('ATTACHMENT_CATEGORY_NONE', 0);
 define('ATTACHMENT_CATEGORY_IMAGE', 1); // Inline Images
-define('ATTACHMENT_CATEGORY_WM', 2); // Windows Media Files - Streaming - @deprecated 3.1
-define('ATTACHMENT_CATEGORY_RM', 3); // Real Media Files - Streaming - @deprecated 3.1
+define('ATTACHMENT_CATEGORY_WM', 2); // Windows Media Files - Streaming - @deprecated 3.2
+define('ATTACHMENT_CATEGORY_RM', 3); // Real Media Files - Streaming - @deprecated 3.2
 define('ATTACHMENT_CATEGORY_THUMB', 4); // Not used within the database, only while displaying posts
 define('ATTACHMENT_CATEGORY_FLASH', 5); // Flash/SWF files
-define('ATTACHMENT_CATEGORY_QUICKTIME', 6); // Quicktime/Mov files - @deprecated 3.1
+define('ATTACHMENT_CATEGORY_QUICKTIME', 6); // Quicktime/Mov files - @deprecated 3.2
 
 // BBCode UID length
 define('BBCODE_UID_LEN', 8);

--- a/phpBB/includes/functions_content.php
+++ b/phpBB/includes/functions_content.php
@@ -1171,38 +1171,6 @@ function parse_attachments($forum_id, &$message, &$attachments, &$update_count, 
 					$update_count[] = $attachment['attach_id'];
 				break;
 
-				// Windows Media Streams
-				case ATTACHMENT_CATEGORY_WM:
-
-					// Giving the filename directly because within the wm object all variables are in local context making it impossible
-					// to validate against a valid session (all params can differ)
-					// $download_link = $filename;
-
-					$block_array += array(
-						'U_FORUM'		=> generate_board_url(),
-						'ATTACH_ID'		=> $attachment['attach_id'],
-						'S_WM_FILE'		=> true,
-					);
-
-					// Viewed/Heared File ... update the download count
-					$update_count[] = $attachment['attach_id'];
-				break;
-
-				// Real Media Streams
-				case ATTACHMENT_CATEGORY_RM:
-				case ATTACHMENT_CATEGORY_QUICKTIME:
-
-					$block_array += array(
-						'S_RM_FILE'			=> ($display_cat == ATTACHMENT_CATEGORY_RM) ? true : false,
-						'S_QUICKTIME_FILE'	=> ($display_cat == ATTACHMENT_CATEGORY_QUICKTIME) ? true : false,
-						'U_FORUM'			=> generate_board_url(),
-						'ATTACH_ID'			=> $attachment['attach_id'],
-					);
-
-					// Viewed/Heared File ... update the download count
-					$update_count[] = $attachment['attach_id'];
-				break;
-
 				// Macromedia Flash Files
 				case ATTACHMENT_CATEGORY_FLASH:
 					list($width, $height) = @getimagesize($filename);

--- a/phpBB/install/schemas/schema_data.sql
+++ b/phpBB/install/schemas/schema_data.sql
@@ -718,10 +718,7 @@ INSERT INTO phpbb_extension_groups (group_name, cat_id, allow_group, download_mo
 INSERT INTO phpbb_extension_groups (group_name, cat_id, allow_group, download_mode, upload_icon, max_filesize, allowed_forums) VALUES ('ARCHIVES', 0, 1, 1, '', 0, '');
 INSERT INTO phpbb_extension_groups (group_name, cat_id, allow_group, download_mode, upload_icon, max_filesize, allowed_forums) VALUES ('PLAIN_TEXT', 0, 0, 1, '', 0, '');
 INSERT INTO phpbb_extension_groups (group_name, cat_id, allow_group, download_mode, upload_icon, max_filesize, allowed_forums) VALUES ('DOCUMENTS', 0, 0, 1, '', 0, '');
-INSERT INTO phpbb_extension_groups (group_name, cat_id, allow_group, download_mode, upload_icon, max_filesize, allowed_forums) VALUES ('REAL_MEDIA', 3, 0, 1, '', 0, '');
-INSERT INTO phpbb_extension_groups (group_name, cat_id, allow_group, download_mode, upload_icon, max_filesize, allowed_forums) VALUES ('WINDOWS_MEDIA', 2, 0, 1, '', 0, '');
 INSERT INTO phpbb_extension_groups (group_name, cat_id, allow_group, download_mode, upload_icon, max_filesize, allowed_forums) VALUES ('FLASH_FILES', 5, 0, 1, '', 0, '');
-INSERT INTO phpbb_extension_groups (group_name, cat_id, allow_group, download_mode, upload_icon, max_filesize, allowed_forums) VALUES ('QUICKTIME_MEDIA', 6, 0, 1, '', 0, '');
 INSERT INTO phpbb_extension_groups (group_name, cat_id, allow_group, download_mode, upload_icon, max_filesize, allowed_forums) VALUES ('DOWNLOADABLE_FILES', 0, 0, 1, '', 0, '');
 
 # -- extensions
@@ -778,27 +775,13 @@ INSERT INTO phpbb_extensions (group_id, extension) VALUES (4, 'ods');
 INSERT INTO phpbb_extensions (group_id, extension) VALUES (4, 'odt');
 INSERT INTO phpbb_extensions (group_id, extension) VALUES (4, 'rtf');
 
-INSERT INTO phpbb_extensions (group_id, extension) VALUES (5, 'rm');
-INSERT INTO phpbb_extensions (group_id, extension) VALUES (5, 'ram');
+INSERT INTO phpbb_extensions (group_id, extension) VALUES (5, 'swf');
 
-INSERT INTO phpbb_extensions (group_id, extension) VALUES (6, 'wma');
-INSERT INTO phpbb_extensions (group_id, extension) VALUES (6, 'wmv');
-
-INSERT INTO phpbb_extensions (group_id, extension) VALUES (7, 'swf');
-
-INSERT INTO phpbb_extensions (group_id, extension) VALUES (8, 'mov');
-INSERT INTO phpbb_extensions (group_id, extension) VALUES (8, 'm4v');
-INSERT INTO phpbb_extensions (group_id, extension) VALUES (8, 'm4a');
-INSERT INTO phpbb_extensions (group_id, extension) VALUES (8, 'mp4');
-INSERT INTO phpbb_extensions (group_id, extension) VALUES (8, '3gp');
-INSERT INTO phpbb_extensions (group_id, extension) VALUES (8, '3g2');
-INSERT INTO phpbb_extensions (group_id, extension) VALUES (8, 'qt');
-
-INSERT INTO phpbb_extensions (group_id, extension) VALUES (9, 'mpeg');
-INSERT INTO phpbb_extensions (group_id, extension) VALUES (9, 'mpg');
-INSERT INTO phpbb_extensions (group_id, extension) VALUES (9, 'mp3');
-INSERT INTO phpbb_extensions (group_id, extension) VALUES (9, 'ogg');
-INSERT INTO phpbb_extensions (group_id, extension) VALUES (9, 'ogm');
+INSERT INTO phpbb_extensions (group_id, extension) VALUES (6, 'mp3');
+INSERT INTO phpbb_extensions (group_id, extension) VALUES (6, 'mpeg');
+INSERT INTO phpbb_extensions (group_id, extension) VALUES (6, 'mpg');
+INSERT INTO phpbb_extensions (group_id, extension) VALUES (6, 'ogg');
+INSERT INTO phpbb_extensions (group_id, extension) VALUES (6, 'ogm');
 
 # Add default profile fields
 INSERT INTO phpbb_profile_fields (field_name, field_type, field_ident, field_length, field_minlen, field_maxlen, field_novalue, field_default_value, field_validation, field_required, field_show_novalue, field_show_on_reg, field_show_on_pm, field_show_on_vt, field_show_on_ml, field_show_profile, field_hide, field_no_view, field_active, field_order, field_is_contact, field_contact_desc, field_contact_url) VALUES ('phpbb_location', 'profilefields.type.string', 'phpbb_location', '20', '2', '100', '', '', '.*', 0, 0, 0, 1, 1, 1, 1, 0, 0, 1, 1, 0, '', '');

--- a/phpBB/language/en/acp/attachments.php
+++ b/phpBB/language/en/acp/attachments.php
@@ -70,9 +70,6 @@ $lang = array_merge($lang, array(
 
 	'CAT_FLASH_FILES'			=> 'Flash files',
 	'CAT_IMAGES'				=> 'Images',
-	'CAT_QUICKTIME_FILES'		=> 'Quicktime media files',
-	'CAT_RM_FILES'				=> 'RealMedia media files',
-	'CAT_WM_FILES'				=> 'Windows Media media files',
 	'CHECK_CONTENT'				=> 'Check attachment files',
 	'CHECK_CONTENT_EXPLAIN'		=> 'Some browsers can be tricked to assume an incorrect mimetype for uploaded files. This option ensures that such files likely to cause this are rejected.',
 	'CREATE_GROUP'				=> 'Create new group',
@@ -105,9 +102,6 @@ $lang = array_merge($lang, array(
 	'EXT_GROUP_FLASH_FILES'			=> 'Flash Files',
 	'EXT_GROUP_IMAGES'				=> 'Images',
 	'EXT_GROUP_PLAIN_TEXT'			=> 'Plain Text',
-	'EXT_GROUP_QUICKTIME_MEDIA'		=> 'Quicktime Media',
-	'EXT_GROUP_REAL_MEDIA'			=> 'Real Media',
-	'EXT_GROUP_WINDOWS_MEDIA'		=> 'Windows Media',
 
 	'FILES_GONE'			=> 'Some of the attachments you selected for deletion do not exist. They may have been already deleted. Attachments that did exist were deleted.',
 	'FILES_STATS_WRONG'		=> 'Your file statistics are likely inaccurate and need to be resynchronised. Actual values: number of attachments = %1$d, total size of attachments = %2$s.<br />Click %3$shere%4$s to resynchronise them.',

--- a/phpBB/language/en/common.php
+++ b/phpBB/language/en/common.php
@@ -553,7 +553,6 @@ $lang = array_merge($lang, array(
 		1	=> '%d pixel',
 		2	=> '%d pixels',
 	),
-	'PLAY_QUICKTIME_FILE'	=> 'Play Quicktime file',
 	'PLEASE_WAIT'			=> 'Please wait.',
 	'PM'					=> 'PM',
 	'PM_REPORTED'			=> 'Click to view report',

--- a/phpBB/phpbb/db/migration/data/v320/remove_outdated_media.php
+++ b/phpBB/phpbb/db/migration/data/v320/remove_outdated_media.php
@@ -1,0 +1,83 @@
+<?php
+/**
+*
+* This file is part of the phpBB Forum Software package.
+*
+* @copyright (c) phpBB Limited <https://www.phpbb.com>
+* @license GNU General Public License, version 2 (GPL-2.0)
+*
+* For full copyright and license information, please see
+* the docs/CREDITS.txt file.
+*
+*/
+
+namespace phpbb\db\migration\data\v320;
+
+class remove_outdated_media extends \phpbb\db\migration\migration
+{
+	protected $cat_id = array(
+			ATTACHMENT_CATEGORY_WM,
+			ATTACHMENT_CATEGORY_RM,
+			ATTACHMENT_CATEGORY_QUICKTIME,
+		);
+
+	public function update_data()
+	{
+		return array(
+			array('custom', array(array($this, 'change_extension_group'))),
+		);
+	}
+
+	public function change_extension_group()
+	{
+		// select group ids of outdated media
+		$sql = 'SELECT group_id
+			FROM ' . EXTENSION_GROUPS_TABLE . '
+			WHERE ' . $this->db->sql_in_set('cat_id', $cat_id);
+		$result = $this->db->sql_query($sql);
+
+		$group_ids = array();
+		while ($group_id = (int) $this->db->sql_fetchfield('group_id'))
+		{
+			$group_ids[] = $group_id;
+		}
+		$this->db->sql_freeresult($result);
+
+		// nothing to do, admin has removed all the outdated media extension groups
+		if (empty($group_ids))
+		{
+			return true;
+		}
+
+		// get the group id of downloadable files
+		$sql = 'SELECT group_id
+			FROM ' . EXTENSION_GROUPS_TABLE . "
+			WHERE group_name = 'DOWNLOADABLE_FILES'";
+		$result = $this->db->sql_query($sql);
+		$download_id = (int) $this->db->sql_fetchfield('group_id');
+		$this->db->sql_freeresult($result);
+
+		if (empty($download_id))
+		{
+			$sql = 'UPDATE ' . EXTENSIONS_TABLE . '
+				SET group_id = 0
+				WHERE ' . $this->db->sql_in_set('group_id', $group_ids);
+		}
+		else
+		{
+			// move outdated media extensions to downloadable files
+			$sql = 'UPDATE ' . EXTENSIONS_TABLE . "
+				SET group_id = $download_id" . '
+				WHERE ' . $this->db->sql_in_set('group_id', $group_ids);
+		}
+
+		$result = $this->db->sql_query($sql);
+		$this->db->sql_freeresult($result);
+
+		// delete the now empty, outdated media extension groups
+		$sql = 'DELETE FROM ' . EXTENSION_GROUPS_TABLE . '
+			WHERE ' . $this->db->sql_in_set('group_id', $group_ids);
+		$result = $this->db->sql_query($sql);
+		$this->db->sql_freeresult($result);
+	}
+}

--- a/phpBB/phpbb/db/migration/data/v320/remove_outdated_media.php
+++ b/phpBB/phpbb/db/migration/data/v320/remove_outdated_media.php
@@ -33,7 +33,7 @@ class remove_outdated_media extends \phpbb\db\migration\migration
 		// select group ids of outdated media
 		$sql = 'SELECT group_id
 			FROM ' . EXTENSION_GROUPS_TABLE . '
-			WHERE ' . $this->db->sql_in_set('cat_id', $cat_id);
+			WHERE ' . $this->db->sql_in_set('cat_id', $this->cat_id);
 		$result = $this->db->sql_query($sql);
 
 		$group_ids = array();

--- a/phpBB/styles/prosilver/template/attachment.html
+++ b/phpBB/styles/prosilver/template/attachment.html
@@ -29,36 +29,7 @@
 		</dl>
 		<!-- ENDIF -->
 
-		<!-- IF _file.S_WM_FILE -->
-			<!-- method used here from http://alistapart.com/articles/byebyeembed / autosizing seems to not work always, this will not fix -->
-			<object width="320" height="285" classid="CLSID:6BF52A52-394A-11d3-B153-00C04F79FAA6" id="wmstream_{_file.ATTACH_ID}">
-				<param name="url" value="{_file.U_DOWNLOAD_LINK}" />
-				<param name="showcontrols" value="1" />
-				<param name="showdisplay" value="0" />
-				<param name="showstatusbar" value="0" />
-				<param name="autosize" value="1" />
-				<param name="autostart" value="0" />
-				<param name="visible" value="1" />
-				<param name="animationstart" value="0" />
-				<param name="loop" value="0" />
-				<param name="src" value="{_file.U_DOWNLOAD_LINK}" />
-				<!--[if !IE]>-->
-					<object width="320" height="285" type="video/x-ms-wmv" data="{_file.U_DOWNLOAD_LINK}">
-						<param name="src" value="{_file.U_DOWNLOAD_LINK}" />
-						<param name="controller" value="1" />
-						<param name="showcontrols" value="1" />
-						<param name="showdisplay" value="0" />
-						<param name="showstatusbar" value="0" />
-						<param name="autosize" value="1" />
-						<param name="autostart" value="0" />
-						<param name="visible" value="1" />
-						<param name="animationstart" value="0" />
-						<param name="loop" value="0" />
-					</object>
-				<!--<![endif]-->
-			</object>
-
-		<!-- ELSEIF _file.S_FLASH_FILE -->
+		<!-- IF _file.S_FLASH_FILE -->
 			<object classid="clsid:D27CDB6E-AE6D-11CF-96B8-444553540000" codebase="http://active.macromedia.com/flash2/cabs/swflash.cab#version=5,0,0,0" width="{_file.WIDTH}" height="{_file.HEIGHT}">
 				<param name="movie" value="{_file.U_VIEW_LINK}" />
 				<param name="play" value="true" />
@@ -68,53 +39,7 @@
 				<param name="allowNetworking" value="internal" />
 				<embed src="{_file.U_VIEW_LINK}" type="application/x-shockwave-flash" pluginspage="http://www.macromedia.com/shockwave/download/index.cgi?P1_Prod_Version=ShockwaveFlash" width="{_file.WIDTH}" height="{_file.HEIGHT}" play="true" loop="true" quality="high" allowscriptaccess="never" allownetworking="internal"></embed>
 			</object>
-		<!-- ELSEIF _file.S_QUICKTIME_FILE -->
-			<object id="qtstream_{_file.ATTACH_ID}" classid="clsid:02BF25D5-8C17-4B23-BC80-D3488ABDDC6B" codebase="http://www.apple.com/qtactivex/qtplugin.cab#version=6,0,2,0" width="320" height="285">
-				<param name="src" value="{_file.U_DOWNLOAD_LINK}" />
-				<param name="controller" value="true" />
-				<param name="autoplay" value="false" />
-				<param name="type" value="video/quicktime" />
-				<embed name="qtstream_{_file.ATTACH_ID}" src="{_file.U_DOWNLOAD_LINK}" pluginspage="http://www.apple.com/quicktime/download/" enablejavascript="true" controller="true" width="320" height="285" type="video/quicktime" autoplay="false"></embed>
-			</object>
-		<!-- ELSEIF _file.S_RM_FILE -->
-			<object id="rmstream_{_file.ATTACH_ID}" classid="clsid:CFCDAA03-8BE4-11cf-B84B-0020AFBBCCFA" width="200" height="50">
-				<param name="src" value="{_file.U_DOWNLOAD_LINK}" />
-				<param name="autostart" value="false" />
-				<param name="controls" value="ImageWindow" />
-				<param name="console" value="ctrls_{_file.ATTACH_ID}" />
-				<param name="prefetch" value="false" />
-				<embed name="rmstream_{_file.ATTACH_ID}" type="audio/x-pn-realaudio-plugin" src="{_file.U_DOWNLOAD_LINK}" width="0" height="0" autostart="false" controls="ImageWindow" console="ctrls_{_file.ATTACH_ID}" prefetch="false"></embed>
-			</object>
-			<br />
-			<object id="ctrls_{_file.ATTACH_ID}" classid="clsid:CFCDAA03-8BE4-11cf-B84B-0020AFBBCCFA" width="0" height="36">
-				<param name="controls" value="ControlPanel" />
-				<param name="console" value="ctrls_{_file.ATTACH_ID}" />
-				<embed name="ctrls_{_file.ATTACH_ID}" type="audio/x-pn-realaudio-plugin" width="200" height="36" controls="ControlPanel" console="ctrls_{_file.ATTACH_ID}"></embed>
-			</object>
-
-			<script type="text/javascript">
-			// <![CDATA[
-				if (document.rmstream_{_file.ATTACH_ID}.GetClipWidth)
-				{
-					while (!document.rmstream_{_file.ATTACH_ID}.GetClipWidth())
-					{
-					}
-
-					var width = document.rmstream_{_file.ATTACH_ID}.GetClipWidth();
-					var height = document.rmstream_{_file.ATTACH_ID}.GetClipHeight();
-
-					document.rmstream_{_file.ATTACH_ID}.width = width;
-					document.rmstream_{_file.ATTACH_ID}.height = height;
-					document.ctrls_{_file.ATTACH_ID}.width = width;
-				}
-			// ]]>
-			</script>
-		<!-- ENDIF -->
-
-		<!-- IF _file.S_WM_FILE or _file.S_RM_FILE or _file.S_FLASH_FILE or _file.S_QUICKTIME_FILE -->
-			<p>
-			<!-- IF _file.S_QUICKTIME_FILE --><a href="#" onclick="play_qt_file(document.qtstream_{_file.ATTACH_ID}); return false;">[ {L_PLAY_QUICKTIME_FILE} ]</a> <!-- ENDIF -->
-			<a href="{_file.U_DOWNLOAD_LINK}">{_file.DOWNLOAD_NAME}</a> [ {_file.FILESIZE} {_file.SIZE_LANG} | {_file.L_DOWNLOAD_COUNT} ]</p>
+			<p><a href="{_file.U_DOWNLOAD_LINK}">{_file.DOWNLOAD_NAME}</a> [ {_file.FILESIZE} {_file.SIZE_LANG} | {_file.L_DOWNLOAD_COUNT} ]</p>
 		<!-- ENDIF -->
 
 		<!-- EVENT attachment_file_append -->


### PR DESCRIPTION
Remove code for handling media in RealPlayer, QuickTime, and Windows Media
Player.

[PHPBB3-12505](https://tracker.phpbb.com/browse/PHPBB3-12505)
~~https://github.com/phpbb/phpbb/pull/2462~~