### PR TITLE
[ticket/14159] Hide version info on ACP if we don't have the permission

### DIFF
--- a/phpBB/adm/style/acp_main.html
+++ b/phpBB/adm/style/acp_main.html
@@ -141,19 +141,24 @@
 		<td>{L_GZIP_COMPRESSION}{L_COLON} </td>
 		<td><strong>{GZIP_COMPRESSION}</strong></td>
 	</tr>
+	<!-- IF S_TOTAL_ORPHAN or S_VERSIONCHECK -->
 	<tr>
+	<!-- IF S_VERSIONCHECK -->
 		<td>{L_BOARD_VERSION}{L_COLON} </td>
 		<td>
 			<strong><a href="{U_VERSIONCHECK}" <!-- IF S_VERSION_UP_TO_DATE -->style="color: #228822;"<!-- ELSE -->style="color: #BC2A4D;"<!-- ENDIF --> title="{L_MORE_INFORMATION}">{BOARD_VERSION}</a></strong> [&nbsp;<a href="{U_VERSIONCHECK_FORCE}">{L_VERSIONCHECK_FORCE_UPDATE}</a>&nbsp;]
 		</td>
+	<!-- ENDIF -->
 	<!-- IF S_TOTAL_ORPHAN -->
 		<td>{L_NUMBER_ORPHAN}{L_COLON} </td>
 		<td><strong>{TOTAL_ORPHAN}</strong></td>
-	<!-- ELSE -->
+	<!-- ENDIF -->
+	<!-- IF not S_TOTAL_ORPHAN or not S_VERSIONCHECK -->
 		<td>&nbsp;</td>
 		<td>&nbsp;</td>
 	<!-- ENDIF -->
 	</tr>
+	<!-- ENDIF -->
 	</tbody>
 	</table>
 

--- a/phpBB/includes/acp/acp_main.php
+++ b/phpBB/includes/acp/acp_main.php
@@ -429,20 +429,28 @@ class acp_main
 			));
 		}
 
-		$version_helper = $phpbb_container->get('version_helper');
-		try
+		if ($auth->acl_get('a_board'))
 		{
-			$recheck = $request->variable('versioncheck_force', false);
-			$updates_available = $version_helper->get_suggested_updates($recheck);
+			$version_helper = $phpbb_container->get('version_helper');
+			try
+			{
+				$recheck = $request->variable('versioncheck_force', false);
+				$updates_available = $version_helper->get_suggested_updates($recheck);
 
-			$template->assign_var('S_VERSION_UP_TO_DATE', empty($updates_available));
+				$template->assign_var('S_VERSION_UP_TO_DATE', empty($updates_available));
+			}
+			catch (\RuntimeException $e)
+			{
+				$template->assign_vars(array(
+					'S_VERSIONCHECK_FAIL'		=> true,
+					'VERSIONCHECK_FAIL_REASON'	=> ($e->getMessage() !== $user->lang('VERSIONCHECK_FAIL')) ? $e->getMessage() : '',
+				));
+			}
 		}
-		catch (\RuntimeException $e)
+		else
 		{
-			$template->assign_vars(array(
-				'S_VERSIONCHECK_FAIL'		=> true,
-				'VERSIONCHECK_FAIL_REASON'	=> ($e->getMessage() !== $user->lang('VERSIONCHECK_FAIL')) ? $e->getMessage() : '',
-			));
+			// We set this template var to true, to not display an outdated version notice.
+			$template->assign_var('S_VERSION_UP_TO_DATE', true);
 		}
 
 		/**
@@ -553,6 +561,7 @@ class acp_main
 			'U_VERSIONCHECK'	=> append_sid("{$phpbb_admin_path}index.$phpEx", 'i=update&amp;mode=version_check'),
 			'U_VERSIONCHECK_FORCE'	=> append_sid("{$phpbb_admin_path}index.$phpEx", 'versioncheck_force=1'),
 
+			'S_VERSIONCHECK'	=> ($auth->acl_get('a_board')) ? true : false,
 			'S_ACTION_OPTIONS'	=> ($auth->acl_get('a_board')) ? true : false,
 			'S_FOUNDER'			=> ($user->data['user_type'] == USER_FOUNDER) ? true : false,
 			)


### PR DESCRIPTION
This also hide a link to an unreachable module (Check phpBB version).

We could have simply remove the link to the module, but if the user hasn't
the permission to access to the phpBB version check module, I think that
he shouldn't view any version information about phpBB.

[PHPBB3-14159](https://tracker.phpbb.com/browse/PHPBB3-14159)