### PR TITLE
[ticket/11742] Remove tabs-to-space conversion in [code]

### DIFF
--- a/phpBB/composer.lock
+++ b/phpBB/composer.lock
@@ -220,12 +220,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/s9e/TextFormatter.git",
-                "reference": "29c5959f4425934a53b6fdb42760d719b95a6e82"
+                "reference": "0a6016ab96ab1da5be73f7a407f96f57d307b6b6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/s9e/TextFormatter/zipball/29c5959f4425934a53b6fdb42760d719b95a6e82",
-                "reference": "29c5959f4425934a53b6fdb42760d719b95a6e82",
+                "url": "https://api.github.com/repos/s9e/TextFormatter/zipball/0a6016ab96ab1da5be73f7a407f96f57d307b6b6",
+                "reference": "0a6016ab96ab1da5be73f7a407f96f57d307b6b6",
                 "shasum": ""
             },
             "require": {
@@ -270,7 +270,7 @@
                 "parser",
                 "shortcodes"
             ],
-            "time": "2015-05-18 04:48:32"
+            "time": "2015-05-23 17:07:15"
         },
         {
             "name": "symfony/config",

--- a/phpBB/phpbb/textformatter/s9e/renderer.php
+++ b/phpBB/phpbb/textformatter/s9e/renderer.php
@@ -234,10 +234,6 @@ class renderer implements \phpbb\textformatter\renderer_interface
 		}
 
 		$html = $this->renderer->render($xml);
