### PR TITLE
[ticket/13948] Correctly forwarding to the RIR for whois feature

### DIFF
--- a/phpBB/includes/functions_user.php
+++ b/phpBB/includes/functions_user.php
@@ -1402,7 +1402,7 @@ function user_ipwhois($ip)
 	$match = array();
 
 	// Test for referrals from $whois_host to other whois databases, roll on rwhois
-	if (preg_match('#ReferralServer: whois://(.+)#im', $ipwhois, $match))
+	if (preg_match('#ReferralServer:[\x20]*whois://(.+)#im', $ipwhois, $match))
 	{
 		if (strpos($match[1], ':') !== false)
 		{


### PR DESCRIPTION
Allow any space count in the ReferralServer string for whois services response.

<a href="https://tracker.phpbb.com/browse/PHPBB3-13948">PHPBB3-13948</a>.