### PR TITLE
[ticket/13908] "After" clause in migration not working

### DIFF
--- a/phpBB/phpbb/db/tools.php
+++ b/phpBB/phpbb/db/tools.php
@@ -1533,6 +1533,11 @@ class tools
 					}
 				}
 
+				if (isset($column_data['after']))
+				{
+				   $return_array['after'] = $column_data['after'];
+				}
+
 			break;
 
 			case 'oracle':

--- a/phpBB/phpbb/db/tools.php
+++ b/phpBB/phpbb/db/tools.php
@@ -1535,7 +1535,7 @@ class tools
 
 				if (isset($column_data['after']))
 				{
-				   $return_array['after'] = $column_data['after'];
+					$return_array['after'] = $column_data['after'];
 				}
 
 			break;


### PR DESCRIPTION
In a migration file, if you try to add a column to a table and specify
the order, by specifying an "after" clause, it is not used at all, even
for databases that support it (like mysql).
This fixes the issue, for mysql databases.

PHPBB3-13908