### PR TITLE
[ticket/13716] Check phpBB version constant against config version

### DIFF
--- a/phpBB/adm/style/acp_main.html
+++ b/phpBB/adm/style/acp_main.html
@@ -14,7 +14,11 @@
 
 	<p>{L_ADMIN_INTRO}</p>
 
-	<!-- IF S_VERSIONCHECK_FAIL -->
+	<!-- IF S_UPDATE_INCOMPLETE -->
+		<div class="errorbox">
+			<p>{L_UPDATE_INCOMPLETE} <a href="{U_VERSIONCHECK}">{L_MORE_INFORMATION}</a></p>
+		</div>
+	<!-- ELSEIF S_VERSIONCHECK_FAIL -->
 		<div class="errorbox notice">
 			<p>{L_VERSIONCHECK_FAIL}</p>
 			<p>{VERSIONCHECK_FAIL_REASON}</p>

--- a/phpBB/adm/style/acp_update.html
+++ b/phpBB/adm/style/acp_update.html
@@ -6,11 +6,16 @@
 
 <p>{L_VERSION_CHECK_EXPLAIN}</p>
 
+<!-- IF S_UPDATE_INCOMPLETE -->
+	<div class="errorbox">
+		<p>{L_UPDATE_INCOMPLETE} {L_UPDATE_INCOMPLETE_MORE}</p>
+	</div>
+<!-- ENDIF -->
 <!-- IF S_UP_TO_DATE -->
 	<div class="successbox">
 		<p>{L_VERSION_UP_TO_DATE_ACP} - <a href="{U_VERSIONCHECK_FORCE}">{L_VERSIONCHECK_FORCE_UPDATE}</a></p>
 	</div>
-<!-- ELSE -->
+<!-- ELSEIF not S_UPDATE_INCOMPLETE -->
 	<div class="errorbox">
 		<p>{L_VERSION_NOT_UP_TO_DATE_ACP} - <a href="{U_VERSIONCHECK_FORCE}">{L_VERSIONCHECK_FORCE_UPDATE}</a></p>
 	</div>
@@ -18,10 +23,21 @@
 
 <fieldset>
 	<legend></legend>
+	<!-- IF not S_UPDATE_INCOMPLETE -->
 	<dl>
 		<dt><label>{L_CURRENT_VERSION}</label></dt>
 		<dd><strong>{CURRENT_VERSION}</strong></dd>
 	</dl>
+	<!-- ELSE -->
+	<dl>
+		<dt><label>{L_FILES_VERSION}</label></dt>
+		<dd><strong>{FILES_VERSION}</strong></dd>
+	</dl>
+	<dl>
+		<dt><label>{L_DATABASE_VERSION}</label></dt>
+		<dd><strong>{CURRENT_VERSION}</strong></dd>
+	</dl>
+	<!-- ENDIF -->
 </fieldset>
 
 <!-- BEGIN updates_available -->
@@ -37,6 +53,11 @@
 		</dl>
 	</fieldset>
 <!-- END updates_available -->
+
+<!-- IF S_UPDATE_INCOMPLETE -->
+	{INCOMPLETE_INSTRUCTIONS}
+	<br /><br />
+<!-- ENDIF -->
 
 <!-- IF not S_UP_TO_DATE -->
 	{UPDATE_INSTRUCTIONS}

--- a/phpBB/includes/acp/acp_main.php
+++ b/phpBB/includes/acp/acp_main.php
@@ -445,6 +445,12 @@ class acp_main
 			));
 		}
 
