### PR TITLE
[ticket/13853] Flexible schema for profilefields step 1 configuration

### DIFF
--- a/phpBB/adm/style/acp_profile.html
+++ b/phpBB/adm/style/acp_profile.html
@@ -103,31 +103,13 @@
 			<dt><label for="lang_explain">{L_FIELD_DESCRIPTION}{L_COLON}</label><br /><span>{L_FIELD_DESCRIPTION_EXPLAIN}</span></dt>
 			<dd><textarea id="lang_explain" name="lang_explain" rows="3" cols="80">{LANG_EXPLAIN}</textarea></dd>
 		</dl>
-		<!-- IF S_TEXT or S_STRING -->
+		<!-- BEGIN option -->
 			<dl>
-				<dt><label for="lang_default_value">{L_DEFAULT_VALUE}{L_COLON}</label><br /><span>{L_DEFAULT_VALUE_EXPLAIN}</span></dt>
-				<dd><!-- IF S_STRING --><input class="text medium" type="text" id="lang_default_value" name="lang_default_value" value="{LANG_DEFAULT_VALUE}" /><!-- ELSE --><textarea id="lang_default_value" name="lang_default_value" rows="5" cols="80">{LANG_DEFAULT_VALUE}</textarea><!-- ENDIF --></dd>
+				<dt><label>{option.TITLE}{L_COLON}</label><!-- IF option.EXPLAIN --><br /><span>{option.EXPLAIN}</span><!-- ENDIF --></dt>
+				<dd>{option.FIELD}</dd>
 			</dl>
-		<!-- ENDIF -->
-		<!-- IF S_BOOL or S_DROPDOWN -->
-			<dl>
-				<dt><label for="lang_options">{L_ENTRIES}{L_COLON}</label>
-					<!-- IF S_EDIT_MODE and S_DROPDOWN -->
-						<br /><span>{L_EDIT_DROPDOWN_LANG_EXPLAIN}</span>
-					<!-- ELSE -->
-						<br /><span>{L_LANG_OPTIONS_EXPLAIN}</span>
-					<!-- ENDIF -->
-				</dt>
-			<!-- IF S_DROPDOWN -->
-				<dd><textarea id="lang_options" name="lang_options" rows="5" cols="80">{LANG_OPTIONS}</textarea></dd>
-			<!-- ELSE -->
-				<dd><input class="medium" id="lang_options" name="lang_options[0]" value="{FIRST_LANG_OPTION}" /> {L_FIRST_OPTION}</dd>
-				<dd><input class="medium" name="lang_options[1]" value="{SECOND_LANG_OPTION}" /> {L_SECOND_OPTION}</dd>
-			<!-- ENDIF -->
-			</dl>
-		<!-- ENDIF -->
+		<!-- END option -->
 		</fieldset>
-
 		<fieldset class="quick">
 			{S_HIDDEN_FIELDS}
 			{S_FORM_TOKEN}

--- a/phpBB/config/profilefield.yml
+++ b/phpBB/config/profilefield.yml
@@ -2,6 +2,7 @@ services:
     profilefields.manager:
         class: phpbb\profilefields\manager
         arguments:
+            - @service_container
             - @auth
             - @dbal.conn
             - @dispatcher

--- a/phpBB/includes/acp/acp_profile.php
+++ b/phpBB/includes/acp/acp_profile.php
@@ -672,7 +672,8 @@ class acp_profile
 				$s_one_need_edit = true;
 			}
 
-			try {
+			try
+			{
 				$profile_field = $this->type_collection[$row['field_type']];
 			}
 			catch (\Exception $e)

--- a/phpBB/includes/acp/acp_profile.php
+++ b/phpBB/includes/acp/acp_profile.php
@@ -595,11 +595,18 @@ class acp_profile
 						);
 
 						$field_data = $cp->vars;
-						$profile_field->display_options($template_vars, $field_data);
+						$doptions = $profile_field->display_options($action, $field_data);
 						$cp->vars = $field_data;
 
 						// Build common create options
 						$template->assign_vars($template_vars);
+
+						// Build options based on profile type
+						foreach ($doptions as $num => $option_ary)
+						{
+							$template->assign_block_vars('option', $option_ary);
+						}
+
 					break;
 
 					case 2:

