### PR TITLE
[ticket/13814] Prevent phpbb_is_writable() method from truncating files

### DIFF
--- a/phpBB/phpbb/filesystem/filesystem.php
+++ b/phpBB/phpbb/filesystem/filesystem.php
@@ -613,7 +613,7 @@ class filesystem implements filesystem_interface
 			}
 			else
 			{
-				$handle = @fopen($file, 'w');
+				$handle = @fopen($file, 'c');
 
 				if (is_resource($handle))
 				{


### PR DESCRIPTION
```phpbb_is_writable()``` of the ```filesystem``` class uses ```w``` mode to ```fopen()``` files
which causes checked files to be truncated. Use the 'c' mode instead.

<a href="https://tracker.phpbb.com/browse/PHPBB3-13814">PHPBB3-13814</a>.