### PR TITLE
[ticket/13733] Allow non-migration files inside migrations folder

### DIFF
--- a/phpBB/phpbb/extension/base.php
+++ b/phpBB/phpbb/extension/base.php
@@ -139,11 +139,21 @@ class base implements \phpbb\extension\extension_interface
 
 		foreach ($migrations as $key => $migration)
 		{
-			// If the class doesn't exist OR the class does not extend the migration class
-			// we need to skip it.
-			if (!class_exists($migration) || ($reflector = new \ReflectionClass($migration) && !$reflector->isSubclassOf('\phpbb\db\migration\migration'))) {
-				unset($migrations[$key]);
+			// If the class exists and is a subclass of the
+			// \phpbb\db\migration\migration abstract class
+			// we skip it.
+
+			// Otherwise, i.e. if it doesn't exist or it is
+			// not an extend the abstract class, we unset it
+			if (class_exists($migration)) {
+				$reflector = new \ReflectionClass($migration);
+				if ($reflector->isSubclassOf('\phpbb\db\migration\migration')) {
+					continue;
+				}
+
 			}
+
+			unset($migrations[$key]);
 		}
 
 		return $migrations;

--- a/phpBB/phpbb/extension/base.php
+++ b/phpBB/phpbb/extension/base.php
@@ -139,8 +139,9 @@ class base implements \phpbb\extension\extension_interface
 
 		foreach ($migrations as $key => $migration)
 		{
-			$reflector = new \ReflectionClass($migration);
-			if (!$reflector->isSubclassOf('\phpbb\db\migration\migration')) {
+			// If the class doesn't exist OR the class does not extend the migration class
+			// we need to skip it.
+			if (!class_exists($migration) || ($reflector = new \ReflectionClass($migration) && !$reflector->isSubclassOf('\phpbb\db\migration\migration'))) {
 				unset($migrations[$key]);
 			}
 		}

--- a/phpBB/phpbb/extension/base.php
+++ b/phpBB/phpbb/extension/base.php
@@ -137,6 +137,14 @@ class base implements \phpbb\extension\extension_interface
 
 		$migrations = $this->extension_finder->get_classes_from_files($migrations);
 
+		foreach ($migrations as $key => $migration)
+		{
+			$reflector = new \ReflectionClass($migration);
+			if (!$reflector->isSubclassOf('\phpbb\db\migration\migration')) {
+				unset($migrations[$key]);
+			}
+		}
+
 		return $migrations;
 	}
 }

--- a/phpBB/phpbb/extension/base.php
+++ b/phpBB/phpbb/extension/base.php
@@ -152,7 +152,7 @@ class base implements \phpbb\extension\extension_interface
 				if (class_exists($migration))
 				{
 					$reflector = new \ReflectionClass($migration);
-					if ($reflector->isSubclassOf('\phpbb\db\migration\migration'))
+					if ($reflector->isSubclassOf('\phpbb\db\migration\migration') && $reflector->isInstantiable())
 					{
 						continue;
 					}

--- a/phpBB/phpbb/extension/base.php
+++ b/phpBB/phpbb/extension/base.php
@@ -121,9 +121,11 @@ class base implements \phpbb\extension\extension_interface
 	/**
 	* Get the list of migration files from this extension
 	*
+	* @var bool $validate_classes Whether or not to check that the migration
+	*		class exists and extends the base migration class.
 	* @return array
 	*/
-	protected function get_migration_file_list()
+	protected function get_migration_file_list($validate_classes = true)
 	{
 		if ($this->migrations !== false)
 		{
@@ -137,23 +139,26 @@ class base implements \phpbb\extension\extension_interface
 
 		$migrations = $this->extension_finder->get_classes_from_files($migrations);
 
-		foreach ($migrations as $key => $migration)
+		if ($validate_classes)
 		{
-			// If the class exists and is a subclass of the
-			// \phpbb\db\migration\migration abstract class
-			// we skip it.
+			foreach ($migrations as $key => $migration)
+			{
+				// If the class exists and is a subclass of the
+				// \phpbb\db\migration\migration abstract class
+				// we skip it.
 
-			// Otherwise, i.e. if it doesn't exist or it is
-			// not an extend the abstract class, we unset it
-			if (class_exists($migration)) {
-				$reflector = new \ReflectionClass($migration);
-				if ($reflector->isSubclassOf('\phpbb\db\migration\migration')) {
-					continue;
+				// Otherwise, i.e. if it doesn't exist or it is
+				// not an extend the abstract class, we unset it
+				if (class_exists($migration)) {
+					$reflector = new \ReflectionClass($migration);
+					if ($reflector->isSubclassOf('\phpbb\db\migration\migration')) {
+						continue;
+					}
+
 				}
 
+				unset($migrations[$key]);
 			}
-
-			unset($migrations[$key]);
 		}
 
 		return $migrations;

--- a/phpBB/phpbb/extension/base.php
+++ b/phpBB/phpbb/extension/base.php
@@ -149,9 +149,11 @@ class base implements \phpbb\extension\extension_interface
 
 				// Otherwise, i.e. if it doesn't exist or it is
 				// not an extend the abstract class, we unset it
-				if (class_exists($migration)) {
+				if (class_exists($migration))
+				{
 					$reflector = new \ReflectionClass($migration);
-					if ($reflector->isSubclassOf('\phpbb\db\migration\migration')) {
+					if ($reflector->isSubclassOf('\phpbb\db\migration\migration'))
+					{
 						continue;
 					}
 

--- a/tests/extension/extension_base_test.php
+++ b/tests/extension/extension_base_test.php
@@ -74,6 +74,6 @@ class phpbb_extension_extension_base_test extends phpbb_test_case
 	public function test_suffix_get_classes($extension_name, $expected)
 	{
 		$extension = $this->extension_manager->get_extension($extension_name);
-		$this->assertEquals($expected, self::$reflection_method_get_migration_file_list->invoke($extension));
+		$this->assertEquals($expected, self::$reflection_method_get_migration_file_list->invoke($extension, false));
 	}
 }


### PR DESCRIPTION
This ignores any classes that don't extend the abstract \phpbb\db\migration\migration class.

https://tracker.phpbb.com/browse/PHPBB3-13733