### PR TITLE
[ticket/13743] Add $phpbb_root_path and $phpEx definitions in message_parser.php

### DIFF
--- a/phpBB/includes/message_parser.php
+++ b/phpBB/includes/message_parser.php
@@ -21,6 +21,19 @@ if (!defined('IN_PHPBB'))
 
 if (!class_exists('bbcode'))
 {
+	// The following lines are for extensions which include message_parser.php
+	// while $phpbb_root_path and $phpEx are out of the script scope
+	// which may lead to the 'Undefined variable' and 'failed to open stream' errors
+	if (!isset($phpbb_root_path))
+	{
+		global $phpbb_root_path;
+	}
+
+	if (!isset($phpEx))
+	{
+		global $phpEx;
+	}
+
 	include($phpbb_root_path . 'includes/bbcode.' . $phpEx);
 }
 


### PR DESCRIPTION
```message_parser.php``` performs include of bbcode.php at the very start using
```$phpbb_root_path``` and ```$phpEx``` vars, so there's a possibility those can be
undefined at that point, especially when message_parser.php is being included
in event listener or another extension file where ```$phpbb_root_path``` and ```$phpEx```
don't exist. This can be fixed by adding the appropriate vars definitions.

<a href="https://tracker.phpbb.com/browse/PHPBB3-13743">PHPBB3-13743</a>.