### PR TITLE
[ticket/8920] Add a MCP PM reports view permission

### DIFF
--- a/phpBB/includes/mcp/info/mcp_pm_reports.php
+++ b/phpBB/includes/mcp/info/mcp_pm_reports.php
@@ -20,9 +20,9 @@ class mcp_pm_reports_info
 			'title'		=> 'MCP_PM_REPORTS',
 			'version'	=> '1.0.0',
 			'modes'		=> array(
-				'pm_reports'		=> array('title' => 'MCP_PM_REPORTS_OPEN', 'auth' => 'aclf_m_report', 'cat' => array('MCP_REPORTS')),
-				'pm_reports_closed'	=> array('title' => 'MCP_PM_REPORTS_CLOSED', 'auth' => 'aclf_m_report', 'cat' => array('MCP_REPORTS')),
-				'pm_report_details'	=> array('title' => 'MCP_PM_REPORT_DETAILS', 'auth' => 'aclf_m_report', 'cat' => array('MCP_REPORTS')),
+				'pm_reports'		=> array('title' => 'MCP_PM_REPORTS_OPEN', 'auth' => 'acl_m_pm_report', 'cat' => array('MCP_REPORTS')),
+				'pm_reports_closed'	=> array('title' => 'MCP_PM_REPORTS_CLOSED', 'auth' => 'acl_m_pm_report', 'cat' => array('MCP_REPORTS')),
+				'pm_report_details'	=> array('title' => 'MCP_PM_REPORT_DETAILS', 'auth' => 'acl_m_pm_report', 'cat' => array('MCP_REPORTS')),
 			),
 		);
 	}

--- a/phpBB/includes/mcp/mcp_front.php
+++ b/phpBB/includes/mcp/mcp_front.php
@@ -274,7 +274,7 @@ function mcp_front_view($id, $mode, $action)
 	}
 
 	// Latest 5 reported PMs
-	if ($module->loaded('pm_reports') && $auth->acl_getf_global('m_report'))
+	if ($module->loaded('pm_reports') && $auth->acl_get('m_pm_report'))
 	{
 		$template->assign_var('S_SHOW_PM_REPORTS', true);
 		$user->add_lang(array('ucp'));

--- a/phpBB/install/schemas/schema_data.sql
+++ b/phpBB/install/schemas/schema_data.sql
@@ -355,6 +355,7 @@ INSERT INTO phpbb_acl_options (auth_option, is_local, is_global) VALUES ('m_soft
 
 # -- Global moderator auth option (not a local option)
 INSERT INTO phpbb_acl_options (auth_option, is_local, is_global) VALUES ('m_ban', 0, 1);
+INSERT INTO phpbb_acl_options (auth_option, is_local, is_global) VALUES ('m_pm_report', 0, 1);
 INSERT INTO phpbb_acl_options (auth_option, is_local, is_global) VALUES ('m_warn', 0, 1);
 
 # -- Admin related auth options
@@ -542,7 +543,7 @@ INSERT INTO phpbb_acl_roles_data (role_id, auth_option_id, auth_setting) SELECT 
 INSERT INTO phpbb_acl_roles_data (role_id, auth_option_id, auth_setting) SELECT 11, auth_option_id, 1 FROM phpbb_acl_options WHERE auth_option LIKE 'm_%' AND auth_option NOT IN ('m_ban', 'm_chgposter');
 
 # Simple Moderator (m_)
-INSERT INTO phpbb_acl_roles_data (role_id, auth_option_id, auth_setting) SELECT 12, auth_option_id, 1 FROM phpbb_acl_options WHERE auth_option LIKE 'm_%' AND auth_option IN ('m_', 'm_delete', 'm_softdelete', 'm_edit', 'm_info', 'm_report');
+INSERT INTO phpbb_acl_roles_data (role_id, auth_option_id, auth_setting) SELECT 12, auth_option_id, 1 FROM phpbb_acl_options WHERE auth_option LIKE 'm_%' AND auth_option IN ('m_', 'm_delete', 'm_softdelete', 'm_edit', 'm_info', 'm_report', 'm_pm_report');
 
 # Queue Moderator (m_)
 INSERT INTO phpbb_acl_roles_data (role_id, auth_option_id, auth_setting) SELECT 13, auth_option_id, 1 FROM phpbb_acl_options WHERE auth_option LIKE 'm_%' AND auth_option IN ('m_', 'm_approve', 'm_edit');

--- a/phpBB/language/en/acp/permissions_phpbb.php
+++ b/phpBB/language/en/acp/permissions_phpbb.php
@@ -155,9 +155,10 @@ $lang = array_merge($lang, array(
 	'ACL_M_SPLIT'	=> 'Can split topics',
 	'ACL_M_MERGE'	=> 'Can merge topics',
 
-	'ACL_M_INFO'	=> 'Can view post details',
-	'ACL_M_WARN'	=> 'Can issue warnings<br /><em>This setting is only assigned globally. It is not forum based.</em>', // This moderator setting is only global (and not local)
-	'ACL_M_BAN'		=> 'Can manage bans<br /><em>This setting is only assigned globally. It is not forum based.</em>', // This moderator setting is only global (and not local)
+	'ACL_M_INFO'		=> 'Can view post details',
+	'ACL_M_WARN'		=> 'Can issue warnings<br /><em>This setting is only assigned globally. It is not forum based.</em>', // This moderator setting is only global (and not local)
+	'ACL_M_PM_REPORT'	=> 'Can close and delete reports of private messages<br /><em>This setting is only assigned globally. It is not forum based.</em>', // This moderator setting is only global (and not local)
+	'ACL_M_BAN'			=> 'Can manage bans<br /><em>This setting is only assigned globally. It is not forum based.</em>', // This moderator setting is only global (and not local)
 ));
 
 // Admin Permissions

--- a/phpBB/phpbb/db/migration/data/v31x/m_pm_report.php
+++ b/phpBB/phpbb/db/migration/data/v31x/m_pm_report.php
@@ -1,0 +1,43 @@
+<?php
+/**
+*
+* This file is part of the phpBB Forum Software package.
+*
+* @copyright (c) phpBB Limited <https://www.phpbb.com>
+* @license GNU General Public License, version 2 (GPL-2.0)
+*
+* For full copyright and license information, please see
+* the docs/CREDITS.txt file.
+*
+*/
+
+namespace phpbb\db\migration\data\v31x;
+
+class m_pm_report extends \phpbb\db\migration\migration
+{
+	static public function depends_on()
+	{
+		return array('\phpbb\db\migration\data\v31x\v316rc1');
+	}
+
+	public function update_data()
+	{
+		return array(
+			array('permission.add', array('m_pm_report', true, 'm_report')),
+			array('custom', array(
+					array($this, 'update_module_auth'),
+				),
+			),
+		);
+	}
+
+	public function update_module_auth()
+	{
+		$sql = 'UPDATE ' . MODULES_TABLE . "
+			SET module_auth = 'acl_m_pm_report'
+			WHERE module_class = 'mcp'
+				AND module_basename = 'mcp_pm_reports'
+				AND module_auth = 'aclf_m_report'";
+		$this->db->sql_query($sql);
+	}
+}

--- a/phpBB/phpbb/db/migration/data/v31x/m_pm_report.php
+++ b/phpBB/phpbb/db/migration/data/v31x/m_pm_report.php
@@ -31,6 +31,17 @@ class m_pm_report extends \phpbb\db\migration\migration
 		);
 	}
 
