### PR TITLE
[ticket/13782] Rename classes that use reserved PHP7 keywords

### DIFF
--- a/phpBB/install/install_convert.php
+++ b/phpBB/install/install_convert.php
@@ -153,7 +153,7 @@ class install_convert extends module
 				unset($dbpasswd);
 
 				// We need to fill the config to let internal functions correctly work
-				$config = new \phpbb\config\db($db, new \phpbb\cache\driver\null, CONFIG_TABLE);
+				$config = new \phpbb\config\db($db, new \phpbb\cache\driver\dummy, CONFIG_TABLE);
 
 				// Detect if there is already a conversion in progress at this point and offer to resume
 				// It's quite possible that the user will get disconnected during a large conversion so they need to be able to resume it
@@ -392,7 +392,7 @@ class install_convert extends module
 		$this->page_title = $lang['STAGE_SETTINGS'];
 
 		// We need to fill the config to let internal functions correctly work
-		$config = new \phpbb\config\db($db, new \phpbb\cache\driver\null, CONFIG_TABLE);
+		$config = new \phpbb\config\db($db, new \phpbb\cache\driver\dummy, CONFIG_TABLE);
 
 		$convertor_tag = $request->variable('tag', '');
 
@@ -639,7 +639,7 @@ class install_convert extends module
 		unset($dbpasswd);
 
 		// We need to fill the config to let internal functions correctly work
-		$config = new \phpbb\config\db($db, new \phpbb\cache\driver\null, CONFIG_TABLE);
+		$config = new \phpbb\config\db($db, new \phpbb\cache\driver\dummy, CONFIG_TABLE);
 
 		// Override a couple of config variables for the duration
 		$config['max_quote_depth'] = 0;

--- a/phpBB/install/install_install.php
+++ b/phpBB/install/install_install.php
@@ -1522,7 +1522,7 @@ class install_install extends module
 		include_once($phpbb_root_path . 'phpbb/search/fulltext_native.' . $phpEx);
 
 		// We need to fill the config to let internal functions correctly work
-		$config = new \phpbb\config\db($db, new \phpbb\cache\driver\null, CONFIG_TABLE);
+		$config = new \phpbb\config\db($db, new \phpbb\cache\driver\dummy, CONFIG_TABLE);
 
 		$error = false;
 		$search = new \phpbb\search\fulltext_native($error, $phpbb_root_path, $phpEx, $auth, $config, $db, $user);
@@ -1937,7 +1937,7 @@ class install_install extends module
 		$data = $this->get_submitted_data();
 
 		// We need to fill the config to let internal functions correctly work
-		$config = new \phpbb\config\db($db, new \phpbb\cache\driver\null, CONFIG_TABLE);
+		$config = new \phpbb\config\db($db, new \phpbb\cache\driver\dummy, CONFIG_TABLE);
 
 		$sql = 'SELECT group_id
 			FROM ' . GROUPS_TABLE . "
@@ -2009,7 +2009,7 @@ class install_install extends module
 		$data = $this->get_submitted_data();
 
 		// We need to fill the config to let internal functions correctly work
-		$config = new \phpbb\config\db($db, new \phpbb\cache\driver\null, CONFIG_TABLE);
+		$config = new \phpbb\config\db($db, new \phpbb\cache\driver\dummy, CONFIG_TABLE);
 
 		$user->session_begin();
 		$auth->login($data['admin_name'], $data['admin_pass1'], false, true, true);

--- a/phpBB/install/install_update.php
+++ b/phpBB/install/install_update.php
@@ -118,7 +118,7 @@ class install_update extends module
 		unset($dbpasswd);
 
 		// We need to fill the config to let internal functions correctly work
-		$config = new \phpbb\config\db($db, new \phpbb\cache\driver\null, CONFIG_TABLE);
+		$config = new \phpbb\config\db($db, new \phpbb\cache\driver\dummy, CONFIG_TABLE);
 
 		// Force template recompile
 		$config['load_tplcompile'] = 1;

--- a/phpBB/phpbb/cache/driver/dummy.php
+++ b/phpBB/phpbb/cache/driver/dummy.php
@@ -14,9 +14,9 @@
 namespace phpbb\cache\driver;
 
 /**
-* ACM Null Caching
+* ACM dummy Caching
 */
