### PR TITLE
[Ticket/13914] Could not get style data via MySQL DB auto_increment_offset != 1

### DIFF
--- a/phpBB/phpbb/user.php
+++ b/phpBB/phpbb/user.php
@@ -236,6 +236,12 @@ class user extends \phpbb\session
 			FROM ' . STYLES_TABLE . " s
 			WHERE s.style_id = $style_id";
 		$result = $db->sql_query($sql, 3600);
+		if (!$result) {
+			$sql = 'SELECT *
+				FROM ' . STYLES_TABLE . " s
+				LIMIT 1";
+			$result = $db->sql_query($sql, 3600);
+		}
 		$this->style = $db->sql_fetchrow($result);
 		$db->sql_freeresult($result);
 


### PR DESCRIPTION
After phpBB3 - installed, I got the error message:

SQL ERROR [ mysqli ]

You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near '' at line 3 [1064]

SQL

SELECT * FROM phpbb_styles s WHERE s.style_id = 

BACKTRACE

FILE: (not given by php)
LINE: (not given by php)
CALL: msg_handler()

FILE: [ROOT]/phpbb/db/driver/driver.php
LINE: 855
CALL: trigger_error()

FILE: [ROOT]/phpbb/db/driver/mysqli.php
LINE: 193
CALL: phpbb\db\driver\driver->sql_error()

FILE: [ROOT]/phpbb/db/driver/factory.php
LINE: 329
CALL: phpbb\db\driver\mysqli->sql_query()

FILE: [ROOT]/phpbb/user.php
LINE: 238
CALL: phpbb\db\driver\factory->sql_query()

FILE: [ROOT]/index.php
LINE: 29
CALL: phpbb\user->setup()

I made a simple patch taking a try to get a style for default usage.

https://tracker.phpbb.com/browse/PHPBB3-13914