### PR TITLE
[ticket/14034] Fix reparser names that contain "text_reparser" in the middle

### DIFF
--- a/phpBB/phpbb/console/command/reparser/list_all.php
+++ b/phpBB/phpbb/console/command/reparser/list_all.php
@@ -36,7 +36,7 @@ class list_all extends \phpbb\console\command\command
 		foreach ($reparsers as $name => $reparser)
 		{
 			// Store the names without the "text_reparser." prefix
-			$this->reparser_names[] = str_replace('text_reparser.', '', $name);
+			$this->reparser_names[] = preg_replace('(^text_reparser\\.)', '', $name);
 		}
 	}
 

--- a/phpBB/phpbb/console/command/reparser/reparse.php
+++ b/phpBB/phpbb/console/command/reparser/reparse.php
@@ -149,7 +149,7 @@ class reparse extends \phpbb\console\command\command
 			return;
 		}
 
-		$this->io->section($this->user->lang('CLI_REPARSER_REPARSE_REPARSING', str_replace('text_reparser.', '', $name), $min, $max));
+		$this->io->section($this->user->lang('CLI_REPARSER_REPARSE_REPARSING', preg_replace('(^text_reparser\\.)', '', $name), $min, $max));
 
 		$progress = $this->io->createProgressBar($max);
 		if ($output->getVerbosity() === OutputInterface::VERBOSITY_VERBOSE)
@@ -171,7 +171,7 @@ class reparse extends \phpbb\console\command\command
 			$progress->setBarWidth(60);
 		}
 
-		$progress->setMessage($this->user->lang('CLI_REPARSER_REPARSE_REPARSING_START', str_replace('text_reparser.', '', $name)));
+		$progress->setMessage($this->user->lang('CLI_REPARSER_REPARSE_REPARSING_START', preg_replace('(^text_reparser\\.)', '', $name)));
 
 		if (!defined('PHP_WINDOWS_VERSION_BUILD'))
 		{
@@ -189,7 +189,7 @@ class reparse extends \phpbb\console\command\command
 			$start = max($min, $current + 1 - $size);
 			$end   = max($min, $current);
 
-			$progress->setMessage($this->user->lang('CLI_REPARSER_REPARSE_REPARSING', str_replace('text_reparser.', '', $name), $start, $end));
+			$progress->setMessage($this->user->lang('CLI_REPARSER_REPARSE_REPARSING', preg_replace('(^text_reparser\\.)', '', $name), $start, $end));
 			$reparser->reparse_range($start, $end);
 
 			$current = $start - 1;


### PR DESCRIPTION
https://tracker.phpbb.com/browse/PHPBB3-14034

Current code removes "text_reparser." from service names to display short names such as "post_text" instead of "text_reparser.post_text". The issue is it removes it everywhere in the string, not just at the beginning. This fixes that.