### PR TITLE
[ticket/9153] Allow users without u_sendpm permission to delete existing PM's

### DIFF
--- a/phpBB/includes/ucp/ucp_pm.php
+++ b/phpBB/includes/ucp/ucp_pm.php
@@ -92,7 +92,7 @@ class ucp_pm
 
 				$user_folders = get_folder($user->data['user_id']);
 
-				if (!$auth->acl_get('u_sendpm'))
+				if ($action != 'delete' && !$auth->acl_get('u_sendpm'))
 				{
 					// trigger_error('NO_AUTH_SEND_MESSAGE');
 					$template->assign_vars(array(


### PR DESCRIPTION
The u_sendpm check in ucp_pm.php is merely for the purpose of displaying the
error message within the UCP template. Otherwise it could be removed as
compose_pm() will check the appropriate permission pertaining to the attempted
action.

[PHPBB3-9153](https://tracker.phpbb.com/browse/PHPBB3-9153)