### PR TITLE
[ticket/14077] Fall back to 1 as focusOffset if length is unsupported

### DIFF
--- a/phpBB/styles/prosilver/template/forum_fn.js
+++ b/phpBB/styles/prosilver/template/forum_fn.js
@@ -156,7 +156,11 @@ function selectCode(a) {
 		// Safari and Chrome
 		if (s.setBaseAndExtent) {
 			var l = (e.innerText.length > 1) ? e.innerText.length - 1 : 1;
-			s.setBaseAndExtent(e, 0, e, l);
+			try {
+				s.setBaseAndExtent(e, 0, e, l);
+			} catch (error) {
+				s.setBaseAndExtent(e, 0, e, 1);
+			}
 		}
 		// Firefox and Opera
 		else {


### PR DESCRIPTION
The setBaseAndExtent() in Microsoft's Edge browser is incompatible with
the one Webkit browsers use. As a result of that, we have to fall back to
setting the focusOffset to 1 instead of the text length.

Ticket: https://tracker.phpbb.com/browse/PHPBB3-14077