### PR TITLE
fix the website issue when auto_increment_offset != 1

### DIFF
--- a/phpBB/phpbb/user.php
+++ b/phpBB/phpbb/user.php
@@ -229,7 +229,7 @@ class user extends \phpbb\session
 		else
 		{
 			// Set up style
-			$style_id = ($style_id) ? $style_id : ((!$config['override_user_style']) ? $this->data['user_style'] : $config['default_style']);
+			$style_id = ($style_id) ? $style_id : ((!$config['override_user_style']) && isset($this->data['user_style']) ? $this->data['user_style'] : $config['default_style']);
 		}
 
 		$sql = 'SELECT *
@@ -240,7 +240,7 @@ class user extends \phpbb\session
 		$db->sql_freeresult($result);
 
 		// Fallback to user's standard style
-		if (!$this->style && $style_id != $this->data['user_style'])
+		if (!$this->style && isset($this->data['user_style']) && $style_id != $this->data['user_style'])
 		{
 			$style_id = $this->data['user_style'];
 
@@ -253,7 +253,7 @@ class user extends \phpbb\session
 		}
 
 		// User has wrong style
-		if (!$this->style && $style_id == $this->data['user_style'])
+		if (!$this->style && isset($this->data['user_style']) && $style_id == $this->data['user_style'])
 		{
 			$style_id = $this->data['user_style'] = $config['default_style'];
 


### PR DESCRIPTION
When db server auto_increment_offset != 1, the default website browsing is error.

The message is: 
```
QL ERROR [ mysqli ]

You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near '' at line 3 [1064]

SQL

SELECT * FROM phpbb_styles s WHERE s.style_id =

BACKTRACE

FILE: (not given by php)
LINE: (not given by php)
CALL: msg_handler()

FILE: [ROOT]/phpbb/db/driver/driver.php
LINE: 855
CALL: trigger_error()

FILE: [ROOT]/phpbb/db/driver/mysqli.php
LINE: 193
CALL: phpbb\db\driver\driver->sql_error()

FILE: [ROOT]/phpbb/db/driver/factory.php
LINE: 329
CALL: phpbb\db\driver\mysqli->sql_query()

FILE: [ROOT]/phpbb/user.php
LINE: 238
CALL: phpbb\db\driver\factory->sql_query()

FILE: [ROOT]/ucp.php
LINE: 36
CALL: phpbb\user->setup()
```

I found $this->data['user_style'] is not defined.


https://tracker.phpbb.com/browse/PHPBB3-13957