### PR TITLE
[ticket/13761] Use __DIR__ for phpbb_root_path

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -12,8 +12,15 @@
 */
 
 define('IN_PHPBB', true);
-$phpbb_root_path = __DIR__ . '/../phpBB/';
+$phpbb_root_path = 'phpBB/';
 $phpEx = 'php';
+
+// We need to check if we got problems with relative paths
+if (!file_exists($phpbb_root_path . 'includes/startup.php'))
+{
+	$phpbb_root_path = __DIR__ . '/../phpBB/';
+}
+
 require_once $phpbb_root_path . 'includes/startup.php';
 
 $table_prefix = 'phpbb_';

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -12,7 +12,7 @@
 */
 
 define('IN_PHPBB', true);
-$phpbb_root_path = 'phpBB/';
+$phpbb_root_path = __DIR__ . '/../phpBB/';
 $phpEx = 'php';
 require_once $phpbb_root_path . 'includes/startup.php';
 


### PR DESCRIPTION
Adding `__DIR__` to `$phpbb_root_path`, so that the correct folder for
includes
is chosen when the test suites are executed in different environments.

PHPBB3-13761