--- a/phpBB/includes/acp/acp_profile.php
+++ b/phpBB/includes/acp/acp_profile.php
@@ -672,7 +672,13 @@ class acp_profile
 				$s_one_need_edit = true;
 			}
 
-			$profile_field = $this->type_collection[$row['field_type']];
+			try {
+				$profile_field = $this->type_collection[$row['field_type']];
+			}
+			catch (\Exception $e)
+			{
+				continue;
+			}
 			$template->assign_block_vars('fields', array(
 				'FIELD_IDENT'		=> $row['field_ident'],
 				'FIELD_TYPE'		=> $profile_field->get_name(),

--- a/phpBB/phpbb/profilefields/manager.php
+++ b/phpBB/phpbb/profilefields/manager.php
@@ -13,11 +13,19 @@
 
 namespace phpbb\profilefields;
 
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
 /**
 * Custom Profile Fields
 */
 class manager
 {
+	/**
+	* Container interface
+	* @var ContainerInterface
+	*/
+	protected $container;
+
 	/**
 	* Auth object
 	* @var \phpbb\auth\auth
@@ -68,9 +76,14 @@ class manager
 
 	protected $profile_cache = array();
 
+	protected $config_text;
+
+	protected $db_tools;
+
 	/**
 	* Construct
 	*
+	* @param	ContainerInterface $container A container
 	* @param	\phpbb\auth\auth			$auth		Auth object
 	* @param	\phpbb\db\driver\driver_interface	$db			Database object
 	* @param	\phpbb\event\dispatcher_interface		$dispatcher	Event dispatcher object
@@ -82,8 +95,9 @@ class manager
 	* @param	string				$fields_language_table
 	* @param	string				$fields_data_table
 	*/
-	public function __construct(\phpbb\auth\auth $auth, \phpbb\db\driver\driver_interface $db, \phpbb\event\dispatcher_interface $dispatcher, \phpbb\request\request $request, \phpbb\template\template $template, \phpbb\di\service_collection $type_collection, \phpbb\user $user, $fields_table, $fields_language_table, $fields_data_table)
+	public function __construct(ContainerInterface $container, \phpbb\auth\auth $auth, \phpbb\db\driver\driver_interface $db, \phpbb\event\dispatcher_interface $dispatcher, \phpbb\request\request $request, \phpbb\template\template $template, \phpbb\di\service_collection $type_collection, \phpbb\user $user, $fields_table, $fields_language_table, $fields_data_table)
 	{
+		$this->container = $container;
 		$this->auth = $auth;
 		$this->db = $db;
 		$this->dispatcher = $dispatcher;
@@ -95,6 +109,9 @@ class manager
 		$this->fields_table = $fields_table;
 		$this->fields_language_table = $fields_language_table;
 		$this->fields_data_table = $fields_data_table;
+
+		$this->config_text = $this->container->get('config_text');
+		$this->db_tools = $this->container->get('dbal.tools');
 	}
 
 	/**
@@ -478,5 +495,162 @@ class manager
 		$this->db->sql_freeresult($result);
 
 		return $cp_data;
+	}
+
+	/**
+	* Disable all profile fields of a certain type
+	*
+	* This should be called when an extension which has profile field types
+	* is disabled so that all those profile fields are hidden and do not
+	* cause errors
+	*
+	* @param string $profilefield_type_name Type identifier of the profile fields
+	*/
+	public function disable_profilefields($profilefield_type_name)
+	{
+		// Get list of profile fields affected by this operation, if any
+		$pfs = array();
+		$sql = 'SELECT field_id, field_ident
+			FROM ' . PROFILE_FIELDS_TABLE . "
+			WHERE field_active = 1
+				AND field_type = '" . $this->db->sql_escape($profilefield_type_name) . "'";
+		$result = $this->db->sql_query($sql);
+		while ($row = $this->db->sql_fetchrow($result))
+		{
+			$pfs[(int) $row['field_id']] = $row['field_ident'];
+		}
+		$this->db->sql_freeresult($result);
+
+		// If no profile fields affected, then nothing to do
+		if (!sizeof($pfs))
+		{
+			return;
+		}
+
+		// Update the affected profile fields to "inactive"
+		$sql = 'UPDATE ' . PROFILE_FIELDS_TABLE . "
+			SET field_active = 0
+			WHERE field_active = 1
+				AND field_type = '" . $this->db->sql_escape($profilefield_type_name) . "'";
+		$this->db->sql_query($sql);
+
+		// Save modified information into a config_text field to recover on enable
+		$this->config_text->set($profilefield_type_name . '.saved', base64_encode(serialize($pfs)));
+
+		// Log activity
+		foreach ($pfs as $field_ident)
+		{
+			add_log('admin', 'LOG_PROFILE_FIELD_DEACTIVATE', $field_ident);
+		}
+	}
+
+	/**
+	* Purge all profile fields of a certain type
+	*
+	* This should be called when an extension which has profile field types
+	* is purged so that all those profile fields are removed
+	*
+	* @param string $profilefield_type_name Type identifier of the profile fields
+	*/
+	public function purge_profilefields($profilefield_type_name)
+	{
+		// Remove the information saved on disable in a config_text field, not needed any longer
+		$this->config_text->delete($profilefield_type_name . '.saved');
+
+		// Get list of profile fields affected by this operation, if any
+		$pfs = array();
+		$sql = 'SELECT field_id, field_ident
+			FROM ' . PROFILE_FIELDS_TABLE . "
+			WHERE field_type = '" . $this->db->sql_escape($profilefield_type_name) . "'";
+		$result = $this->db->sql_query($sql);
+		while ($row = $this->db->sql_fetchrow($result))
+		{
+			$pfs[(int) $row['field_id']] = $row['field_ident'];
+		}
+		$this->db->sql_freeresult($result);
+
+		// If no profile fields exist, then nothing to do
+		if (!sizeof($pfs))
+		{
+			return;
+		}
+
+		$this->db->sql_transaction('begin');
+
+		// Delete entries from all profile field definition tables
+		$where = $this->db->sql_in_set('field_id', array_keys($pfs));
+		$this->db->sql_query('DELETE FROM ' . PROFILE_FIELDS_TABLE . ' WHERE ' . $where);
+		$this->db->sql_query('DELETE FROM ' . PROFILE_FIELDS_LANG_TABLE . ' WHERE ' . $where);
+		$this->db->sql_query('DELETE FROM ' . PROFILE_LANG_TABLE . ' WHERE ' . $where);
+
+		// Drop columns from the Profile Fields data table
+		foreach ($pfs as $field_ident)
+		{
+			$this->db_tools->sql_column_remove(PROFILE_FIELDS_DATA_TABLE, 'pf_' . $field_ident);
+		}
+
+		// Reset the order of the remaining fields
+		$order = 0;
+
+		$sql = 'SELECT *
+			FROM ' . PROFILE_FIELDS_TABLE . '
+			ORDER BY field_order';
+		$result = $this->db->sql_query($sql);
+
+		while ($row = $this->db->sql_fetchrow($result))
+		{
+			$order++;
+			if ($row['field_order'] != $order)
+			{
+				$sql = 'UPDATE ' . PROFILE_FIELDS_TABLE . "
+					SET field_order = $order
+					WHERE field_id = {$row['field_id']}";
+				$this->db->sql_query($sql);
+			}
+		}
+		$this->db->sql_freeresult($result);
+
+		$this->db->sql_transaction('commit');
+
+		// Log activity
+		foreach ($pfs as $field_ident)
+		{
+			add_log('admin', 'LOG_PROFILE_FIELD_REMOVED', $field_ident);
+		}
+	}
+
+	/**
+	* Enable the profile fields of a certain type
+	*
+	* This should be called when an extension which has profile field types
+	* that was disabled is re-enabled so that all those profile fields that
+	* were disabled are enabled again
+	*
+	* @param string $profilefield_type_name Type identifier of the profile fields
+	*/
+	public function enable_profilefields($profilefield_type_name)
+	{
+		// Read the modified information saved on disable from a config_text field to recover values, then remove it
+		$pfs = $this->config_text->get($profilefield_type_name . '.saved');
+		$this->config_text->delete($profilefield_type_name . '.saved');
+
+		// If nothing saved, then nothing to do
+		if ($pfs == '')
+		{
+			return;
+		}
+
+		$pfs = unserialize(base64_decode($pfs));
+
+		// Restore the affected profile fields to "active"
+		$sql = 'UPDATE ' . PROFILE_FIELDS_TABLE . "
+			SET field_active = 1
+			WHERE field_active = 0
+				AND " . $this->db->sql_in_set('field_id', array_keys($pfs));
+		$this->db->sql_query($sql);
+		foreach ($pfs as $field_ident)
+		{
+			add_log('admin', 'LOG_PROFILE_FIELD_ACTIVATE', $field_ident);
+		}
 	}
 }

--- a/phpBB/phpbb/profilefields/type/type_base.php
+++ b/phpBB/phpbb/profilefields/type/type_base.php
@@ -177,9 +177,9 @@ abstract class type_base implements type_interface
 	/**
 	* {@inheritDoc}
 	*/
-	public function display_options(&$template_vars, &$field_data)
+	public function display_options($action, &$field_data)
 	{
-		return;
+		return array();
 	}
 
 	/**

--- a/phpBB/phpbb/profilefields/type/type_bool.php
+++ b/phpBB/phpbb/profilefields/type/type_bool.php
@@ -395,7 +395,7 @@ class type_bool extends type_base
 	/**
 	* {@inheritDoc}
 	*/
-	public function display_options(&$template_vars, &$field_data)
+	public function display_options($action, &$field_data)
 	{
 		// Initialize these array elements if we are creating a new field
 		if (!sizeof($field_data['lang_options']))
@@ -405,11 +405,14 @@ class type_bool extends type_base
 			$field_data['lang_options'][1] = '';
 		}
 
-		$template_vars = array_merge($template_vars, array(
-			'S_BOOL'					=> true,
-			'L_LANG_OPTIONS_EXPLAIN'	=> $this->user->lang['BOOL_ENTRIES_EXPLAIN'],
-			'FIRST_LANG_OPTION'			=> $field_data['lang_options'][0],
-			'SECOND_LANG_OPTION'		=> $field_data['lang_options'][1],
-		));
+		$doptions = array(
+			0 => array(
+					'TITLE' => $this->user->lang['ENTRIES'],
+					'EXPLAIN' => $this->user->lang['BOOL_ENTRIES_EXPLAIN'],
+					'FIELD' => '<input class="medium" id="lang_options" name="lang_options[0]" value="' . $field_data['lang_options'][0] . '" /> ' . $this->user->lang['FIRST_OPTION'] . '</dd><dd><input class="medium" name="lang_options[1]" value="' . $field_data['lang_options'][1] . '" /> ' . $this->user->lang['SECOND_OPTION']
+				),
+		);
+
+		return $doptions;
 	}
 }

