### PR TITLE
[ticket/13815] Event parameters in posting have no effect

### DIFF
--- a/phpBB/posting.php
+++ b/phpBB/posting.php
@@ -1371,10 +1371,8 @@ if ($submit || $preview || $refresh)
 			* @var	string	post_author_name	Author name for guest posts
 			* @var	bool	update_message		Boolean if the post message was changed
 			* @var	bool	update_subject		Boolean if the post subject was changed
-			* @var	bool	submit		Whether or not the form has been submitted
-			* @var	array	error		Any error strings; a non-empty array aborts form submission.
-			*				NOTE: Should be actual language strings, NOT language keys.
 			* @since 3.1.0-RC5
+			* @updated 3.1.5-RC1
 			*/
 			$vars = array(
 				'post_data',
@@ -1388,8 +1386,6 @@ if ($submit || $preview || $refresh)
 				'post_author_name',
 				'update_message',
 				'update_subject',
-				'submit',
-				'error',
 			);
 			extract($phpbb_dispatcher->trigger_event('core.posting_modify_submit_post_before', compact($vars)));
 
@@ -1413,10 +1409,8 @@ if ($submit || $preview || $refresh)
 			* @var	bool	update_message		Boolean if the post message was changed
 			* @var	bool	update_subject		Boolean if the post subject was changed
 			* @var	string	redirect_url		URL the user is going to be redirected to
-			* @var	bool	submit		Whether or not the form has been submitted
-			* @var	array	error		Any error strings; a non-empty array aborts form submission.
-			*				NOTE: Should be actual language strings, NOT language keys.
 			* @since 3.1.0-RC5
+			* @updated 3.1.5-RC1
 			*/
 			$vars = array(
 				'post_data',
@@ -1431,8 +1425,6 @@ if ($submit || $preview || $refresh)
 				'update_message',
 				'update_subject',
 				'redirect_url',
-				'submit',
-				'error',
 			);
 			extract($phpbb_dispatcher->trigger_event('core.posting_modify_submit_post_after', compact($vars)));
 

--- a/phpBB/posting.php
+++ b/phpBB/posting.php
@@ -1372,7 +1372,7 @@ if ($submit || $preview || $refresh)
 			* @var	bool	update_message		Boolean if the post message was changed
 			* @var	bool	update_subject		Boolean if the post subject was changed
 			* @since 3.1.0-RC5
-			* @updated 3.1.5-RC1
+			* @change 3.1.5-RC1 remove submit and error from event  Submit and Error are checked previously prior to running event
 			*/
 			$vars = array(
 				'post_data',
@@ -1410,7 +1410,7 @@ if ($submit || $preview || $refresh)
 			* @var	bool	update_subject		Boolean if the post subject was changed
 			* @var	string	redirect_url		URL the user is going to be redirected to
 			* @since 3.1.0-RC5
-			* @updated 3.1.5-RC1
+			* @change 3.1.5-RC1 remove submit and error from event  Submit and Error are checked previously prior to running event
 			*/
 			$vars = array(
 				'post_data',

--- a/phpBB/posting.php
+++ b/phpBB/posting.php
@@ -1372,7 +1372,7 @@ if ($submit || $preview || $refresh)
 			* @var	bool	update_message		Boolean if the post message was changed
 			* @var	bool	update_subject		Boolean if the post subject was changed
 			* @since 3.1.0-RC5
-			* @updated 3.1.5-RC1
+			* @updated 3.1.5-RC1 remove submit and error from event  Submit and Error are checked previously prior to running event
 			*/
 			$vars = array(
 				'post_data',
@@ -1410,7 +1410,7 @@ if ($submit || $preview || $refresh)
 			* @var	bool	update_subject		Boolean if the post subject was changed
 			* @var	string	redirect_url		URL the user is going to be redirected to
 			* @since 3.1.0-RC5
-			* @updated 3.1.5-RC1
+			* @updated 3.1.5-RC1 remove submit and error from event  Submit and Error are checked previously prior to running event
 			*/
 			$vars = array(
 				'post_data',

--- a/phpBB/posting.php
+++ b/phpBB/posting.php
@@ -1372,7 +1372,7 @@ if ($submit || $preview || $refresh)
 			* @var	bool	update_message		Boolean if the post message was changed
 			* @var	bool	update_subject		Boolean if the post subject was changed
 			* @since 3.1.0-RC5
-			* @updated 3.1.5-RC1 remove submit and error from event  Submit and Error are checked previously prior to running event
+			* @updated 3.1.5-RC1
 			*/
 			$vars = array(
 				'post_data',
@@ -1410,7 +1410,7 @@ if ($submit || $preview || $refresh)
 			* @var	bool	update_subject		Boolean if the post subject was changed
 			* @var	string	redirect_url		URL the user is going to be redirected to
 			* @since 3.1.0-RC5
-			* @updated 3.1.5-RC1 remove submit and error from event  Submit and Error are checked previously prior to running event
+			* @updated 3.1.5-RC1
 			*/
 			$vars = array(
 				'post_data',

--- a/phpBB/posting.php
+++ b/phpBB/posting.php
@@ -1372,7 +1372,7 @@ if ($submit || $preview || $refresh)
 			* @var	bool	update_message		Boolean if the post message was changed
 			* @var	bool	update_subject		Boolean if the post subject was changed
 			* @since 3.1.0-RC5
-			* @change 3.1.5-RC1 remove submit and error from event  Submit and Error are checked previously prior to running event
+			* @change 3.1.6-RC1 remove submit and error from event  Submit and Error are checked previously prior to running event
 			*/
 			$vars = array(
 				'post_data',
@@ -1410,7 +1410,7 @@ if ($submit || $preview || $refresh)
 			* @var	bool	update_subject		Boolean if the post subject was changed
 			* @var	string	redirect_url		URL the user is going to be redirected to
 			* @since 3.1.0-RC5
-			* @change 3.1.5-RC1 remove submit and error from event  Submit and Error are checked previously prior to running event
+			* @change 3.1.6-RC1 remove submit and error from event  Submit and Error are checked previously prior to running event
 			*/
 			$vars = array(
 				'post_data',


### PR DESCRIPTION
The submit and error parameters within the core.posting_modify_submit_post_before/after have no effect as the event is only allowed if submit and not error

[PHPBB3-13815] (https://tracker.phpbb.com/browse/PHPBB3-13815)