### PR TITLE
[ticket/13988] Use absolute path for image attachments in feeds

### DIFF
--- a/phpBB/phpbb/feed/helper.php
+++ b/phpBB/phpbb/feed/helper.php
@@ -149,12 +149,10 @@ class helper
 		{
 			$update_count = array();
 			parse_attachments($forum_id, $content, $post_attachments, $update_count);
-			$post_attachments = implode('<br />', $post_attachments);
+			$content .= implode('<br />', $post_attachments);
 
 			// Convert attachments' relative path to absolute path
-			$post_attachments = str_replace($this->phpbb_root_path . 'download/file.' . $this->phpEx, $this->get_board_url() . '/download/file.' . $this->phpEx, $post_attachments);
-
-			$content .= $post_attachments;
+			$content = str_replace($this->phpbb_root_path . 'download/file.' . $this->phpEx, $this->get_board_url() . '/download/file.' . $this->phpEx, $content);
 		}
 
 		// Remove Comments from inline attachments [ia]

--- a/tests/functional/feed_test.php
+++ b/tests/functional/feed_test.php
@@ -1395,7 +1395,7 @@ class phpbb_functional_feed_test extends phpbb_functional_test_case
 					foreach ($attachments as $i => $attachment)
 					{
 						$content = $crawler->filterXPath("//entry[{$entry_id}]/content")->text();
-						$url = "./download/file.php?id={$attachment['id']}";
+						$url = self::$root_url . "download/file.php?id={$attachment['id']}";
 						$string = "Attachment #{$i}";
 
 						if ($attachment['displayed'])


### PR DESCRIPTION
Previously, atom feeds use relative links for image attachments

https://tracker.phpbb.com/browse/PHPBB3-13988