### PR TITLE
[ticket/12230] Remove users from new users group when post limit is 0

### DIFF
--- a/phpBB/includes/session.php
+++ b/phpBB/includes/session.php
@@ -443,7 +443,7 @@ class session
 								$db->sql_query($sql);
 							}
 
-							if ($this->data['user_id'] != ANONYMOUS && !empty($config['new_member_post_limit']) && $this->data['user_new'] && $config['new_member_post_limit'] <= $this->data['user_posts'])
+							if ($this->data['user_id'] != ANONYMOUS && isset($config['new_member_post_limit']) && $this->data['user_new'] && $config['new_member_post_limit'] <= $this->data['user_posts'])
 							{
 								$this->leave_newly_registered();
 							}


### PR DESCRIPTION
I thought about removing that part completely, but I saw that session_begin() is used in the updater so I just changed it to an `isset()` call.

I'm not sure - do we need a special 3.1.x PR? GitHub said at first that it can't be merged without problems, but when I merged this branch into a 3.1.x branch there were no conflicts.

[PHPBB3-12230](https://tracker.phpbb.com/browse/PHPBB3-12230)