### PR TITLE
[ticket/13753] Add template events to forum category row headers

### DIFF
--- a/phpBB/docs/events.md
+++ b/phpBB/docs/events.md
@@ -297,15 +297,15 @@ forumlist_body_category_header_row_append
 ===
 * Locations:
     + styles/prosilver/template/forumlist_body.html
-* Since: 3.1.4-RC1
-* Purpose: Add content before the header row of the category on the forum list.
+* Since: 3.1.5-RC1
+* Purpose: Add content after the header row of the category on the forum list.
 
 forumlist_body_category_header_row_prepend
 ===
 * Locations:
     + styles/prosilver/template/forumlist_body.html
-* Since: 3.1.4-RC1
-* Purpose: Add content after the header row of the category on the forum list.
+* Since: 3.1.5-RC1
+* Purpose: Add content before the header row of the category on the forum list.
 
 forumlist_body_forum_row_after
 ===

--- a/phpBB/docs/events.md
+++ b/phpBB/docs/events.md
@@ -293,6 +293,20 @@ forumlist_body_category_header_before
 * Since: 3.1.0-a4
 * Purpose: Add content before the header of the category on the forum list.
 
+forumlist_body_category_header_row_append
+===
+* Locations:
+    + styles/prosilver/template/forumlist_body.html
+* Since: 3.1.4-RC1
+* Purpose: Add content before the header row of the category on the forum list.
+
+forumlist_body_category_header_row_prepend
+===
+* Locations:
+    + styles/prosilver/template/forumlist_body.html
+* Since: 3.1.4-RC1
+* Purpose: Add content after the header row of the category on the forum list.
+
 forumlist_body_forum_row_after
 ===
 * Locations:

--- a/phpBB/styles/prosilver/template/forumlist_body.html
+++ b/phpBB/styles/prosilver/template/forumlist_body.html
@@ -13,12 +13,14 @@
 			<div class="inner">
 			<ul class="topiclist">
 				<li class="header">
+					<!-- EVENT forumlist_body_category_header_row_prepend -->
 					<dl class="icon">
 						<dt><div class="list-inner"><!-- IF forumrow.S_IS_CAT --><a href="{forumrow.U_VIEWFORUM}">{forumrow.FORUM_NAME}</a><!-- ELSE -->{L_FORUM}<!-- ENDIF --></div></dt>
 						<dd class="topics">{L_TOPICS}</dd>
 						<dd class="posts">{L_POSTS}</dd>
 						<dd class="lastpost"><span>{L_LAST_POST}</span></dd>
 					</dl>
+					<!-- EVENT forumlist_body_category_header_row_append -->
 				</li>
 			</ul>
 			<ul class="topiclist forums">


### PR DESCRIPTION
https://tracker.phpbb.com/browse/PHPBB3-13753

PHPBB3-13753

I did not include subsilver in this PR because it's design does not seem to lend itself well to this event, partly because it's tabular but mostly because unlike in prosilver, this category/header section of subsilver is broken into three different locations.