### PR TITLE
[Ticket/13742] Update local.php same as ticket/13703

### DIFF
--- a/phpBB/phpbb/avatar/driver/local.php
+++ b/phpBB/phpbb/avatar/driver/local.php
@@ -23,8 +23,9 @@ class local extends \phpbb\avatar\driver\driver
 	*/
 	public function get_data($row)
 	{
+		$root_path = (defined('PHPBB_USE_BOARD_URL_PATH') && PHPBB_USE_BOARD_URL_PATH) ? generate_board_url() . '/' : $this->path_helper->get_web_root_path();
 		return array(
-			'src' => $this->path_helper->get_web_root_path() . $this->config['avatar_gallery_path'] . '/' . $row['avatar'],
+			'src' => $root_path . $this->config['avatar_gallery_path'] . '/' . $row['avatar'],
 			'width' => $row['avatar_width'],
 			'height' => $row['avatar_height'],
 		);


### PR DESCRIPTION


[Ticket/13742] Local Gallery driver for avatar tweak

This change makes the uploaded avatars use the PHPBB_USE_BOARD_URL_PATH constant, which is needed when trying to use the get_user_avatar() function in a listener for index changes.

The reason for this is change is avatars when loaded thru events for index page when phpbb is is a subfolder situation would be set to ./../ instead of still being set to ./ for avatar this change permits that it's a simple line i saw in your smilies functions.

PHPBB3-13742
