### PR TITLE
[ticket/13847] Move quote generation to text_formatter.utils

### DIFF
--- a/phpBB/includes/ucp/ucp_pm_compose.php
+++ b/phpBB/includes/ucp/ucp_pm_compose.php
@@ -947,7 +947,11 @@ function compose_pm($id, $mode, $action, $user_folders = array())
 		{
 			$message_link = '';
 		}
-		$message_parser->message = $message_link . '[quote=&quot;' . $quote_username . '&quot;]' . censor_text(trim($message_parser->message)) . "[/quote]\n";
+		$quote_text = $phpbb_container->get('text_formatter.utils')->generate_quote(
+			censor_text(trim($message_parser->message)),
+			array('author' => $quote_username)
+		);
+		$message_parser->message = $message_link . $quote_text . "\n";
 	}
 
 	if (($action == 'reply' || $action == 'quote' || $action == 'quotepost') && !$preview && !$refresh)

--- a/phpBB/includes/ucp/ucp_pm_compose.php
+++ b/phpBB/includes/ucp/ucp_pm_compose.php
@@ -979,7 +979,11 @@ function compose_pm($id, $mode, $action, $user_folders = array())
 		$forward_text[] = sprintf($user->lang['FWD_FROM'], $quote_username_text);
 		$forward_text[] = sprintf($user->lang['FWD_TO'], implode($user->lang['COMMA_SEPARATOR'], $fwd_to_field['to']));
 
-		$message_parser->message = implode("\n", $forward_text) . "\n\n[quote=&quot;{$quote_username}&quot;]\n" . censor_text(trim($message_parser->message)) . "\n[/quote]";
+		$quote_text = $phpbb_container->get('text_formatter.utils')->generate_quote(
+			censor_text(trim($message_parser->message)),
+			array('author' => $quote_username)
+		);
+		$message_parser->message = implode("\n", $forward_text) . "\n\n" . $quote_text;
 		$message_subject = ((!preg_match('/^Fwd:/', $message_subject)) ? 'Fwd: ' : '') . censor_text($message_subject);
 	}
 

