### PR TITLE
[Ticket/14139] Stop styling with IDs

### DIFF
--- a/phpBB/assets/javascript/core.js
+++ b/phpBB/assets/javascript/core.js
@@ -27,7 +27,10 @@ phpbb.isTouch = (window && typeof window.ontouchstart !== 'undefined');
  */
 phpbb.loadingIndicator = function() {
 	if (!$loadingIndicator) {
-		$loadingIndicator = $('<div />', { id: 'loading_indicator' });
+		$loadingIndicator = $('<div />', { 
+			id: 'loading_indicator', 
+			class: 'loading_indicator', 
+		});
 		$loadingIndicator.appendTo('#page-footer');
 	}
 

--- a/phpBB/styles/prosilver/template/mcp_header.html
+++ b/phpBB/styles/prosilver/template/mcp_header.html
@@ -21,14 +21,14 @@
 
 	<div style="width: 100%;">
 
-	<div id="cp-menu">
-		<div id="navigation" role="navigation">
+	<div id="cp-menu" class="cp-menu">
+		<div id="navigation" class="navigation" role="navigation">
 			<ul>
 			<!-- BEGIN l_block1 -->
 			<!-- IF l_block1.S_SELECTED -->
 				<!-- BEGIN l_block2 -->
 				<!-- IF l_block1.l_block2.S_SELECTED -->
-				<li id="active-subsection"><a href="{l_block1.l_block2.U_TITLE}"><span>{l_block1.l_block2.L_TITLE}<!-- IF l_block1.l_block2.ADD_ITEM --> ({l_block1.l_block2.ADD_ITEM})<!-- ENDIF --></span></a></li>
+				<li id="active-subsection" class="active-subsection"><a href="{l_block1.l_block2.U_TITLE}"><span>{l_block1.l_block2.L_TITLE}<!-- IF l_block1.l_block2.ADD_ITEM --> ({l_block1.l_block2.ADD_ITEM})<!-- ENDIF --></span></a></li>
 				<!-- ELSE -->
 				<li><a href="{l_block1.l_block2.U_TITLE}"><span>{l_block1.l_block2.L_TITLE}<!-- IF l_block1.l_block2.ADD_ITEM --> ({l_block1.l_block2.ADD_ITEM})<!-- ENDIF --></span></a></li>
 				<!-- ENDIF -->
@@ -39,7 +39,7 @@
 		</div>
 	</div>
 
-	<div id="cp-main" class="mcp-main panel-container">
+	<div id="cp-main" class="cp-main mcp-main panel-container">
 		<!-- IF MESSAGE -->
 		<div class="content">
 			<h2 class="message-title">{L_MESSAGE}</h2>

--- a/phpBB/styles/prosilver/template/mcp_post.html
+++ b/phpBB/styles/prosilver/template/mcp_post.html
@@ -106,7 +106,7 @@
 			</p>
 		<!-- ENDIF -->
 
-		<div class="content" id="post_details">
+		<div id="post_details" class="content post_details">
 			{POST_PREVIEW}
 		</div>
 

--- a/phpBB/styles/prosilver/template/mcp_topic.html
+++ b/phpBB/styles/prosilver/template/mcp_topic.html
@@ -11,7 +11,7 @@
 	<!-- DEFINE $SHOW_PANEL = 'display-panel' -->
 <!-- ENDIF -->
 
-<div id="minitabs" class="sub-panels" data-show-panel="{$SHOW_PANEL}" role="tablist">
+<div id="minitabs" class="minitabs sub-panels" data-show-panel="{$SHOW_PANEL}" role="tablist">
 	<ul>
 		<li id="display-panel-tab" class="tab<!-- IF not S_MERGE_VIEW --> activetab<!-- ENDIF -->">
 			<a href="#minitabs" data-subpanel="display-panel" role="tab" aria-controls="display-panel">{L_DISPLAY_OPTIONS}</a>
@@ -87,12 +87,12 @@
 <div class="panel">
 	<div class="inner">
 
-	<h3 id="review">
+	<h3 id="review" class="review">
 		<span class="right-box"><a href="#review" onclick="viewableArea(getElementById('topicreview'), true); var rev_text = getElementById('review').getElementsByTagName('a').item(0).firstChild; if (rev_text.data == '{LA_EXPAND_VIEW}'){rev_text.data = '{LA_COLLAPSE_VIEW}'; } else if (rev_text.data == '{LA_COLLAPSE_VIEW}'){rev_text.data = '{LA_EXPAND_VIEW}'};">{L_EXPAND_VIEW}</a></span>
 		{L_TOPIC_REVIEW}{L_COLON} <!-- EVENT mcp_topic_topic_title_before -->{TOPIC_TITLE}<!-- EVENT mcp_topic_topic_title_after -->
 	</h3>
 
-	<div id="topicreview">
+	<div id="topicreview" class="topicreview">
 		<!-- BEGIN postrow -->
 		<div class="post <!-- IF postrow.S_ROW_COUNT is odd -->bg1<!-- ELSE -->bg2<!-- ENDIF -->">
 			<div class="inner">

--- a/phpBB/styles/prosilver/template/memberlist_body.html
+++ b/phpBB/styles/prosilver/template/memberlist_body.html
@@ -48,7 +48,7 @@
 	<div class="forumbg forumbg-table">
 		<div class="inner">
 
-		<table class="table1" id="memberlist">
+		<table class="table1 memberlist" id="memberlist">
 		<thead>
 		<tr>
 			<th class="name" data-dfn="{L_RANK}{L_COMMA_SEPARATOR}<!-- IF S_SHOW_GROUP and .memberrow -->{L_GROUP_LEADER}<!-- ELSE -->{L_USERNAME}<!-- ENDIF -->"><span class="rank-img"><a href="{U_SORT_RANK}">{L_RANK}</a></span><a href="{U_SORT_USERNAME}"><!-- IF S_SHOW_GROUP and .memberrow -->{L_GROUP_LEADER}<!-- ELSE -->{L_USERNAME}<!-- ENDIF --></a></th>

--- a/phpBB/styles/prosilver/template/navbar_header.html
+++ b/phpBB/styles/prosilver/template/navbar_header.html
@@ -3,7 +3,7 @@
 
 	<ul id="nav-main" class="linklist bulletin" role="menubar">
 
-		<li id="quick-links" class="small-icon responsive-menu dropdown-container<!-- IF not S_DISPLAY_QUICK_LINKS and not S_DISPLAY_SEARCH --> hidden<!-- ENDIF -->" data-skip-responsive="true">
+		<li id="quick-links" class="quick-links small-icon responsive-menu dropdown-container<!-- IF not S_DISPLAY_QUICK_LINKS and not S_DISPLAY_SEARCH --> hidden<!-- ENDIF -->" data-skip-responsive="true">
 			<a href="#" class="responsive-menu-link dropdown-trigger">{L_QUICK_LINKS}</a>
 			<div class="dropdown hidden">
 				<div class="pointer"><div class="pointer-inner"></div></div>

--- a/phpBB/styles/prosilver/template/overall_footer.html
+++ b/phpBB/styles/prosilver/template/overall_footer.html
@@ -3,7 +3,7 @@
 
 <!-- EVENT overall_footer_page_body_after -->
 
-<div id="page-footer" role="contentinfo">
+<div id="page-footer" class="page-footer" role="contentinfo">
 	<!-- INCLUDE navbar_footer.html -->
 
 	<div class="copyright">
@@ -15,8 +15,8 @@
 		<!-- IF U_ACP --><br /><strong><a href="{U_ACP}">{L_ACP}</a></strong><!-- ENDIF -->
 	</div>
 
-	<div id="darkenwrapper" data-ajax-error-title="{L_AJAX_ERROR_TITLE}" data-ajax-error-text="{L_AJAX_ERROR_TEXT}" data-ajax-error-text-abort="{L_AJAX_ERROR_TEXT_ABORT}" data-ajax-error-text-timeout="{L_AJAX_ERROR_TEXT_TIMEOUT}" data-ajax-error-text-parsererror="{L_AJAX_ERROR_TEXT_PARSERERROR}">
-		<div id="darken">&nbsp;</div>
+	<div id="darkenwrapper" class="darkenwrapper" data-ajax-error-title="{L_AJAX_ERROR_TITLE}" data-ajax-error-text="{L_AJAX_ERROR_TEXT}" data-ajax-error-text-abort="{L_AJAX_ERROR_TEXT_ABORT}" data-ajax-error-text-timeout="{L_AJAX_ERROR_TEXT_TIMEOUT}" data-ajax-error-text-parsererror="{L_AJAX_ERROR_TEXT_PARSERERROR}">
+		<div id="darken" class="darken">&nbsp;</div>
 	</div>
 
 	<div id="phpbb_alert" class="phpbb_alert" data-l-err="{L_ERROR}" data-l-timeout-processing-req="{L_TIMEOUT_PROCESSING_REQ}">

--- a/phpBB/styles/prosilver/template/overall_header.html
+++ b/phpBB/styles/prosilver/template/overall_header.html
@@ -71,13 +71,13 @@
 
 <!-- EVENT overall_header_body_before -->
 
-<div id="wrap">
-	<a id="top" class="anchor" accesskey="t"></a>
+<div id="wrap" class="wrap">
+	<a id="top" class="top-anchor" accesskey="t"></a>
 	<div id="page-header">
 		<div class="headerbar" role="banner">
 			<div class="inner">
 
-			<div id="site-description">
+			<div id="site-description" class="site-description">
 				<a id="logo" class="logo" href="<!-- IF U_SITE_HOME -->{U_SITE_HOME}<!-- ELSE -->{U_INDEX}<!-- ENDIF -->" title="<!-- IF U_SITE_HOME -->{L_SITE_HOME}<!-- ELSE -->{L_INDEX}<!-- ENDIF -->">{SITE_LOGO_IMG}</a>
 				<h1>{SITENAME}</h1>
 				<p>{SITE_DESCRIPTION}</p>
@@ -107,7 +107,7 @@
 	<!-- EVENT overall_header_page_body_before -->
 
 	<a id="start_here" class="anchor"></a>
-	<div id="page-body" role="main">
+	<div id="page-body" class="page-body" role="main">
 		<!-- IF S_BOARD_DISABLED and S_USER_LOGGED_IN and (U_MCP or U_ACP) -->
 		<div id="information" class="rules">
 			<div class="inner">

--- a/phpBB/styles/prosilver/template/posting_attach_body.html
+++ b/phpBB/styles/prosilver/template/posting_attach_body.html
@@ -17,11 +17,11 @@
 	</dl>
 	</fieldset>
 
-	<div id="attach-panel-multi">
+	<div id="attach-panel-multi" class="attach-panel-multi">
 		<input type="button" class="button2" value="{L_PLUPLOAD_ADD_FILES}" id="add_files" />
 	</div>
 
-	<div class="panel<!-- IF not .attach_row --> hidden<!-- ENDIF -->" id="file-list-container">
+	<div class="panel<!-- IF not .attach_row --> hidden<!-- ENDIF --> file-list-container" id="file-list-container">
 		<div class="inner">
 			<table class="table1 zebra-list fixed-width-table">
 				<thead>
@@ -32,7 +32,7 @@
 						<th class="attach-status">{L_PLUPLOAD_STATUS}</th>
 					</tr>
 				</thead>
-				<tbody class="responsive-skip-empty" id="file-list">
+				<tbody class="responsive-skip-empty file-list" id="file-list">
 					<tr class="attach-row" id="attach-row-tpl">
 							<td class="attach-name">
 								<span class="file-name ellipsis-text"></span>

--- a/phpBB/styles/prosilver/template/posting_buttons.html
+++ b/phpBB/styles/prosilver/template/posting_buttons.html
@@ -55,12 +55,12 @@
 <div id="colour_palette" style="display: none;">
 	<dl style="clear: left;">
 		<dt><label>{L_FONT_COLOR}{L_COLON}</label></dt>
-		<dd id="color_palette_placeholder" data-orientation="h" data-height="12" data-width="15" data-bbcode="true"></dd>
+		<dd id="color_palette_placeholder" class="color_palette_placeholder" data-orientation="h" data-height="12" data-width="15" data-bbcode="true"></dd>
 	</dl>
 </div>
 
 <!-- EVENT posting_editor_buttons_before -->
-<div id="format-buttons">
+<div id="format-buttons" class="format-buttons">
 	<input type="button" class="button2 bbcode-b" accesskey="b" name="addbbcode0" value=" B " style="font-weight:bold; width: 30px" onclick="bbstyle(0)" title="{L_BBCODE_B_HELP}" />
 	<input type="button" class="button2 bbcode-i" accesskey="i" name="addbbcode2" value=" i " style="font-style:italic; width: 30px" onclick="bbstyle(2)" title="{L_BBCODE_I_HELP}" />
 	<input type="button" class="button2 bbcode-u" accesskey="u" name="addbbcode4" value=" u " style="text-decoration: underline; width: 30px" onclick="bbstyle(4)" title="{L_BBCODE_U_HELP}" />

--- a/phpBB/styles/prosilver/template/posting_editor.html
+++ b/phpBB/styles/prosilver/template/posting_editor.html
@@ -35,7 +35,7 @@
 
 	<!-- INCLUDE posting_buttons.html -->
 
-	<div id="smiley-box">
+	<div id="smiley-box" class="smiley-box">
 		<!-- EVENT posting_editor_smilies_before -->	
 		<!-- IF S_SMILIES_ALLOWED and .smiley -->
 			<strong>{L_SMILIES}</strong><br />
@@ -69,7 +69,7 @@
 
 	<!-- EVENT posting_editor_message_before -->
 
-	<div id="message-box">
+	<div id="message-box" class="message-box">
 		<textarea <!-- IF S_UCP_ACTION and not S_PRIVMSGS and not S_EDIT_DRAFT -->name="signature" id="signature" style="height: 9em;"<!-- ELSE -->name="message" id="message"<!-- ENDIF --> rows="15" cols="76" tabindex="4" onselect="storeCaret(this);" onclick="storeCaret(this);" onkeyup="storeCaret(this);" onfocus="initInsertions();" class="inputbox">{MESSAGE}{DRAFT_MESSAGE}{SIGNATURE}</textarea>
 	</div>
 
@@ -102,13 +102,13 @@
 	<!-- ENDIF -->
 
 	<!-- IF not S_PRIVMSGS and not S_SHOW_DRAFTS and not $SIG_EDIT eq 1 -->
-		<div id="tabs" class="sub-panels" data-show-panel="<!-- IF SHOW_PANEL -->{SHOW_PANEL}<!-- ELSE -->options-panel<!-- ENDIF -->" role="tablist">
+		<div id="tabs" class="tabs sub-panels" data-show-panel="<!-- IF SHOW_PANEL -->{SHOW_PANEL}<!-- ELSE -->options-panel<!-- ENDIF -->" role="tablist">
 			<ul>
 				<li id="options-panel-tab" class="tab activetab"><a href="#tabs" data-subpanel="options-panel" role="tab" aria-controls="options-panel"><span>{L_OPTIONS}</span></a></li>
 				<!-- IF S_SHOW_ATTACH_BOX -->
 					<li id="attach-panel-tab" class="tab">
 						<a href="#tabs" data-subpanel="attach-panel" role="tab" aria-controls="attach-panel">
-							{L_ATTACHMENTS} <strong id="file-total-progress"><strong id="file-total-progress-bar"></strong></strong>
+							{L_ATTACHMENTS} <strong id="file-total-progress" class="file-total-progress"><strong id="file-total-progress-bar" class="file-total-progress-bar"></strong></strong>
 						</a>
 					</li>
 				<!-- ENDIF -->

--- a/phpBB/styles/prosilver/template/posting_topic_review.html
+++ b/phpBB/styles/prosilver/template/posting_topic_review.html
@@ -1,10 +1,10 @@
 
-<h3 id="review">
+<h3 id="review" class="review">
 	<span class="right-box"><a href="#review" onclick="viewableArea(getElementById('topicreview'), true); var rev_text = getElementById('review').getElementsByTagName('a').item(0).firstChild; if (rev_text.data == '{LA_EXPAND_VIEW}'){rev_text.data = '{LA_COLLAPSE_VIEW}'; } else if (rev_text.data == '{LA_COLLAPSE_VIEW}'){rev_text.data = '{LA_EXPAND_VIEW}'};">{L_EXPAND_VIEW}</a></span>
 	{L_TOPIC_REVIEW}{L_COLON} {TOPIC_TITLE}
 </h3>
 
-<div id="topicreview">
+<div id="topicreview" class="topicreview">
 <script type="text/javascript">
 // <![CDATA[
 	bbcodeEnabled = {S_BBCODE_ALLOWED};

--- a/phpBB/styles/prosilver/template/quickreply_editor.html
+++ b/phpBB/styles/prosilver/template/quickreply_editor.html
@@ -9,7 +9,7 @@
 						<dd><input type="text" name="subject" id="subject" size="45" maxlength="124" tabindex="2" value="{SUBJECT}" class="inputbox autowidth" /></dd>
 					</dl>
 				<!-- EVENT quickreply_editor_message_before -->
-				<div id="message-box">
+				<div id="message-box" class="message-box">
 					<textarea style="height: 9em;" name="message" rows="7" cols="76" tabindex="3" class="inputbox"></textarea>
 				</div>
 				<!-- EVENT quickreply_editor_message_after -->

--- a/phpBB/styles/prosilver/template/simple_footer.html
+++ b/phpBB/styles/prosilver/template/simple_footer.html
@@ -5,10 +5,10 @@
 		<!-- IF DEBUG_OUTPUT --><br />{DEBUG_OUTPUT}<!-- ENDIF -->
 	</div>
 
-	<div id="darkenwrapper" data-ajax-error-title="{L_AJAX_ERROR_TITLE}" data-ajax-error-text="{L_AJAX_ERROR_TEXT}" data-ajax-error-text-abort="{L_AJAX_ERROR_TEXT_ABORT}" data-ajax-error-text-timeout="{L_AJAX_ERROR_TEXT_TIMEOUT}" data-ajax-error-text-parsererror="{L_AJAX_ERROR_TEXT_PARSERERROR}">
-		<div id="darken">&nbsp;</div>
+	<div id="darkenwrapper" class="darkenwrapper" data-ajax-error-title="{L_AJAX_ERROR_TITLE}" data-ajax-error-text="{L_AJAX_ERROR_TEXT}" data-ajax-error-text-abort="{L_AJAX_ERROR_TEXT_ABORT}" data-ajax-error-text-timeout="{L_AJAX_ERROR_TEXT_TIMEOUT}" data-ajax-error-text-parsererror="{L_AJAX_ERROR_TEXT_PARSERERROR}">
+		<div id="darken" class="darken">&nbsp;</div>
 	</div>
-	<div id="loading_indicator"></div>
+	<div id="loading_indicator" class="loading_indicator"></div>
 
 	<div id="phpbb_alert" class="phpbb_alert" data-l-err="{L_ERROR}" data-l-timeout-processing-req="{L_TIMEOUT_PROCESSING_REQ}">
 		<a href="#" class="alert_close"></a>

--- a/phpBB/styles/prosilver/template/simple_header.html
+++ b/phpBB/styles/prosilver/template/simple_header.html
@@ -48,6 +48,6 @@
 
 <!-- EVENT simple_header_body_before -->
 
-<div id="wrap">
-	<a id="top" class="anchor" accesskey="t"></a>
-	<div id="page-body" role="main">
+<div id="wrap" class="wrap">
+	<a id="top" class="top-anchor" accesskey="t"></a>
+	<div id="page-body" class="page-body" role="main">

--- a/phpBB/styles/prosilver/template/timezone_option.html
+++ b/phpBB/styles/prosilver/template/timezone_option.html
@@ -12,7 +12,7 @@
 	</dd>
 	<!-- ENDIF -->
 	<dd>
-		<select name="tz" id="timezone" class="autowidth tz_select">
+		<select name="tz" id="timezone" class="autowidth tz_select timezone">
 			<option value="">{L_SELECT_TIMEZONE}</option>
 			<!-- BEGIN timezone_select -->
 			<optgroup label="{timezone_select.LABEL}" data-tz-value="{timezone_select.VALUE}">

--- a/phpBB/styles/prosilver/template/ucp_avatar_options_local.html
+++ b/phpBB/styles/prosilver/template/ucp_avatar_options_local.html
@@ -6,7 +6,7 @@
 </select></label>
 <input type="submit" value="{L_GO}" name="avatar_local_go" class="button2" />
 
-<div id="gallery">
+<div id="gallery" class="gallery">
 <!-- BEGIN avatar_local_row -->
 <!-- BEGIN avatar_local_col -->
 	<label for="av-{avatar_local_row.S_ROW_COUNT}-{avatar_local_row.avatar_local_col.S_ROW_COUNT}"><img src="{avatar_local_row.avatar_local_col.AVATAR_IMAGE}" alt="" /><br />

--- a/phpBB/styles/prosilver/template/ucp_groups_manage.html
+++ b/phpBB/styles/prosilver/template/ucp_groups_manage.html
@@ -58,7 +58,7 @@
 			<input name="group_colour" type="text" id="group_colour" value="{GROUP_COLOUR}" size="6" maxlength="6" class="inputbox narrow" />
 			<span style="background-color: #{GROUP_COLOUR};">&nbsp;&nbsp;&nbsp;</span>
 			[ <a href="#" id="color_palette_toggle">{L_COLOUR_SWATCH}</a> ]
-			<div id="color_palette_placeholder" class="hidden" data-orientation="h" data-height="12" data-width="15" data-target="#group_colour"></div>
+			<div id="color_palette_placeholder" class="color_palette_placeholder hidden" data-orientation="h" data-height="12" data-width="15" data-target="#group_colour"></div>
 		</dd>
 	</dl>
 	<dl>

--- a/phpBB/styles/prosilver/template/ucp_header.html
+++ b/phpBB/styles/prosilver/template/ucp_header.html
@@ -19,15 +19,15 @@
 
 	<div style="width: 100%;">
 
-	<div id="cp-menu">
-		<div id="navigation" role="navigation">
+	<div id="cp-menu" class="cp-menu">
+		<div id="navigation" class="navigation" role="navigation">
 
 		<!-- IF S_PRIVMSGS -->
 			<!-- BEGIN t_block2 -->
 				<!-- IF S_PRIVMSGS and not t_block2.S_LAST_ROW -->
 				<ul>
 					<!-- IF t_block2.S_SELECTED -->
-						<li id="active-subsection"><a href="{t_block2.U_TITLE}"><span>{t_block2.L_TITLE}</span></a></li>
+						<li id="active-subsection" class="active-subsection"><a href="{t_block2.U_TITLE}"><span>{t_block2.L_TITLE}</span></a></li>
 					<!-- ELSE -->
 						<li><a href="{t_block2.U_TITLE}"><span>{t_block2.L_TITLE}</span></a></li>
 					<!-- ENDIF -->
@@ -39,7 +39,7 @@
 			<!-- BEGIN folder -->
 				<!-- IF folder.S_FIRST_ROW --><ul><!-- ENDIF -->
 				<!-- IF folder.S_CUR_FOLDER -->
-					<li id="active-subsection"><a href="{folder.U_FOLDER}"><!-- IF folder.UNREAD_MESSAGES > 0 --><strong>{folder.FOLDER_NAME} ({folder.UNREAD_MESSAGES})</strong><!-- ELSE -->{folder.FOLDER_NAME}<!-- ENDIF --></a></li>
+					<li id="active-subsection" class="active-subsection"><a href="{folder.U_FOLDER}"><!-- IF folder.UNREAD_MESSAGES > 0 --><strong>{folder.FOLDER_NAME} ({folder.UNREAD_MESSAGES})</strong><!-- ELSE -->{folder.FOLDER_NAME}<!-- ENDIF --></a></li>
 				<!-- ELSE -->
 					<li><a href="{folder.U_FOLDER}"><span><!-- IF folder.UNREAD_MESSAGES > 0 --><strong>{folder.FOLDER_NAME} ({folder.UNREAD_MESSAGES})</strong><!-- ELSE -->{folder.FOLDER_NAME}<!-- ENDIF --></span></a></li>
 				<!-- ENDIF -->
@@ -52,7 +52,7 @@
 		<!-- BEGIN t_block2 -->
 			<!-- IF (S_PRIVMSGS and t_block2.S_LAST_ROW) or not S_PRIVMSGS -->
 				<!-- IF t_block2.S_SELECTED -->
-					<li id="active-subsection"><a href="{t_block2.U_TITLE}"><span>{t_block2.L_TITLE}</span></a></li>
+					<li id="active-subsection" class="active-subsection"><a href="{t_block2.U_TITLE}"><span>{t_block2.L_TITLE}</span></a></li>
 				<!-- ELSE -->
 					<li><a href="{t_block2.U_TITLE}"><span>{t_block2.L_TITLE}</span></a></li>
 				<!-- ENDIF -->
@@ -98,4 +98,4 @@
 
 	</div>
 
-	<div id="cp-main" class="ucp-main panel-container">
+	<div id="cp-main" class="cp main ucp-main panel-container">

--- a/phpBB/styles/prosilver/template/ucp_pm_history.html
+++ b/phpBB/styles/prosilver/template/ucp_pm_history.html
@@ -1,11 +1,11 @@
 
-<h3 id="review">
+<h3 id="review" class="review">
 	<span class="right-box"><a href="#review" onclick="viewableArea(getElementById('topicreview'), true); var rev_text = getElementById('review').getElementsByTagName('a').item(0).firstChild; if (rev_text.data == '{LA_EXPAND_VIEW}'){rev_text.data = '{LA_COLLAPSE_VIEW}'; } else if (rev_text.data == '{LA_COLLAPSE_VIEW}'){rev_text.data = '{LA_EXPAND_VIEW}'};">{L_EXPAND_VIEW}</a></span>
 	{L_MESSAGE_HISTORY}{L_COLON}
 </h3>
 
 <!-- EVENT ucp_pm_history_review_before -->
-<div id="topicreview">
+<div id="topicreview" class="topicreview">
 	<script type="text/javascript">
 	// <![CDATA[
 		bbcodeEnabled = {S_BBCODE_ALLOWED};

--- a/phpBB/styles/prosilver/template/ucp_pm_viewmessage_print.html
+++ b/phpBB/styles/prosilver/template/ucp_pm_viewmessage_print.html
@@ -10,8 +10,8 @@
 <!-- EVENT ucp_pm_viewmessage_print_head_append -->
 </head>
 <body id="phpbb">
-<div id="wrap">
-	<a id="top" class="anchor" accesskey="t"></a>
+<div id="wrap" class="wrap">
+	<a id="top" class="top-anchor" accesskey="t"></a>
 
 	<div id="page-header">
 		<h1>{SITENAME}</h1>
@@ -20,7 +20,7 @@
 		<h2>{L_PRIVATE_MESSAGING}</h2>
 	</div>
 
-	<div id="page-body">
+	<div id="page-body" class="page-body">
 		<div class="page-number">{PAGE_NUMBER}</div>
 			<div class="post">
 				<h3>{SUBJECT}</h3>
@@ -38,7 +38,7 @@
 			<hr />
 	</div>
 
-	<div id="page-footer">
+	<div id="page-footer" class="page-footer">
 		<div class="page-number">{S_TIMEZONE}<br />{PAGE_NUMBER}</div>
 		<div class="copyright">Powered by phpBB&reg; Forum Software &copy; phpBB Limited<br />https://www.phpbb.com/</div>
 	</div>

--- a/phpBB/styles/prosilver/template/viewtopic_print.html
+++ b/phpBB/styles/prosilver/template/viewtopic_print.html
@@ -10,8 +10,8 @@
 <!-- EVENT viewtopic_print_head_append -->
 </head>
 <body id="phpbb">
-<div id="wrap">
-	<a id="top" class="anchor" accesskey="t"></a>
+<div id="wrap" class="wrap">
+	<a id="top" class="top-anchor" accesskey="t"></a>
 
 	<div id="page-header">
 		<h1>{SITENAME}</h1>
@@ -21,7 +21,7 @@
 		<p><a href="{U_TOPIC}">{U_TOPIC}</a></p>
 	</div>
 
-	<div id="page-body">
+	<div id="page-body" class="page-body">
 		<div class="page-number">{PAGE_NUMBER}</div>
 		<!-- BEGIN postrow -->
 			<div class="post">
@@ -34,7 +34,7 @@
 		<!-- END postrow -->
 	</div>
 
-	<div id="page-footer">
+	<div id="page-footer" class="page-footer">
 		<div class="page-number">{S_TIMEZONE}<br />{PAGE_NUMBER}</div>
 		<div class="copyright">Powered by phpBB&reg; Forum Software &copy; phpBB Limited<br />https://www.phpbb.com/</div>
 	</div>

--- a/phpBB/styles/prosilver/theme/bidi.css
+++ b/phpBB/styles/prosilver/theme/bidi.css
@@ -27,11 +27,11 @@
 
 /* Site Description
 --------------------------------------------- */
-.rtl #site-description {
+.rtl .site-description {
 	float: right;
 }
 
-.rtl #site-description h1 {
+.rtl .site-description h1 {
 	margin-left: 0;
 }
 
@@ -268,16 +268,7 @@
 
 /* Miscellaneous styles
 ---------------------------------------- */
-.rtl #forum-permissions {
-	float: left;
-	padding-right: 5px;
-	padding-left: 0;
-	margin-right: 5px;
-	margin-left: 0;
-	text-align: left;
-}
-
-.rtl #quick-links {
+.rtl .quick-links {
 	margin-left: 7px;
 	margin-right: 0;
 }
