### PR TITLE
[ticket/13867] Enable/disable mechanism for new profile field types

### DIFF
--- a/phpBB/config/profilefield.yml
+++ b/phpBB/config/profilefield.yml
@@ -2,14 +2,15 @@ services:
     profilefields.manager:
         class: phpbb\profilefields\manager
         arguments:
-            - @service_container
             - @auth
             - @dbal.conn
+            - @dbal.tools
             - @dispatcher
             - @request
             - @template
             - @profilefields.type_collection
             - @user
+            - @config_text
             - %tables.profile_fields%
             - %tables.profile_fields_language%
             - %tables.profile_fields_data%

--- a/phpBB/config/profilefield.yml
+++ b/phpBB/config/profilefield.yml
@@ -2,6 +2,7 @@ services:
     profilefields.manager:
         class: phpbb\profilefields\manager
         arguments:
+            - @service_container
             - @auth
             - @dbal.conn
             - @dispatcher

--- a/phpBB/includes/acp/acp_profile.php
+++ b/phpBB/includes/acp/acp_profile.php
@@ -672,7 +672,8 @@ class acp_profile
 				$s_one_need_edit = true;
 			}
 
-			try {
+			try
+			{
 				$profile_field = $this->type_collection[$row['field_type']];
 			}
 			catch (\Exception $e)

--- a/phpBB/includes/acp/acp_profile.php
+++ b/phpBB/includes/acp/acp_profile.php
@@ -672,14 +672,12 @@ class acp_profile
 				$s_one_need_edit = true;
 			}
 
-			try
-			{
-				$profile_field = $this->type_collection[$row['field_type']];
-			}
-			catch (\Exception $e)
+			if (!isset($this->type_collection[$row['field_type']]))
 			{
 				continue;
 			}
