### PR TITLE
[ticket/13995] Fixes for invalid HTML in docs and phpBB

### DIFF
--- a/phpBB/docs/CHANGELOG.html
+++ b/phpBB/docs/CHANGELOG.html
@@ -6,7 +6,7 @@
 <meta name="description" content="phpBB 3.1.x Changelog" />
 <title>phpBB &bull; Changelog</title>
 
-<link href="assets/css/stylesheet.css" rel="stylesheet" type="text/css" media="screen, projection" />
+<link href="assets/css/stylesheet.css" rel="stylesheet" type="text/css" media="screen" />
 
 </head>
 

--- a/phpBB/docs/CHANGELOG.html
+++ b/phpBB/docs/CHANGELOG.html
@@ -4979,7 +4979,7 @@
 </div></div>
 
 <div>
-	<a id="bottom" name="bottom" accesskey="z"></a>
+	<a id="bottom" accesskey="z"></a>
 </div>
 
 </body>

--- a/phpBB/docs/FAQ.html
+++ b/phpBB/docs/FAQ.html
@@ -6,7 +6,7 @@
 <meta name="description" content="phpBB 3.1.x frequently asked questions" />
 <title>phpBB &bull; FAQ</title>
 
-<link href="assets/css/stylesheet.css" rel="stylesheet" type="text/css" media="screen, projection" />
+<link href="assets/css/stylesheet.css" rel="stylesheet" type="text/css" media="screen" />
 
 </head>
 

--- a/phpBB/docs/FAQ.html
+++ b/phpBB/docs/FAQ.html
@@ -343,7 +343,7 @@ I want to sue you because i think you host an illegal board!</h2>
 </div></div>
 
 <div>
-	<a id="bottom" name="bottom" accesskey="z"></a>
+	<a id="bottom" accesskey="z"></a>
 </div>
 
 </body>

--- a/phpBB/docs/INSTALL.html
+++ b/phpBB/docs/INSTALL.html
@@ -507,7 +507,7 @@
 </div></div>
 
 <div>
-	<a id="bottom" name="bottom" accesskey="z"></a>
+	<a id="bottom" accesskey="z"></a>
 </div>
 
 </body>

--- a/phpBB/docs/INSTALL.html
+++ b/phpBB/docs/INSTALL.html
@@ -6,7 +6,7 @@
 <meta name="description" content="phpBB 3.1.x Installation, updating and conversion informations" />
 <title>phpBB &bull; Install</title>
 
-<link href="assets/css/stylesheet.css" rel="stylesheet" type="text/css" media="screen, projection" />
+<link href="assets/css/stylesheet.css" rel="stylesheet" type="text/css" media="screen" />
 
 </head>
 

--- a/phpBB/docs/README.html
+++ b/phpBB/docs/README.html
@@ -6,7 +6,7 @@
 <meta name="description" content="phpBB 3.1.x Readme" />
 <title>phpBB &bull; Readme</title>
 
-<link href="assets/css/stylesheet.css" rel="stylesheet" type="text/css" media="screen, projection" />
+<link href="assets/css/stylesheet.css" rel="stylesheet" type="text/css" media="screen" />
 
 </head>
 

--- a/phpBB/docs/README.html
+++ b/phpBB/docs/README.html
@@ -366,7 +366,7 @@
 </div></div>
 
 <div>
-	<a id="bottom" name="bottom" accesskey="z"></a>
+	<a id="bottom" accesskey="z"></a>
 </div>
 
 </body>

--- a/phpBB/docs/auth_api.html
+++ b/phpBB/docs/auth_api.html
@@ -285,7 +285,7 @@ $auth_admin = new auth_admin();</pre>
 </div></div>
 
 <div>
-	<a id="bottom" name="bottom" accesskey="z"></a>
+	<a id="bottom" accesskey="z"></a>
 </div>
 
 </body>

--- a/phpBB/docs/auth_api.html
+++ b/phpBB/docs/auth_api.html
@@ -6,7 +6,7 @@
 <meta name="description" content="This is an explanation of how to use the phpBB auth/acl API" />
 <title>phpBB3 &bull; Auth API</title>
 
-<link href="assets/css/stylesheet.css" rel="stylesheet" type="text/css" media="screen, projection" />
+<link href="assets/css/stylesheet.css" rel="stylesheet" type="text/css" media="screen" />
 
 </head>
 
@@ -110,7 +110,7 @@ $auth = new phpbb\auth\auth();</pre>
 	<p>Following are the methods you are able to use.</p>
 
 	<a name="acl"></a><h3>2.i. acl</h3>
-	
+
 	<p>The <code>acl</code> method is the initialisation routine for all the acl functions. If you intend calling any acl method you must first call this. The method takes as its one and only required parameter an associative array containing user information as stored in the database. This array must contain at least the following information; user_id, user_permissions and user_type. It is called in the following way:</p>
 
 	<div class="codebox"><pre>

