### PR TITLE
[ticket/14070] Disabled avatar types is still displayed on the forum

### DIFF
--- a/phpBB/includes/functions.php
+++ b/phpBB/includes/functions.php
@@ -4839,6 +4839,11 @@ function phpbb_get_avatar($row, $alt, $ignore_config = false, $lazy = false)
 	$phpbb_avatar_manager = $phpbb_container->get('avatar.manager');
 	$driver = $phpbb_avatar_manager->get_driver($row['avatar_type'], $ignore_config);
 	$html = '';
+	
+	if (!($phpbb_avatar_manager->is_enabled($driver) || $ignore_config))
+	{
+		return '';
+	}
 
 	if ($driver)
 	{


### PR DESCRIPTION
If you turn off of any type of avatar (or all at once), then they will still be displayed at the forum and in the profiles of users using a disconnected type of avatar.
[PHPBB3-14070](https://tracker.phpbb.com/browse/PHPBB3-14070)