--- a/phpBB/phpbb/textformatter/s9e/utils.php
+++ b/phpBB/phpbb/textformatter/s9e/utils.php
@@ -35,6 +35,43 @@ class utils implements \phpbb\textformatter\utils_interface
 	}
 
 	/**
+	* Return given string between quotes
+	*
+	* Will use either single- or double- quotes depending on whichever requires to be escaped.
+	* Quotes and backslashes are escaped with backslashes where necessary
+	*
+	* @param  string $str Original string
+	* @return string      Escaped string within quotes
+	*/
+	protected function enquote($str)
+	{
+		$quote = (strpos($str, '"') === false || strpos($str, "'") !== false) ? '"' : "'";
+
+		return $quote . addcslashes($str, '\\' . $quote) . $quote;
+	}
+
+	/**
+	* {@inheritdoc}
+	*/
+	public function generate_quote($text, array $attributes = array())
+	{
+		$quote = '[quote';
+		if (isset($attributes['author']))
+		{
+			// Add the author as the BBCode's default attribute
+			$quote .= '=' . $this->enquote($attributes['author']);
+			unset($attributes['author']);
+		}
+		foreach ($attributes as $name => $value)
+		{
+			$quote .= ' ' . $name . '=' . $this->enquote($value);
+		}
+		$quote .= ']' . $text . '[/quote]';
+
+		return $quote;
+	}
+
+	/**
 	* Get a list of quote authors, limited to the outermost quotes
 	*
 	* @param  string   $xml Parsed text

--- a/phpBB/phpbb/textformatter/s9e/utils.php
+++ b/phpBB/phpbb/textformatter/s9e/utils.php
@@ -37,7 +37,7 @@ class utils implements \phpbb\textformatter\utils_interface
 	/**
 	* Return given string between quotes
 	*
-	* Will use either single- or double- quotes depending on whichever requires to be escaped.
+	* Will use either single- or double- quotes depending on whichever requires less escaping.
 	* Quotes and backslashes are escaped with backslashes where necessary
 	*
 	* @param  string $str Original string
@@ -45,9 +45,10 @@ class utils implements \phpbb\textformatter\utils_interface
 	*/
 	protected function enquote($str)
 	{
-		$quote = (strpos($str, '"') === false || strpos($str, "'") !== false) ? '"' : "'";
+		$singleQuoted = "'" . addcslashes($str, "\\'") . "'";
+		$doubleQuoted = '"' . addcslashes($str, '\\"') . '"';
 
-		return $quote . addcslashes($str, '\\' . $quote) . $quote;
+		return (strlen($singleQuoted) < strlen($doubleQuoted)) ? $singleQuoted : $doubleQuoted;
 	}
 
 	/**

--- a/phpBB/phpbb/textformatter/utils_interface.php
+++ b/phpBB/phpbb/textformatter/utils_interface.php
@@ -29,6 +29,18 @@ interface utils_interface
 	public function clean_formatting($text);
 
 	/**
+	* Create a quote block for given text
+	*
+	* Possible attributes:
+	*   - author
+	*
+	* @param  string $text       Quote's text
+	* @param  array  $attributes Quote's attributes
+	* @return string             Quote block to be used in a new post/text
+	*/
+	public function generate_quote($text, array $attributes = array());
+
+	/**
 	* Get a list of quote authors, limited to the outermost quotes
 	*
 	* @param  string   $text Parsed text

--- a/phpBB/posting.php
+++ b/phpBB/posting.php
@@ -1597,7 +1597,11 @@ if ($generate_quote)
 {
 	if ($config['allow_bbcode'])
 	{
-		$message_parser->message = '[quote=&quot;' . $post_data['quote_username'] . '&quot;]' . censor_text(trim($message_parser->message)) . "[/quote]\n";
+		$message_parser->message = $phpbb_container->get('text_formatter.utils')->generate_quote(
+			censor_text(trim($message_parser->message)),
+			array('author' => $post_data['quote_username'])
+		);
+		$message_parser->message .= "\n";
 	}
 	else
 	{

--- a/tests/functional/posting_test.php
+++ b/tests/functional/posting_test.php
@@ -72,6 +72,20 @@ class phpbb_functional_posting_test extends phpbb_functional_test_case
 		$this->assertContains('&#128512;', $crawler->text());
 	}
 
+	public function test_quote()
+	{
+		$text     = 'Test post </textarea>"\' &&amp;amp;';
+		$expected = '[quote="admin"]' . $text . '[/quote]';
+
+		$this->login();
+		$topic = $this->create_topic(2, 'Test Topic 1', 'Test topic');
+		$post  = $this->create_post(2, $topic['topic_id'], 'Re: Test Topic 1', $text);
+
+		$crawler = self::request('GET', "posting.php?mode=quote&f=2&t={$post['topic_id']}&p={$post['post_id']}&sid={$this->sid}");
+
+		$this->assertContains($expected, $crawler->filter('textarea#message')->text());
+	}
+
 	/**
 	* @testdox max_quote_depth is applied to the text populating the posting form
 	*/

--- a/tests/functional/private_messages_test.php
+++ b/tests/functional/private_messages_test.php
@@ -67,7 +67,7 @@ class phpbb_functional_private_messages_test extends phpbb_functional_test_case
 		$this->assertContains($this->lang('CONFIG_UPDATED'), $crawler->filter('.successbox')->text());
 	}
 
-	public function test_quote()
+	public function test_quote_post()
 	{
 		$text     = 'Test post';
 		$expected = '[quote="admin"]' . $text . '[/quote]';
@@ -77,6 +77,19 @@ class phpbb_functional_private_messages_test extends phpbb_functional_test_case
 		$post  = $this->create_post(2, $topic['topic_id'], 'Re: Test Topic 1', $text);
 
 		$crawler = self::request('GET', 'ucp.php?i=pm&mode=compose&action=quotepost&p=' . $post['post_id'] . '&sid=' . $this->sid);
+
+		$this->assertContains($expected, $crawler->filter('textarea#message')->text());
+	}
+
+	public function test_quote_forward()
+	{
+		$text     = 'This is a test private message sent by the testing framework.';
+		$expected = '[quote="admin"]' . $text . '[/quote]';
+
+		$this->login();
+		$message_id = $this->create_private_message('Test', $text, array(2));
+
+		$crawler = self::request('GET', 'ucp.php?i=pm&mode=compose&action=forward&f=0&p=' . $message_id . '&sid=' . $this->sid);
 
 		$this->assertContains($expected, $crawler->filter('textarea#message')->text());
 	}