+			$profile_field = $this->type_collection[$row['field_type']];
+
 			$template->assign_block_vars('fields', array(
 				'FIELD_IDENT'		=> $row['field_ident'],
 				'FIELD_TYPE'		=> $profile_field->get_name(),

--- a/phpBB/includes/acp/acp_profile.php
+++ b/phpBB/includes/acp/acp_profile.php
@@ -672,7 +672,13 @@ class acp_profile
 				$s_one_need_edit = true;
 			}
 
-			$profile_field = $this->type_collection[$row['field_type']];
+			try {
+				$profile_field = $this->type_collection[$row['field_type']];
+			}
+			catch (\Exception $e)
+			{
+				continue;
+			}
 			$template->assign_block_vars('fields', array(
 				'FIELD_IDENT'		=> $row['field_ident'],
 				'FIELD_TYPE'		=> $profile_field->get_name(),

--- a/phpBB/includes/acp/acp_profile.php
+++ b/phpBB/includes/acp/acp_profile.php
@@ -672,12 +672,7 @@ class acp_profile
 				$s_one_need_edit = true;
 			}
 
-			if (!isset($this->type_collection[$row['field_type']]))
-			{
-				continue;
-			}
 			$profile_field = $this->type_collection[$row['field_type']];
-
 			$template->assign_block_vars('fields', array(
 				'FIELD_IDENT'		=> $row['field_ident'],
 				'FIELD_TYPE'		=> $profile_field->get_name(),

--- a/phpBB/phpbb/profilefields/manager.php
+++ b/phpBB/phpbb/profilefields/manager.php
@@ -13,11 +13,19 @@
 
 namespace phpbb\profilefields;
 
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
 /**
 * Custom Profile Fields
 */
 class manager
 {
+	/**
+	* Container interface
+	* @var ContainerInterface
+	*/
+	protected $container;
+
 	/**
 	* Auth object
 	* @var \phpbb\auth\auth
@@ -68,9 +76,14 @@ class manager
 
 	protected $profile_cache = array();
 
+	protected $config_text;
+
+	protected $db_tools;
+
 	/**
 	* Construct
 	*
+	* @param	ContainerInterface $container A container
 	* @param	\phpbb\auth\auth			$auth		Auth object
 	* @param	\phpbb\db\driver\driver_interface	$db			Database object
 	* @param	\phpbb\event\dispatcher_interface		$dispatcher	Event dispatcher object
@@ -82,8 +95,9 @@ class manager
 	* @param	string				$fields_language_table
 	* @param	string				$fields_data_table
 	*/
-	public function __construct(\phpbb\auth\auth $auth, \phpbb\db\driver\driver_interface $db, \phpbb\event\dispatcher_interface $dispatcher, \phpbb\request\request $request, \phpbb\template\template $template, \phpbb\di\service_collection $type_collection, \phpbb\user $user, $fields_table, $fields_language_table, $fields_data_table)
+	public function __construct(ContainerInterface $container, \phpbb\auth\auth $auth, \phpbb\db\driver\driver_interface $db, \phpbb\event\dispatcher_interface $dispatcher, \phpbb\request\request $request, \phpbb\template\template $template, \phpbb\di\service_collection $type_collection, \phpbb\user $user, $fields_table, $fields_language_table, $fields_data_table)
 	{
+		$this->container = $container;
 		$this->auth = $auth;
 		$this->db = $db;
 		$this->dispatcher = $dispatcher;
@@ -95,6 +109,9 @@ class manager
 		$this->fields_table = $fields_table;
 		$this->fields_language_table = $fields_language_table;
 		$this->fields_data_table = $fields_data_table;
+
+		$this->config_text = $this->container->get('config_text');
+		$this->db_tools = $this->container->get('dbal.tools');
 	}
 
 	/**
@@ -478,5 +495,162 @@ class manager
 		$this->db->sql_freeresult($result);
 
 		return $cp_data;
+	}
+
+	/**
+	* Disable all profile fields of a certain type
+	*
+	* This should be called when an extension which has profile field types
+	* is disabled so that all those profile fields are hidden and do not
+	* cause errors
+	*
+	* @param string $profilefield_type_name Type identifier of the profile fields
+	*/
+	public function disable_profilefields($profilefield_type_name)
+	{
+		// Get list of profile fields affected by this operation, if any
+		$pfs = array();
+		$sql = 'SELECT field_id, field_ident
+			FROM ' . PROFILE_FIELDS_TABLE . "
+			WHERE field_active = 1
+				AND field_type = '" . $this->db->sql_escape($profilefield_type_name) . "'";
+		$result = $this->db->sql_query($sql);
+		while ($row = $this->db->sql_fetchrow($result))
+		{
+			$pfs[(int) $row['field_id']] = $row['field_ident'];
+		}
+		$this->db->sql_freeresult($result);
+
+		// If no profile fields affected, then nothing to do
+		if (!sizeof($pfs))
+		{
+			return;
+		}
+
+		// Update the affected profile fields to "inactive"
+		$sql = 'UPDATE ' . PROFILE_FIELDS_TABLE . "
+			SET field_active = 0
+			WHERE field_active = 1
+				AND field_type = '" . $this->db->sql_escape($profilefield_type_name) . "'";
+		$this->db->sql_query($sql);
+
+		// Save modified information into a config_text field to recover on enable
+		$this->config_text->set($profilefield_type_name . '.saved', base64_encode(serialize($pfs)));
+
+		// Log activity
+		foreach ($pfs as $field_ident)
+		{
+			add_log('admin', 'LOG_PROFILE_FIELD_DEACTIVATE', $field_ident);
+		}
+	}
+
+	/**
+	* Purge all profile fields of a certain type
+	*
+	* This should be called when an extension which has profile field types
+	* is purged so that all those profile fields are removed
+	*
+	* @param string $profilefield_type_name Type identifier of the profile fields
+	*/
+	public function purge_profilefields($profilefield_type_name)
+	{
+		// Remove the information saved on disable in a config_text field, not needed any longer
+		$this->config_text->delete($profilefield_type_name . '.saved');
+
+		// Get list of profile fields affected by this operation, if any
+		$pfs = array();
+		$sql = 'SELECT field_id, field_ident
+			FROM ' . PROFILE_FIELDS_TABLE . "
+			WHERE field_type = '" . $this->db->sql_escape($profilefield_type_name) . "'";
+		$result = $this->db->sql_query($sql);
+		while ($row = $this->db->sql_fetchrow($result))
+		{
+			$pfs[(int) $row['field_id']] = $row['field_ident'];
+		}
+		$this->db->sql_freeresult($result);
+
+		// If no profile fields exist, then nothing to do
+		if (!sizeof($pfs))
+		{
+			return;
+		}
+
+		$this->db->sql_transaction('begin');
+
+		// Delete entries from all profile field definition tables
+		$where = $this->db->sql_in_set('field_id', array_keys($pfs));
+		$this->db->sql_query('DELETE FROM ' . PROFILE_FIELDS_TABLE . ' WHERE ' . $where);
+		$this->db->sql_query('DELETE FROM ' . PROFILE_FIELDS_LANG_TABLE . ' WHERE ' . $where);
+		$this->db->sql_query('DELETE FROM ' . PROFILE_LANG_TABLE . ' WHERE ' . $where);
+
+		// Drop columns from the Profile Fields data table
+		foreach ($pfs as $field_ident)
+		{
+			$this->db_tools->sql_column_remove(PROFILE_FIELDS_DATA_TABLE, 'pf_' . $field_ident);
+		}
+
+		// Reset the order of the remaining fields
+		$order = 0;
+
+		$sql = 'SELECT *
+			FROM ' . PROFILE_FIELDS_TABLE . '
+			ORDER BY field_order';
+		$result = $this->db->sql_query($sql);
+
+		while ($row = $this->db->sql_fetchrow($result))
+		{
+			$order++;
+			if ($row['field_order'] != $order)
+			{
+				$sql = 'UPDATE ' . PROFILE_FIELDS_TABLE . "
+					SET field_order = $order
+					WHERE field_id = {$row['field_id']}";
+				$this->db->sql_query($sql);
+			}
+		}
+		$this->db->sql_freeresult($result);
+
+		$this->db->sql_transaction('commit');
+
+		// Log activity
+		foreach ($pfs as $field_ident)
+		{
+			add_log('admin', 'LOG_PROFILE_FIELD_REMOVED', $field_ident);
+		}
+	}
+
+	/**
+	* Enable the profile fields of a certain type
+	*
+	* This should be called when an extension which has profile field types
+	* that was disabled is re-enabled so that all those profile fields that
+	* were disabled are enabled again
+	*
+	* @param string $profilefield_type_name Type identifier of the profile fields
+	*/
+	public function enable_profilefields($profilefield_type_name)
+	{
+		// Read the modified information saved on disable from a config_text field to recover values, then remove it
+		$pfs = $this->config_text->get($profilefield_type_name . '.saved');
+		$this->config_text->delete($profilefield_type_name . '.saved');
+
+		// If nothing saved, then nothing to do
+		if ($pfs == '')
+		{
+			return;
+		}
+
+		$pfs = unserialize(base64_decode($pfs));
+
+		// Restore the affected profile fields to "active"
+		$sql = 'UPDATE ' . PROFILE_FIELDS_TABLE . "
+			SET field_active = 1
+			WHERE field_active = 0
+				AND " . $this->db->sql_in_set('field_id', array_keys($pfs));
+		$this->db->sql_query($sql);
+		foreach ($pfs as $field_ident)
+		{
+			add_log('admin', 'LOG_PROFILE_FIELD_ACTIVATE', $field_ident);
+		}
 	}
 }

--- a/phpBB/phpbb/profilefields/manager.php
+++ b/phpBB/phpbb/profilefields/manager.php
@@ -13,19 +13,11 @@
 
 namespace phpbb\profilefields;
 
-use Symfony\Component\DependencyInjection\ContainerInterface;
-
 /**
 * Custom Profile Fields
 */
 class manager
 {
-	/**
-	* Container interface
-	* @var ContainerInterface
-	*/
-	protected $container;
-
 	/**
 	* Auth object
 	* @var \phpbb\auth\auth
@@ -37,6 +29,12 @@ class manager
 	* @var \phpbb\db\driver\driver_interface
 	*/
 	protected $db;
+
+	/**
+	* Database tools object
+	* @var \phpbb\db\tools
+	*/
+	protected $db_tools;
 
 	/**
 	* Event dispatcher object
@@ -68,6 +66,12 @@ class manager
 	*/
 	protected $user;
 
+	/**
+	* Config_text object
+	* @var \phpbb\config\db_text
+	*/
+	protected $config_text;
+
 	protected $fields_table;
 
 	protected $fields_language_table;
@@ -76,42 +80,37 @@ class manager
 
 	protected $profile_cache = array();
 
-	protected $config_text;
-
-	protected $db_tools;
-
 	/**
 	* Construct
 	*
-	* @param	ContainerInterface $container A container
 	* @param	\phpbb\auth\auth			$auth		Auth object
 	* @param	\phpbb\db\driver\driver_interface	$db			Database object
+	* @param	\phpbb\db\tools				$db_tools	Database object
 	* @param	\phpbb\event\dispatcher_interface		$dispatcher	Event dispatcher object
 	* @param	\phpbb\request\request		$request	Request object
 	* @param	\phpbb\template\template	$template	Template object
 	* @param	\phpbb\di\service_collection $type_collection
 	* @param	\phpbb\user					$user		User object
+	* @param	\phpbb\config\db_text		$config_text		Config_text object
 	* @param	string				$fields_table
 	* @param	string				$fields_language_table
 	* @param	string				$fields_data_table
 	*/
-	public function __construct(ContainerInterface $container, \phpbb\auth\auth $auth, \phpbb\db\driver\driver_interface $db, \phpbb\event\dispatcher_interface $dispatcher, \phpbb\request\request $request, \phpbb\template\template $template, \phpbb\di\service_collection $type_collection, \phpbb\user $user, $fields_table, $fields_language_table, $fields_data_table)
+	public function __construct(\phpbb\auth\auth $auth, \phpbb\db\driver\driver_interface $db, \phpbb\db\tools $db_tools, \phpbb\event\dispatcher_interface $dispatcher, \phpbb\request\request $request, \phpbb\template\template $template, \phpbb\di\service_collection $type_collection, \phpbb\user $user, \phpbb\config\db_text $config_text, $fields_table, $fields_language_table, $fields_data_table)
 	{
-		$this->container = $container;
 		$this->auth = $auth;
 		$this->db = $db;
+		$this->db_tools = $db_tools;
 		$this->dispatcher = $dispatcher;
 		$this->request = $request;
 		$this->template = $template;
 		$this->type_collection = $type_collection;
 		$this->user = $user;
+		$this->config_text = $config_text;
 
 		$this->fields_table = $fields_table;
 		$this->fields_language_table = $fields_language_table;
 		$this->fields_data_table = $fields_data_table;
-
-		$this->config_text = $this->container->get('config_text');
-		$this->db_tools = $this->container->get('dbal.tools');
 	}
 
 	/**

--- a/phpBB/phpbb/profilefields/manager.php
+++ b/phpBB/phpbb/profilefields/manager.php
@@ -507,18 +507,8 @@ class manager
 	*/
 	public function disable_profilefields($profilefield_type_name)
 	{
-		// Get list of profile fields affected by this operation, if any
-		$profile_fields = array();
-		$sql = 'SELECT field_id, field_ident
-			FROM ' . PROFILE_FIELDS_TABLE . "
-			WHERE field_active = 1
-				AND field_type = '" . $this->db->sql_escape($profilefield_type_name) . "'";
-		$result = $this->db->sql_query($sql);
-		while ($row = $this->db->sql_fetchrow($result))
-		{
-			$profile_fields[(int) $row['field_id']] = $row['field_ident'];
-		}
-		$this->db->sql_freeresult($result);
+		// Get the list of active profile fields of this type
+		$profile_fields = $this->list_profilefields($profilefield_type_name, true);
 
 		// If no profile fields affected, then nothing to do
 		if (!sizeof($profile_fields))
@@ -527,10 +517,10 @@ class manager
 		}
 
 		// Update the affected profile fields to "inactive"
-		$sql = 'UPDATE ' . PROFILE_FIELDS_TABLE . "
+		$sql = 'UPDATE ' . PROFILE_FIELDS_TABLE . '
 			SET field_active = 0
 			WHERE field_active = 1
-				AND field_type = '" . $this->db->sql_escape($profilefield_type_name) . "'";
+				AND ' . $this->db->sql_in_set('field_id', array_keys($profile_fields));
 		$this->db->sql_query($sql);
 
 		// Save modified information into a config_text field to recover on enable
@@ -556,17 +546,8 @@ class manager
 		// Remove the information saved on disable in a config_text field, not needed any longer
 		$this->config_text->delete($profilefield_type_name . '.saved');
 
-		// Get list of profile fields affected by this operation, if any
-		$profile_fields = array();
-		$sql = 'SELECT field_id, field_ident
-			FROM ' . PROFILE_FIELDS_TABLE . "
-			WHERE field_type = '" . $this->db->sql_escape($profilefield_type_name) . "'";
-		$result = $this->db->sql_query($sql);
-		while ($row = $this->db->sql_fetchrow($result))
-		{
-			$profile_fields[(int) $row['field_id']] = $row['field_ident'];
-		}
-		$this->db->sql_freeresult($result);
+		// Get the list of all profile fields of this type
+		$profile_fields = $this->list_profilefields($profilefield_type_name);
 
 		// If no profile fields exist, then nothing to do
 		if (!sizeof($profile_fields))
@@ -641,10 +622,10 @@ class manager
 		$profile_fields = json_decode($profile_fields, true);
 
 		// Restore the affected profile fields to "active"
-		$sql = 'UPDATE ' . PROFILE_FIELDS_TABLE . "
+		$sql = 'UPDATE ' . PROFILE_FIELDS_TABLE . '
 			SET field_active = 1
 			WHERE field_active = 0
-				AND " . $this->db->sql_in_set('field_id', array_keys($profile_fields));
+				AND ' . $this->db->sql_in_set('field_id', array_keys($profile_fields));
 		$this->db->sql_query($sql);
 
 		// Remove the information saved in the config_text field, not needed any longer
@@ -655,5 +636,29 @@ class manager
 		{
 			add_log('admin', 'LOG_PROFILE_FIELD_ACTIVATE', $field_ident);
 		}
+	}
+
+	/**
+	* Get list of profile fields of a certain type, if any 
+	*
+	* @param string $profilefield_type_name Type identifier of the profile fields
+	* @param bool	$active					True to limit output to active profile fields,  false for all
+	* @return array Array with profile field ids as keys and idents as values
+	*/
+	private function list_profilefields($profilefield_type_name, $active=false)
+	{
+		// Get list of profile fields affected by this operation, if any
+		$profile_fields = array();
+		$sql = 'SELECT field_id, field_ident
+			FROM ' . PROFILE_FIELDS_TABLE . "
+			WHERE field_type = '" . $this->db->sql_escape($profilefield_type_name) . "'" . 
+				($active) ? 'AND field_active = 1' : '';
+		$result = $this->db->sql_query($sql);
+		while ($row = $this->db->sql_fetchrow($result))
+		{
+			$profile_fields[(int) $row['field_id']] = $row['field_ident'];
+		}
+		$this->db->sql_freeresult($result);
+		return $profile_fields;
 	}
 }

--- a/phpBB/phpbb/profilefields/manager.php
+++ b/phpBB/phpbb/profilefields/manager.php
@@ -508,7 +508,7 @@ class manager
 	public function disable_profilefields($profilefield_type_name)
 	{
 		// Get list of profile fields affected by this operation, if any
-		$pfs = array();
+		$profile_fields = array();
 		$sql = 'SELECT field_id, field_ident
 			FROM ' . PROFILE_FIELDS_TABLE . "
 			WHERE field_active = 1
@@ -516,12 +516,12 @@ class manager
 		$result = $this->db->sql_query($sql);
 		while ($row = $this->db->sql_fetchrow($result))
 		{
-			$pfs[(int) $row['field_id']] = $row['field_ident'];
+			$profile_fields[(int) $row['field_id']] = $row['field_ident'];
 		}
 		$this->db->sql_freeresult($result);
 
 		// If no profile fields affected, then nothing to do
-		if (!sizeof($pfs))
+		if (!sizeof($profile_fields))
 		{
 			return;
 		}
@@ -534,10 +534,10 @@ class manager
 		$this->db->sql_query($sql);
 
 		// Save modified information into a config_text field to recover on enable
-		$this->config_text->set($profilefield_type_name . '.saved', base64_encode(serialize($pfs)));
+		$this->config_text->set($profilefield_type_name . '.saved', json_encode($profile_fields));
 
 		// Log activity
-		foreach ($pfs as $field_ident)
+		foreach ($profile_fields as $field_ident)
 		{
 			add_log('admin', 'LOG_PROFILE_FIELD_DEACTIVATE', $field_ident);
 		}
@@ -557,19 +557,19 @@ class manager
 		$this->config_text->delete($profilefield_type_name . '.saved');
 
 		// Get list of profile fields affected by this operation, if any
-		$pfs = array();
+		$profile_fields = array();
 		$sql = 'SELECT field_id, field_ident
 			FROM ' . PROFILE_FIELDS_TABLE . "
 			WHERE field_type = '" . $this->db->sql_escape($profilefield_type_name) . "'";
 		$result = $this->db->sql_query($sql);
 		while ($row = $this->db->sql_fetchrow($result))
 		{
-			$pfs[(int) $row['field_id']] = $row['field_ident'];
+			$profile_fields[(int) $row['field_id']] = $row['field_ident'];
 		}
 		$this->db->sql_freeresult($result);
 
 		// If no profile fields exist, then nothing to do
-		if (!sizeof($pfs))
+		if (!sizeof($profile_fields))
 		{
 			return;
 		}
@@ -577,13 +577,13 @@ class manager
 		$this->db->sql_transaction('begin');
 
 		// Delete entries from all profile field definition tables
-		$where = $this->db->sql_in_set('field_id', array_keys($pfs));
+		$where = $this->db->sql_in_set('field_id', array_keys($profile_fields));
 		$this->db->sql_query('DELETE FROM ' . PROFILE_FIELDS_TABLE . ' WHERE ' . $where);
 		$this->db->sql_query('DELETE FROM ' . PROFILE_FIELDS_LANG_TABLE . ' WHERE ' . $where);
 		$this->db->sql_query('DELETE FROM ' . PROFILE_LANG_TABLE . ' WHERE ' . $where);
 
 		// Drop columns from the Profile Fields data table
-		foreach ($pfs as $field_ident)
+		foreach ($profile_fields as $field_ident)
 		{
 			$this->db_tools->sql_column_remove(PROFILE_FIELDS_DATA_TABLE, 'pf_' . $field_ident);
 		}
@@ -612,7 +612,7 @@ class manager
 		$this->db->sql_transaction('commit');
 
 		// Log activity
-		foreach ($pfs as $field_ident)
+		foreach ($profile_fields as $field_ident)
 		{
 			add_log('admin', 'LOG_PROFILE_FIELD_REMOVED', $field_ident);
 		}
@@ -629,25 +629,29 @@ class manager
 	*/
 	public function enable_profilefields($profilefield_type_name)
 	{
-		// Read the modified information saved on disable from a config_text field to recover values, then remove it
-		$pfs = $this->config_text->get($profilefield_type_name . '.saved');
-		$this->config_text->delete($profilefield_type_name . '.saved');
+		// Read the modified information saved on disable from a config_text field to recover values
+		$profile_fields = $this->config_text->get($profilefield_type_name . '.saved');
 
 		// If nothing saved, then nothing to do
-		if ($pfs == '')
+		if (empty($profile_fields))
 		{
 			return;
 		}
 
-		$pfs = unserialize(base64_decode($pfs));
+		$profile_fields = json_decode($profile_fields, true);
 
 		// Restore the affected profile fields to "active"
 		$sql = 'UPDATE ' . PROFILE_FIELDS_TABLE . "
 			SET field_active = 1
 			WHERE field_active = 0
-				AND " . $this->db->sql_in_set('field_id', array_keys($pfs));
+				AND " . $this->db->sql_in_set('field_id', array_keys($profile_fields));
 		$this->db->sql_query($sql);
-		foreach ($pfs as $field_ident)
+
+		// Remove the information saved in the config_text field, not needed any longer
+		$this->config_text->delete($profilefield_type_name . '.saved');
+
+		// Log activity
+		foreach ($profile_fields as $field_ident)
 		{
 			add_log('admin', 'LOG_PROFILE_FIELD_ACTIVATE', $field_ident);
 		}


### PR DESCRIPTION
Adds methods to enable, disable and purge profile field types to the
profilefields\manager class.  These methods are to be called from
extensions that add new profile field types on the enable, disable
and purge methods of the ext class.  If not done, any profile field
of a new type that is left after extension is disabled or removed will
break the forum in several places.

PHPBB3-13867
