### PR TITLE
[ticket/14256] Remove PHP7 from the allowed failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,6 @@ matrix:
     - php: hhvm
       env: DB=mysqli
   allow_failures:
-    - php: 7.0
     - php: hhvm
   fast_finish: true
 


### PR DESCRIPTION
We're currently doing a pretty good job at letting our test suite not fail on PHP7 and I really want us to be compatible with PHP7 so I think we should be safe now to remove this from the allowed failures.

[PHPBB3-14256](https://tracker.phpbb.com/browse/PHPBB3-14256)