### PR TITLE
[ticket/13990] Reparse markup inside of forum rules/description

### DIFF
--- a/phpBB/phpbb/textreparser/base.php
+++ b/phpBB/phpbb/textreparser/base.php
@@ -47,11 +47,22 @@ abstract class base implements reparser_interface
 	{
 		if (!isset($record['enable_bbcode'], $record['enable_smilies'], $record['enable_magic_url']))
 		{
-			$record += array(
-				'enable_bbcode'    => $this->guess_bbcodes($record),
-				'enable_smilies'   => $this->guess_smilies($record),
-				'enable_magic_url' => $this->guess_magic_url($record),
-			);
+			if (isset($record['options']))
+			{
+				$record += array(
+					'enable_bbcode'    => (bool) ($record['options'] & OPTION_FLAG_BBCODE),
+					'enable_smilies'   => (bool) ($record['options'] & OPTION_FLAG_SMILIES),
+					'enable_magic_url' => (bool) ($record['options'] & OPTION_FLAG_LINKS),
+				);
+			}
+			else
+			{
+				$record += array(
+					'enable_bbcode'    => $this->guess_bbcodes($record),
+					'enable_smilies'   => $this->guess_smilies($record),
+					'enable_magic_url' => $this->guess_magic_url($record),
+				);
+			}
 		}
 
 		// Those BBCodes are disabled based on context and user permissions and that value is never
@@ -92,7 +103,7 @@ abstract class base implements reparser_interface
 			}
 		}
 
-		if (substr($record['text'], 0, 2) == '<r')
+		if (substr($record['text'], 0, 2) === '<r')
 		{
 			// Look for the closing tag inside of a e element, in an element of the same name, e.g.
 			// <e>[/url]</e></URL>
@@ -124,7 +135,7 @@ abstract class base implements reparser_interface
 			}
 		}
 
-		if (substr($record['text'], 0, 2) == '<r')
+		if (substr($record['text'], 0, 2) === '<r')
 		{
 			// Look for a closing tag inside of an e element
 			return (bool) preg_match('(<e>\\[/\\w+\\]</e>)', $match);

--- a/phpBB/phpbb/textreparser/plugins/forum_description.php
+++ b/phpBB/phpbb/textreparser/plugins/forum_description.php
@@ -24,6 +24,7 @@ class forum_description extends \phpbb\textreparser\row_based_plugin
 			'id'         => 'forum_id',
 			'text'       => 'forum_desc',
 			'bbcode_uid' => 'forum_desc_uid',
+			'options'    => 'forum_desc_options',
 		);
 	}
 

--- a/phpBB/phpbb/textreparser/plugins/forum_rules.php
+++ b/phpBB/phpbb/textreparser/plugins/forum_rules.php
@@ -24,6 +24,7 @@ class forum_rules extends \phpbb\textreparser\row_based_plugin
 			'id'         => 'forum_id',
 			'text'       => 'forum_rules',
 			'bbcode_uid' => 'forum_rules_uid',
+			'options'    => 'forum_rules_options',
 		);
 	}
 

--- a/phpBB/phpbb/textreparser/plugins/group_description.php
+++ b/phpBB/phpbb/textreparser/plugins/group_description.php
@@ -24,6 +24,7 @@ class group_description extends \phpbb\textreparser\row_based_plugin
 			'id'         => 'group_id',
 			'text'       => 'group_desc',
 			'bbcode_uid' => 'group_desc_uid',
+			'options'    => 'group_desc_options',
 		);
 	}
 

