### PR TITLE
[ticket/13881] Ported changes from PHPBB3-13880

### DIFF
--- a/phpBB/includes/message_parser.php
+++ b/phpBB/includes/message_parser.php
@@ -792,28 +792,6 @@ class bbcode_firstpass extends bbcode
 				else if (preg_match('#^quote(?:=&quot;(.*?)&quot;)?$#is', $buffer, $m) && substr($out, -1, 1) == '[')
 				{
 					$this->parsed_items['quote']++;
-
-					// the buffer holds a valid opening tag
-					if ($config['max_quote_depth'] && sizeof($close_tags) >= $config['max_quote_depth'])
-					{
-						if ($config['max_quote_depth'] == 1)
-						{
-							// Depth 1 - no nesting is allowed
-							$error_ary['quote_depth'] = $user->lang('QUOTE_NO_NESTING');
-						}
-						else
-						{
-							// There are too many nested quotes
-							$error_ary['quote_depth'] = $user->lang('QUOTE_DEPTH_EXCEEDED', (int) $config['max_quote_depth']);
-						}
-
-						$out .= $buffer . $tok;
-						$tok = '[]';
-						$buffer = '';
-
-						continue;
-					}
-
 					array_push($close_tags, '/quote:' . $this->bbcode_uid);
 
 					if (isset($m[1]) && $m[1])
@@ -1245,22 +1223,18 @@ class parse_message extends bbcode_firstpass
 		// Parse this message
 		$this->message = $parser->parse(htmlspecialchars_decode($this->message, ENT_QUOTES));
 
+		// Remove quotes that are nested too deep
+		if ($config['max_quote_depth'] > 0)
+		{
+			$this->remove_nested_quotes($config['max_quote_depth']);
+		}
+
 		// Check for "empty" message. We do not check here for maximum length, because bbcode, smilies, etc. can add to the length.
 		// The maximum length check happened before any parsings.
 		if ($mode === 'post' && utf8_clean_string($this->message) === '')
 		{
 			$this->warn_msg[] = $user->lang['TOO_FEW_CHARS'];
 			return (!$update_this_message) ? $return_message : $this->warn_msg;
-		}
-
-		// Remove quotes that are nested too deep
-		if ($config['max_quote_depth'] > 0)
-		{
-			$this->message = $phpbb_container->get('text_formatter.utils')->remove_bbcode(
-				$this->message,
-				'quote',
-				$config['max_quote_depth']
-			);
 		}
 
 		// Check for errors
@@ -1833,6 +1807,60 @@ class parse_message extends bbcode_firstpass
 		$poll['poll_max_options'] = ($poll['poll_max_options'] < 1) ? 1 : (($poll['poll_max_options'] > $config['max_poll_options']) ? $config['max_poll_options'] : $poll['poll_max_options']);
 
 		$this->message = $tmp_message;
+	}
+
+	/**
+	* Remove nested quotes at given depth in current parsed message
+	*
+	* @param  integer $max_depth Depth limit
+	* @return null
+	*/
+	public function remove_nested_quotes($max_depth)
+	{
+		if (preg_match('#^<[rt][ >]#', $this->message))
+		{
+			global $phpbb_container;
+			$this->message = $phpbb_container->get('text_formatter.utils')->remove_bbcode(
+				$this->message,
+				'quote',
+				$max_depth
+			);
+		}
+
+		// Capture all [quote] and [/quote] tags
+		preg_match_all('(\\[/?quote(?:=[^]]+)?:' . $this->bbcode_uid . '\\])', $this->message, $matches, PREG_OFFSET_CAPTURE);
+
+		// Iterate over the quote tags to mark the ranges that must be removed
+		$depth = 0;
+		$ranges = array();
+		$start_pos = 0;
+		foreach ($matches[0] as $match)
+		{
+			if ($match[0][1] === '/')
+			{
+				--$depth;
+				if ($depth == $max_depth)
+				{
+					$end_pos = $match[1] + strlen($match[0]);
+					$length = $end_pos - $start_pos;
+					$ranges[] = array($start_pos, $length);
+				}
+			}
+			else
+			{
+				++$depth;
+				if ($depth == $max_depth + 1)
+				{
+					$start_pos = $match[1];
+				}
+			}
+		}
+
+		foreach (array_reverse($ranges) as $range)
+		{
+			list($start_pos, $length) = $range;
+			$this->message = substr_replace($this->message, '', $start_pos, $length);
+		}
 	}
 
 	/**

--- a/phpBB/posting.php
+++ b/phpBB/posting.php
@@ -1580,13 +1580,12 @@ if (!sizeof($error) && $preview)
 
 // Remove quotes that would become nested too deep before decoding the text
 $generate_quote = ($mode == 'quote' && !$submit && !$preview && !$refresh);
-if ($generate_quote && $config['max_quote_depth'] > 0 && preg_match('#^<[rt][ >]#', $message_parser->message))
+if ($generate_quote && $config['max_quote_depth'] > 0)
 {
-	$message_parser->message = $phpbb_container->get('text_formatter.utils')->remove_bbcode(
-		$message_parser->message,
-		'quote',
-		$config['max_quote_depth'] - 1
-	);
+	$tmp_bbcode_uid = $message_parser->bbcode_uid;
+	$message_parser->bbcode_uid = $post_data['bbcode_uid'];
+	$message_parser->remove_nested_quotes($config['max_quote_depth'] - 1);
+	$message_parser->bbcode_uid = $tmp_bbcode_uid;
 }
 
 // Decode text for message display


### PR DESCRIPTION
https://tracker.phpbb.com/browse/PHPBB3-13881

Fixes an issue in 3.2 where deep quotes are not immediately removed when quoting old posts, because of the different BBCode engines.
