### PR TITLE
[ticket/13968] Add core.user_setup_after event

### DIFF
--- a/phpBB/phpbb/user.php
+++ b/phpBB/phpbb/user.php
@@ -301,6 +301,14 @@ class user extends \phpbb\session
 		// After calling it we continue script execution...
 		phpbb_user_session_handler();
 
+		/**
+		* Execute code at the end of user setup
+		*
+		* @event core.user_setup_after
+		* @since 3.1.6-RC1
+		*/
+		$phpbb_dispatcher->dispatch('core.user_setup_after');
+
 		// If this function got called from the error handler we are finished here.
 		if (defined('IN_ERROR_HANDLER'))
 		{


### PR DESCRIPTION
It allows to execute code at the end of user setup.
It can replace the `phpbb_user_session_handler` hook.

https://tracker.phpbb.com/browse/PHPBB3-13968