@@ -471,7 +462,7 @@ li.breadcrumbs span:first-child > a {
 
 /* Topic review panel
 ----------------------------------------*/
-.rtl #topicreview {
+.rtl .topicreview {
 	padding-right: 0;
 	padding-left: 5px;
 }
@@ -687,20 +678,20 @@ li.breadcrumbs span:first-child > a {
 
 /* Main CP box
 ----------------------------------------*/
-.rtl #cp-menu {
+.rtl .cp-menu {
 	float: right;
 }
 
-.rtl #cp-main {
+.rtl .cp-main {
 	float: right;
 }
 
-.rtl #cp-main .panel ol {
+.rtl .cp-main .panel ol {
 	margin-right: 2em;
 	margin-left: 0;
 }
 
-.rtl #cp-main .buttons {
+.rtl .cp-main .buttons {
 	margin-right: 0;
 	margin-left: 0;
 }
@@ -711,52 +702,52 @@ li.breadcrumbs span:first-child > a {
 
 /* CP tabbed menu
 ----------------------------------------*/
-.rtl #tabs {
+.rtl .tabs {
 	margin-left: 0;
 	margin-right: 7px;
 }
 
-.rtl #tabs .tab {
+.rtl .tabs .tab {
 	float: right;
 }
 
-.rtl #tabs .tab > a {
+.rtl .tabs .tab > a {
 	margin-left: 1px;
 	margin-right: 0;
 }
 
 /* Mini tabbed menu used in MCP
 ----------------------------------------*/
-.rtl #minitabs {
+.rtl .minitabs {
 	float: left;
 	margin-right: 0;
 	margin-left: 7px;
 }
 
-.rtl #minitabs .tab {
+.rtl .minitabs .tab {
 	float: left;
 }
 
-.rtl #minitabs .tab > a {
+.rtl .minitabs .tab > a {
 	margin-right: 2px;
 	margin-left: 0;
 }
 
 /* Responsive tabs
 ----------------------------------------*/
-.rtl #tabs .dropdown {
+.rtl .tabs .dropdown {
 	margin-left: -2px;
 }
 
-.rtl #tabs .dropdown li {
+.rtl .tabs .dropdown li {
 	text-align: left;
 }
 
-.rtl #minitabs .dropdown {
+.rtl .minitabs .dropdown {
 	margin-left: -4px;
 }
 
-.rtl #minitabs .dropdown li {
+.rtl .minitabs .dropdown li {
 	text-align: right;
 }
 
@@ -764,7 +755,7 @@ li.breadcrumbs span:first-child > a {
 ----------------------------------------*/
 @media only screen and (max-width: 900px), only screen and (max-device-width: 900px)
 {
-	.rtl #cp-menu, .rtl #navigation, .rtl #cp-main {
+	.rtl .cp-menu, .rtl .navigation, .rtl .cp-main {
 		float: none;
 	}
 }
@@ -774,7 +765,7 @@ li.breadcrumbs span:first-child > a {
 
 /* Preferences pane layout
 ----------------------------------------*/
-.rtl #cp-main h2 {
+.rtl .cp-main h2 {
 	margin-left: 0;
 	margin-right: 10px;
 }
@@ -815,7 +806,7 @@ li.breadcrumbs span:first-child > a {
 }
 
 /* Avatar gallery */
-.rtl #gallery label {
+.rtl .gallery label {
 	float: right;
 }
 
@@ -823,7 +814,7 @@ li.breadcrumbs span:first-child > a {
 ----------------------------------------*/
 @media only screen and (max-width: 900px), only screen and (max-device-width: 900px)
 {
-	.rtl #cp-menu, .rtl #navigation, .rtl #cp-main {
+	.rtl .cp-menu, .rtl .navigation, .rtl .cp-main {
 		float: none;
 	}
 }
@@ -935,7 +926,7 @@ li.breadcrumbs span:first-child > a {
 ----------------------------------------*/
 
 /* Emoticons panel */
-.rtl #smiley-box {
+.rtl .smiley-box {
 	float: left;
 }
 
@@ -984,7 +975,7 @@ li.breadcrumbs span:first-child > a {
 ---------------------------------------- */
 
 /** Reference: Bug #27155 */
-.rtl #wrap, .rtl .headerbar, .rtl #site-description, .rtl .navbar {
+.rtl .wrap, .rtl .headerbar, .rtl .site-description, .rtl .navbar {
 	position: relative;
 }
 

--- a/phpBB/styles/prosilver/theme/buttons.css
+++ b/phpBB/styles/prosilver/theme/buttons.css
@@ -61,7 +61,7 @@
 	margin-right: 5px;
 }
 
-#jumpbox .dropdown-select {
+.jumpbox .dropdown-select {
 	margin: 0;
 }
 

--- a/phpBB/styles/prosilver/theme/colours.css
+++ b/phpBB/styles/prosilver/theme/colours.css
@@ -42,7 +42,7 @@ hr {
 
 /* Round cornered boxes and backgrounds
 ---------------------------------------- */
-#wrap {
+.wrap {
 	background-color: #FFF;
 	border-color: #E6E9ED;
 }
@@ -771,7 +771,7 @@ Colours and backgrounds for cp.css
 /* Main CP box
 ----------------------------------------*/
 
-.panel-container h3, .panel-container hr, #cp-menu hr {
+.panel-container h3, .panel-container hr, .cp-menu hr {
 	border-color: #A4B3BF;
 }
 
@@ -793,25 +793,25 @@ ul.cplist {
 	border-bottom-color: #333333;
 }
 
-#cp-main .pm-message {
+.cp-main .pm-message {
 	border-color: #DBDEE2;
 	background-color: #FFFFFF;
 }
 
 /* CP tabbed menu
 ----------------------------------------*/
-#tabs .tab > a {
+.tabs .tab > a {
 	background: #BACCD9;
 	color: #536482;
 }
 
-#tabs .tab > a:hover {
+.tabs .tab > a:hover {
 	background: #DDEDFB;
 	color: #D31141;
 }
 
-#tabs .activetab > a,
-#tabs .activetab > a:hover {
+.tabs .activetab > a,
+.tabs .activetab > a:hover {
 	background-color: #CADCEB; /* Old browsers */ /* FF3.6+ */
 	background-image: -webkit-linear-gradient(top, #E2F2FF 0%, #CADCEB 100%);
 	background-image: linear-gradient(to bottom, #E2F2FF 0%,#CADCEB 100%); /* W3C */
@@ -821,18 +821,18 @@ ul.cplist {
 	color: #333333;
 }
 
-#tabs .activetab > a:hover {
+.tabs .activetab > a:hover {
 	color: #000000;
 }
 
 /* Mini tabbed menu used in MCP
 ----------------------------------------*/
-#minitabs .tab > a {
+.minitabs .tab > a {
 	background-color: #E1EBF2;
 }
 
-#minitabs .activetab > a,
-#minitabs .activetab > a:hover {
+.minitabs .activetab > a,
+.minitabs .activetab > a:hover {
 	background-color: #F9F9F9;
 	color: #333333;
 }
@@ -851,7 +851,7 @@ ul.cplist {
 ----------------------------------------*/
 
 /* Link styles for the sub-section links */
-#navigation a {
+.navigation a {
 	color: #333;
 	background: #CADCEB; /* Old browsers */ /* FF3.6+ */
 	background: -webkit-linear-gradient(left, #B4C4D1 50%, #CADCEB 100%);
@@ -859,26 +859,26 @@ ul.cplist {
 	filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#B4C4D1', endColorstr='#CADCEB',GradientType=1 ); /* IE6-9 */
 }
 
-.rtl #navigation a {
+.rtl .navigation a {
 	background: #B4C4D1; /* Old browsers */ /* FF3.6+ */
 	background: -webkit-linear-gradient(left, #CADCEB 50%, #B4C4D1 100%);
 	background: linear-gradient(to right, #CADCEB 50%,#B4C4D1 100%); /* W3C */
 	filter: progid:DXImageTransform.Microsoft.gradient( startColorstr='#CADCEB', endColorstr='#B4C4D1',GradientType=1 ); /* IE6-9 */
 }
 
-#navigation a:hover {
+.navigation a:hover {
 	background: #AABAC6;
 	color: #BC2A4D;
 	filter: progid:DXImageTransform.Microsoft.gradient(enabled = false);
 }
 
-#navigation #active-subsection a {
+.navigation .active-subsection a {
 	background: #F9F9F9;
 	color: #D31141;
 	filter: progid:DXImageTransform.Microsoft.gradient(enabled = false);
 }
 
-#navigation #active-subsection a:hover {
+.navigation .active-subsection a:hover {
 	color: #D31141;
 }
 
@@ -899,7 +899,7 @@ ul.cplist {
 	background-color: #F9F9F9;
 }
 
-#cp-main .pm {
+.cp-main .pm {
 	background-color: #FFFFFF;
 }
 
@@ -942,12 +942,12 @@ dl.mini dt {
 }
 
 /* Avatar gallery */
-#gallery label {
+.gallery label {
 	background: #FFFFFF;
 	border-color: #CCC;
 }
 
-#gallery label:hover {
+.gallery label:hover {
 	background-color: #EEE;
 }
 
@@ -999,15 +999,15 @@ fieldset.quick-login input.inputbox {
 /* Posting page styles
 ----------------------------------------*/
 
-#message-box textarea {
+.message-box textarea {
 	color: #333333;
 }
 
-#message-box textarea.drag-n-drop {
+.message-box textarea.drag-n-drop {
 	outline-color: rgba(102, 102, 102, 0.5);
 }
 
-#message-box textarea.drag-n-drop-highlight {
+.message-box textarea.drag-n-drop-highlight {
 	outline-color: rgba(17, 163, 234, 0.5);
 }
 
@@ -1107,11 +1107,11 @@ input.disabled {
 .phpbb_alert .alert_close {
 	background-image: url("./images/alert_close.png");
 }
-#darken {
+.darken {
 	background-color: #000000;
 }
 
-#loading_indicator {
+.loading_indicator {
 	background-color: #000000;
 	background-image: url("./images/loading.gif");
 }

--- a/phpBB/styles/prosilver/theme/common.css
+++ b/phpBB/styles/prosilver/theme/common.css
@@ -126,7 +126,7 @@ ol ol ul, ol ul ul, ul ol ul, ul ul ul {
 
 /* Main blocks
 ---------------------------------------- */
-#wrap {
+.wrap {
 	border: 1px solid transparent;
 	border-radius: 8px;
 	margin: 0 auto;
@@ -136,21 +136,21 @@ ol ol ul, ol ul ul, ul ol ul, ul ul ul {
 }
 
 @media only screen and (max-width: 1220px), only screen and (max-device-width: 1220px) {
-	#wrap {
+	.wrap {
 		margin: 0 12px;
 	}
 }
 
-#page-body {
+.page-body {
 	margin: 4px 0;
 	clear: both;
 }
 
-#page-footer {
+.page-footer {
 	clear: both;
 }
 
-#page-footer h3 {
+.page-footer h3 {
 	margin-top: 20px;
 }
 
@@ -165,12 +165,12 @@ ol ol ul, ol ul ul, ul ol ul, ul ul ul {
 }
 
 /* Site description and logo */
-#site-description {
+.site-description {
 	float: left;
 	width: 65%;
 }
 
-#site-description h1 {
+.site-description h1 {
 	margin-right: 0;
 }
 
@@ -231,7 +231,7 @@ ul.linklist {
 	margin: 0;
 }
 
-#cp-main .panel {
+.cp-main .panel {
 	padding: 5px 10px;
 }
 
@@ -275,7 +275,7 @@ ul.linklist li.responsive-menu {
 	margin: 0 5px;
 }
 
-ul.linklist li.responsive-menu a.responsive-menu-link {
+ul.linklist .responsive-menu-link {
 	display: inline-block;
 	margin: 0 5px;
 	font-size: 1.455em;
@@ -285,7 +285,7 @@ ul.linklist li.responsive-menu a.responsive-menu-link {
 	text-decoration: none;
 }
 
-ul.linklist li.responsive-menu a.responsive-menu-link:before {
+ul.linklist .responsive-menu-link:before {
 	content: '';
 	position: absolute;
 	left: 0;
@@ -491,6 +491,9 @@ ul.linklist.bulletin > li.no-bulletin:before {
 	padding: 5px;
 }
 
+.jumpbox {
+	margin: 5px 0;
+}
 
 .jumpbox .dropdown li {
 	border-top: 1px solid transparent;
@@ -619,10 +622,6 @@ table.table1 {
 	width: 100%;
 }
 
-#ucp-main table.table1 {
-	padding: 2px;
-}
-
 table.table1 thead th {
 	font-weight: normal;
 	text-transform: uppercase;
@@ -691,7 +690,7 @@ table.info tbody th {
 	margin: 0 -1px;
 }
 
-#color_palette_placeholder table {
+.color_palette_placeholder table {
 	border-collapse: separate;
 	border-spacing: 1px;
 }
@@ -941,13 +940,13 @@ fieldset.fields1 dl.pmlist dd.recipients {
 	font-size: 1.1em;
 }
 
-#darkenwrapper {
+.darkenwrapper {
 	display: none;
 	position: relative;
 	z-index: 44;
 }
 
-#darken {
+.darken {
 	position: fixed;
 	left: 0;
 	top: 0;
@@ -957,7 +956,7 @@ fieldset.fields1 dl.pmlist dd.recipients {
 	z-index: 45;
 }
 
-#loading_indicator {
+.loading_indicator {
 	background: center center no-repeat;
 	border-radius: 5px;
 	display: none;
@@ -974,15 +973,6 @@ fieldset.fields1 dl.pmlist dd.recipients {
 
 /* Miscellaneous styles
 ---------------------------------------- */
-#forum-permissions {
-	float: right;
-	width: auto;
-	padding-left: 5px;
-	margin-left: 5px;
-	margin-top: 10px;
-	text-align: right;
-}
-
 .copyright {
 	padding: 5px;
 	text-align: center;
@@ -1040,15 +1030,12 @@ form > p.post-notice strong {
 	line-height: 20px;
 }
 
-#jumpbox {
-	margin: 5px 0;
-}
-
 .stat-block {
 	clear: both;
 }
 
-#top {
+.top-anchor {
+	display: block;
 	position: absolute;
 	top: -20px;
 }
@@ -1067,8 +1054,8 @@ ul.linklist:after,
 .action-bar:after,
 .notification_text:after,
 .tabs-container:after,
-#tabs > ul:after,
-#minitabs > ul:after,
+.tabs > ul:after,
+.minitabs > ul:after,
 .postprofile .avatar-container:after {
 	clear: both;
 	content: '';
@@ -1243,11 +1230,11 @@ ul.linklist:after,
 /* Navbar specific list items
 ----------------------------------------*/
 
-#quick-links {
+.linklist .quick-links {
 	margin: 0 7px 0 0;
 }
 
-#quick-links a.responsive-menu-link {
+.linklist .quick-links .responsive-menu-link {
 	display: block;
 	font-size: inherit;
 	line-height: inherit;
@@ -1255,12 +1242,12 @@ ul.linklist:after,
 	width: auto;
 }
 
-#quick-links a.responsive-menu-link:before {
+.linklist .quick-links .responsive-menu-link:before {
 	font-size: 1.455em;
 	line-height: 16.5px;
 }
 
-.compact #quick-links a.responsive-menu-link {
+.compact .quick-links .responsive-menu-link {
 	width: 0;
 	overflow: hidden;
 	white-space: nowrap;

--- a/phpBB/styles/prosilver/theme/content.css
+++ b/phpBB/styles/prosilver/theme/content.css
@@ -282,28 +282,28 @@ dd.option {
 
 /* Topic review panel
 ----------------------------------------*/
-#review {
+.panel .review {
 	margin-top: 2em;
 }
 
-#topicreview {
+.topicreview {
 	padding-right: 5px;
 	overflow: auto;
 	height: 300px;
 }
 
-#topicreview .postbody {
+.topicreview .postbody {
 	width: auto;
 	float: none;
 	margin: 0;
 	height: auto;
 }
 
-#topicreview .post {
+.topicreview .post {
 	height: auto;
 }
 
-#topicreview h2 {
+.topicreview h2 {
 	border-bottom-width: 0;
 }
 
@@ -313,7 +313,7 @@ dd.option {
 
 /* MCP Post details
 ----------------------------------------*/
-#post_details {
+.post_details {
 	/* This will only work in IE7+, plus the others */
 	overflow: auto;
 	max-height: 300px;
@@ -829,7 +829,7 @@ table.fixed-width-table {
 
 /* Show scrollbars for items with overflow on iOS devices
 ----------------------------------------*/
-.postbody .content::-webkit-scrollbar, #topicreview::-webkit-scrollbar, #post_details::-webkit-scrollbar, .codebox code::-webkit-scrollbar, .attachbox dd::-webkit-scrollbar, .attach-image::-webkit-scrollbar, .dropdown-extended ul::-webkit-scrollbar {
+.postbody .content::-webkit-scrollbar, .topicreview::-webkit-scrollbar, .post_details::-webkit-scrollbar, .codebox code::-webkit-scrollbar, .attachbox dd::-webkit-scrollbar, .attach-image::-webkit-scrollbar, .dropdown-extended ul::-webkit-scrollbar {
 	width: 8px;
 	height: 8px;
 	-webkit-appearance: none;
@@ -837,7 +837,7 @@ table.fixed-width-table {
 	border-radius: 3px;
 }
 
-.postbody .content::-webkit-scrollbar-thumb, #topicreview::-webkit-scrollbar-thumb, #post_details::-webkit-scrollbar-thumb, .codebox code::-webkit-scrollbar-thumb, .attachbox dd::-webkit-scrollbar-thumb, .attach-image::-webkit-scrollbar-thumb, .dropdown-extended ul::-webkit-scrollbar-thumb {
+.postbody .content::-webkit-scrollbar-thumb, .topicreview::-webkit-scrollbar-thumb, .post_details::-webkit-scrollbar-thumb, .codebox code::-webkit-scrollbar-thumb, .attachbox dd::-webkit-scrollbar-thumb, .attach-image::-webkit-scrollbar-thumb, .dropdown-extended ul::-webkit-scrollbar-thumb {
 	background: rgba(0, 0, 0, .3);
 	border-radius: 3px;
 }

--- a/phpBB/styles/prosilver/theme/cp.css
+++ b/phpBB/styles/prosilver/theme/cp.css
@@ -4,19 +4,19 @@
 
 /* Main CP box
 ----------------------------------------*/
-#cp-menu {
+.cp-menu {
 	float:left;
 	width: 19%;
 	margin-top: 1em;
 	margin-bottom: 5px;
 }
 
-#cp-main {
+.cp-main {
 	float: left;
 	width: 81%;
 }
 
-#cp-main .content {
+.cp-main .content {
 	padding: 0;
 }
 
@@ -59,7 +59,7 @@ ul.cplist {
 	border-bottom: none;
 }
 
-#cp-main .pm-message {
+.cp-main .pm-message {
 	border: 1px solid transparent;
 	margin: 10px 0;
 	width: auto;
@@ -70,7 +70,7 @@ ul.cplist {
 	padding-bottom: 5px;
 }
 
-#cp-main .postbody h3, #cp-main .box2 h3 {
+.cp-main .postbody h3, .cp-main .box2 h3 {
 	margin-top: 0;
 }
 
@@ -78,11 +78,11 @@ ul.cplist {
 	font-size: 1.1em;
 }
 
-#cp-main .buttons {
+.cp-main .buttons {
 	margin-left: 0;
 }
 
-#cp-main ul.linklist {
+.cp-main ul.linklist {
 	margin: 0;
 }
 
@@ -98,18 +98,18 @@ ul.cplist {
 
 /* CP tabs shared
 ----------------------------------------*/
-#tabs, #minitabs {
+.tabs, .minitabs {
 	line-height: normal;
 }
 
-#tabs > ul, #minitabs > ul {
+.tabs > ul, .minitabs > ul {
 	list-style: none;
 	margin: 0;
 	padding: 0;
 	position: relative;
 }
 
-#tabs .tab, #minitabs .tab {
+.tabs .tab, .minitabs .tab {
 	display: block;
 	float: left;
 	font-size: 1em;
@@ -117,7 +117,7 @@ ul.cplist {
 	line-height: 1.4em;
 }
 
-#tabs .tab > a, #minitabs .tab > a {
+.tabs .tab > a, .minitabs .tab > a {
 	display: block;
 	padding: 5px 9px;
 	position: relative;
@@ -128,39 +128,39 @@ ul.cplist {
 
 /* CP tabbed menu
 ----------------------------------------*/
-#tabs {
+.tabs {
 	margin: 20px 0 0 7px;
 }
 
-#tabs .tab > a {
+.tabs .tab > a {
 	border: 1px solid transparent;
 	border-radius: 4px 4px 0 0;
 	margin: 1px 1px 0 0;
 }
 
-#tabs .activetab > a {
+.tabs .activetab > a {
 	margin-top: 0;
 	padding-bottom: 7px;
 }
 
 /* Mini tabbed menu used in MCP
 ----------------------------------------*/
-#minitabs {
+.minitabs {
 	float: right;
 	margin: 15px 7px 0 0;
 	max-width: 50%;
 }
 
-#minitabs .tab {
+.minitabs .tab {
 	float: right;
 }
 
-#minitabs .tab > a {
+.minitabs .tab > a {
 	border-radius: 5px 5px 0 0;
 	margin-left: 2px;
 }
 
-#minitabs .tab > a:hover {
+.minitabs .tab > a:hover {
 	text-decoration: none;
 }
 
@@ -190,44 +190,44 @@ ul.cplist {
 	border-top: 0.375em double transparent;
 }
 
-#tabs .dropdown, #minitabs .dropdown {
+.tabs .dropdown, .minitabs .dropdown {
 	top: 20px;
 	margin-right: -2px;
 	font-size: 1.1em;
 	font-weight: normal;
 }
 
-#minitabs .dropdown {
+.minitabs .dropdown {
 	margin-right: -4px;
 }
 
-#tabs .dropdown-up .dropdown, #minitabs .dropdown-up .dropdown {
+.tabs .dropdown-up .dropdown, .minitabs .dropdown-up .dropdown {
 	bottom: 20px;
 	top: auto;
 }
 
-#tabs .dropdown li {
+.tabs .dropdown li {
 	text-align: right;
 }
 
-#minitabs .dropdown li {
+.minitabs .dropdown li {
 	text-align: left;
 }
 
 /* UCP navigation menu
 ----------------------------------------*/
 /* Container for sub-navigation list */
-#navigation {
+.navigation {
 	width: 100%;
 	padding-top: 36px;
 }
 
-#navigation ul {
+.navigation ul {
 	list-style: none;
 }
 
 /* Default list state */
-#navigation li {
+.navigation li {
 	display: inline;
 	font-weight: bold;
 	margin: 1px 0;
@@ -235,20 +235,20 @@ ul.cplist {
 }
 
 /* Link styles for the sub-section links */
-#navigation a {
+.navigation a {
 	display: block;
 	padding: 5px;
 	margin: 1px 0;
 	text-decoration: none;
 }
 
-#navigation a:hover {
+.navigation a:hover {
 	text-decoration: none;
 }
 
 /* Preferences pane layout
 ----------------------------------------*/
-#cp-main h2 {
+.cp-main h2 {
 	border-bottom: none;
 	padding: 0;
 	margin-left: 10px;
@@ -281,10 +281,6 @@ dl.mini dd {
 
 /* PM Styles
 ----------------------------------------*/
-#pm-menu {
-	line-height: 2.5em;
-}
-
 /* Defined rules list for PM options */
 ol.def-rules {
 	padding-left: 0;
@@ -327,7 +323,7 @@ ol.def-rules li {
 }
 
 /* Avatar gallery */
-#gallery label {
+.gallery label {
 	position: relative;
 	float: left;
 	margin: 10px;
@@ -341,35 +337,35 @@ ol.def-rules li {
 ----------------------------------------*/
 @media only screen and (max-width: 900px), only screen and (max-device-width: 900px)
 {
-	.nojs #tabs a span, .nojs #minitabs a span {
+	.nojs .tabs a span, .nojs .minitabs a span {
 		max-width: 40px;
 		overflow: hidden;
 		text-overflow: ellipsis;
 		letter-spacing: -.5px;
 	}
 
-	#cp-menu, #navigation, #cp-main {
+	.cp-menu, .navigation, .cp-main {
 		float: none;
 		width: auto;
 		margin: 0;
 	}
 
-	#navigation {
+	.navigation {
 		padding: 0;
 		margin: 0 auto;
 		max-width: 320px;
 	}
 
-	#navigation a {
+	.navigation a {
 		background-image: none;
 	}
 
-	#navigation li:first-child a {
+	.navigation li:first-child a {
 		border-top-left-radius: 5px;
 		border-top-right-radius: 5px;
 	}
 
-	#navigation li:last-child a {
+	.navigation li:last-child a {
 		border-bottom-left-radius: 5px;
 		border-bottom-right-radius: 5px;
 	}

--- a/phpBB/styles/prosilver/theme/forms.css
+++ b/phpBB/styles/prosilver/theme/forms.css
@@ -96,7 +96,7 @@ fieldset.fields1 div {
 }
 
 /* Set it back to 0px for the reCaptcha divs: PHPBB3-9587 */
-fieldset.fields1 #recaptcha_widget_div div, fieldset.fields1 .live-search div {
+fieldset.fields1 .live-search div {
 	margin-bottom: 0;
 }
 
@@ -138,7 +138,7 @@ dd textarea {
 }
 
 /* Hover effects */
-#timezone {
+.timezone {
 	width: 95%;
 }
 
@@ -222,20 +222,20 @@ fieldset.submit-buttons input {
 ----------------------------------------*/
 
 /* Buttons used in the editor */
-#format-buttons {
+.format-buttons {
 	margin: 15px 0 2px 0;
 }
 
-#format-buttons input, #format-buttons select {
+.format-buttons input, .format-buttons select {
 	vertical-align: middle;
 }
 
 /* Main message box */
-#message-box {
+.message-box {
 	width: 80%;
 }
 
-#message-box textarea {
+.message-box textarea {
 	font-family: "Trebuchet MS", Verdana, Helvetica, Arial, sans-serif;
 	width: 450px;
 	height: 270px;
@@ -253,12 +253,12 @@ fieldset.submit-buttons input {
 }
 
 /* Emoticons panel */
-#smiley-box {
+.smiley-box {
 	width: 18%;
 	float: right;
 }
 
-#smiley-box img {
+.smiley-box img {
 	margin: 3px;
 }
 

--- a/phpBB/styles/prosilver/theme/plupload.css
+++ b/phpBB/styles/prosilver/theme/plupload.css
@@ -1,9 +1,9 @@
-#attach-panel-multi {
+.attach-panel-multi {
 	display: none;
 	margin-bottom: 1em;
 }
 
-#file-list td {
+.file-list td {
 	vertical-align: middle;
 }
 
@@ -32,11 +32,11 @@
 	float: right;
 }
 
-#attach-row-tpl, .nojs .file-inline-bbcode {
+.nojs .file-inline-bbcode {
 	display: none;
 }
 
-#file-total-progress {
+.file-total-progress {
 	height: 2px;
 	display: block;
 	position: relative;
@@ -50,7 +50,7 @@
 	width: 50px;
 }
 
-.file-progress-bar, #file-total-progress-bar {
+.file-progress-bar, .file-total-progress-bar {
 	background-color: green;
 	display: block;
 	height: 100%;

--- a/phpBB/styles/prosilver/theme/print.css
+++ b/phpBB/styles/prosilver/theme/print.css
@@ -19,14 +19,14 @@ a:link		{ color: #000000; text-decoration: none; }
 a:visited	{ color: #000000; text-decoration: none; }
 a:active	{ color: #000000; text-decoration: none; }
 
-img, .noprint, #sub-header, #sub-footer, .navbar, .box1, .divider, .signature { display: none; }
+img, .noprint, .navbar, .box1, .divider, .signature { display: none; }
 /* Display smilies (Bug #47265) */
 .content img {
 	display: inline;
 }
 
 /* Container for the main body */
-#wrap {
+.wrap {
 	margin: 0 2em;
 }
 

--- a/phpBB/styles/prosilver/theme/responsive.css
+++ b/phpBB/styles/prosilver/theme/responsive.css
@@ -16,7 +16,7 @@ body {
 	padding: 0;
 }
 
-#wrap {
+.wrap {
 	border: none;
 	border-radius: 0;
 	margin: 0;
@@ -32,13 +32,13 @@ body {
 	margin-right: -5px;
 }
 
-#cp-main .forabg, #cp-main .forumdb, #cp-main .post, #cp-main .panel {
+.cp-main .forabg, .cp-main .forumdb, .cp-main .post, .cp-main .panel {
 	border-radius: 7px;
 }
 
 /* Logo block
 ----------------------------------------*/
-#site-description {
+.site-description {
 	float: none;
 	width: auto;
 	text-align: center;
@@ -51,7 +51,7 @@ body {
 	padding: 10px;
 }
 
-#site-description h1, #site-description p {
+.site-description h1, .site-description p {
 	text-align: inherit;
 	float: none;
 	margin: 5px;
@@ -60,7 +60,7 @@ body {
 	text-overflow: ellipsis;
 }
 
-#site-description p, .search-header {
+.site-description p, .search-header {
 	display: none;
 }
 
@@ -254,7 +254,7 @@ table.responsive span.rank-img {
 	padding-right: 5px;
 }
 
-table.responsive#memberlist td:first-child input[type="checkbox"] {
+table.responsive.memberlist td:first-child input[type="checkbox"] {
 	float: right;
 }
 
@@ -269,7 +269,7 @@ fieldset dd, fieldset.fields1 dd, fieldset.fields2 dd {
 	margin-left: 20px;
 }
 
-textarea, dd textarea, #message-box textarea {
+textarea, dd textarea, .message-box textarea {
 	width: 100%;
 	-moz-box-sizing: border-box;
 	box-sizing: border-box;
@@ -289,12 +289,12 @@ dl.pmlist dd:first-of-type {
 	padding-left: 20px;
 }
 
-#smiley-box, #message-box {
+.smiley-box, .message-box {
 	float: none;
 	width: auto;
 }
 
-#smiley-box {
+.smiley-box {
 	margin-top: 5px;
 }
 
@@ -357,13 +357,6 @@ fieldset.quick-login label[for="autologin"] {
 
 	.captcha-panel dd.captcha-image img {
 		width: 100%;
-	}
-
-	#recaptcha_challenge_image,
-	#recaptcha_response_field,
-	.recaptchatable #recaptcha_image {
-		width: 100% !important;
-		height: auto !important;
 	}
 
 	.recaptchatable tr td:last-child {
@@ -518,7 +511,7 @@ dl.mini dd.pm-legend {
 	min-width: 200px;
 }
 
-#topicreview {
+.topicreview {
 	margin: 0 -5px;
 	padding: 0 5px;
 }

--- a/phpBB/styles/prosilver/theme/tweaks.css
+++ b/phpBB/styles/prosilver/theme/tweaks.css
@@ -36,6 +36,6 @@ dd label input { vertical-align: text-bottom\9; }
 	background-image: url("./images/bg_list.gif");
 }
 
-#tabs .tab > a {
+.tabs .tab > a {
 	border-radius: 0;
 }


### PR DESCRIPTION
Its considered bad practice and adds to specificity nightmare when combining styling of IDs and classes. As such we should add duplicate classes to all elements that are currently being styled with IDs in order to move the style to a class to improve specificity and transparency of the theme.

Ticket: https://tracker.phpbb.com/browse/PHPBB3-14139

PHPBB3-14139