### PR TITLE
[ticket/13828] Renamed testing doubles to avoid PHP7 keywords

### DIFF
--- a/tests/di/fixtures/config.php
+++ b/tests/di/fixtures/config.php
@@ -8,4 +8,4 @@ $dbname = 'phpbb';
 $dbuser = 'root';
 $dbpasswd = '';
 $table_prefix = 'phpbb_';
-$acm_type = '\phpbb\cache\driver\null';
+$acm_type = '\phpbb\cache\driver\dummy';

--- a/tests/notification/submit_post_type_topic_test.php
+++ b/tests/notification/submit_post_type_topic_test.php
@@ -42,7 +42,7 @@ class phpbb_notification_submit_post_type_topic_test extends phpbb_notification_
 				),
 			)));
 
-		$phpbb_log = $this->getMock('\phpbb\log\null');
+		$phpbb_log = $this->getMock('\phpbb\log\dummy');
 	}
 
 	/**


### PR DESCRIPTION
Related to https://github.com/phpbb/phpbb/pull/3589