### PR TITLE
[ticket/14108] MySQL search backend add post_text index

### DIFF
--- a/phpBB/phpbb/search/fulltext_mysql.php
+++ b/phpBB/phpbb/search/fulltext_mysql.php
@@ -889,7 +889,10 @@ class fulltext_mysql extends \phpbb\search\base
 				$alter[] = 'MODIFY post_subject text NOT NULL';
 			}
 			$alter[] = 'ADD FULLTEXT (post_subject)';
+			$this->db->sql_query('ALTER TABLE ' . POSTS_TABLE . ' ' . implode(', ', $alter));
 		}
+
+		$alter = array();
 
 		if (!isset($this->stats['post_content']))
 		{
@@ -903,10 +906,6 @@ class fulltext_mysql extends \phpbb\search\base
 			}
 
 			$alter[] = 'ADD FULLTEXT post_content (post_text, post_subject)';
-		}
-
-		if (sizeof($alter))
-		{
 			$this->db->sql_query('ALTER TABLE ' . POSTS_TABLE . ' ' . implode(', ', $alter));
 		}
 

--- a/phpBB/phpbb/search/fulltext_mysql.php
+++ b/phpBB/phpbb/search/fulltext_mysql.php
@@ -944,6 +944,7 @@ class fulltext_mysql extends \phpbb\search\base
 		if (isset($this->stats['post_content']))
 		{
 			$alter[] = 'DROP INDEX post_content';
+			$alter[] = 'DROP INDEX post_text';
 		}
 
 		if (sizeof($alter))

--- a/phpBB/phpbb/search/fulltext_mysql.php
+++ b/phpBB/phpbb/search/fulltext_mysql.php
@@ -907,6 +907,8 @@ class fulltext_mysql extends \phpbb\search\base
 
 			$alter[] = 'ADD FULLTEXT post_content (post_text, post_subject)';
 			$this->db->sql_query('ALTER TABLE ' . POSTS_TABLE . ' ' . implode(', ', $alter));
+
+			$this->db->sql_query('ALTER TABLE ' . POSTS_TABLE . ' ADD FULLTEXT post_text (post_text)');
 		}
 
 		$this->db->sql_query('TRUNCATE TABLE ' . SEARCH_RESULTS_TABLE);


### PR DESCRIPTION
When creating the indexes for MySQL, the index for just post_text is not done.
Such index is required for topic searches when searching on the message only (without the title)

https://tracker.phpbb.com/browse/PHPBB3-14108
