### PR TITLE
[ticket/12230] Disable newly registered group when post limit is set to 0

### DIFF
--- a/phpBB/phpbb/session.php
+++ b/phpBB/phpbb/session.php
@@ -1585,7 +1585,7 @@ class session
 
 			$this->data = array_merge($this->data, $sql_ary);
 
-			if ($this->data['user_id'] != ANONYMOUS && !empty($config['new_member_post_limit']) && $this->data['user_new'] && $config['new_member_post_limit'] <= $this->data['user_posts'])
+			if ($this->data['user_id'] != ANONYMOUS && isset($config['new_member_post_limit']) && $this->data['user_new'] && $config['new_member_post_limit'] <= $this->data['user_posts'])
 			{
 				$this->leave_newly_registered();
 			}


### PR DESCRIPTION
Old PR: #3553
Older PR: #3536

Now all users are just removed from the group when the limit is set to 0. :)

[PHPBB3-12230](https://tracker.phpbb.com/browse/PHPBB3-12230)