### PR TITLE
[ticket/12143] Make it possible to use translated group names for non-special groups

### DIFF
--- a/phpBB/config/default/container/services.yml
+++ b/phpBB/config/default/container/services.yml
@@ -113,6 +113,11 @@ services:
     file_downloader:
         class: phpbb\file_downloader
 
+    group_helper:
+        class: phpbb\group\helper
+        arguments:
+            - @language
+
     log:
         class: phpbb\log\log
         arguments:

--- a/phpBB/includes/acp/acp_groups.php
+++ b/phpBB/includes/acp/acp_groups.php
@@ -54,6 +54,9 @@ class acp_groups
 		$start		= $request->variable('start', 0);
 		$update		= (isset($_POST['update'])) ? true : false;
 
+		/** @var \phpbb\group\helper $group_helper */
+		$group_helper = $phpbb_container->get('group_helper');
+
 		// Clear some vars
 		$group_row = array();
 
@@ -98,7 +101,7 @@ class acp_groups
 				}
 
 				// Approve, demote or promote
-				$group_name = ($group_row['group_type'] == GROUP_SPECIAL) ? $user->lang['G_' . $group_row['group_name']] : $group_row['group_name'];
+				$group_name = $group_helper->get_name($group_row['group_name']);
 				$error = group_user_attributes($action, $group_id, $mark_ary, false, $group_name);
 
 				if (!$error)
@@ -139,7 +142,7 @@ class acp_groups
 
 				if (confirm_box(true))
 				{
-					$group_name = ($group_row['group_type'] == GROUP_SPECIAL) ? $user->lang['G_' . $group_row['group_name']] : $group_row['group_name'];
+					$group_name = $group_helper->get_name($group_row['group_name']);
 					group_user_attributes('default', $group_id, $mark_ary, false, $group_name, $group_row);
 					trigger_error($user->lang['GROUP_DEFS_UPDATED'] . adm_back_link($this->u_action . '&amp;action=list&amp;g=' . $group_id));
 				}
@@ -158,7 +161,7 @@ class acp_groups
 			case 'set_default_on_all':
 				if (confirm_box(true))
 				{
-					$group_name = ($group_row['group_type'] == GROUP_SPECIAL) ? $user->lang['G_' . $group_row['group_name']] : $group_row['group_name'];
+					$group_name = $group_helper->get_name($group_row['group_name']);
 
 					$start = 0;
 
@@ -236,7 +239,7 @@ class acp_groups
 						break;
 
 						case 'deleteusers':
-							$group_name = ($group_row['group_type'] == GROUP_SPECIAL) ? $user->lang['G_' . $group_row['group_name']] : $group_row['group_name'];
+							$group_name = $group_helper->get_name($group_row['group_name']);
 							$error = group_user_del($group_id, $mark_ary, false, $group_name);
 						break;
 					}
@@ -280,7 +283,7 @@ class acp_groups
 				}
 
 				$name_ary = array_unique(explode("\n", $name_ary));
-				$group_name = ($group_row['group_type'] == GROUP_SPECIAL) ? $user->lang['G_' . $group_row['group_name']] : $group_row['group_name'];
+				$group_name = $group_helper->get_name($group_row['group_name']);
 
 				// Add user/s to group
 				if ($error = group_user_add($group_id, false, $name_ary, $group_name, $default, $leader, 0, $group_row))
@@ -720,7 +723,7 @@ class acp_groups
 					'S_AVATARS_ENABLED'		=> ($config['allow_avatar'] && $avatars_enabled),
 
 					'ERROR_MSG'				=> (sizeof($error)) ? implode('<br />', $error) : '',
-					'GROUP_NAME'			=> ($group_type == GROUP_SPECIAL) ? $user->lang['G_' . $group_name] : $group_name,
+					'GROUP_NAME'			=> $group_helper->get_name($group_name),
 					'GROUP_INTERNAL_NAME'	=> $group_name,
 					'GROUP_DESC'			=> $group_desc_data['text'],
 					'GROUP_RECEIVE_PM'		=> (isset($group_row['group_receive_pm']) && $group_row['group_receive_pm']) ? ' checked="checked"' : '',
@@ -855,7 +858,7 @@ class acp_groups
 					'S_GROUP_SPECIAL'	=> ($group_row['group_type'] == GROUP_SPECIAL) ? true : false,
 					'S_ACTION_OPTIONS'	=> $s_action_options,
 
-					'GROUP_NAME'	=> ($group_row['group_type'] == GROUP_SPECIAL) ? $user->lang['G_' . $group_row['group_name']] : $group_row['group_name'],
+					'GROUP_NAME'	=> $group_helper->get_name($group_row['group_name']),
 
 					'U_ACTION'			=> $this->u_action . "&amp;g=$group_id",
 					'U_BACK'			=> $this->u_action,
@@ -984,6 +987,9 @@ class acp_groups
 		$teampage_id = $request->variable('t', 0);
 		$category_id = $request->variable('c', 0);
 
