### PR TITLE
[ticket/13742] Use correct avatar path for local avatar

### DIFF
--- a/phpBB/phpbb/avatar/driver/local.php
+++ b/phpBB/phpbb/avatar/driver/local.php
@@ -23,8 +23,10 @@ class local extends \phpbb\avatar\driver\driver
 	*/
 	public function get_data($row)
 	{
+		$root_path = (defined('PHPBB_USE_BOARD_URL_PATH') && PHPBB_USE_BOARD_URL_PATH) ? generate_board_url() . '/' : $this->path_helper->get_web_root_path();
+
 		return array(
-			'src' => $this->path_helper->get_web_root_path() . $this->config['avatar_gallery_path'] . '/' . $row['avatar'],
+			'src' => $root_path . $this->config['avatar_gallery_path'] . '/' . $row['avatar'],
 			'width' => $row['avatar_width'],
 			'height' => $row['avatar_height'],
 		);


### PR DESCRIPTION
Prior to this change, the path might have been incorrect when using
PHPBB_USE_BOARD_URL_PATH.

Ticket: https://tracker.phpbb.com/browse/PHPBB3-13742

Replaces #3516 