### PR TITLE
[ticket/14142] Remove unused ignore_configs from avatar drivers

### DIFF
--- a/phpBB/includes/functions.php
+++ b/phpBB/includes/functions.php
@@ -4848,7 +4848,7 @@ function phpbb_get_avatar($row, $alt, $ignore_config = false, $lazy = false)
 			return $html;
 		}
 
-		$avatar_data = $driver->get_data($row, $ignore_config);
+		$avatar_data = $driver->get_data($row);
 	}
 	else
 	{

--- a/phpBB/phpbb/avatar/driver/upload.php
+++ b/phpBB/phpbb/avatar/driver/upload.php
@@ -53,7 +53,7 @@ class upload extends \phpbb\avatar\driver\driver
 	/**
 	* {@inheritdoc}
 	*/
-	public function get_data($row, $ignore_config = false)
+	public function get_data($row)
 	{
 		$root_path = (defined('PHPBB_USE_BOARD_URL_PATH') && PHPBB_USE_BOARD_URL_PATH) ? generate_board_url() . '/' : $this->path_helper->get_web_root_path();
 


### PR DESCRIPTION
The `$ignore_config` appears to never be used in any avatar driver. It is only passed to the upload driver, but not used in it. None of the other drivers even have an argument for it.

PHPBB3-14142