### PR TITLE
[ticket/13791] Add more post buttons template events to viewtopic_body.html

### DIFF
--- a/phpBB/docs/events.md
+++ b/phpBB/docs/events.md
@@ -1635,6 +1635,22 @@ viewtopic_body_post_buttons_before
 * Purpose: Add post button to posts (next to edit, quote etc), at the start of
 the list.
 
+viewtopic_body_post_buttons_list_after
+===
+* Locations:
+    + styles/prosilver/template/viewtopic_body.html
+* Since: 3.1.5-RC1
+* Purpose: Add post button custom list to posts (next to edit, quote etc),
+after the original list.
+
+viewtopic_body_post_buttons_list_before
+===
+* Locations:
+    + styles/prosilver/template/viewtopic_body.html
+* Since: 3.1.5-RC1
+* Purpose: Add post button custom list to posts (next to edit, quote etc),
+before the original list.
+
 viewtopic_body_postrow_custom_fields_after
 ===
 * Locations:

--- a/phpBB/styles/prosilver/template/viewtopic_body.html
+++ b/phpBB/styles/prosilver/template/viewtopic_body.html
@@ -210,6 +210,7 @@
 
 			<h3 <!-- IF postrow.S_FIRST_ROW -->class="first"<!-- ENDIF -->><!-- IF postrow.POST_ICON_IMG --><img src="{T_ICONS_PATH}{postrow.POST_ICON_IMG}" width="{postrow.POST_ICON_IMG_WIDTH}" height="{postrow.POST_ICON_IMG_HEIGHT}" alt="" /> <!-- ENDIF --><a href="#p{postrow.POST_ID}">{postrow.POST_SUBJECT}</a></h3>
 
+		<!-- EVENT viewtopic_body_post_buttons_list_before -->
 		<!-- IF not S_IS_BOT -->
 			<!-- IF postrow.U_EDIT or postrow.U_DELETE or postrow.U_REPORT or postrow.U_WARN or postrow.U_INFO or postrow.U_QUOTE -->
 				<ul class="post-buttons">
@@ -248,6 +249,7 @@
 				</ul>
 			<!-- ENDIF -->
 		<!-- ENDIF -->
+		<!-- EVENT viewtopic_body_post_buttons_list_after -->
 
 			<!-- EVENT viewtopic_body_postrow_post_details_before -->
 			<p class="author"><!-- IF S_IS_BOT -->{postrow.MINI_POST_IMG}<!-- ELSE --><a href="{postrow.U_MINI_POST}">{postrow.MINI_POST_IMG}</a><!-- ENDIF --><span class="responsive-hide">{L_POST_BY_AUTHOR} <strong>{postrow.POST_AUTHOR_FULL}</strong> &raquo; </span>{postrow.POST_DATE} </p>


### PR DESCRIPTION
The purpose is to allow adding custom post buttons outside of the original post
buttons conditionals/list in prosilver (for subsilver2 it's not the issue).

<a href="https://tracker.phpbb.com/browse/PHPBB3-13791">PHPBB3-13791</a>.