--- a/phpBB/phpbb/textreparser/plugins/poll_option.php
+++ b/phpBB/phpbb/textreparser/plugins/poll_option.php
@@ -48,7 +48,7 @@ class poll_option extends \phpbb\textreparser\base
 	*/
 	protected function get_records_by_range($min_id, $max_id)
 	{
-		$sql = 'SELECT o.topic_id, o.poll_option_id, o.poll_option_text AS text, p.bbcode_uid
+		$sql = 'SELECT o.topic_id, o.poll_option_id, o.poll_option_text AS text, p.enable_bbcode, p.enable_smilies, p.enable_magic_url, p.bbcode_uid
 			FROM ' . POLL_OPTIONS_TABLE . ' o, ' . TOPICS_TABLE . ' t, ' . POSTS_TABLE . ' p
 			WHERE o.topic_id BETWEEN ' . $min_id . ' AND ' . $max_id .'
 				AND t.topic_id = o.topic_id

--- a/phpBB/phpbb/textreparser/plugins/poll_title.php
+++ b/phpBB/phpbb/textreparser/plugins/poll_title.php
@@ -31,7 +31,7 @@ class poll_title extends \phpbb\textreparser\row_based_plugin
 	*/
 	protected function get_records_by_range_query($min_id, $max_id)
 	{
-		$sql = 'SELECT t.topic_id AS id, t.poll_title AS text, p.bbcode_uid
+		$sql = 'SELECT t.topic_id AS id, t.poll_title AS text, p.enable_bbcode, p.enable_smilies, p.enable_magic_url, p.bbcode_uid
 			FROM ' . TOPICS_TABLE . ' t, ' . POSTS_TABLE . ' p
 			WHERE t.topic_id BETWEEN ' . $min_id . ' AND ' . $max_id .'
 				AND t.poll_max_options > 0

--- a/tests/text_reparser/plugins/fixtures/forums.xml
+++ b/tests/text_reparser/plugins/fixtures/forums.xml
@@ -5,87 +5,109 @@
 		<column>forum_parents</column>
 		<column>forum_desc</column>
 		<column>forum_desc_uid</column>
+		<column>forum_desc_options</column>
 		<column>forum_rules</column>
 		<column>forum_rules_uid</column>
+		<column>forum_rules_options</column>
 		<row>
 			<value>1</value>
 			<value></value>
 			<value>This row should be [b]ignored[/b]</value>
 			<value>abcd1234</value>
+			<value>0</value>
 			<value>This row should be [b]ignored[/b]</value>
 			<value>abcd1234</value>
+			<value>0</value>
 		</row>
 		<row>
 			<value>2</value>
 			<value></value>
 			<value>[b]Not bold[/b] :) http://example.org</value>
 			<value>abcd1234</value>
+			<value>0</value>
 			<value>[b]Not bold[/b] :) http://example.org</value>
 			<value>abcd1234</value>
+			<value>0</value>
 		</row>
 		<row>
 			<value>3</value>
 			<value></value>
 			<value>[b:abcd1234]Bold[/b:abcd1234] :) http://example.org</value>
 			<value>abcd1234</value>
+			<value>1</value>
 			<value>[b:abcd1234]Bold[/b:abcd1234] :) http://example.org</value>
 			<value>abcd1234</value>
+			<value>1</value>
 		</row>
 		<row>
 			<value>4</value>
 			<value></value>
 			<value><![CDATA[[b]Not bold[/b] <!-- s:) --><img src="{SMILIES_PATH}/icon_e_smile.gif" alt=":)" title="Smile" /><!-- s:) --> http://example.org]]></value>
 			<value>abcd1234</value>
+			<value>2</value>
 			<value><![CDATA[[b]Not bold[/b] <!-- s:) --><img src="{SMILIES_PATH}/icon_e_smile.gif" alt=":)" title="Smile" /><!-- s:) --> http://example.org]]></value>
 			<value>abcd1234</value>
