### PR TITLE
[ticket/13986] Add --resume option to reparser CLI

### DIFF
--- a/phpBB/config/default/container/services_console.yml
+++ b/phpBB/config/default/container/services_console.yml
@@ -154,5 +154,6 @@ services:
         arguments:
             - @user
             - @text_reparser_collection
+            - @config_text
         tags:
             - { name: console.command }

--- a/phpBB/language/en/cli.php
+++ b/phpBB/language/en/cli.php
@@ -68,6 +68,7 @@ $lang = array_merge($lang, array(
 	'CLI_DESCRIPTION_REPARSER_REPARSE_OPT_RANGE_MIN'	=> 'Lowest record ID to process',
 	'CLI_DESCRIPTION_REPARSER_REPARSE_OPT_RANGE_MAX'	=> 'Highest record ID to process',
 	'CLI_DESCRIPTION_REPARSER_REPARSE_OPT_RANGE_SIZE'	=> 'Approximate number of records to process at a time',
+	'CLI_DESCRIPTION_REPARSER_REPARSE_OPT_RESUME'		=> 'Start reparsing where the last execution stopped',
 	'CLI_DESCRIPTION_RECALCULATE_EMAIL_HASH'	=> 'Recalculates the user_email_hash column of the users table.',
 	'CLI_DESCRIPTION_SET_ATOMIC_CONFIG'			=> 'Sets a configuration option’s value only if the old matches the current value',
 	'CLI_DESCRIPTION_SET_CONFIG'				=> 'Sets a configuration option’s value',

--- a/phpBB/phpbb/console/command/reparser/reparse.php
+++ b/phpBB/phpbb/console/command/reparser/reparse.php
@@ -296,9 +296,9 @@ class reparse extends \phpbb\console\command\command
 	protected function update_resume_data($name, $current)
 	{
 		$this->resume_data[$name] = array(
-			'range-min'  => $this->input->getOption('range-min'),
+			'range-min'  => $this->get_option($name, 'range-min'),
 			'range-max'  => $current,
-			'range-size' => $this->input->getOption('range-size'),
+			'range-size' => $this->get_option($name, 'range-size'),
 		);
 		$this->save_resume_data();
 	}

--- a/phpBB/phpbb/console/command/reparser/reparse.php
+++ b/phpBB/phpbb/console/command/reparser/reparse.php
@@ -248,7 +248,7 @@ class reparse extends \phpbb\console\command\command
 		$min  = $this->get_option($name, 'range-min');
 		$size = $this->get_option($name, 'range-size');
 
-		if ($max === 0)
+		if ($max < $min)
 		{
 			return;
 		}


### PR DESCRIPTION
https://tracker.phpbb.com/browse/PHPBB3-13986
~~https://tracker.phpbb.com/browse/PHPBB3-13989~~

Resumes where the last execution stopped. If the last execution stopped at 227600/583468,  ~~it resumes at 227600/583468. The caveat is that it skews the estimation in the progress bar.~~ Not anymore, it resumes at 0/355868 and the estimation is as accurate as a normal execution.