+		/** @var \phpbb\group\helper $group_helper */
+		$group_helper = $phpbb_container->get('group_helper');
+
 		if ($field && !in_array($field, array('legend', 'teampage')))
 		{
 			// Invalid mode
@@ -1086,7 +1092,7 @@ class acp_groups
 		$s_group_select_legend = '';
 		while ($row = $db->sql_fetchrow($result))
 		{
-			$group_name = ($row['group_type'] == GROUP_SPECIAL) ? $user->lang['G_' . $row['group_name']] : $row['group_name'];
+			$group_name = $group_helper->get_name($row['group_name']);
 			if ($row['group_legend'])
 			{
 				$template->assign_block_vars('legend', array(
@@ -1134,7 +1140,7 @@ class acp_groups
 
 			if ($row['group_id'])
 			{
-				$group_name = ($row['group_type'] == GROUP_SPECIAL) ? $user->lang['G_' . $row['group_name']] : $row['group_name'];
+				$group_name = $group_helper->get_name($row['group_name']);
 				$group_type = $user->lang[\phpbb\groupposition\teampage::group_type_language($row['group_type'])];
 			}
 			else
@@ -1167,7 +1173,7 @@ class acp_groups
 		$s_group_select_teampage = '';
 		while ($row = $db->sql_fetchrow($result))
 		{
-			$group_name = ($row['group_type'] == GROUP_SPECIAL) ? $user->lang['G_' . $row['group_name']] : $row['group_name'];
+			$group_name = $group_helper->get_name($row['group_name']);
 			$template->assign_block_vars('add_teampage', array(
 				'GROUP_ID'		=> (int) $row['group_id'],
 				'GROUP_NAME'	=> $group_name,

--- a/phpBB/includes/acp/acp_permissions.php
+++ b/phpBB/includes/acp/acp_permissions.php
@@ -932,7 +932,7 @@ class acp_permissions
 		$l_ug_list = '';
 		while ($row = $db->sql_fetchrow($result))
 		{
-			$group_name = $group_helper->get_name($row['group_name']);
+			$group_name = $group_helper->get_name($row['name']);
 			$l_ug_list .= (($l_ug_list != '') ? ', ' : '') . ((isset($row['group_type']) && $row['group_type'] == GROUP_SPECIAL) ? '<span class="sep">' . $group_name . '</span>' : $group_name);
 		}
 		$db->sql_freeresult($result);

--- a/phpBB/includes/acp/acp_prune.php
+++ b/phpBB/includes/acp/acp_prune.php
@@ -230,7 +230,10 @@ class acp_prune
 	function prune_users($id, $mode)
 	{
 		global $db, $user, $auth, $template, $cache, $phpbb_log, $request;
-		global $config, $phpbb_root_path, $phpbb_admin_path, $phpEx;
+		global $config, $phpbb_root_path, $phpbb_admin_path, $phpEx, $phpbb_container;
+
+		/** @var \phpbb\group\helper $group_helper */
+		$group_helper = $phpbb_container->get('group_helper');
 
 		$user->add_lang('memberlist');
 
@@ -342,7 +345,7 @@ class acp_prune
 		$s_group_list = '';
 		while ($row = $db->sql_fetchrow($result))
 		{
-			$s_group_list .= '<option value="' . $row['group_id'] . '">' . $row['group_name'] . '</option>';
+			$s_group_list .= '<option value="' . $row['group_id'] . '">' . $group_helper->get_name($row['group_name']) . '</option>';
 		}
 		$db->sql_freeresult($result);
 

--- a/phpBB/includes/acp/acp_users.php
+++ b/phpBB/includes/acp/acp_users.php
@@ -2348,6 +2348,9 @@ class acp_users
 					$error = array();
 				}
 
+				/** @var \phpbb\group\helper $group_helper */
+				$group_helper = $phpbb_container->get('group_helper');
+
 				$sql = 'SELECT ug.*, g.*
 					FROM ' . GROUPS_TABLE . ' g, ' . USER_GROUP_TABLE . " ug
 					WHERE ug.user_id = $user_id
@@ -2392,7 +2395,7 @@ class acp_users
 						continue;
 					}
 
-					$s_group_options .= '<option' . (($row['group_type'] == GROUP_SPECIAL) ? ' class="sep"' : '') . ' value="' . $row['group_id'] . '">' . (($row['group_type'] == GROUP_SPECIAL) ? $user->lang['G_' . $row['group_name']] : $row['group_name']) . '</option>';
+					$s_group_options .= '<option' . (($row['group_type'] == GROUP_SPECIAL) ? ' class="sep"' : '') . ' value="' . $row['group_id'] . '">' . $group_helper->get_name($row['group_name']) . '</option>';
 				}
 				$db->sql_freeresult($result);
 

--- a/phpBB/includes/functions_admin.php
+++ b/phpBB/includes/functions_admin.php
@@ -171,7 +171,10 @@ function size_select_options($size_compare)
 */
 function group_select_options($group_id, $exclude_ids = false, $manage_founder = false)
 {
-	global $db, $user, $config;
+	global $db, $config, $phpbb_container;
+
+	/** @var \phpbb\group\helper $group_helper */
+	$group_helper = $phpbb_container->get('group_helper');
 
 	$exclude_sql = ($exclude_ids !== false && sizeof($exclude_ids)) ? 'WHERE ' . $db->sql_in_set('group_id', array_map('intval', $exclude_ids), true) : '';
 	$sql_and = (!$config['coppa_enable']) ? (($exclude_sql) ? ' AND ' : ' WHERE ') . "group_name <> 'REGISTERED_COPPA'" : '';
@@ -189,7 +192,7 @@ function group_select_options($group_id, $exclude_ids = false, $manage_founder =
 	while ($row = $db->sql_fetchrow($result))
 	{
 		$selected = ($row['group_id'] == $group_id) ? ' selected="selected"' : '';
-		$s_group_options .= '<option' . (($row['group_type'] == GROUP_SPECIAL) ? ' class="sep"' : '') . ' value="' . $row['group_id'] . '"' . $selected . '>' . (($row['group_type'] == GROUP_SPECIAL) ? $user->lang['G_' . $row['group_name']] : $row['group_name']) . '</option>';
+		$s_group_options .= '<option' . (($row['group_type'] == GROUP_SPECIAL) ? ' class="sep"' : '') . ' value="' . $row['group_id'] . '"' . $selected . '>' . $group_helper->get_name($row['group_name']) . '</option>';
 	}
 	$db->sql_freeresult($result);
 

--- a/phpBB/includes/functions_display.php
+++ b/phpBB/includes/functions_display.php
@@ -886,6 +886,7 @@ function get_forum_parents(&$forum_data)
 function get_moderators(&$forum_moderators, $forum_id = false)
 {
 	global $config, $template, $db, $phpbb_root_path, $phpEx, $user, $auth;
+	global $phpbb_container;
 
 	$forum_id_ary = array();
 
@@ -921,6 +922,9 @@ function get_moderators(&$forum_moderators, $forum_id = false)
 		'WHERE'		=> 'm.display_on_index = 1',
 	);
 
+	/** @var \phpbb\group\helper $group_helper */
+	$group_helper = $phpbb_container->get('group_helper');
+
 	// We query every forum here because for caching we should not have any parameter.
 	$sql = $db->sql_build_query('SELECT', $sql_array);
 	$result = $db->sql_query($sql, 3600);
@@ -940,7 +944,7 @@ function get_moderators(&$forum_moderators, $forum_id = false)
 		}
 		else
 		{
-			$group_name = (($row['group_type'] == GROUP_SPECIAL) ? $user->lang['G_' . $row['group_name']] : $row['group_name']);
+			$group_name = $group_helper->get_name($row['group_name']);
 
 			if ($user->data['user_id'] != ANONYMOUS && !$auth->acl_get('u_viewprofile'))
 			{

--- a/phpBB/includes/functions_privmsgs.php
+++ b/phpBB/includes/functions_privmsgs.php
@@ -1436,7 +1436,10 @@ function rebuild_header($check_ary)
 */
 function write_pm_addresses($check_ary, $author_id, $plaintext = false)
 {
-	global $db, $user, $template, $phpbb_root_path, $phpEx;
+	global $db, $user, $template, $phpbb_root_path, $phpEx, $phpbb_container;
+
+	/** @var \phpbb\group\helper $group_helper */
+	$group_helper = $phpbb_container->get('group_helper');
 
 	$addresses = array();
 
@@ -1497,7 +1500,7 @@ function write_pm_addresses($check_ary, $author_id, $plaintext = false)
 				{
 					if ($check_type == 'to' || $author_id == $user->data['user_id'] || $row['user_id'] == $user->data['user_id'])
 					{
-						$address[] = ($row['group_type'] == GROUP_SPECIAL) ? $user->lang['G_' . $row['group_name']] : $row['group_name'];
+						$address[] = $group_helper->get_name($row['group_name']);
 					}
 				}
 				$db->sql_freeresult($result);
@@ -1517,7 +1520,7 @@ function write_pm_addresses($check_ary, $author_id, $plaintext = false)
 					{
 						if ($check_type == 'to' || $author_id == $user->data['user_id'] || $row['user_id'] == $user->data['user_id'])
 						{
-							$row['group_name'] = ($row['group_type'] == GROUP_SPECIAL) ? $user->lang['G_' . $row['group_name']] : $row['group_name'];
+							$row['group_name'] = $group_helper->get_name($row['group_name']);
 							$address['group'][$row['group_id']] = array('name' => $row['group_name'], 'colour' => $row['group_colour']);
 						}
 					}
@@ -2178,7 +2181,10 @@ function phpbb_get_max_setting_from_group(\phpbb\db\driver\driver_interface $db,
 */
 function get_recipient_strings($pm_by_id)
 {
-	global $db, $phpbb_root_path, $phpEx, $user;
+	global $db, $phpbb_root_path, $phpEx, $user, $phpbb_container;
+
+	/** @var \phpbb\group\helper $group_helper */
+	$group_helper = $phpbb_container->get('group_helper');
 
 	$address_list = $recipient_list = $address = array();
 
@@ -2224,7 +2230,7 @@ function get_recipient_strings($pm_by_id)
 			{
 				if ($ug_type == 'g')
 				{
-					$row['name'] = ($row['group_type'] == GROUP_SPECIAL) ? $user->lang['G_' . $row['name']] : $row['name'];
+					$row['name'] = $group_helper->get_name($row['name']);
 				}
 
 				$recipient_list[$ug_type][$row['id']] = array('name' => $row['name'], 'colour' => $row['colour']);

--- a/phpBB/includes/functions_user.php
+++ b/phpBB/includes/functions_user.php
@@ -2215,6 +2215,9 @@ function group_create(&$group_id, $type, $name, $desc, $group_attributes, $allow
 {
 	global $phpbb_root_path, $config, $db, $user, $file_upload, $phpbb_container, $phpbb_log;
 
+	/** @var \phpbb\group\helper $group_helper */
+	$group_helper = $phpbb_container->get('group_helper');
+
 	$error = array();
 
 	// Attributes which also affect the users table
@@ -2466,7 +2469,7 @@ function group_create(&$group_id, $type, $name, $desc, $group_attributes, $allow
 			group_set_user_default($group_id, $user_ary, $sql_ary);
 		}
 
-		$name = ($type == GROUP_SPECIAL) ? $user->lang['G_' . $name] : $name;
+		$name = $group_helper->get_name($name);
 		$phpbb_log->add('admin', $user->data['user_id'], $user->ip, $log, false, array($name));
 
 		group_update_listings($group_id);
@@ -3320,7 +3323,7 @@ function group_set_user_default($group_id, $user_id_ary, $group_attributes = fal
 */
 function get_group_name($group_id)
 {
-	global $db, $user;
+	global $db, $user, $phpbb_container;
 
 	$sql = 'SELECT group_name, group_type
 		FROM ' . GROUPS_TABLE . '
@@ -3329,12 +3332,15 @@ function get_group_name($group_id)
 	$row = $db->sql_fetchrow($result);
 	$db->sql_freeresult($result);
 
-	if (!$row || ($row['group_type'] == GROUP_SPECIAL && !$user->is_setup()))
+	if (!$row || !$user->is_setup())
 	{
 		return '';
 	}
 
-	return ($row['group_type'] == GROUP_SPECIAL) ? $user->lang['G_' . $row['group_name']] : $row['group_name'];
+	/** @var \phpbb\group\helper $group_helper */
+	$group_helper = $phpbb_container->get('group_helper');
+
+	return $group_helper->get_name($row['group_name']);
 }
 
 /**

--- a/phpBB/includes/functions_user.php
+++ b/phpBB/includes/functions_user.php
@@ -3332,7 +3332,7 @@ function get_group_name($group_id)
 	$row = $db->sql_fetchrow($result);
 	$db->sql_freeresult($result);
 
-	if (!$row || !$user->is_setup())
+	if (!$row)
 	{
 		return '';
 	}

--- a/phpBB/includes/ucp/ucp_groups.php
+++ b/phpBB/includes/ucp/ucp_groups.php
@@ -41,6 +41,9 @@ class ucp_groups
 		$delete		= $request->variable('delete', false, false, \phpbb\request\request_interface::POST);
 		$error = $data = array();
 
+		/** @var \phpbb\group\helper $group_helper */
+		$group_helper = $phpbb_container->get('group_helper');
+
 		switch ($mode)
 		{
 			case 'membership':
@@ -65,7 +68,7 @@ class ucp_groups
 					$group_row = array();
 					while ($row = $db->sql_fetchrow($result))
 					{
-						$row['group_name'] = ($row['group_type'] == GROUP_SPECIAL) ? $user->lang['G_' . $row['group_name']] : $row['group_name'];
+						$row['group_name'] = $group_helper->get_name($row['group_name']);
 						$group_row[$row['group_id']] = $row;
 					}
 					$db->sql_freeresult($result);
@@ -307,7 +310,7 @@ class ucp_groups
 
 					$template->assign_block_vars($block, array(
 						'GROUP_ID'		=> $row['group_id'],
-						'GROUP_NAME'	=> ($row['group_type'] == GROUP_SPECIAL) ? $user->lang['G_' . $row['group_name']] : $row['group_name'],
+						'GROUP_NAME'	=> $group_helper->get_name($row['group_name']),
 						'GROUP_DESC'	=> ($row['group_type'] <> GROUP_SPECIAL) ? generate_text_for_display($row['group_desc'], $row['group_desc_uid'], $row['group_desc_bitfield'], $row['group_desc_options']) : $user->lang['GROUP_IS_SPECIAL'],
 						'GROUP_SPECIAL'	=> ($row['group_type'] <> GROUP_SPECIAL) ? false : true,
 						'GROUP_STATUS'	=> $user->lang['GROUP_IS_' . $group_status],
@@ -361,7 +364,7 @@ class ucp_groups
 
 					$template->assign_block_vars('nonmember', array(
 						'GROUP_ID'		=> $row['group_id'],
-						'GROUP_NAME'	=> ($row['group_type'] == GROUP_SPECIAL) ? $user->lang['G_' . $row['group_name']] : $row['group_name'],
+						'GROUP_NAME'	=> $group_helper->get_name($row['group_name']),
 						'GROUP_DESC'	=> ($row['group_type'] <> GROUP_SPECIAL) ? generate_text_for_display($row['group_desc'], $row['group_desc_uid'], $row['group_desc_bitfield'], $row['group_desc_options']) : $user->lang['GROUP_IS_SPECIAL'],
 						'GROUP_SPECIAL'	=> ($row['group_type'] <> GROUP_SPECIAL) ? false : true,
 						'GROUP_CLOSED'	=> ($row['group_type'] <> GROUP_CLOSED || $auth->acl_gets('a_group', 'a_groupadd', 'a_groupdel')) ? false : true,
@@ -426,7 +429,7 @@ class ucp_groups
 					$avatar = phpbb_get_group_avatar($group_row, 'GROUP_AVATAR', true);
 
 					$template->assign_vars(array(
-						'GROUP_NAME'			=> ($group_type == GROUP_SPECIAL) ? $user->lang['G_' . $group_name] : $group_name,
+						'GROUP_NAME'			=> $group_helper->get_name($group_name),
 						'GROUP_INTERNAL_NAME'	=> $group_name,
 						'GROUP_COLOUR'			=> (isset($group_row['group_colour'])) ? $group_row['group_colour'] : '',
 						'GROUP_DESC_DISP'		=> generate_text_for_display($group_row['group_desc'], $group_row['group_desc_uid'], $group_row['group_desc_bitfield'], $group_row['group_desc_options']),
@@ -901,7 +904,7 @@ class ucp_groups
 							trigger_error($user->lang['NOT_LEADER_OF_GROUP'] . $return_page);
 						}
 
-						$group_row['group_name'] = ($group_row['group_type'] == GROUP_SPECIAL) ? $user->lang['G_' . $group_row['group_name']] : $group_row['group_name'];
+						$group_row['group_name'] = $group_helper->get_name($group_row['group_name']);
 
 						if (confirm_box(true))
 						{
@@ -980,7 +983,7 @@ class ucp_groups
 							trigger_error($user->lang['NOT_LEADER_OF_GROUP'] . $return_page);
 						}
 
-						$group_row['group_name'] = ($group_row['group_type'] == GROUP_SPECIAL) ? $user->lang['G_' . $group_row['group_name']] : $group_row['group_name'];
+						$group_row['group_name'] = $group_helper->get_name($group_row['group_name']);
 
 						if (confirm_box(true))
 						{
@@ -1042,7 +1045,7 @@ class ucp_groups
 						}
 
 						$name_ary = array_unique(explode("\n", $names));
-						$group_name = ($group_row['group_type'] == GROUP_SPECIAL) ? $user->lang['G_' . $group_row['group_name']] : $group_row['group_name'];
+						$group_name = $group_helper->get_name($group_row['group_name']);
 
 						$default = $request->variable('default', 0);
 
@@ -1088,7 +1091,7 @@ class ucp_groups
 						while ($value = $db->sql_fetchrow($result))
 						{
 							$template->assign_block_vars('leader', array(
-								'GROUP_NAME'	=> ($value['group_type'] == GROUP_SPECIAL) ? $user->lang['G_' . $value['group_name']] : $value['group_name'],
+								'GROUP_NAME'	=> $group_helper->get_name($value['group_name']),
 								'GROUP_DESC'	=> generate_text_for_display($value['group_desc'], $value['group_desc_uid'], $value['group_desc_bitfield'], $value['group_desc_options']),
 								'GROUP_TYPE'	=> $value['group_type'],
 								'GROUP_ID'		=> $value['group_id'],

--- a/phpBB/includes/ucp/ucp_pm_compose.php
+++ b/phpBB/includes/ucp/ucp_pm_compose.php
@@ -76,6 +76,9 @@ function compose_pm($id, $mode, $action, $user_folders = array())
 	$error = array();
 	$current_time = time();
 
+	/** @var \phpbb\group\helper $group_helper */
+	$group_helper = $phpbb_container->get('group_helper');
+
 	// Was cancel pressed? If so then redirect to the appropriate page
 	if ($cancel || ($current_time - $lastclick < 2 && $submit))
 	{
@@ -145,7 +148,7 @@ function compose_pm($id, $mode, $action, $user_folders = array())
 			$group_options = '';
 			while ($row = $db->sql_fetchrow($result))
 			{
-				$group_options .= '<option' . (($row['group_type'] == GROUP_SPECIAL) ? ' class="sep"' : '') . ' value="' . $row['group_id'] . '">' . (($row['group_type'] == GROUP_SPECIAL) ? $user->lang['G_' . $row['group_name']] : $row['group_name']) . '</option>';
+				$group_options .= '<option' . (($row['group_type'] == GROUP_SPECIAL) ? ' class="sep"' : '') . ' value="' . $row['group_id'] . '">' . $group_helper->get_name($row['group_name']) . '</option>';
 			}
 			$db->sql_freeresult($result);
 		}
@@ -1059,7 +1062,7 @@ function compose_pm($id, $mode, $action, $user_folders = array())
 				{
 					if ($type == 'g')
 					{
-						$row['name'] = ($row['group_type'] == GROUP_SPECIAL) ? $user->lang['G_' . $row['name']] : $row['name'];
+						$row['name'] = $group_helper->get_name($row['name']);
 					}
 
 					${$type}[$row['id']] = array('name' => $row['name'], 'colour' => $row['colour']);

--- a/phpBB/includes/ucp/ucp_pm_options.php
+++ b/phpBB/includes/ucp/ucp_pm_options.php
@@ -700,7 +700,10 @@ function define_rule_option($hardcoded, $rule_option, $rule_lang, $check_ary)
 */
 function define_cond_option($hardcoded, $cond_option, $rule_option, $global_rule_conditions)
 {
-	global $db, $template, $auth, $user, $request;
+	global $db, $template, $auth, $user, $request, $phpbb_container;
+
+	/** @var \phpbb\group\helper $group_helper */
+	$group_helper = $phpbb_container->get('group_helper');
 
 	$template->assign_vars(array(
 		'S_COND_DEFINED'	=> true,
@@ -812,13 +815,13 @@ function define_cond_option($hardcoded, $cond_option, $rule_option, $global_rule
 			{
 				if ($rule_group_id && ($row['group_id'] == $rule_group_id))
 				{
-					$rule_string = (($row['group_type'] == GROUP_SPECIAL) ? $user->lang['G_' . $row['group_name']] : $row['group_name']);
+					$rule_string = $group_helper->get_name($row['group_name']);
 				}
 
 				$s_class	= ($row['group_type'] == GROUP_SPECIAL) ? ' class="sep"' : '';
 				$s_selected	= ($row['group_id'] == $rule_group_id) ? ' selected="selected"' : '';
 
-				$s_group_options .= '<option value="' . $row['group_id'] . '"' . $s_class . $s_selected . '>' . (($row['group_type'] == GROUP_SPECIAL) ? $user->lang['G_' . $row['group_name']] : $row['group_name']) . '</option>';
+				$s_group_options .= '<option value="' . $row['group_id'] . '"' . $s_class . $s_selected . '>' . $group_helper->get_name($row['group_name']) . '</option>';
 			}
 			$db->sql_freeresult($result);
 

--- a/phpBB/index.php
+++ b/phpBB/index.php
@@ -100,11 +100,14 @@ else
 }
 $result = $db->sql_query($sql);
 
+/** @var \phpbb\group\helper $group_helper */
+$group_helper = $phpbb_container->get('group_helper');
+
 $legend = array();
 while ($row = $db->sql_fetchrow($result))
 {
 	$colour_text = ($row['group_colour']) ? ' style="color:#' . $row['group_colour'] . '"' : '';
-	$group_name = ($row['group_type'] == GROUP_SPECIAL) ? $user->lang['G_' . $row['group_name']] : $row['group_name'];
+	$group_name = $group_helper->get_name($row['group_name']);
 
 	if ($row['group_name'] == 'BOTS' || ($user->data['user_id'] != ANONYMOUS && !$auth->acl_get('u_viewprofile')))
 	{

--- a/phpBB/memberlist.php
+++ b/phpBB/memberlist.php
@@ -1133,7 +1133,7 @@ switch ($mode)
 
 			$template->assign_vars(array(
 				'GROUP_DESC'	=> generate_text_for_display($group_row['group_desc'], $group_row['group_desc_uid'], $group_row['group_desc_bitfield'], $group_row['group_desc_options']),
-				'GROUP_NAME'	=> $group_helper->get_name($row['group_name']),
+				'GROUP_NAME'	=> $group_helper->get_name($group_row['group_name']),
 				'GROUP_COLOR'	=> $group_row['group_colour'],
 				'GROUP_TYPE'	=> $user->lang['GROUP_IS_' . $group_row['l_group_type']],
 				'GROUP_RANK'	=> $user_rank_data['title'],

--- a/phpBB/memberlist.php
+++ b/phpBB/memberlist.php
@@ -83,6 +83,9 @@ switch ($mode)
 	break;
 }
 
+/** @var \phpbb\group\helper $group_helper */
+$group_helper = $phpbb_container->get('group_helper');
+
 $start	= $request->variable('start', 0);
 $submit = (isset($_POST['submit'])) ? true : false;
 
@@ -136,7 +139,7 @@ switch ($mode)
 			}
 			else
 			{
-				$row['group_name'] = ($row['group_type'] == GROUP_SPECIAL) ? $user->lang['G_' . $row['group_name']] : $row['group_name'];
+				$row['group_name'] = $group_helper->get_name($row['group_name']);
 				$row['u_group'] = append_sid("{$phpbb_root_path}memberlist.$phpEx", 'mode=group&amp;g=' . $row['group_id']);
 			}
 
@@ -536,19 +539,13 @@ switch ($mode)
 		$group_data = $group_sort = array();
 		foreach ($profile_groups as $row)
 		{
-			if ($row['group_type'] == GROUP_SPECIAL)
-			{
-				// Lookup group name in language dictionary
-				if (isset($user->lang['G_' . $row['group_name']]))
-				{
-					$row['group_name'] = $user->lang['G_' . $row['group_name']];
-				}
-			}
-			else if (!$auth_hidden_groups && $row['group_type'] == GROUP_HIDDEN && !isset($user_groups[$row['group_id']]))
+			if (!$auth_hidden_groups && $row['group_type'] == GROUP_HIDDEN && !isset($user_groups[$row['group_id']]))
 			{
 				// Skip over hidden groups the user cannot see
 				continue;
 			}
+
+			$row['group_name'] = $group_helper->get_name($row['group_name']);
 
 			$group_sort[$row['group_id']] = utf8_clean_string($row['group_name']);
 			$group_data[$row['group_id']] = $row;
@@ -1136,7 +1133,7 @@ switch ($mode)
 
 			$template->assign_vars(array(
 				'GROUP_DESC'	=> generate_text_for_display($group_row['group_desc'], $group_row['group_desc_uid'], $group_row['group_desc_bitfield'], $group_row['group_desc_options']),
-				'GROUP_NAME'	=> ($group_row['group_type'] == GROUP_SPECIAL) ? $user->lang['G_' . $group_row['group_name']] : $group_row['group_name'],
+				'GROUP_NAME'	=> $group_helper->get_name($row['group_name']),
 				'GROUP_COLOR'	=> $group_row['group_colour'],
 				'GROUP_TYPE'	=> $user->lang['GROUP_IS_' . $group_row['l_group_type']],
 				'GROUP_RANK'	=> $user_rank_data['title'],
@@ -1315,7 +1312,7 @@ switch ($mode)
 			while ($row = $db->sql_fetchrow($result))
 			{
 				$group_ids[] = $row['group_id'];
-				$s_group_select .= '<option value="' . $row['group_id'] . '"' . (($group_selected == $row['group_id']) ? ' selected="selected"' : '') . '>' . (($row['group_type'] == GROUP_SPECIAL) ? $user->lang['G_' . $row['group_name']] : $row['group_name']) . '</option>';
+				$s_group_select .= '<option value="' . $row['group_id'] . '"' . (($group_selected == $row['group_id']) ? ' selected="selected"' : '') . '>' . $group_helper->get_name($row['group_name']) . '</option>';
 			}
 			$db->sql_freeresult($result);
 

--- a/phpBB/phpbb/group/helper.php
+++ b/phpBB/phpbb/group/helper.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ *
+ * This file is part of the phpBB Forum Software package.
+ *
+ * @copyright (c) phpBB Limited <https://www.phpbb.com>
+ * @license GNU General Public License, version 2 (GPL-2.0)
+ *
+ * For full copyright and license information, please see
+ * the docs/CREDITS.txt file.
+ *
+ */
+
+namespace phpbb\group;
+
+class helper
+{
+	/** @var  \phpbb\language\language */
+	protected $language;
+
+	/**
+	 * Constructor
+	 *
+	 * @param \phpbb\language\language $language	Language object
+	 */
+	public function __construct(\phpbb\language\language $language)
+	{
+		$this->language = $language;
+	}
+
+	/**
+	 * @param $group_name string	The stored group name
+	 *
+	 * @return string		Group name or translated group name if it exists
+	 */
+	public function get_name($group_name)
+	{
+		return $this->language->is_set('G_' . utf8_strtoupper($group_name)) ? $this->language->lang('G_' . utf8_strtoupper($group_name)) : $group_name;
+	}
+}

--- a/phpBB/phpbb/language/language.php
+++ b/phpBB/phpbb/language/language.php
@@ -194,6 +194,36 @@ class language
 	}
 
 	/**
+	 * @param $key array|string		The language key we want to know more about. Can be string or array.
+	 *
+	 * @return bool		Returns whether the language key is set.
+	 */
+	public function is_set($key)
+	{
+		// Load common language files if they not loaded yet
+		if (!$this->common_language_files_loaded)
+		{
+			$this->load_common_language_files();
+		}
+
+		if (is_array($key))
+		{
+			$lang = &$this->lang[array_shift($key)];
+
+			foreach ($key as $_key)
+			{
+				$lang = &$lang[$_key];
+			}
+		}
+		else
+		{
+			$lang = &$this->lang[$key];
+		}
+
+		return isset($lang);
+	}
+
+	/**
 	 * Advanced language substitution
 	 *
 	 * Function to mimic sprintf() with the possibility of using phpBB's language system to substitute nullar/singular/plural forms.

--- a/phpBB/viewonline.php
+++ b/phpBB/viewonline.php
@@ -182,6 +182,9 @@ $logged_visible_online = $logged_hidden_online = $counter = 0;
 /** @var \phpbb\controller\helper $controller_helper */
 $controller_helper = $phpbb_container->get('controller.helper');
 
+/** @var \phpbb\group\helper $group_helper */
+$group_helper = $phpbb_container->get('group_helper');
+
 while ($row = $db->sql_fetchrow($result))
 {
 	if ($row['user_id'] != ANONYMOUS && !isset($prev_id[$row['user_id']]))
@@ -467,7 +470,7 @@ while ($row = $db->sql_fetchrow($result))
 	}
 	else
 	{
-		$legend .= (($legend != '') ? ', ' : '') . '<a style="color:#' . $row['group_colour'] . '" href="' . append_sid("{$phpbb_root_path}memberlist.$phpEx", 'mode=group&amp;g=' . $row['group_id']) . '">' . (($row['group_type'] == GROUP_SPECIAL) ? $user->lang['G_' . $row['group_name']] : $row['group_name']) . '</a>';
+		$legend .= (($legend != '') ? ', ' : '') . '<a style="color:#' . $row['group_colour'] . '" href="' . append_sid("{$phpbb_root_path}memberlist.$phpEx", 'mode=group&amp;g=' . $row['group_id']) . '">' . $group_helper->get_name($row['group_name']) . '</a>';
 	}
 }
 $db->sql_freeresult($result);

--- a/tests/group/helper_test.php
+++ b/tests/group/helper_test.php
@@ -45,15 +45,15 @@ class phpbb_group_helper_test extends phpbb_test_case
 	public function test_get_name()
 	{
 		// They should be totally fine
-		$this->assertEquals('Bots', 'Bots');
-		$this->assertEquals('Some new group', 'new_group');
-		$this->assertEquals('Should work', 'group_with_ümlauts');
+		$this->assertEquals('Bots', $this->group_helper->get_name('Bots'));
+		$this->assertEquals('Some new group', $this->group_helper->get_name('new_group'));
+		$this->assertEquals('Should work', $this->group_helper->get_name('group_with_ümlauts'));
 
 		// This should fail (obviously)
-		$this->assertNotEquals('They key does not contain uppercase letters', 'not_uppercase');
+		$this->assertNotEquals('They key does not contain uppercase letters', $this->group_helper->get_name('not_uppercase'));
 
 		// The key doesn't exist so just return group name...
-		$this->assertEquals('Awesome group', 'Awesome group');
+		$this->assertEquals('Awesome group', $this->group_helper->get_name('Awesome group'));
 	}
 
 	protected function get_test_language_data_set()

--- a/tests/group/helper_test.php
+++ b/tests/group/helper_test.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ *
+ * This file is part of the phpBB Forum Software package.
+ *
+ * @copyright (c) phpBB Limited <https://www.phpbb.com>
+ * @license GNU General Public License, version 2 (GPL-2.0)
+ *
+ * For full copyright and license information, please see
+ * the docs/CREDITS.txt file.
+ *
+ */
+
+class phpbb_group_helper_test extends phpbb_test_case
+{
+	/** @var  \phpbb\group\helper */
+	protected $group_helper;
+
+	public function setUp()
+	{
+		global $phpbb_root_path, $phpEx;
+
+		// Set up language service
+		$lang = new \phpbb\language\language(
+			new \phpbb\language\language_file_loader($phpbb_root_path, $phpEx)
+		);
+
+		// Set up language data for testing
+		$reflection_class = new ReflectionClass('\phpbb\language\language');
+
+		// Set default language files loaded flag to true
+		$loaded_flag = $reflection_class->getProperty('common_language_files_loaded');
+		$loaded_flag->setAccessible(true);
+		$loaded_flag->setValue($lang, true);
+
+		// Set up test language data
+		$lang_array = $reflection_class->getProperty('lang');
+		$lang_array->setAccessible(true);
+		$lang_array->setValue($lang, $this->get_test_language_data_set());
+
+		// Set up group helper
+		$this->group_helper = new \phpbb\group\helper($lang);
+	}
+
+	public function test_get_name()
+	{
+		// They should be totally fine
+		$this->assertEquals('Bots', 'Bots');
+		$this->assertEquals('Some new group', 'new_group');
+		$this->assertEquals('Should work', 'group_with_ümlauts');
+
+		// This should fail (obviously)
+		$this->assertNotEquals('They key does not contain uppercase letters', 'not_uppercase');
+
+		// The key doesn't exist so just return group name...
+		$this->assertEquals('Awesome group', 'Awesome group');
+	}
+
+	protected function get_test_language_data_set()
+	{
+		return array(
+			'G_BOTS'					=> 'Bots',
+			'G_NEW_GROUP'				=> 'Some new group',
+			'G_not_uppercase'			=> 'The key does not contain uppercase letters',
+			'G_GROUP_WITH_ÜMLAUTS'		=> 'Should work',
+		);
+	}
+}

--- a/tests/language/language_test.php
+++ b/tests/language/language_test.php
@@ -39,6 +39,20 @@ class phpbb_language_test extends phpbb_test_case
 		$lang_array->setValue($this->lang, $this->get_test_data_set());
 	}
 
+	public function test_is_set()
+	{
+		// Check for non-existing key
+		$this->assertFalse($this->lang->is_set('VALUE'));
+		$this->assertFalse($this->lang->is_set(array('dateformat', 'MAYBE')));
+
+		// Check for existing key
+		$this->assertTrue($this->lang->is_set('FOO'));
+		$this->assertTrue($this->lang->is_set(array('dateformat', 'AGO')));
+
+		// Array doesn't exist at all...
+		$this->assertFalse($this->lang->is_set(array('PHPBB', 'PHP')));
+	}
+
 	public function test_lang()
 	{
 		// No param

--- a/tests/notification/fixtures/services_notification.yml
+++ b/tests/notification/fixtures/services_notification.yml
@@ -23,6 +23,9 @@ services:
     cache.driver:
         synthetic: true
 
+    group_helper:
+        synthetic: true
+
     path_helper:
         synthetic: true
 

--- a/tests/notification/group_request_test.php
+++ b/tests/notification/group_request_test.php
@@ -49,6 +49,11 @@ class phpbb_notification_group_request_test extends phpbb_tests_notification_bas
 			$this->user,
 			$this->cache->get_driver()
 		));
+		$this->container->set('group_helper', new \phpbb\group\helper(
+			new \phpbb\language\language(
+				new phpbb\language\language_file_loader($phpbb_root_path, $phpEx)
+			)
+		));
 		$phpbb_dispatcher = new phpbb_mock_event_dispatcher;
 		$phpbb_log = new \phpbb\log\dummy();
 		$this->get_test_case_helpers()->set_s9e_services();


### PR DESCRIPTION
Yeah, so I did this... out of the old PR #2247 

I had to do a new method in language service - I think it should be fine to do that in this PR.

I want to create another class like this, which is based on the function get_username_string, but splitted up to several functions like get_name, get_color, etc.
These methods (get_name, get_color) can be added to this class to at a later point too, I guess.

[PHPBB3-12143](https://tracker.phpbb.com/browse/PHPBB3-12143)