-class null extends \phpbb\cache\driver\base
+class dummy extends \phpbb\cache\driver\base
 {
 	/**
 	* Set cache path

--- a/phpBB/phpbb/log/dummy.php
+++ b/phpBB/phpbb/log/dummy.php
@@ -14,9 +14,9 @@
 namespace phpbb\log;
 
 /**
-* Null logger
+* Dummy logger
 */
-class null implements log_interface
+class dummy implements log_interface
 {
 	/**
 	* {@inheritdoc}

--- a/tests/cache/dummy_driver_test.php
+++ b/tests/cache/dummy_driver_test.php
@@ -11,7 +11,7 @@
 *
 */
 
-class phpbb_cache_null_driver_test extends phpbb_database_test_case
+class phpbb_cache_dummy_driver_test extends phpbb_database_test_case
 {
 	protected $driver;
 

--- a/tests/cache/null_driver_test.php
+++ b/tests/cache/null_driver_test.php
@@ -24,7 +24,7 @@ class phpbb_cache_null_driver_test extends phpbb_database_test_case
 	{
 		parent::setUp();
 
-		$this->driver = new \phpbb\cache\driver\null;
+		$this->driver = new \phpbb\cache\driver\dummy;
 	}
 
 	public function test_get_put()

--- a/tests/console/cache/purge_test.php
+++ b/tests/console/cache/purge_test.php
@@ -91,7 +91,7 @@ class phpbb_console_command_cache_purge_test extends phpbb_test_case
 	public function get_command_tester()
 	{
 		$application = new Application();
-		$application->add(new purge($this->user, $this->cache, $this->db, $this->getMock('\phpbb\auth\auth'), new \phpbb\log\null(), $this->config));
+		$application->add(new purge($this->user, $this->cache, $this->db, $this->getMock('\phpbb\auth\auth'), new \phpbb\log\dummy(), $this->config));
 
 		$command = $application->find('cache:purge');
 		$this->command_name = $command->getName();

--- a/tests/dbal/migrator_tool_module_test.php
+++ b/tests/dbal/migrator_tool_module_test.php
@@ -31,7 +31,7 @@ class phpbb_dbal_migrator_tool_module_test extends phpbb_database_test_case
 		$skip_add_log = true;
 
 		$db = $this->db = $this->new_dbal();
-		$this->cache = new \phpbb\cache\service(new \phpbb\cache\driver\null(), new \phpbb\config\config(array()), $this->db, $phpbb_root_path, $phpEx);
+		$this->cache = new \phpbb\cache\service(new \phpbb\cache\driver\dummy(), new \phpbb\config\config(array()), $this->db, $phpbb_root_path, $phpEx);
 		$lang_loader = new \phpbb\language\language_file_loader($phpbb_root_path, $phpEx);
 		$lang = new \phpbb\language\language($lang_loader);
 		$user = $this->user = new \phpbb\user($lang, '\phpbb\datetime');

--- a/tests/dbal/migrator_tool_permission_test.php
+++ b/tests/dbal/migrator_tool_permission_test.php
@@ -28,7 +28,7 @@ class phpbb_dbal_migrator_tool_permission_test extends phpbb_database_test_case
 		parent::setup();
 
 		$db = $this->db = $this->new_dbal();
-		$cache = $this->cache = new \phpbb\cache\service(new \phpbb\cache\driver\null(), new \phpbb\config\config(array()), $this->db, $phpbb_root_path, $phpEx);
+		$cache = $this->cache = new \phpbb\cache\service(new \phpbb\cache\driver\dummy(), new \phpbb\config\config(array()), $this->db, $phpbb_root_path, $phpEx);
 		$this->auth = new \phpbb\auth\auth();
 
 		$this->tool = new \phpbb\db\migration\tool\permission($this->db, $this->cache, $this->auth, $phpbb_root_path, $phpEx);

--- a/tests/functions_user/group_user_attributes_test.php
+++ b/tests/functions_user/group_user_attributes_test.php
@@ -139,7 +139,7 @@ class phpbb_functions_user_group_user_attributes_test extends phpbb_database_tes
 		$auth = $this->getMock('\phpbb\auth\auth');
 		$auth->expects($this->any())
 			->method('acl_clear_prefetch');
-		$cache_driver = new \phpbb\cache\driver\null();
+		$cache_driver = new \phpbb\cache\driver\dummy();
 		$phpbb_container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
 		$phpbb_container
 			->expects($this->any())

--- a/tests/notification/base.php
+++ b/tests/notification/base.php
@@ -63,7 +63,7 @@ abstract class phpbb_tests_notification_base extends phpbb_database_test_case
 		$this->user_loader = new \phpbb\user_loader($this->db, $phpbb_root_path, $phpEx, 'phpbb_users');
 		$auth = $this->auth = new phpbb_mock_notifications_auth();
 		$cache = $this->cache = new \phpbb\cache\service(
-			new \phpbb\cache\driver\null(),
+			new \phpbb\cache\driver\dummy(),
 			$this->config,
 			$this->db,
 			$phpbb_root_path,

--- a/tests/notification/group_request_test.php
+++ b/tests/notification/group_request_test.php
@@ -50,7 +50,7 @@ class phpbb_notification_group_request_test extends phpbb_tests_notification_bas
 			$this->cache->get_driver()
 		));
 		$phpbb_dispatcher = new phpbb_mock_event_dispatcher;
-		$phpbb_log = new \phpbb\log\null();
+		$phpbb_log = new \phpbb\log\dummy();
 		$this->get_test_case_helpers()->set_s9e_services();
 
 		// Now on to the actual test

--- a/tests/notification/submit_post_base.php
+++ b/tests/notification/submit_post_base.php
@@ -72,7 +72,7 @@ abstract class phpbb_notification_submit_post_base extends phpbb_database_test_c
 		$config = new \phpbb\config\config(array('num_topics' => 1,'num_posts' => 1,));
 
 		$cache = new \phpbb\cache\service(
-			new \phpbb\cache\driver\null(),
+			new \phpbb\cache\driver\dummy(),
 			$config,
 			$db,
 			$phpbb_root_path,

--- a/tests/notification/user_list_trim_test.php
+++ b/tests/notification/user_list_trim_test.php
@@ -35,7 +35,7 @@ class phpbb_notification_user_list_trim_test extends phpbb_database_test_case
 		$config = new \phpbb\config\config(array());
 
 		$cache = new \phpbb\cache\service(
-			new \phpbb\cache\driver\null(),
+			new \phpbb\cache\driver\dummy(),
 			$config,
 			$db,
 			$phpbb_root_path,

--- a/tests/test_framework/phpbb_functional_test_case.php
+++ b/tests/test_framework/phpbb_functional_test_case.php
@@ -574,7 +574,7 @@ class phpbb_functional_test_case extends phpbb_test_case
 		}
 		$cache = new phpbb_mock_null_cache;
 
-		$cache_driver = new \phpbb\cache\driver\null();
+		$cache_driver = new \phpbb\cache\driver\dummy();
 		$phpbb_container = new phpbb_mock_container_builder();
 		$phpbb_container->set('cache.driver', $cache_driver);
 		$phpbb_notifications = new phpbb_mock_notification_manager();
@@ -623,7 +623,7 @@ class phpbb_functional_test_case extends phpbb_test_case
 		$phpbb_log = new \phpbb\log\log($db, $user, $auth, $phpbb_dispatcher, $phpbb_root_path, 'adm/', $phpEx, LOG_TABLE);
 		$cache = new phpbb_mock_null_cache;
 
-		$cache_driver = new \phpbb\cache\driver\null();
+		$cache_driver = new \phpbb\cache\driver\dummy();
 		$phpbb_container = new phpbb_mock_container_builder();
 		$phpbb_container->set('cache.driver', $cache_driver);
 		$phpbb_container->set('notification_manager', new phpbb_mock_notification_manager());
@@ -665,7 +665,7 @@ class phpbb_functional_test_case extends phpbb_test_case
 		$phpbb_log = new \phpbb\log\log($db, $user, $auth, $phpbb_dispatcher, $phpbb_root_path, 'adm/', $phpEx, LOG_TABLE);
 		$cache = new phpbb_mock_null_cache;
 
-		$cache_driver = new \phpbb\cache\driver\null();
+		$cache_driver = new \phpbb\cache\driver\dummy();
 		$phpbb_container = $this->getMock('Symfony\Component\DependencyInjection\ContainerInterface');
 		$phpbb_container
 			->expects($this->any())

--- a/tests/version/version_helper_remote_test.php
+++ b/tests/version/version_helper_remote_test.php
@@ -30,7 +30,7 @@ class version_helper_remote_test extends \phpbb_test_case
 		));
 		$container = new \phpbb_mock_container_builder();
 		$db = new \phpbb\db\driver\factory($container);
-		$this->cache = $this->getMock('\phpbb\cache\service', array('get'), array(new \phpbb\cache\driver\null(), $config, $db, '../../', 'php'));
+		$this->cache = $this->getMock('\phpbb\cache\service', array('get'), array(new \phpbb\cache\driver\dummy(), $config, $db, '../../', 'php'));
 		$this->cache->expects($this->any())
 			->method('get')
 			->with($this->anything())


### PR DESCRIPTION
Ticket: https://tracker.phpbb.com/browse/PHPBB3-13782