### PR TITLE
[ticket/9405] Only increase last_post_time when bumping topic

### DIFF
--- a/phpBB/includes/functions_posting.php
+++ b/phpBB/includes/functions_posting.php
@@ -2479,13 +2479,6 @@ function phpbb_bump_topic($forum_id, $topic_id, $post_data, $bump_time = false)
 	// Begin bumping
 	$db->sql_transaction('begin');
 
-	// Update the topic's last post post_time
-	$sql = 'UPDATE ' . POSTS_TABLE . "
-		SET post_time = $bump_time
-		WHERE post_id = {$post_data['topic_last_post_id']}
-			AND topic_id = $topic_id";
-	$db->sql_query($sql);
-
 	// Sync the topic's last post time, the rest of the topic's last post data isn't changed
 	$sql = 'UPDATE ' . TOPICS_TABLE . "
 		SET topic_last_post_time = $bump_time,


### PR DESCRIPTION
There is no need to update the last post's post time. After this
change, the topic/post is still properly reported as new (bumped).

https://tracker.phpbb.com/browse/PHPBB3-9405

PHPBB3-9405