--- a/tests/functional/private_messages_test.php
+++ b/tests/functional/private_messages_test.php
@@ -66,4 +66,18 @@ class phpbb_functional_private_messages_test extends phpbb_functional_test_case
 		$crawler = self::submit($form);
 		$this->assertContains($this->lang('CONFIG_UPDATED'), $crawler->filter('.successbox')->text());
 	}
+
+	public function test_quote()
+	{
+		$text     = 'Test post';
+		$expected = '[quote="admin"]' . $text . '[/quote]';
+
+		$this->login();
+		$topic = $this->create_topic(2, 'Test Topic 1', 'Test topic');
+		$post  = $this->create_post(2, $topic['topic_id'], 'Re: Test Topic 1', $text);
+
+		$crawler = self::request('GET', 'ucp.php?i=pm&mode=compose&action=quotepost&p=' . $post['post_id'] . '&sid=' . $this->sid);
+
+		$this->assertContains($expected, $crawler->filter('textarea#message')->text());
+	}
 }

--- a/tests/text_formatter/s9e/utils_test.php
+++ b/tests/text_formatter/s9e/utils_test.php
@@ -149,6 +149,21 @@ class phpbb_textformatter_s9e_utils_test extends phpbb_test_case
 			),
 			array(
 				'...',
+				array('author' => 'Lots of doubles """ one single \' one backslash \\'),
+				'[quote=\'Lots of doubles """ one single \\\' one backslash \\\\\']...[/quote]',
+			),
+			array(
+				'...',
+				array('author' => "Lots of singles ''' one double \" one backslash \\"),
+				'[quote="Lots of singles \'\'\' one double \\" one backslash \\\\"]...[/quote]',
+			),
+			array(
+				'...',
+				array('author' => 'Defaults to doublequotes """\'\'\''),
+				'[quote="Defaults to doublequotes \\"\\"\\"\'\'\'"]...[/quote]',
+			),
+			array(
+				'...',
 				array(
 					'author'  => 'user',
 					'post_id' => 123,

--- a/tests/text_formatter/s9e/utils_test.php
+++ b/tests/text_formatter/s9e/utils_test.php
@@ -109,6 +109,57 @@ class phpbb_textformatter_s9e_utils_test extends phpbb_test_case
 	}
 
 	/**
+	* @dataProvider get_generate_quote_tests
+	*/
+	public function test_generate_quote($text, $params, $expected)
+	{
+		$container = $this->get_test_case_helpers()->set_s9e_services();
+		$utils     = $container->get('text_formatter.utils');
+
+		$this->assertSame($expected, $utils->generate_quote($text, $params));
+	}
+
+	public function get_generate_quote_tests()
+	{
+		return array(
+			array(
+				'...',
+				array(),
+				'[quote]...[/quote]',
+			),
+			array(
+				'...',
+				array('author' => 'Brian Kibler'),
+				'[quote="Brian Kibler"]...[/quote]',
+			),
+			array(
+				'...',
+				array('author' => 'Brian "Brian Kibler" Kibler of Brian Kibler Gaming'),
+				'[quote=\'Brian "Brian Kibler" Kibler of Brian Kibler Gaming\']...[/quote]',
+			),
+			array(
+				'...',
+				array('author' => "Brian Kibler Gaming's Brian Kibler"),
+				'[quote="Brian Kibler Gaming\'s Brian Kibler"]...[/quote]',
+			),
+			array(
+				'...',
+				array('author' => "\\\"'"),
+				'[quote="\\\\\\"\'"]...[/quote]',
+			),
+			array(
+				'...',
+				array(
+					'author'  => 'user',
+					'post_id' => 123,
+					'url'     => 'http://example.org'
+				),
+				'[quote="user" post_id="123" url="http://example.org"]...[/quote]',
+			),
+		);
+	}
+
+	/**
 	* @dataProvider get_remove_bbcode_tests
 	*/
 	public function test_remove_bbcode($original, $name, $depth, $expected)


### PR DESCRIPTION
https://tracker.phpbb.com/browse/PHPBB3-13847

The markup used for quotes, `[quote=".."]...[/quote]` is currently hardcoded in posting.php. This could be moved to a method in the `text_formatter.utils` service.

Ultimately, anything that manipulates markup should live in a `text_formatter.*` service.