+			<value>2</value>
 		</row>
 		<row>
 			<value>5</value>
 			<value></value>
 			<value><![CDATA[[b]Not bold[/b] :) <!-- m --><a class="postlink" href="http://example.org">http://example.org</a><!-- m -->]]></value>
 			<value>abcd1234</value>
+			<value>4</value>
 			<value><![CDATA[[b]Not bold[/b] :) <!-- m --><a class="postlink" href="http://example.org">http://example.org</a><!-- m -->]]></value>
 			<value>abcd1234</value>
+			<value>4</value>
 		</row>
 		<row>
 			<value>6</value>
 			<value></value>
 			<value><![CDATA[[flash=123,345:abcd1234]http&#58;//example&#46;org/flash&#46;swf[/flash:abcd1234]]]></value>
 			<value>abcd1234</value>
+			<value>1</value>
 			<value><![CDATA[[flash=123,345:abcd1234]http&#58;//example&#46;org/flash&#46;swf[/flash:abcd1234]]]></value>
 			<value>abcd1234</value>
+			<value>1</value>
 		</row>
 		<row>
 			<value>7</value>
 			<value></value>
 			<value><![CDATA[[flash=123,345]http://example.org/flash.swf[/flash]]]></value>
 			<value>abcd1234</value>
+			<value>0</value>
 			<value><![CDATA[[flash=123,345]http://example.org/flash.swf[/flash]]]></value>
 			<value>abcd1234</value>
+			<value>0</value>
 		</row>
 		<row>
 			<value>8</value>
 			<value></value>
 			<value><![CDATA[[img:abcd1234]http&#58;//example&#46;org/img&#46;png[/img:abcd1234]]]></value>
 			<value>abcd1234</value>
+			<value>1</value>
 			<value><![CDATA[[img:abcd1234]http&#58;//example&#46;org/img&#46;png[/img:abcd1234]]]></value>
 			<value>abcd1234</value>
+			<value>1</value>
 		</row>
 		<row>
 			<value>9</value>
 			<value></value>
 			<value><![CDATA[[img]http://example.org/img.png[/img]]]></value>
 			<value>abcd1234</value>
+			<value>0</value>
 			<value><![CDATA[[img]http://example.org/img.png[/img]]]></value>
 			<value>abcd1234</value>
+			<value>0</value>
 		</row>
 		<row>
 			<value>1000</value>
 			<value></value>
 			<value>This row should be [b]ignored[/b]</value>
 			<value>abcd1234</value>
+			<value>0</value>
 			<value>This row should be [b]ignored[/b]</value>
 			<value>abcd1234</value>
+			<value>0</value>
 		</row>
 	</table>
 </dataset>

--- a/tests/text_reparser/plugins/fixtures/groups.xml
+++ b/tests/text_reparser/plugins/fixtures/groups.xml
@@ -38,25 +38,25 @@
 		<row>
 			<value>6</value>
 			<value><![CDATA[[flash=123,345:abcd1234]http&#58;//example&#46;org/flash&#46;swf[/flash:abcd1234]]]></value>
-			<value>7</value>
+			<value>1</value>
 			<value>abcd1234</value>
 		</row>
 		<row>
 			<value>7</value>
 			<value><![CDATA[[flash=123,345]http://example.org/flash.swf[/flash]]]></value>
-			<value>7</value>
+			<value>1</value>
 			<value>abcd1234</value>
 		</row>
 		<row>
 			<value>8</value>
 			<value><![CDATA[[img:abcd1234]http&#58;//example&#46;org/img&#46;png[/img:abcd1234]]]></value>
-			<value>7</value>
+			<value>1</value>
 			<value>abcd1234</value>
 		</row>
 		<row>
 			<value>9</value>
 			<value><![CDATA[[img]http://example.org/img.png[/img]]]></value>
-			<value>7</value>
+			<value>1</value>
 			<value>abcd1234</value>
 		</row>
 		<row>

--- a/tests/text_reparser/plugins/fixtures/poll_options.xml
+++ b/tests/text_reparser/plugins/fixtures/poll_options.xml
@@ -31,6 +31,21 @@
 		</row>
 		<row>
 			<value>1</value>
+			<value>11</value>
+			<value>[b:abcd1234]Bold[/b:abcd1234] :) http://example.org</value>
+		</row>
+		<row>
+			<value>1</value>
+			<value>12</value>
+			<value><![CDATA[[b]Not bold[/b] <!-- s:) --><img src="{SMILIES_PATH}/icon_e_smile.gif" alt=":)" title="Smile" /><!-- s:) --> http://example.org]]></value>
+		</row>
+		<row>
+			<value>1</value>
+			<value>13</value>
+			<value><![CDATA[[b]Not bold[/b] :) <!-- m --><a class="postlink" href="http://example.org">http://example.org</a><!-- m -->]]></value>
+		</row>
+		<row>
+			<value>1</value>
 			<value>123</value>
 			<value>This row should be [b]ignored[/b]</value>
 		</row>
@@ -42,9 +57,39 @@
 	</table>
 	<table name="phpbb_posts">
 		<column>post_id</column>
+		<column>enable_bbcode</column>
+		<column>enable_smilies</column>
+		<column>enable_magic_url</column>
 		<column>post_text</column>
 		<column>bbcode_uid</column>
 		<row>
+			<value>1</value>
+			<value>1</value>
+			<value>1</value>
+			<value>1</value>
+			<value></value>
+			<value>abcd1234</value>
+		</row>
+		<row>
+			<value>11</value>
+			<value>1</value>
+			<value>0</value>
+			<value>0</value>
+			<value></value>
+			<value>abcd1234</value>
+		</row>
+		<row>
+			<value>12</value>
+			<value>0</value>
+			<value>1</value>
+			<value>0</value>
+			<value></value>
+			<value>abcd1234</value>
+		</row>
+		<row>
+			<value>13</value>
+			<value>0</value>
+			<value>0</value>
 			<value>1</value>
 			<value></value>
 			<value>abcd1234</value>
@@ -63,6 +108,21 @@
 			<value>2</value>
 			<value>1</value>
 			<value>This row should be [b]ignored[/b]</value>
+		</row>
+		<row>
+			<value>11</value>
+			<value>11</value>
+			<value>BBCode</value>
+		</row>
+		<row>
+			<value>12</value>
+			<value>12</value>
+			<value>Smilies</value>
+		</row>
+		<row>
+			<value>13</value>
+			<value>13</value>
+			<value>Magic URLs</value>
 		</row>
 		<row>
 			<value>123</value>

--- a/tests/text_reparser/plugins/fixtures/polls.xml
+++ b/tests/text_reparser/plugins/fixtures/polls.xml
@@ -2,9 +2,39 @@
 <dataset>
 	<table name="phpbb_posts">
 		<column>post_id</column>
+		<column>enable_bbcode</column>
+		<column>enable_smilies</column>
+		<column>enable_magic_url</column>
 		<column>post_text</column>
 		<column>bbcode_uid</column>
 		<row>
+			<value>1</value>
+			<value>0</value>
+			<value>0</value>
+			<value>0</value>
+			<value></value>
+			<value>abcd1234</value>
+		</row>
+		<row>
+			<value>2</value>
+			<value>1</value>
+			<value>0</value>
+			<value>0</value>
+			<value></value>
+			<value>abcd1234</value>
+		</row>
+		<row>
+			<value>3</value>
+			<value>0</value>
+			<value>1</value>
+			<value>0</value>
+			<value></value>
+			<value>abcd1234</value>
+		</row>
+		<row>
+			<value>4</value>
+			<value>0</value>
+			<value>0</value>
 			<value>1</value>
 			<value></value>
 			<value>abcd1234</value>
@@ -26,22 +56,22 @@
 		</row>
 		<row>
 			<value>3</value>
-			<value>1</value>
+			<value>2</value>
 			<value>[b:abcd1234]Bold[/b:abcd1234] :) http://example.org</value>
 		</row>
 		<row>
 			<value>4</value>
-			<value>1</value>
+			<value>3</value>
 			<value><![CDATA[[b]Not bold[/b] <!-- s:) --><img src="{SMILIES_PATH}/icon_e_smile.gif" alt=":)" title="Smile" /><!-- s:) --> http://example.org]]></value>
 		</row>
 		<row>
 			<value>5</value>
-			<value>1</value>
+			<value>4</value>
 			<value><![CDATA[[b]Not bold[/b] :) <!-- m --><a class="postlink" href="http://example.org">http://example.org</a><!-- m -->]]></value>
 		</row>
 		<row>
 			<value>6</value>
-			<value>1</value>
+			<value>2</value>
 			<value><![CDATA[[flash=123,345:abcd1234]http&#58;//example&#46;org/flash&#46;swf[/flash:abcd1234]]]></value>
 		</row>
 		<row>
@@ -51,7 +81,7 @@
 		</row>
 		<row>
 			<value>8</value>
-			<value>1</value>
+			<value>2</value>
 			<value><![CDATA[[img:abcd1234]http&#58;//example&#46;org/img&#46;png[/img:abcd1234]]]></value>
 		</row>
 		<row>

--- a/tests/text_reparser/plugins/poll_option_test.php
+++ b/tests/text_reparser/plugins/poll_option_test.php
@@ -49,7 +49,7 @@ class phpbb_textreparser_poll_option_test extends phpbb_database_test_case
 	public function testReparse()
 	{
 		$reparser = $this->get_reparser();
-		$reparser->reparse_range(2, 3);
+		$reparser->reparse_range(2, 13);
 
 		$sql = 'SELECT topic_id, poll_option_id, poll_option_text
 			FROM ' . POLL_OPTIONS_TABLE . '
@@ -83,6 +83,21 @@ class phpbb_textreparser_poll_option_test extends phpbb_database_test_case
 				'topic_id'         => 2,
 				'poll_option_id'   => 3,
 				'poll_option_text' => '<r><URL url="http://example.org">http://example.org</URL></r>',
+			),
+			array(
+				'topic_id'         => 11,
+				'poll_option_id'   => 1,
+				'poll_option_text' => '<r><B><s>[b]</s>Bold<e>[/b]</e></B> :) http://example.org</r>',
+			),
+			array(
+				'topic_id'         => 12,
+				'poll_option_id'   => 1,
+				'poll_option_text' => '<r>[b]Not bold[/b] <E>:)</E> http://example.org</r>',
+			),
+			array(
+				'topic_id'         => 13,
+				'poll_option_id'   => 1,
+				'poll_option_text' => '<r>[b]Not bold[/b] :) <URL url="http://example.org">http://example.org</URL></r>',
 			),
 			array(
 				'topic_id'         => 123,


### PR DESCRIPTION
https://tracker.phpbb.com/browse/PHPBB3-13990
https://area51.phpbb.com/phpBB/viewtopic.php?p=281441#p281441

Some plugins did not retrieve the *_options bitfield to determine which of BBCodes/smilies/magic URLs should be enabled. This fixes that.