### PR TITLE
[ticket/13984] Fix the call of Ajax loading indicator

### DIFF
--- a/phpBB/assets/javascript/core.js
+++ b/phpBB/assets/javascript/core.js
@@ -394,8 +394,11 @@ phpbb.ajaxify = function(options) {
 				error: errorHandler,
 				cache: false
 			});
+
 			request.always(function() {
-				$loadingIndicator.fadeOut(phpbb.alertTime);
+				if ($loadingIndicator && $loadingIndicator.is(':visible')) {
+					$loadingIndicator.fadeOut(phpbb.alertTime);
+				}
 			});
 		};
 


### PR DESCRIPTION
<a href="https://tracker.phpbb.com/browse/PHPBB3-13984">PHPBB3-13984</a>.