### PR TITLE
[ticket/13960] Profile field validation breaks ACP

### DIFF
--- a/phpBB/includes/acp/acp_profile.php
+++ b/phpBB/includes/acp/acp_profile.php
@@ -511,12 +511,13 @@ class acp_profile
 					}
 				}
 
-				$step = (isset($_REQUEST['next'])) ? $step + 1 : ((isset($_REQUEST['prev'])) ? $step - 1 : $step);
-
 				if (sizeof($error))
 				{
-					$step--;
 					$submit = false;
+				}
+				else
+				{
+					$step = (isset($_REQUEST['next'])) ? $step + 1 : ((isset($_REQUEST['prev'])) ? $step - 1 : $step);
 				}
 
 				// Build up the specific hidden fields
@@ -535,7 +536,7 @@ class acp_profile
 						$var = $profile_field->prepare_hidden_fields($step, $key, $action, $field_data);
 						if ($var !== null)
 						{
-							$_new_key_ary[$key] = $profile_field->prepare_hidden_fields($step, $key, $action, $field_data);
+							$_new_key_ary[$key] = $var;
 						}
 					}
 					$cp->vars = $field_data;
@@ -545,11 +546,7 @@ class acp_profile
 
 				if (!sizeof($error))
 				{
-					if ($step == 3 && (sizeof($this->lang_defs['iso']) == 1 || $save))
-					{
-						$this->save_profile_field($cp, $field_type, $action);
-					}
-					else if ($action == 'edit' && $save)
+					if (($step == 3 && (sizeof($this->lang_defs['iso']) == 1 || $save)) || ($action == 'edit' && $save))
 					{
 						$this->save_profile_field($cp, $field_type, $action);
 					}


### PR DESCRIPTION
Make sure new step is calculated only if no error has been identified
during validation.  Also, cleanup redundant code in acp_profile.php.

PHPBB3-13960