### PR TITLE
[ticket/12745] Allow Unicode characters from the SMP to be used in text

### DIFF
--- a/phpBB/composer.lock
+++ b/phpBB/composer.lock
@@ -169,12 +169,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/s9e/TextFormatter.git",
-                "reference": "5b7d4c40bdef53f26ca6b09e85163f28e852f16b"
+                "reference": "31fe627a4a82d41098a2db8036287c0693c79f13"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/s9e/TextFormatter/zipball/5b7d4c40bdef53f26ca6b09e85163f28e852f16b",
-                "reference": "5b7d4c40bdef53f26ca6b09e85163f28e852f16b",
+                "url": "https://api.github.com/repos/s9e/TextFormatter/zipball/31fe627a4a82d41098a2db8036287c0693c79f13",
+                "reference": "31fe627a4a82d41098a2db8036287c0693c79f13",
                 "shasum": ""
             },
             "require": {
@@ -219,7 +219,7 @@
                 "parser",
                 "shortcodes"
             ],
-            "time": "2015-04-22 15:15:46"
+            "time": "2015-04-25 20:58:33"
         },
         {
             "name": "symfony/config",

--- a/phpBB/includes/message_parser.php
+++ b/phpBB/includes/message_parser.php
@@ -1241,15 +1241,6 @@ class parse_message extends bbcode_firstpass
 		// Parse this message
 		$this->message = $parser->parse(htmlspecialchars_decode($this->message, ENT_QUOTES));
 
-		// Check for out-of-bounds characters that are currently
-		// not supported by utf8_bin in MySQL
-		if (preg_match_all('/[\x{10000}-\x{10FFFF}]/u', $this->message, $matches))
-		{
-			$character_list = implode('<br />', $matches[0]);
-			$this->warn_msg[] = $user->lang('UNSUPPORTED_CHARACTERS_MESSAGE', $character_list);
-			return $update_this_message ? $this->warn_msg : $return_message;
-		}
-
 		// Check for "empty" message. We do not check here for maximum length, because bbcode, smilies, etc. can add to the length.
 		// The maximum length check happened before any parsings.
 		if ($mode === 'post' && utf8_clean_string($this->message) === '')

--- a/tests/functional/posting_test.php
+++ b/tests/functional/posting_test.php
@@ -45,18 +45,20 @@ class phpbb_functional_posting_test extends phpbb_functional_test_case
 
 		self::create_post(2,
 			1,
-			'Unsupported characters',
-			"This is a test with these weird characters: \xF0\x9F\x88\xB3 \xF0\x9F\x9A\xB6",
-			array(),
-			'Your message contains the following unsupported characters'
-		);
-
-		self::create_post(2,
-			1,
 			"Unsupported: \xF0\x9F\x88\xB3 \xF0\x9F\x9A\xB6",
 			'This is a test with emoji characters in the topic title.',
 			array(),
 			'Your subject contains the following unsupported characters'
 		);
+	}
+
+	public function test_supported_unicode_characters()
+	{
+		$this->login();
+
+		$post = $this->create_topic(2, 'Test Topic 1', 'This is a test topic posted by the testing framework.');
+		$this->create_post(2, $post['topic_id'], 'Re: Test Topic 1', "This is a test with these weird characters: \xF0\x9F\x88\xB3 \xF0\x9F\x9A\xB6");
+		$crawler = self::request('GET', "viewtopic.php?t={$post['topic_id']}&sid={$this->sid}");
+		$this->assertContains("\xF0\x9F\x88\xB3 \xF0\x9F\x9A\xB6", $crawler->text());
 	}
 }

--- a/tests/functional/posting_test.php
+++ b/tests/functional/posting_test.php
@@ -61,4 +61,14 @@ class phpbb_functional_posting_test extends phpbb_functional_test_case
 		$crawler = self::request('GET', "viewtopic.php?t={$post['topic_id']}&sid={$this->sid}");
 		$this->assertContains("\xF0\x9F\x88\xB3 \xF0\x9F\x9A\xB6", $crawler->text());
 	}
+
+	public function test_html_entities()
+	{
+		$this->login();
+
+		$post = $this->create_topic(2, 'Test Topic 1', 'This is a test topic posted by the testing framework.');
+		$this->create_post(2, $post['topic_id'], 'Re: Test Topic 1', '&#128512;');
+		$crawler = self::request('GET', "viewtopic.php?t={$post['topic_id']}&sid={$this->sid}");
+		$this->assertContains('&#128512;', $crawler->text());
+	}
 }


### PR DESCRIPTION
https://tracker.phpbb.com/browse/PHPBB3-12745
https://tracker.phpbb.com/browse/PHPBB3-13178
~~https://tracker.phpbb.com/browse/PHPBB3-11711~~

[This update to s9e\TextFormatter](https://github.com/s9e/TextFormatter/commit/42d614c08e5f3ce5d35a29867d58a7f50fed7c91) automatically encodes characters from the Supplementary Multilingual Plane, making it possible to use those characters in formatted text regardless of the database.