--- a/phpBB/phpbb/profilefields/type/type_dropdown.php
+++ b/phpBB/phpbb/profilefields/type/type_dropdown.php
@@ -307,7 +307,7 @@ class type_dropdown extends type_base
 	/**
 	* {@inheritDoc}
 	*/
-	public function display_options(&$template_vars, &$field_data)
+	public function display_options($action, &$field_data)
 	{
 		// Initialize these array elements if we are creating a new field
 		if (!sizeof($field_data['lang_options']))
@@ -316,10 +316,14 @@ class type_dropdown extends type_base
 			$field_data['lang_options'] = array();
 		}
 
-		$template_vars = array_merge($template_vars, array(
-			'S_DROPDOWN'				=> true,
-			'L_LANG_OPTIONS_EXPLAIN'	=> $this->user->lang['DROPDOWN_ENTRIES_EXPLAIN'],
-			'LANG_OPTIONS'				=> implode("\n", $field_data['lang_options']),
-		));
+		$doptions = array(
+			0 => array(
+					'TITLE' => $this->user->lang['ENTRIES'],
+					'EXPLAIN' => $this->user->lang[($action == 'edit') ? 'EDIT_DROPDOWN_LANG_EXPLAIN' : 'DROPDOWN_ENTRIES_EXPLAIN'],
+					'FIELD' => '<textarea id="lang_options" name="lang_options" rows="5" cols="80">' . implode("\n", $field_data['lang_options']) . '</textarea>'
+				),
+		);
+
+		return $doptions;
 	}
 }

