### PR TITLE
[ticket/13711] Notifications are sent to inactive users

### DIFF
--- a/phpBB/phpbb/notification/method/messenger_base.php
+++ b/phpBB/phpbb/notification/method/messenger_base.php
@@ -69,7 +69,7 @@ abstract class messenger_base extends \phpbb\notification\method\base
 
 			$user = $this->user_loader->get_user($notification->user_id);
 
-			if ($user['user_type'] == USER_IGNORE || in_array($notification->user_id, $banned_users))
+			if ($user['user_type'] == USER_IGNORE || ($user['user_type'] == USER_INACTIVE && $user['user_inactive_reason'] == INACTIVE_MANUAL) || in_array($notification->user_id, $banned_users))
 			{
 				continue;
 			}


### PR DESCRIPTION
Notifications are sent to inactive users for emails and jabber.  There is no check if a user is set to inactive.

[PHPBB3-13711] (https://tracker.phpbb.com/browse/PHPBB3-13711)