### PR TITLE
[ticket/13966] Adds the missing phpbb_dispatcher to includes/mcp/mcp_…

### DIFF
--- a/phpBB/includes/mcp/mcp_post.php
+++ b/phpBB/includes/mcp/mcp_post.php
@@ -461,7 +461,7 @@ function mcp_post_details($id, $mode, $action)
 */
 function change_poster(&$post_info, $userdata)
 {
-	global $auth, $db, $config, $phpbb_root_path, $phpEx, $user;
+	global $auth, $db, $config, $phpbb_root_path, $phpEx, $user, $phpbb_dispatcher;
 
 	if (empty($userdata) || $userdata['user_id'] == $post_info['user_id'])
 	{


### PR DESCRIPTION
…post.php

If you change the author of a posting, the notice appears:
>     [phpBB Debug] PHP Notice: in file [ROOT]/includes/mcp/mcp_post.php on line 541: Undefined variable: phpbb_dispatcher

PHPBB3-13966 - https://tracker.phpbb.com/browse/PHPBB3-13966 