--- a/phpBB/phpbb/profilefields/type/type_interface.php
+++ b/phpBB/phpbb/profilefields/type/type_interface.php
@@ -134,6 +134,14 @@ interface type_interface
 	public function get_field_ident($field_data);
 
 	/**
+	* Get the localized name of the field
+	*
+	* @param string $field_name		Unlocalized name of this field
+	* @return string 	Localized name of the field
+	*/
+	public function get_field_name($field_name);
+
+	/**
 	* Get the column type for the database
 	*
 	* @return string	Returns the database column type

--- a/phpBB/phpbb/profilefields/type/type_interface.php
+++ b/phpBB/phpbb/profilefields/type/type_interface.php
@@ -200,11 +200,11 @@ interface type_interface
 	/**
 	* Allows assigning of additional template variables
 	*
-	* @param array	$template_vars	Template variables we are going to assign
+	* @param string	$action			Currently performed action (create|edit)
 	* @param array	$field_data		Array with data for this field
-	* @return null
+	* @return array	with the acp options for step 1
 	*/
-	public function display_options(&$template_vars, &$field_data);
+	public function display_options($action, &$field_data);
 
 	/**
 	* Return templated value/field. Possible values for $mode are:

--- a/phpBB/phpbb/profilefields/type/type_string.php
+++ b/phpBB/phpbb/profilefields/type/type_string.php
@@ -148,12 +148,16 @@ class type_string extends type_string_common
 	/**
 	* {@inheritDoc}
 	*/
