### PR TITLE
[ticket/14212] Adding event after users have been removed to a group

### DIFF
--- a/phpBB/includes/functions_user.php
+++ b/phpBB/includes/functions_user.php
@@ -2933,6 +2933,19 @@ function group_user_del($group_id, $user_id_ary = false, $username_ary = false, 
 	// Clear permissions cache of relevant users
 	$auth->acl_clear_prefetch($user_id_ary);
 
+	/**
+	* Event after users are removed from a group
+	*
+	* @event core.group_delete_user_after
+	* @var	int		group_id		ID of the group from which users are deleted
+	* @var	string	group_name		Name of the group
+	* @var	array	user_id_ary		IDs of the users which are removed
+	* @var	array	username_ary	names of the users which are removed
+	* @since 3.7
+	*/
+	$vars = array('group_id', 'group_name', 'user_id_ary', 'username_ary');
+	extract($phpbb_dispatcher->trigger_event('core.group_delete_user_after', compact($vars)));
+
 	if (!$group_name)
 	{
 		$group_name = get_group_name($group_id);

--- a/phpBB/includes/functions_user.php
+++ b/phpBB/includes/functions_user.php
@@ -2941,7 +2941,7 @@ function group_user_del($group_id, $user_id_ary = false, $username_ary = false, 
 	* @var	string	group_name		Name of the group
 	* @var	array	user_id_ary		IDs of the users which are removed
 	* @var	array	username_ary	names of the users which are removed
-	* @since 3.7
+	* @since 3.1.7-RC1
 	*/
 	$vars = array('group_id', 'group_name', 'user_id_ary', 'username_ary');
 	extract($phpbb_dispatcher->trigger_event('core.group_delete_user_after', compact($vars)));


### PR DESCRIPTION
The idea is to be able to map with others CMS by exposing most commons user configuration & changes.
Difference between the event before and after group belonging removal is that
users belongs to multiple groups, so that the belonging into a group also
depends on the others groups (and not only the deleted one), which is not
reflected before as the user is not yet deleted

PHPBB-14212

https://tracker.phpbb.com/browse/PHPBB3-14215