### PR TITLE
[ticket/8419] Custom tag eats up space character

### DIFF
--- a/tests/text_processing/tickets_data/PHPBB3-8419.html
+++ b/tests/text_processing/tickets_data/PHPBB3-8419.html
@@ -1,0 +1,1 @@
+<span style="font-style: italic"><span style="font-weight: bold"><span style="color: #FF0000">tę </span></span></span>przykład

--- a/tests/text_processing/tickets_data/PHPBB3-8419.txt
+++ b/tests/text_processing/tickets_data/PHPBB3-8419.txt
@@ -1,0 +1,1 @@
+[ort]tę [/ort]przykład

--- a/tests/text_processing/tickets_data/PHPBB3-8419.xml
+++ b/tests/text_processing/tickets_data/PHPBB3-8419.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<dataset>
+	<table name="phpbb_bbcodes">
+		<column>bbcode_id</column>
+		<column>bbcode_tag</column>
+		<column>bbcode_helpline</column>
+		<column>display_on_posting</column>
+		<column>bbcode_match</column>
+		<column>bbcode_tpl</column>
+		<column>first_pass_match</column>
+		<column>first_pass_replace</column>
+		<column>second_pass_match</column>
+		<column>second_pass_replace</column>
+
+		<row>
+			<value>13</value>
+			<value>myemail</value>
+			<value></value>
+			<value>1</value>
+			<value>[ort]{TEXT}[/ort]</value>
+			<value><![CDATA[<span style="font-style: italic"><span style="font-weight: bold"><span style="color: #FF0000">{TEXT}</span></span></span>]]></value>
+			<value><![CDATA[!\[ort\](.*?)\[/ort\]!ies]]></value>
+			<value><![CDATA['[ort:$uid]'.str_replace(array("\r\n", '\"', '\'', '(', ')'), array("\n", '"', '&#39;', '&#40;', '&#41;'), trim('${1}')).'[/ort:$uid]']]></value>
+			<value><![CDATA[!\[ort:$uid\](.*?)\[/ort:$uid\]!s]]></value>
+			<value><![CDATA[<span style="font-style: italic"><span style="font-weight: bold"><span style="color: #FF0000">${1}</span></span></span>]]></value>
+		</row>
+	</table>
+</dataset>


### PR DESCRIPTION
The original ticket has some formatting problem of its own but I tested it manually on my local board and indeed 3.1 removes the space at the end and 3.2 does not.

https://tracker.phpbb.com/browse/PHPBB3-8419