### PR TITLE
[ticket/14103] Set proper text-decoration for abbr element.

### DIFF
--- a/phpBB/adm/style/admin.css
+++ b/phpBB/adm/style/admin.css
@@ -105,6 +105,11 @@ hr {
 	height: 1px;
 }
 
+abbr[title] {
+	text-decoration: none;
+	border-bottom: dotted 1px;
+}
+
 .centered-text {
 	text-align: center;
 }

--- a/phpBB/styles/prosilver/theme/common.css
+++ b/phpBB/styles/prosilver/theme/common.css
@@ -129,6 +129,11 @@ hr.divider {
 	display: none;
 }
 
+abbr[title] {
+	text-decoration: none;
+	border-bottom: dotted 1px;
+}
+
 p.right {
 	text-align: right;
 }

--- a/phpBB/styles/subsilver2/theme/stylesheet.css
+++ b/phpBB/styles/subsilver2/theme/stylesheet.css
@@ -129,6 +129,11 @@ h4 {
 	font-weight: bold;
 }
 
+abbr[title] {
+	text-decoration: none;
+	border-bottom: dotted 1px;
+}
+
 p {
 	font-size: 1.1em;
 }


### PR DESCRIPTION
According to [this W3C Recommendation](http://www.w3.org/TR/html5/rendering.html#phrasing-content-0) the `<abbr>` and `<acronym>` elements that have the `title` attribute should have the following style in browsers:
```
abbr[title], acronym[title] { text-decoration: dotted underline; }
```

Currently not all browsers comply with this recommendation.
Firefox 40 is one of the first.

Other browsers usually use `border-bottom` for styling those elements. That border is currently being deleted in prosilver, but not in subsilver2 and the ACP.

Moreover, not every browser supports the new `text-decoration` syntax (e.g. IE11 doesn't support it).
The cross-browser solution is to remove the `text-decoration` and replace it with `border-bottom` for `<abbr>` elements.

No need to do that for `<acronym>` as it is deprecated.

[MDN suggests](https://developer.mozilla.org/en-US/docs/Styling_Abbreviations_and_Acronyms#_The_Solution_) styling the `<abbr>` elements appropriately so that users know that a certain element has extra information available.

>The "underline" tells readers that the word in question has extra information associated with it. ... Removing the "underline" from these elements will rob readers of an indication that there is extra information available.

PHPBB3-14103