+	public function revert_data()
+	{
+		return array(
+			array('permission.remove', array('m_pm_report')),
+			array('custom', array(
+					array($this, 'revert_module_auth'),
+				),
+			),
+		);
+	}
+
 	public function update_module_auth()
 	{
 		$sql = 'UPDATE ' . MODULES_TABLE . "
@@ -38,6 +49,16 @@ class m_pm_report extends \phpbb\db\migration\migration
 			WHERE module_class = 'mcp'
 				AND module_basename = 'mcp_pm_reports'
 				AND module_auth = 'aclf_m_report'";
+		$this->db->sql_query($sql);
+	}
+
+	public function revert_module_auth()
+	{
+		$sql = 'UPDATE ' . MODULES_TABLE . "
+			SET module_auth = 'aclf_m_report'
+			WHERE module_class = 'mcp'
+				AND module_basename = 'mcp_pm_reports'
+				AND module_auth = 'acl_m_pm_report'";
 		$this->db->sql_query($sql);
 	}
 }

--- a/phpBB/phpbb/permissions.php
+++ b/phpBB/phpbb/permissions.php
@@ -285,8 +285,9 @@ class permissions
 		'm_split'	=> array('lang' => 'ACL_M_SPLIT', 'cat' => 'topic_actions'),
 		'm_merge'	=> array('lang' => 'ACL_M_MERGE', 'cat' => 'topic_actions'),
 
-		'm_warn'	=> array('lang' => 'ACL_M_WARN', 'cat' => 'misc'),
-		'm_ban'		=> array('lang' => 'ACL_M_BAN', 'cat' => 'misc'),
+		'm_warn'		=> array('lang' => 'ACL_M_WARN', 'cat' => 'misc'),
+		'm_pm_report'	=> array('lang' => 'ACL_M_PM_REPORT', 'cat' => 'misc'),
+		'm_ban'			=> array('lang' => 'ACL_M_BAN', 'cat' => 'misc'),
 
 		// Admin Permissions
 		'a_board'		=> array('lang' => 'ACL_A_BOARD', 'cat' => 'settings'),


### PR DESCRIPTION
Anybody who has the permission to read reports in one forum can read PM reports.

Solving this problem by adding a new permission to read PM reports.

https://tracker.phpbb.com/browse/PHPBB3-8920