### PR TITLE
[ticket/10711] Duplicate key error on forum_tracks_table

### DIFF
--- a/phpBB/includes/functions.php
+++ b/phpBB/includes/functions.php
@@ -1258,6 +1258,10 @@ function markread($mode, $forum_id = false, $topic_id = false, $post_time = 0, $
 		{
 			$forum_id = array($forum_id);
 		}
+		else
+		{
+			$forum_id = array_unique($forum_id);
+		}
 
 		$phpbb_notifications = $phpbb_container->get('notification_manager');
 


### PR DESCRIPTION
In certain situations, an SQL error DUPLICATE ERROR for KEY 'PRIMARY'
in the forums_track table is produced when marking forums read
(viewforum.php?f=xx&mark=forums).

The problem happens when there are duplicates in the forum_id array.
The solution is to remove those duplicates.

https://tracker.phpbb.com/browse/PHPBB3-10711