+		// Incomplete update?
+		if (phpbb_version_compare($config['version'], PHPBB_VERSION, '<'))
+		{
+			$template->assign_var('S_UPDATE_INCOMPLETE', true);
+		}
+
 		/**
 		* Notice admin
 		*

--- a/phpBB/includes/acp/acp_update.php
+++ b/phpBB/includes/acp/acp_update.php
@@ -62,5 +62,17 @@ class acp_update
 
 			'UPDATE_INSTRUCTIONS'	=> sprintf($user->lang['UPDATE_INSTRUCTIONS'], $update_link),
 		));
+
+		// Incomplete update?
+		if (phpbb_version_compare($config['version'], PHPBB_VERSION, '<'))
+		{
+			$database_update_link = append_sid($phpbb_root_path . 'install/database_update.' . $phpEx);
+
+			$template->assign_vars(array(
+				'S_UPDATE_INCOMPLETE'		=> true,
+				'FILES_VERSION'				=> PHPBB_VERSION,
+				'INCOMPLETE_INSTRUCTIONS'	=> $user->lang('UPDATE_INCOMPLETE_EXPLAIN', $update_link, $database_update_link),
+			));
+		}
 	}
 }

--- a/phpBB/language/en/install.php
+++ b/phpBB/language/en/install.php
@@ -400,6 +400,7 @@ $lang = array_merge($lang, array(
 	'DATABASE_UPDATE_CONTINUE'			=> 'Continue database update',
 	'DATABASE_UPDATE_INFO_OLD'			=> 'The database update file within the install directory is outdated. Please make sure you uploaded the correct version of the file.',
 	'DATABASE_UPDATE_NOT_COMPLETED'		=> 'The database update has not yet completed.',
+	'DATABASE_VERSION'					=> 'Database version',
 	'DELETE_USER_REMOVE'				=> 'Delete user and remove posts',
 	'DELETE_USER_RETAIN'				=> 'Delete user but keep posts',
 	'DESTINATION'						=> 'Destination file',
@@ -486,6 +487,7 @@ $lang = array_merge($lang, array(
 	'OLD_UPDATE_FILES'		=> 'Update files are out of date. The update files found are for updating from phpBB %1$s to phpBB %2$s but the latest version of phpBB is %3$s.',
 
 	'PACKAGE_UPDATES_TO'				=> 'Current package updates to version',
+	'PACKAGE_VERSION'					=> 'Package version installed',
 	'PERFORM_DATABASE_UPDATE'			=> 'Perform database update',
 	'PERFORM_DATABASE_UPDATE_EXPLAIN'	=> 'Below you will find a button to the database update script. The database update can take a while, so please do not stop the execution if it seems to hang. After the database update has been performed just follow the instructions to continue the update process.',
 	'PREVIOUS_VERSION'					=> 'Previous version',
@@ -530,6 +532,27 @@ $lang = array_merge($lang, array(
 	'UPDATE_DATABASE_SCHEMA'		=> 'Updating database schema',
 	'UPDATE_FILES'					=> 'Update files',
 	'UPDATE_FILES_NOTICE'			=> 'Please make sure you have updated your board files too, this file is only updating your database.',
+	'UPDATE_INCOMPLETE'				=> 'Your phpBB installation has not been correctly updated.',
+	'UPDATE_INCOMPLETE_MORE'		=> 'Please see the information below to know how to fix that.',
+	'UPDATE_INCOMPLETE_EXPLAIN'		=> '<h1>Incomplete update</h1>
+
+		<p>We noticed that the last update of your phpBB installation hasn’t been correctly completed. Have you updated your files and forget to update your database? In this case, phpBB can’t work correctly and you may notice some strange behaviour.</p>
+
+		<br />
+
+		<h1>How to complete the update of phpBB?</h1>
+
+		<p>If you have updated phpBB using the Automatic Update Package, please restart the update process to be sure that all steps are correctly completed.</p>
+
+		<ul style="margin-left: 20px; font-size: 1.1em;">
+			<li>Retrieve the Automatic Update Package that you’ve used to update phpBB. The latest package can be found <a href="https://www.phpbb.com/downloads/" title="https://www.phpbb.com/downloads/">on phpBB.com</a>. For previous version, the package can be found <a href="https://download.phpbb.com/pub/release/" title="https://download.phpbb.com/pub/release/">on the phpBB download servers</a>.<br /><br /></li>
+			<li>Unpack the archive.<br /><br /></li>
+			<li>Upload the complete uncompressed "install" and "vendor" folders to your phpBB root directory (where your config.php file is).<br /><br /></li>
+			<li>Once uploaded your board will be offline for normal users due to the install directory you uploaded now present.<br /><br /></li>
+			<li><strong><a href="%1$s" title="%1$s">Now restart the update process by pointing your browser to the install folder</a>.</strong><br /><br /></li>
+		</ul>
+
+		<p>If you have updated phpBB using any other method, please <a href="https://www.phpbb.com/downloads/" title="https://www.phpbb.com/downloads/">download the latest package</a>, upload the "install" folder to your phpBB root directory (where your config.php file is) and <a href="%2$s" title="%2$s">run the database update script</a>.</p>',
 	'UPDATE_INSTALLATION'			=> 'Update phpBB installation',
 	'UPDATE_INSTALLATION_EXPLAIN'	=> 'With this option, it is possible to update your phpBB installation to the latest version.<br />During the process all of your files will be checked for their integrity. You are able to review all differences and files before the update.<br /><br />The file update itself can be done in two different ways.</p><h2>Manual Update</h2><p>With this update you only download your personal set of changed files to make sure you do not lose your file modifications you may have done. After you downloaded this package you need to manually upload the files to their correct position under your phpBB root directory. Once done, you are able to do the file check stage again to see if you moved the files to their correct location.</p><h2>Automatic Update with FTP</h2><p>This method is similar to the first one but without the need to download the changed files and uploading them on your own. This will be done for you. In order to use this method you need to know your FTP login details since you will be asked for them. Once finished you will be redirected to the file check again to make sure everything got updated correctly.<br /><br />',
 	'UPDATE_INSTRUCTIONS'			=> '


### PR DESCRIPTION
On the ACP display a warning if the version constant (files) does not
match the `phpbb_config` version (often indicating that the database updater
hasn't been run)

[PHPBB3-13716](https://tracker.phpbb.com/browse/PHPBB3-13716)