### PR TITLE
[ticket/13923] Update startup.php

### DIFF
--- a/phpBB/includes/startup.php
+++ b/phpBB/includes/startup.php
@@ -94,7 +94,7 @@ if (version_compare(PHP_VERSION, '5.4.0-dev', '>='))
 }
 else
 {
-	if(get_magic_quotes_runtime())
+	if (get_magic_quotes_runtime())
 	{
 		// Deactivate
 		@set_magic_quotes_runtime(0);

--- a/phpBB/includes/startup.php
+++ b/phpBB/includes/startup.php
@@ -94,7 +94,11 @@ if (version_compare(PHP_VERSION, '5.4.0-dev', '>='))
 }
 else
 {
-	@set_magic_quotes_runtime(0);
+	if(get_magic_quotes_runtime())
+	{
+		// Deactivate
+		@set_magic_quotes_runtime(0);
+	}
 
 	// Be paranoid with passed vars
 	if (@ini_get('register_globals') == '1' || strtolower(@ini_get('register_globals')) == 'on' || !function_exists('ini_get'))


### PR DESCRIPTION
While suppressing the output from the 'set_magic_quotes_runtime(0)'
is sufficient with normal phpBB installs, using this file in association
with the oauth plugin will cause an error on some versions of PHP.
This fixes a potential bug where set_magic_quotes_runtime is depreciated
in newer versions of PHP.

Replaces https://github.com/phpbb/phpbb/pull/3491

https://tracker.phpbb.com/browse/PHPBB3-13923

PHPBB3-13923