### PR TITLE
[ticket/13906] Fixed old signatures in post preview

### DIFF
--- a/phpBB/posting.php
+++ b/phpBB/posting.php
@@ -1487,14 +1487,11 @@ if (!sizeof($error) && $preview)
 	// Signature
 	if ($post_data['enable_sig'] && $config['allow_sig'] && $preview_signature && $auth->acl_get('f_sigs', $forum_id))
 	{
-		$parse_sig = new parse_message($preview_signature);
-		$parse_sig->bbcode_uid = $preview_signature_uid;
-		$parse_sig->bbcode_bitfield = $preview_signature_bitfield;
+		$flags = ($config['allow_sig_bbcode']) ? OPTION_FLAG_BBCODE : 0;
+		$flags |= ($config['allow_sig_links']) ? OPTION_FLAG_LINKS : 0;
+		$flags |= ($config['allow_sig_smilies']) ? OPTION_FLAG_SMILIES : 0;
 
-		// Not sure about parameters for bbcode/smilies/urls... in signatures
-		$parse_sig->format_display($config['allow_sig_bbcode'], $config['allow_sig_links'], $config['allow_sig_smilies']);
-		$preview_signature = $parse_sig->message;
-		unset($parse_sig);
+		$preview_signature = generate_text_for_display($preview_signature, $preview_signature_uid, $preview_signature_bitfield, $flags, false);
 	}
 	else
 	{

--- a/tests/functional/posting_test.php
+++ b/tests/functional/posting_test.php
@@ -181,7 +181,7 @@ class phpbb_functional_posting_test extends phpbb_functional_test_case
 		$this->assertEquals($text, $crawler->filter('#message')->text());
 	}
 
-	public function test_ticket_13906()
+	public function test_old_signature_in_preview()
 	{
 		$sql = 'UPDATE ' . USERS_TABLE . "
 			SET user_sig = '[b:2u8sdcwb]My signature[/b:2u8sdcwb]',

--- a/tests/functional/posting_test.php
+++ b/tests/functional/posting_test.php
@@ -180,4 +180,26 @@ class phpbb_functional_posting_test extends phpbb_functional_test_case
 		$crawler = self::submit($form);
 		$this->assertEquals($text, $crawler->filter('#message')->text());
 	}
+
+	public function test_ticket_13906()
+	{
+		$sql = 'UPDATE ' . USERS_TABLE . "
+			SET user_sig = '[b:2u8sdcwb]My signature[/b:2u8sdcwb]',
+				user_sig_bbcode_uid = '2u8sdcwb',
+				user_sig_bbcode_bitfield = 'QA=='
+			WHERE user_id = 2";
+		$this->get_db()->sql_query($sql);
+
+		$this->login();
+		$crawler = self::request('GET', 'posting.php?mode=post&f=2');
+		$form = $crawler->selectButton('Preview')->form(array(
+			'subject' => 'Test subject',
+			'message' => 'My post',
+		));
+		$crawler = self::submit($form);
+		$this->assertContains(
+			'<span style="font-weight: bold">My signature</span>',
+			$crawler->filter('#preview .signature')->html()
+		);
+	}
 }


### PR DESCRIPTION
PHPBB3-13906

I couldn't create a test for it because it requires a signature parsed with 3.1. Since it cannot be created in 3.2 it has to be inserted directly in the DB, and I don't know whether it's possible to access the database of the system being tested by a functional test.