### PR TITLE
[ticket/13700] Add dependency to migration profilefield_interests

### DIFF
--- a/phpBB/phpbb/db/migration/data/v310/profilefield_interests.php
+++ b/phpBB/phpbb/db/migration/data/v310/profilefield_interests.php
@@ -20,6 +20,7 @@ class profilefield_interests extends \phpbb\db\migration\profilefield_base_migra
 		return array(
 			'\phpbb\db\migration\data\v310\profilefield_types',
 			'\phpbb\db\migration\data\v310\profilefield_show_novalue',
+			'\phpbb\db\migration\data\v310\dev',
 		);
 	}
 


### PR DESCRIPTION
\phpbb\db\migration\data\v310\profilefield_interests should
be dependent on \phpbb\db\migration\data\v310\dev , otherwise
the database column field_show_on_pm is not created in time. This
dependency is added in this commit.

PHPBB3-13700