### PR TITLE
[ticket/13808] search_body_form_before

### DIFF
--- a/phpBB/docs/events.md
+++ b/phpBB/docs/events.md
@@ -1076,6 +1076,14 @@ quickreply_editor_message_before
 * Since: 3.1.0-a4
 * Purpose: Add content before the quick reply textbox
 
+search_body_form_before
+===
+* Locations:
+    + styles/prosilver/template/search_body.html
+    + styles/subsilver2/template/search_body.html
+* Since: 3.1.5
+* Purpose: Add content before the search form
+
 search_results_header_after
 ===
 * Locations:

--- a/phpBB/styles/prosilver/template/search_body.html
+++ b/phpBB/styles/prosilver/template/search_body.html
@@ -2,6 +2,7 @@
 
 <h2 class="solo">{L_SEARCH}</h2>
 
+<!-- EVENT search_body_form_before -->
 <form method="get" action="{S_SEARCH_ACTION}" data-focus="keywords">
 
 <div class="panel">

--- a/phpBB/styles/subsilver2/template/search_body.html
+++ b/phpBB/styles/subsilver2/template/search_body.html
@@ -2,6 +2,7 @@
 
 <div id="pagecontent">
 
+	<!-- EVENT search_body_form_before -->
 	<form method="get" action="{S_SEARCH_ACTION}">
 	
 	<table class="tablebg" width="100%" cellspacing="1">


### PR DESCRIPTION
Extensions may be designed to add secondary search options,
such as Google search in the search_body.html.
There are no events in the searchbody, so this should be merged.

PHPBB3-13808