-	public function display_options(&$template_vars, &$field_data)
+	public function display_options($action, &$field_data)
 	{
-		$template_vars = array_merge($template_vars, array(
-			'S_STRING'					=> true,
-			'L_DEFAULT_VALUE_EXPLAIN'	=> $this->user->lang['STRING_DEFAULT_VALUE_EXPLAIN'],
-			'LANG_DEFAULT_VALUE'		=> $field_data['lang_default_value'],
-		));
+		$doptions = array(
+			0 => array(
+					'TITLE' => $this->user->lang['DEFAULT_VALUE'],
+					'EXPLAIN' => $this->user->lang['TEXT_DEFAULT_VALUE_EXPLAIN'],
+					'FIELD' => '<textarea id="lang_default_value" name="lang_default_value" rows="5" cols="80">' . $field_data['lang_default_value'] . '</textarea>'
+				),
+		);
+
+		return $doptions;
 	}
 }

--- a/phpBB/phpbb/profilefields/type/type_text.php
+++ b/phpBB/phpbb/profilefields/type/type_text.php
@@ -193,12 +193,16 @@ class type_text extends type_string_common
 	/**
 	* {@inheritDoc}
 	*/
-	public function display_options(&$template_vars, &$field_data)
+	public function display_options($action, &$field_data)
 	{
-		$template_vars = array_merge($template_vars, array(
-			'S_TEXT'					=> true,
-			'L_DEFAULT_VALUE_EXPLAIN'	=> $this->user->lang['TEXT_DEFAULT_VALUE_EXPLAIN'],
-			'LANG_DEFAULT_VALUE'		=> $field_data['lang_default_value'],
-		));
+		$doptions = array(
+			0 => array(
+					'TITLE' => $this->user->lang['DEFAULT_VALUE'],
+					'EXPLAIN' => $this->user->lang['TEXT_DEFAULT_VALUE_EXPLAIN'],
+					'FIELD' => '<input class="text medium" type="text" id="lang_default_value" name="lang_default_value" value="' . $field_data['lang_default_value'] . '" />'
+				),
+		);
+
+		return $doptions;
 	}
 }


### PR DESCRIPTION
Modify the way adm/style/acp_profile.html STEP 1 (lines 106 to 128)
is coded to make it flexible and expandable to other new types of
profile fields, rather than the current mechanism, hardcoded for
the default types.

A flexible mechanism similar to the one used of STEP 2 is used.

This required a slight modification of the type_interface, and
corresponding modifications to all implementations of that interface.

PHPBB3-13853
