### PR TITLE
[ticket/12101] Remove HTML redirect workaround for Microsoft/IIS webserver

### DIFF
--- a/phpBB/includes/functions.php
+++ b/phpBB/includes/functions.php
@@ -2389,7 +2389,7 @@ function redirect($url, $return = false, $disable_cd_check = false)
 	}
 
 	// Redirect via an HTML form for PITA webservers
-	if (@preg_match('#Microsoft|WebSTAR|Xitami#', getenv('SERVER_SOFTWARE')))
+	if (@preg_match('#WebSTAR|Xitami#', getenv('SERVER_SOFTWARE')))
 	{
 		header('Refresh: 0; URL=' . $url);
 


### PR DESCRIPTION
The code was added as a workaround for bugs in very old versions of IIS,
dating back to 2002: see commit 849d76697444f4e3523845f8c96569ccde57d868.

Newer IIS versions handle the "Location" header just fine, so we can avoid
the unnecessary HTML page for redirects. Given that it seems to work fine
since IIS 6.0 (on WinServer 2003), I don't think it's worth adding a special
check for earlier versions as they are no longer supported by MS as well.

[PHPBB3-12101](https://tracker.phpbb.com/browse/PHPBB3-12101)