### PR TITLE
[ticket/13949] Replace colon with colon lang key in memberlist search page

### DIFF
--- a/phpBB/styles/prosilver/template/memberlist_search.html
+++ b/phpBB/styles/prosilver/template/memberlist_search.html
@@ -32,7 +32,7 @@
 <!-- ENDIF -->
 <!-- IF S_JABBER_ENABLED -->
 	<dl>
-		<dt><label for="jabber">{L_JABBER}:</label></dt>
+		<dt><label for="jabber">{L_JABBER}{L_COLON}</label></dt>
 		<dd><input type="text" name="jabber" id="jabber" value="{JABBER}" class="inputbox" /></dd>
 	</dl>
 <!-- ENDIF -->

--- a/phpBB/styles/prosilver/template/memberlist_search.html
+++ b/phpBB/styles/prosilver/template/memberlist_search.html
@@ -32,7 +32,7 @@
 <!-- ENDIF -->
 <!-- IF S_JABBER_ENABLED -->
 	<dl>
-		<dt><label for="jabber">{L_JABBER}{L_COLON}</label></dt>
+		<dt><label for="jabber">{L_JABBER}:</label></dt>
 		<dd><input type="text" name="jabber" id="jabber" value="{JABBER}" class="inputbox" /></dd>
 	</dl>
 <!-- ENDIF -->


### PR DESCRIPTION
Replacing of one ```:``` with one ```{L_COLON}``` in memberlist search page.

https://tracker.phpbb.com/browse/PHPBB3-13949