### PR TITLE
[ticket/13818] Add Extension and Style CDB Links into ACP Management pages

### DIFF
--- a/phpBB/adm/style/acp_ext_list.html
+++ b/phpBB/adm/style/acp_ext_list.html
@@ -7,7 +7,7 @@
 	<p>{L_EXTENSIONS_EXPLAIN}</p>
 
 	<fieldset class="quick">
-		<span class="small"><a href="{U_VERSIONCHECK_FORCE}">{L_VERSIONCHECK_FORCE_UPDATE_ALL}</a> &bull; <a href="javascript:phpbb.toggleDisplay('version_check_settings');">{L_SETTINGS}</a></span>
+		<span class="small"><a href="https://www.phpbb.com/go/customise/extensions/3.1" target="_blank">{L_BROWSE_EXTENSIONS_DATABASE}</a> &bull; <a href="{U_VERSIONCHECK_FORCE}">{L_VERSIONCHECK_FORCE_UPDATE_ALL}</a> &bull; <a href="javascript:phpbb.toggleDisplay('version_check_settings');">{L_SETTINGS}</a></span>
 	</fieldset>
 
 	<form id="version_check_settings" method="post" action="{U_ACTION}" style="display:none">
@@ -97,6 +97,12 @@
 	</table>
 
 	<table class="table1">
+	<tr>
+		<th>{L_EXTENSION_INSTALL_HEADLINE}</th>
+	</tr>
+	<tr>
+		<td class="row3">{L_EXTENSION_INSTALL_EXPLAIN}</td>
+	</tr>
 	<tr>
 		<th>{L_EXTENSION_UPDATE_HEADLINE}</th>
 	</tr>

--- a/phpBB/adm/style/acp_language.html
+++ b/phpBB/adm/style/acp_language.html
@@ -68,6 +68,10 @@
 
 	<p>{L_ACP_LANGUAGE_PACKS_EXPLAIN}</p>
 
+	<fieldset class="quick">
+		<span class="small"><a href="https://www.phpbb.com/go/customise/language-packs/3.1" target="_blank">{L_BROWSE_LANGUAGE_PACKS_DATABASE}</a></span>
+	</fieldset>
+
 	<table class="table1 zebra-table">
 	<thead>
 	<tr>

--- a/phpBB/adm/style/acp_styles.html
+++ b/phpBB/adm/style/acp_styles.html
@@ -19,7 +19,7 @@
 	{S_HIDDEN_FIELDS}
 
 	<div style="text-align: center;">
-		<input type="submit" name="confirm" value="{L_YES}" class="button2" />&nbsp; 
+		<input type="submit" name="confirm" value="{L_YES}" class="button2" />&nbsp;
 		<input type="submit" name="cancel" value="{L_NO}" class="button2" />
 	</div>
 
@@ -31,6 +31,10 @@
 <!-- IF L_TITLE --><h1>{L_TITLE}</h1><!-- ENDIF -->
 
 <!-- IF L_EXPLAIN --><p>{L_EXPLAIN}</p><!-- ENDIF -->
+
+<fieldset class="quick">
+	<span class="small"><a href="https://www.phpbb.com/go/customise/styles/3.1" target="_blank">{L_BROWSE_STYLES_DATABASE}</a></span>
+</fieldset>
 
 <form id="acp_styles" method="post" action="{U_ACTION}">
 {S_HIDDEN_FIELDS}

--- a/phpBB/language/en/acp/extensions.php
+++ b/phpBB/language/en/acp/extensions.php
@@ -68,6 +68,12 @@ $lang = array_merge($lang, array(
 	'EXTENSION_NAME'			=> 'Extension Name',
 	'EXTENSION_ACTIONS'			=> 'Actions',
 	'EXTENSION_OPTIONS'			=> 'Options',
+	'EXTENSION_INSTALL_HEADLINE'=> 'Installing an extension',
+	'EXTENSION_INSTALL_EXPLAIN'	=> '<ol>
+			<li>Download an extension from phpBB’s extensions database</li>
+			<li>Unzip the extension and upload it to the <samp>ext/</samp> directory of your phpBB board</li>
+			<li>Enable the extension, here in the Extensions manager</li>
+		</ol>',
 	'EXTENSION_UPDATE_HEADLINE'	=> 'Updating an extension',
 	'EXTENSION_UPDATE_EXPLAIN'	=> '<ol>
 			<li>Disable the extension</li>
@@ -118,6 +124,8 @@ $lang = array_merge($lang, array(
 	'VERSIONCHECK_FORCE_UPDATE_ALL'		=> 'Re-Check all versions',
 	'FORCE_UNSTABLE'					=> 'Always check for unstable versions',
 	'EXTENSIONS_VERSION_CHECK_SETTINGS'	=> 'Version check settings',
+
+	'BROWSE_EXTENSIONS_DATABASE'		=> 'Browse extensions database',
 
 	'META_FIELD_NOT_SET'	=> 'Required meta field %s has not been set.',
 	'META_FIELD_INVALID'	=> 'Meta field %s is invalid.',

--- a/phpBB/language/en/acp/language.php
+++ b/phpBB/language/en/acp/language.php
@@ -73,4 +73,6 @@ $lang = array_merge($lang, array(
 	'THOSE_MISSING_LANG_VARIABLES'		=> 'The following language variables are missing from the “%s” language pack',
 
 	'UNINSTALLED_LANGUAGE_PACKS'	=> 'Uninstalled language packs',
+
+	'BROWSE_LANGUAGE_PACKS_DATABASE'	=> 'Browse language packs database',
 ));

--- a/phpBB/language/en/acp/styles.php
+++ b/phpBB/language/en/acp/styles.php
@@ -83,4 +83,6 @@ $lang = array_merge($lang, array(
 	'STYLE_USED_BY'				=> 'Used by (including robots)',
 
 	'UNINSTALL_DEFAULT'		=> 'You cannot uninstall the default style.',
+
+	'BROWSE_STYLES_DATABASE'	=> 'Browse styles database',
 ));


### PR DESCRIPTION
Adds a link to our extensions database in extension manager, and to our styles database in the styles manager. This makes it quick and easy to get to the right CDB section from within the ACP to help users browse released extensions and styles (opens in a new window of course).

Also add installing an extension quick guide to the existing updating and removing guides, so we have somewhere in phpBB itself that quickly explains to new users how to get and install a released/validated extension.

![ext](https://cloud.githubusercontent.com/assets/303711/7711596/5b8b3ab6-fe20-11e4-8d5d-55d47c8e3f43.png)
![styles](https://cloud.githubusercontent.com/assets/303711/7711598/5e41e3ea-fe20-11e4-89f5-fc094f42ffc8.png)

https://tracker.phpbb.com/browse/PHPBB3-13818

PHPBB3-13818