-		if (stripos($html, '<code') !== false)
-		{
-			$html = $this->replace_tabs_in_code($html);
-		}
 
 		/**
 		* Modify a rendered text
@@ -251,45 +247,6 @@ class renderer implements \phpbb\textformatter\renderer_interface
 		extract($this->dispatcher->trigger_event('core.text_formatter_s9e_render_after', compact($vars)));
 
 		return $html;
-	}
-
-	/**
-	* Replace tabs in code elements
-	*
-	* @see bbcode::bbcode_second_pass_code()
-	*
-	* @param  string $html Original HTML
-	* @return string       Modified HTML
-	*/
-	protected function replace_tabs_in_code($html)
-	{
-		return preg_replace_callback(
-			'((<code[^>]*>)(.*?)(</code>))is',
-			function ($captures)
-			{
-				$code = $captures[2];
-
-				$code = str_replace("\t", '&nbsp; &nbsp;', $code);
-				$code = str_replace('  ', '&nbsp; ', $code);
-				$code = str_replace('  ', ' &nbsp;', $code);
-				$code = str_replace("\n ", "\n&nbsp;", $code);
-
-				// keep space at the beginning
-				if (!empty($code) && $code[0] == ' ')
-				{
-					$code = '&nbsp;' . substr($code, 1);
-				}
-
-				// remove newline at the beginning
-				if (!empty($code) && $code[0] == "\n")
-				{
-					$code = substr($code, 1);
-				}
-
-				return $captures[1] . $code . $captures[3];
-			},
-			$html
-		);
 	}
 
 	/**

--- a/phpBB/styles/prosilver/template/bbcode.html
+++ b/phpBB/styles/prosilver/template/bbcode.html
@@ -12,8 +12,8 @@
 <!-- BEGIN quote_open --><blockquote class="uncited"><div><!-- END quote_open -->
 <!-- BEGIN quote_close --></div></blockquote><!-- END quote_close -->
 
-<!-- BEGIN code_open --><div class="codebox"><p>{L_CODE}{L_COLON} <a href="#" onclick="selectCode(this); return false;">{L_SELECT_ALL_CODE}</a></p><code><!-- END code_open -->
-<!-- BEGIN code_close --></code></div><!-- END code_close -->
+<!-- BEGIN code_open --><div class="codebox"><p>{L_CODE}{L_COLON} <a href="#" onclick="selectCode(this); return false;">{L_SELECT_ALL_CODE}</a></p><pre><code><!-- END code_open -->
+<!-- BEGIN code_close --></code></pre></div><!-- END code_close -->
 
 <!-- BEGIN inline_attachment_open --><div class="inline-attachment"><!-- END inline_attachment_open -->
 <!-- BEGIN inline_attachment_close --></div><!-- END inline_attachment_close -->

--- a/phpBB/styles/prosilver/theme/content.css
+++ b/phpBB/styles/prosilver/theme/content.css
@@ -513,7 +513,6 @@ blockquote .codebox {
 	display: block;
 	height: auto;
 	max-height: 200px;
-	white-space: normal;
 	padding-top: 5px;
 	font: 0.9em Monaco, "Andale Mono","Courier New", Courier, mono;
 	line-height: 1.3em;

--- a/tests/text_formatter/s9e/default_formatting_test.php
+++ b/tests/text_formatter/s9e/default_formatting_test.php
@@ -68,7 +68,7 @@ class phpbb_textformatter_s9e_default_formatting_test extends phpbb_test_case
 			),
 			array(
 				'[code]unparsed code[/code]',
-				'<div class="codebox"><p>CODE: <a href="#" onclick="selectCode(this); return false;">Select all</a></p><code>unparsed code</code></div>'
+				'<div class="codebox"><p>CODE: <a href="#" onclick="selectCode(this); return false;">Select all</a></p><pre><code>unparsed code</code></pre></div>'
 			),
 			array(
 				'[list]no item[/list]',
@@ -181,12 +181,12 @@ class phpbb_textformatter_s9e_default_formatting_test extends phpbb_test_case
 			array(
 				// Do not parse textual bbcodes in code
 				'[code]unparsed code [b]bold [i]bold + italic[/i][/b][/code]',
-				'<div class="codebox"><p>CODE: <a href="#" onclick="selectCode(this); return false;">Select all</a></p><code>unparsed code [b]bold [i]bold + italic[/i][/b]</code></div>'
+				'<div class="codebox"><p>CODE: <a href="#" onclick="selectCode(this); return false;">Select all</a></p><pre><code>unparsed code [b]bold [i]bold + italic[/i][/b]</code></pre></div>'
 			),
 			array(
 				// Do not parse quote bbcodes in code
 				'[code]unparsed code [quote="username"]quoted[/quote][/code]',
-				'<div class="codebox"><p>CODE: <a href="#" onclick="selectCode(this); return false;">Select all</a></p><code>unparsed code [quote="username"]quoted[/quote]</code></div>'
+				'<div class="codebox"><p>CODE: <a href="#" onclick="selectCode(this); return false;">Select all</a></p><pre><code>unparsed code [quote="username"]quoted[/quote]</code></pre></div>'
 			),
 			array(
 				// Textual bbcode nesting into textual bbcode
@@ -195,7 +195,7 @@ class phpbb_textformatter_s9e_default_formatting_test extends phpbb_test_case
 			),
 			array(
 				"[code]\tline1\n  line2[/code]",
-				'<div class="codebox"><p>CODE: <a href="#" onclick="selectCode(this); return false;">Select all</a></p><code>&nbsp; &nbsp;line1<br>' . "\n" . '&nbsp; line2</code></div>'
+				'<div class="codebox"><p>CODE: <a href="#" onclick="selectCode(this); return false;">Select all</a></p><pre><code>' . "\tline1\n  line2</code></pre></div>"
 			),
 			array(
 				'... http://example.org ...',

--- a/tests/text_formatter/s9e/default_formatting_test.php
+++ b/tests/text_formatter/s9e/default_formatting_test.php
@@ -198,6 +198,10 @@ class phpbb_textformatter_s9e_default_formatting_test extends phpbb_test_case
 				'<div class="codebox"><p>CODE: <a href="#" onclick="selectCode(this); return false;">Select all</a></p><pre><code>' . "\tline1\n  line2</code></pre></div>"
 			),
 			array(
+				"[code]\n\tline1\n  line2[/code]",
+				'<div class="codebox"><p>CODE: <a href="#" onclick="selectCode(this); return false;">Select all</a></p><pre><code>' . "\tline1\n  line2</code></pre></div>"
+			),
+			array(
 				'... http://example.org ...',
 				'... <a href="http://example.org" class="postlink">http://example.org</a> ...'
 			),

--- a/tests/text_processing/tickets_data/PHPBB3-11742.html
+++ b/tests/text_processing/tickets_data/PHPBB3-11742.html
@@ -1,0 +1,1 @@
+<div class="codebox"><p>CODE: <a href="#" onclick="selectCode(this); return false;">Select all</a></p><pre><code>	tab</code></pre></div>

--- a/tests/text_processing/tickets_data/PHPBB3-11742.txt
+++ b/tests/text_processing/tickets_data/PHPBB3-11742.txt
@@ -1,0 +1,1 @@
+[code]	tab[/code]


### PR DESCRIPTION
https://tracker.phpbb.com/browse/PHPBB3-11742
Previous PR: ~~https://github.com/phpbb/phpbb/pull/3570~~ (I accidentally closed it and I can't reopen it)

This PR removes the tabs-to-space conversion by preserving all space in code blocks, including new lines.