### PR TITLE
[ticket/13823] Change diff options while packaging to not ignore all whitespaces

### DIFF
--- a/build/build.xml
+++ b/build/build.xml
@@ -105,7 +105,7 @@
 			<property name="dir" value="build/old_versions/release-${version}" />
 		</phingcall>
 
-		<exec dir="build/old_versions" command="LC_ALL=C diff -crNEBwd release-${version} release-${newversion} >
+		<exec dir="build/old_versions" command="LC_ALL=C diff -crNEBZbd release-${version} release-${newversion} >
 			../new_version/patches/phpBB-${version}_to_${newversion}.patch" escape="false" />
 	</target>
 
@@ -132,13 +132,13 @@
 	<target name="package" depends="clean,prepare,prepare-new-version,old-version-diffs">
 		<exec dir="build" command="php -f package.php '${versions}' > logs/package.log" escape="false" />
 		<exec dir="build" escape="false"
-			command="diff -crNEBwd old_versions/release-${prevversion}/language new_version/phpBB3/language >
+			command="LC_ALL=C diff -crNEBZbd old_versions/release-${prevversion}/language new_version/phpBB3/language >
 				save/phpbb-${prevversion}_to_${newversion}_language.patch" />
 		<exec dir="build" escape="false"
-			command="diff -crNEBwd old_versions/release-${prevversion}/styles/prosilver new_version/phpBB3/styles/prosilver >
+			command="LC_ALL=C diff -crNEBZbd old_versions/release-${prevversion}/styles/prosilver new_version/phpBB3/styles/prosilver >
 				save/phpbb-${prevversion}_to_${newversion}_prosilver.patch" />
 		<exec dir="build" escape="false"
-			command="diff -crNEBwd old_versions/release-${prevversion}/styles/subsilver2 new_version/phpBB3/styles/subsilver2 >
+			command="LC_ALL=C diff -crNEBZbd old_versions/release-${prevversion}/styles/subsilver2 new_version/phpBB3/styles/subsilver2 >
 				save/phpbb-${prevversion}_to_${newversion}_subsilver2.patch" />
 
 		<exec dir="build" escape="false"

--- a/build/build_helper.php
+++ b/build/build_helper.php
@@ -18,11 +18,11 @@ class build_package
 	// -r - compare recursive
 	// -N - Treat missing files as empty
 	// -E - Ignore tab expansions
-	//		not used: -b - Ignore space changes.
-	// -w - Ignore all whitespace
+	// -Z - Ignore white space at line end.
+	// -b - Ignore changes in the amount of white space.
 	// -B - Ignore blank lines
 	// -d - Try to find smaller set of changes
-	var $diff_options = '-crNEBwd';
+	var $diff_options = '-crNEBZbd';
 	var $diff_options_long = '-x images -crNEB'; // -x fonts -x imageset //imageset not used here, because it includes the imageset.cfg file. ;)
 
 	var $verbose = false;


### PR DESCRIPTION
Removed:
    -w, --ignore-all-space       Ignore white space when comparing lines.

Added:
    -Z, --ignore-trailing-space  Ignore white space at line end.
    -b, --ignore-space-change    Ignore changes in the amount of white space.

https://tracker.phpbb.com/browse/PHPBB3-13823

PHPBB3-13823