### PR TITLE
[ticket/13892] Respect "Someone reports a post" notification setting.

### DIFF
--- a/phpBB/phpbb/notification/type/approve_post.php
+++ b/phpBB/phpbb/notification/type/approve_post.php
@@ -82,7 +82,7 @@ class approve_post extends \phpbb\notification\type\post
 		$users[$post['poster_id']] = array('');
 
 		return $this->get_authorised_recipients(array_keys($users), $post['forum_id'], array_merge($options, array(
-			'item_type'		=> self::$notification_option['id'],
+			'item_type'		=> static::$notification_option['id'],
 		)));
 	}
 

--- a/phpBB/phpbb/notification/type/approve_topic.php
+++ b/phpBB/phpbb/notification/type/approve_topic.php
@@ -82,7 +82,7 @@ class approve_topic extends \phpbb\notification\type\topic
 		$users[$post['poster_id']] = array('');
 
 		return $this->get_authorised_recipients(array_keys($users), $post['forum_id'], array_merge($options, array(
-			'item_type'		=> self::$notification_option['id'],
+			'item_type'		=> static::$notification_option['id'],
 		)));
 	}
 

--- a/phpBB/phpbb/notification/type/bookmark.php
+++ b/phpBB/phpbb/notification/type/bookmark.php
@@ -95,7 +95,7 @@ class bookmark extends \phpbb\notification\type\post
 		$sql = 'SELECT n.*
 			FROM ' . $this->notifications_table . ' n, ' . $this->notification_types_table . ' nt
 			WHERE n.notification_type_id = ' . (int) $this->notification_type_id . '
-				AND n.item_parent_id = ' . (int) self::get_item_parent_id($post) . '
+				AND n.item_parent_id = ' . (int) static::get_item_parent_id($post) . '
 				AND n.notification_read = 0
 				AND nt.notification_type_id = n.notification_type_id
 				AND nt.notification_type_enabled = 1';

--- a/phpBB/phpbb/notification/type/post.php
+++ b/phpBB/phpbb/notification/type/post.php
@@ -135,7 +135,7 @@ class post extends \phpbb\notification\type\base
 		$sql = 'SELECT n.*
 			FROM ' . $this->notifications_table . ' n, ' . $this->notification_types_table . ' nt
 			WHERE n.notification_type_id = ' . (int) $this->notification_type_id . '
-				AND n.item_parent_id = ' . (int) self::get_item_parent_id($post) . '
+				AND n.item_parent_id = ' . (int) static::get_item_parent_id($post) . '
 				AND n.notification_read = 0
 				AND nt.notification_type_id = n.notification_type_id
 				AND nt.notification_type_enabled = 1';

--- a/phpBB/phpbb/notification/type/post_in_queue.php
+++ b/phpBB/phpbb/notification/type/post_in_queue.php
@@ -108,7 +108,7 @@ class post_in_queue extends \phpbb\notification\type\post
 		}
 
 		return $this->check_user_notification_options($auth_read[$post['forum_id']]['f_read'], array_merge($options, array(
-			'item_type'		=> self::$notification_option['id'],
+			'item_type'		=> static::$notification_option['id'],
 		)));
 	}
 

--- a/phpBB/phpbb/notification/type/quote.php
+++ b/phpBB/phpbb/notification/type/quote.php
@@ -78,7 +78,7 @@ class quote extends \phpbb\notification\type\post
 		), $options);
 
 		$usernames = false;
-		preg_match_all(self::$regular_expression_match, $post['post_text'], $usernames);
+		preg_match_all(static::$regular_expression_match, $post['post_text'], $usernames);
 
 		if (empty($usernames[1]))
 		{
@@ -116,7 +116,7 @@ class quote extends \phpbb\notification\type\post
 		$sql = 'SELECT n.user_id
 			FROM ' . $this->notifications_table . ' n, ' . $this->notification_types_table . ' nt
 			WHERE n.notification_type_id = ' . (int) $this->notification_type_id . '
-				AND n.item_id = ' . self::get_item_id($post) . '
+				AND n.item_id = ' . static::get_item_id($post) . '
 				AND nt.notification_type_id = n.notification_type_id
 				AND nt.notification_type_enabled = 1';
 		$result = $this->db->sql_query($sql);
@@ -147,7 +147,7 @@ class quote extends \phpbb\notification\type\post
 		{
 			$sql = 'DELETE FROM ' . $this->notifications_table . '
 				WHERE notification_type_id = ' . (int) $this->notification_type_id . '
-					AND item_id = ' . self::get_item_id($post) . '
+					AND item_id = ' . static::get_item_id($post) . '
 					AND ' . $this->db->sql_in_set('user_id', $remove_notifications);
 			$this->db->sql_query($sql);
 		}

--- a/phpBB/phpbb/notification/type/report_pm.php
+++ b/phpBB/phpbb/notification/type/report_pm.php
@@ -120,7 +120,7 @@ class report_pm extends \phpbb\notification\type\pm
 		}
 
 		return $this->check_user_notification_options($auth_approve[$post['forum_id']][$this->permission], array_merge($options, array(
-			'item_type'		=> self::$notification_option['id'],
+			'item_type'		=> static::$notification_option['id'],
 		)));
 	}
 

--- a/phpBB/phpbb/notification/type/topic_in_queue.php
+++ b/phpBB/phpbb/notification/type/topic_in_queue.php
@@ -108,7 +108,7 @@ class topic_in_queue extends \phpbb\notification\type\topic
 		}
 
 		return $this->check_user_notification_options($auth_read[$topic['forum_id']]['f_read'], array_merge($options, array(
-			'item_type'		=> self::$notification_option['id'],
+			'item_type'		=> static::$notification_option['id'],
 		)));
 	}
 


### PR DESCRIPTION
report_post inherits from post_in_queue, therefore using self:: instead of static:: results in the incorrect notification type being used to determine which users to exclude from the notification.

Updated all other instances of self in the notification types that may cause problems in the future.

[PHPBB3-13892](https://tracker.phpbb.com/browse/PHPBB3-13892)