### PR TITLE
[ticket/13703] Update upload.php

### DIFF
--- a/phpBB/phpbb/avatar/driver/upload.php
+++ b/phpBB/phpbb/avatar/driver/upload.php
@@ -48,8 +48,9 @@ class upload extends \phpbb\avatar\driver\driver
 	*/
 	public function get_data($row, $ignore_config = false)
 	{
+		$root_path = (defined('PHPBB_USE_BOARD_URL_PATH') && PHPBB_USE_BOARD_URL_PATH) ? generate_board_url() . '/' : $this->path_helper->get_web_root_path();
 		return array(
-			'src' => $this->path_helper->get_web_root_path() . 'download/file.' . $this->php_ext . '?avatar=' . $row['avatar'],
+			'src' => $root_path . 'download/file.' . $this->php_ext . '?avatar=' . $row['avatar'],
 			'width' => $row['avatar_width'],
 			'height' => $row['avatar_height'],
 		);


### PR DESCRIPTION
[3.1.X] upload driver for avatar tweak

This change makes the uploaded avatars use the PHPBB_USE_BOARD_URL_PATH constant, which is needed when trying to use the get_user_avatar() function in a listener for index changes.

The reason for this is change is avatars when loaded thru events for index page when phpbb is is a subfolder situation would be set to ./../ instead of still being set to ./ for avatar this change permits that it's a simple line i saw in your smilies functions.

PHPBB3-13703