--- a/phpBB/docs/coding-guidelines.html
+++ b/phpBB/docs/coding-guidelines.html
@@ -2568,7 +2568,7 @@ if (utf8_case_fold_nfc($string1) == utf8_case_fold_nfc($string2))
 </div></div>
 
 <div>
-	<a id="bottom" name="bottom" accesskey="z"></a>
+	<a id="bottom" accesskey="z"></a>
 </div>
 
 </body>

--- a/phpBB/docs/coding-guidelines.html
+++ b/phpBB/docs/coding-guidelines.html
@@ -6,7 +6,7 @@
 <meta name="description" content="Ascraeus coding guidelines document" />
 <title>phpBB3 &bull; Coding Guidelines</title>
 
-<link href="assets/css/stylesheet.css" rel="stylesheet" type="text/css" media="screen, projection" />
+<link href="assets/css/stylesheet.css" rel="stylesheet" type="text/css" media="screen" />
 
 </head>
 
@@ -300,9 +300,9 @@ PHPBB_QA                   (Set board to QA-Mode, which means the updater also c
 	<div class="indent">
 		<p><code>$current_user</code> is right, but <code>$currentuser</code> and <code> $currentUser</code> are not.</p>
 	</div>
-	
+
 	<p>In JavaScript, variable names should use camel case:</p>
-	
+
 	<div class="indent">
 		<p><code>currentUser</code> is right, but <code>currentuser</code> and <code>current_user</code> are not.</p>
 	</div>
@@ -431,7 +431,7 @@ function do_stuff()
 	...
 }</pre>
 	</div>
-	
+
 	<p>In JavaScript code, braces always go on the same line:</p>
 
 	<div class="codebox"><pre>

--- a/phpBB/includes/functions.php
+++ b/phpBB/includes/functions.php
@@ -4878,7 +4878,7 @@ function phpbb_get_avatar($row, $alt, $ignore_config = false, $lazy = false)
 			$src = 'src="' . $avatar_data['src'] . '"';
 		}
 
-		$html = '<img class="avatar" ' . $src .
+		$html = '<img class="avatar" ' . $src . ' ' .
 			($avatar_data['width'] ? ('width="' . $avatar_data['width'] . '" ') : '') .
 			($avatar_data['height'] ? ('height="' . $avatar_data['height'] . '" ') : '') .
 			'alt="' . ((!empty($user->lang[$alt])) ? $user->lang[$alt] : $alt) . '" />';

--- a/phpBB/phpbb/template/twig/node/includecss.php
+++ b/phpBB/phpbb/template/twig/node/includecss.php
@@ -31,7 +31,7 @@ class includecss extends \phpbb\template\twig\node\includeasset
 		$compiler
 			->raw("<link href=\"' . ")
 			->raw("\$asset_file . '\"")
-			->raw(' rel="stylesheet" type="text/css" media="screen, projection" />')
+			->raw(' rel="stylesheet" type="text/css" media="screen" />')
 		;
 	}
 }

--- a/tests/template/template_includecss_test.php
+++ b/tests/template/template_includecss_test.php
@@ -71,19 +71,19 @@ class phpbb_template_template_includecss_test extends phpbb_template_template_te
 			*/
 			array(
 				array('TEST' => 1),
-				'<link href="tests/template/templates/child_only.css?assets_version=1" rel="stylesheet" type="text/css" media="screen, projection" />',
+				'<link href="tests/template/templates/child_only.css?assets_version=1" rel="stylesheet" type="text/css" media="screen" />',
 			),
 			array(
 				array('TEST' => 2),
-				'<link href="tests/template/parent_templates/parent_only.css?assets_version=1" rel="stylesheet" type="text/css" media="screen, projection" />',
+				'<link href="tests/template/parent_templates/parent_only.css?assets_version=1" rel="stylesheet" type="text/css" media="screen" />',
 			),
 			array(
 				array('TEST' => 3),
-				'<link href="' . $url_base . '/ext/include/css/styles/all/theme/test.css?assets_version=1" rel="stylesheet" type="text/css" media="screen, projection" />',
+				'<link href="' . $url_base . '/ext/include/css/styles/all/theme/test.css?assets_version=1" rel="stylesheet" type="text/css" media="screen" />',
 			),
 			array(
 				array('TEST' => 4),
-				'<link href="' . $url_base . '/ext/include/css/styles/all/theme/child_only.css?assets_version=1" rel="stylesheet" type="text/css" media="screen, projection" />',
+				'<link href="' . $url_base . '/ext/include/css/styles/all/theme/child_only.css?assets_version=1" rel="stylesheet" type="text/css" media="screen" />',
 			),
 		);
 	}


### PR DESCRIPTION
Projection is a deprecated media type and should not be used.
Name is an invalid attribute in anchors and ID is used instead.
Avatars are invalid by missing a space between elements.

https://tracker.phpbb.com/browse/PHPBB3-13996