### PR TITLE
[ticket/12618] Allow extension author to use SSL for version-check.

### DIFF
--- a/phpBB/includes/acp/acp_extensions.php
+++ b/phpBB/includes/acp/acp_extensions.php
@@ -537,7 +537,7 @@ class acp_extensions
 
 		$version_helper = new \phpbb\version_helper($this->cache, $this->config, new \phpbb\file_downloader(), $this->user);
 		$version_helper->set_current_version($meta['version']);
-		$version_helper->set_file_location($version_check['host'], $version_check['directory'], $version_check['filename'], isset($version_check['ssl']) ? (int) $version_check['ssl'] : false);
+		$version_helper->set_file_location($version_check['host'], $version_check['directory'], $version_check['filename'], isset($version_check['ssl']) ? $version_check['ssl'] : false);
 		$version_helper->force_stability($this->config['extension_force_unstable'] ? 'unstable' : null);
 
 		return $updates = $version_helper->get_suggested_updates($force_update, $force_cache);

--- a/phpBB/includes/acp/acp_extensions.php
+++ b/phpBB/includes/acp/acp_extensions.php
@@ -537,7 +537,7 @@ class acp_extensions
 
 		$version_helper = new \phpbb\version_helper($this->cache, $this->config, new \phpbb\file_downloader(), $this->user);
 		$version_helper->set_current_version($meta['version']);
-		$version_helper->set_file_location($version_check['host'], $version_check['directory'], $version_check['filename']);
+		$version_helper->set_file_location($version_check['host'], $version_check['directory'], $version_check['filename'], isset($version_check['ssl']) ? (int) $version_check['ssl'] : false);
 		$version_helper->force_stability($this->config['extension_force_unstable'] ? 'unstable' : null);
 
 		return $updates = $version_helper->get_suggested_updates($force_update, $force_cache);

--- a/phpBB/phpbb/file_downloader.php
+++ b/phpBB/phpbb/file_downloader.php
@@ -42,7 +42,7 @@ class file_downloader
 		$this->error_number = 0;
 		$this->error_string = '';
 
-		if ($socket = @fsockopen(($port == 443 ? 'ssl://' : '') . $host, $port, $this->error_number, $this->error_string, $timeout))
+		if ($socket = @fsockopen(($port == 443 ? 'tls://' : '') . $host, $port, $this->error_number, $this->error_string, $timeout))
 		{
 			@fputs($socket, "GET $directory/$filename HTTP/1.0\r\n");
 			@fputs($socket, "HOST: $host\r\n");

--- a/phpBB/phpbb/file_downloader.php
+++ b/phpBB/phpbb/file_downloader.php
@@ -42,7 +42,7 @@ class file_downloader
 		$this->error_number = 0;
 		$this->error_string = '';
 
-		if ($socket = @fsockopen($host, $port, $this->error_number, $this->error_string, $timeout))
+		if ($socket = @fsockopen(($port == 443 ? 'ssl://' : '') . $host, $port, $this->error_number, $this->error_string, $timeout))
 		{
 			@fputs($socket, "GET $directory/$filename HTTP/1.0\r\n");
 			@fputs($socket, "HOST: $host\r\n");

--- a/phpBB/phpbb/version_helper.php
+++ b/phpBB/phpbb/version_helper.php
@@ -34,6 +34,11 @@ class version_helper
 	protected $file = 'versions.json';
 
 	/**
+	 * @var bool Use SSL or not
+	 */
+	protected $use_ssl = false;
+
+	/**
 	 * @var string Current version installed
 	 */
 	protected $current_version;
@@ -85,13 +90,15 @@ class version_helper
 	 * @param string $host Host (e.g. version.phpbb.com)
 	 * @param string $path Path to file (e.g. /phpbb)
 	 * @param string $file File name (Default: versions.json)
+	 * @param bool $use_ssl Use SSL or not (Default: false)
 	 * @return version_helper
 	 */
-	public function set_file_location($host, $path, $file = 'versions.json')
+	public function set_file_location($host, $path, $file = 'versions.json', $use_ssl = false)
 	{
 		$this->host = $host;
 		$this->path = $path;
 		$this->file = $file;
+		$this->use_ssl = $use_ssl;
 
 		return $this;
 	}
@@ -244,7 +251,7 @@ class version_helper
 	*/
 	public function get_versions($force_update = false, $force_cache = false)
 	{
-		$cache_file = '_versioncheck_' . $this->host . $this->path . $this->file;
+		$cache_file = '_versioncheck_' . $this->host . $this->path . $this->file . $this->use_ssl;
 
 		$info = $this->cache->get($cache_file);
 
@@ -255,7 +262,7 @@ class version_helper
 		else if ($info === false || $force_update)
 		{
 			try {
-				$info = $this->file_downloader->get($this->host, $this->path, $this->file);
+				$info = $this->file_downloader->get($this->host, $this->path, $this->file, $this->use_ssl ? 443 : 80);
 			}
 			catch (\phpbb\exception\runtime_exception $exception)
 			{


### PR DESCRIPTION
Fixes Ticket 12618 (https://tracker.phpbb.com/browse/PHPBB3-12618)

In order to be able to use SSL with fsockopen, one has to append 'ssl://' to the host. Thus, the class file_downloader needed to be changed.
'ssl://' will always be appended now, if the port is 443.
I have checked, that this does not influence any other uses of that class (there are none).