### PR TITLE
Take into account $data['post_time'] in submit_post

### DIFF
--- a/phpBB/includes/functions_posting.php
+++ b/phpBB/includes/functions_posting.php
@@ -1542,7 +1542,14 @@ function submit_post($mode, $subject, $username, $topic_type, &$poll, &$data, $u
 		return false;
 	}
 
-	$current_time = time();
+	if (!empty($data['post_time']))
+	{
+		$current_time = $data['post_time'];
+	}
+	else
+	{
+		$current_time = time();
+	}
 
 	if ($mode == 'post')
 	{


### PR DESCRIPTION
Without this, the $data['post_time'] mentioned in the Function.submit_post documentation is pretty useless.

This is fundamental when migrating non mySQL-based forums (e.g. Sourceforge) with posts back in time