### PR TITLE
[ticket/13779] Set new auth options to the role only if matching the role type

### DIFF
--- a/tests/dbal/fixtures/migrator_permission.xml
+++ b/tests/dbal/fixtures/migrator_permission.xml
@@ -27,5 +27,139 @@
 			<value>1</value>
 			<value>0</value>
 		</row>
+		<row>
+			<value>4</value>
+			<value>a_test</value>
+			<value>1</value>
+			<value>0</value>
+			<value>0</value>
+		</row>
+		<row>
+			<value>5</value>
+			<value>m_test</value>
+			<value>1</value>
+			<value>0</value>
+			<value>0</value>
+		</row>
+		<row>
+			<value>6</value>
+			<value>u_test</value>
+			<value>1</value>
+			<value>0</value>
+			<value>0</value>
+		</row>
+	</table>
+
+	<table name="phpbb_groups">
+		<column>group_id</column>
+		<column>group_name</column>
+		<column>group_desc</column>
+		<row>
+			<value>2</value>
+			<value>REGISTERED</value>
+			<value></value>
+		</row>
+		<row>
+			<value>4</value>
+			<value>GLOBAL_MODERATORS</value>
+			<value></value>
+		</row>
+		<row>
+			<value>5</value>
+			<value>ADMINISTRATORS</value>
+			<value></value>
+		</row>
+	</table>
+
+	<table name="phpbb_acl_groups">
+		<column>group_id</column>
+		<column>auth_role_id</column>
+		<column>forum_id</column>
+		<row>
+			<value>2</value>
+			<value>5</value>
+			<value>0</value>
+		</row>
+		<row>
+			<value>4</value>
+			<value>5</value>
+			<value>0</value>
+		</row>
+		<row>
+			<value>4</value>
+			<value>10</value>
+			<value>0</value>
+		</row>
+		<row>
+			<value>5</value>
+			<value>1</value>
+			<value>0</value>
+		</row>
+		<row>
+			<value>5</value>
+			<value>5</value>
+			<value>0</value>
+		</row>
+	</table>
+
+	<table name="phpbb_acl_roles">
+		<column>role_id</column>
+		<column>role_name</column>
+		<column>role_type</column>
+		<column>role_description</column>
+		<row>
+			<value>1</value>
+			<value>ROLE_ADMIN_STANDARD</value>
+			<value>a_</value>
+			<value></value>
+		</row>
+		<row>
+			<value>5</value>
+			<value>ROLE_USER_FULL</value>
+			<value>u_</value>
+			<value></value>
+		</row>
+		<row>
+			<value>10</value>
+			<value>ROLE_MOD_FULL</value>
+			<value>m_</value>
+			<value></value>
+		</row>
+	</table>
+
+	<table name="phpbb_acl_roles_data">
+		<column>role_id</column>
+		<column>auth_option_id</column>
+		<column>auth_setting</column>
+		<row>
+			<value>1</value>
+			<value>4</value>
+			<value>0</value>
+		</row>
+		<row>
+			<value>1</value>
+			<value>5</value>
+			<value>0</value>
+		</row>
+		<row>
+			<value>1</value>
+			<value>6</value>
+			<value>0</value>
+		</row>
+		<row>
+			<value>6</value>
+			<value>6</value>
+			<value>0</value>
+		</row>
+		<row>
+			<value>10</value>
+			<value>5</value>
+			<value>0</value>
+		</row>
+		<row>
+			<value>10</value>
+			<value>6</value>
+			<value>0</value>
+		</row>
 	</table>
 </dataset>


### PR DESCRIPTION
Migrations' permission tool allows setting permissions to the role which
doesn't match the role type, e.g. m_ permissions for u_ role types and so on.
As one of side effects, this may lead to granting users moderative/admin
permissions silently.
With this patch the only new permissions matching the role type will be set.

<a href="https://tracker.phpbb.com/browse/PHPBB3-13779">PHPBB3-13779</a>.