### PR TITLE
[ticket/14257] Reparse after update

### DIFF
--- a/phpBB/config/default/container/services_console.yml
+++ b/phpBB/config/default/container/services_console.yml
@@ -187,9 +187,9 @@ services:
         class: phpbb\console\command\reparser\reparse
         arguments:
             - @user
-            - @text_reparser_collection
-            - @config_text
             - @text_reparser.lock
+            - @text_reparser_collection
+            - @text_reparser.manager
         tags:
             - { name: console.command }
 

--- a/phpBB/config/default/container/services_console.yml
+++ b/phpBB/config/default/container/services_console.yml
@@ -189,6 +189,7 @@ services:
             - @user
             - @text_reparser_collection
             - @config_text
+            - @text_reparser.lock
         tags:
             - { name: console.command }
 

--- a/phpBB/config/default/container/services_cron.yml
+++ b/phpBB/config/default/container/services_cron.yml
@@ -147,58 +147,6 @@ services:
         tags:
             - { name: cron.task }
 
-    cron.task.text_reparser.contact_admin_info:
-        class: phpbb\cron\task\text_reparser\reparser
-        arguments:
-            - @config
-            - @config_text
-            - @text_reparser.lock
-            - @text_reparser_collection
-        calls:
-            - [set_name, [cron.task.text_reparser.contact_admin_info]]
-            - [set_reparser, [text_reparser.contact_admin_info]]
-        tags:
-            - { name: cron.task }
-
-    cron.task.text_reparser.forum_description:
-        class: phpbb\cron\task\text_reparser\reparser
-        arguments:
-            - @config
-            - @config_text
-            - @text_reparser.lock
-            - @text_reparser_collection
-        calls:
-            - [set_name, [cron.task.text_reparser.forum_description]]
-            - [set_reparser, [text_reparser.forum_description]]
-        tags:
-            - { name: cron.task }
-
-    cron.task.text_reparser.forum_rules:
-        class: phpbb\cron\task\text_reparser\reparser
-        arguments:
-            - @config
-            - @config_text
-            - @text_reparser.lock
-            - @text_reparser_collection
-        calls:
-            - [set_name, [cron.task.text_reparser.forum_rules]]
-            - [set_reparser, [text_reparser.forum_rules]]
-        tags:
-            - { name: cron.task }
-
-    cron.task.text_reparser.group_description:
-        class: phpbb\cron\task\text_reparser\reparser
-        arguments:
-            - @config
-            - @config_text
-            - @text_reparser.lock
-            - @text_reparser_collection
-        calls:
-            - [set_name, [cron.task.text_reparser.group_description]]
-            - [set_reparser, [text_reparser.group_description]]
-        tags:
-            - { name: cron.task }
-
     cron.task.text_reparser.pm_text:
         class: phpbb\cron\task\text_reparser\reparser
         arguments:

--- a/phpBB/config/default/container/services_cron.yml
+++ b/phpBB/config/default/container/services_cron.yml
@@ -146,3 +146,120 @@ services:
             - [set_name, [cron.task.core.tidy_warnings]]
         tags:
             - { name: cron.task }
+
+    cron.task.text_reparser.contact_admin_info:
+        class: phpbb\cron\task\text_reparser\reparser
+        arguments:
+            - @config
+            - @config_text
+            - @text_reparser.lock
+            - @text_reparser_collection
+        calls:
+            - [set_name, [cron.task.text_reparser.contact_admin_info]]
+            - [set_reparser, [text_reparser.contact_admin_info]]
+        tags:
+            - { name: cron.task }
+
+    cron.task.text_reparser.forum_description:
+        class: phpbb\cron\task\text_reparser\reparser
+        arguments:
+            - @config
+            - @config_text
+            - @text_reparser.lock
+            - @text_reparser_collection
+        calls:
+            - [set_name, [cron.task.text_reparser.forum_description]]
+            - [set_reparser, [text_reparser.forum_description]]
+        tags:
+            - { name: cron.task }
+
+    cron.task.text_reparser.forum_rules:
+        class: phpbb\cron\task\text_reparser\reparser
+        arguments:
+            - @config
+            - @config_text
+            - @text_reparser.lock
+            - @text_reparser_collection
+        calls:
+            - [set_name, [cron.task.text_reparser.forum_rules]]
+            - [set_reparser, [text_reparser.forum_rules]]
+        tags:
+            - { name: cron.task }
+
+    cron.task.text_reparser.group_description:
+        class: phpbb\cron\task\text_reparser\reparser
+        arguments:
+            - @config
+            - @config_text
+            - @text_reparser.lock
+            - @text_reparser_collection
+        calls:
+            - [set_name, [cron.task.text_reparser.group_description]]
+            - [set_reparser, [text_reparser.group_description]]
+        tags:
+            - { name: cron.task }
+
+    cron.task.text_reparser.pm_text:
+        class: phpbb\cron\task\text_reparser\reparser
+        arguments:
+            - @config
+            - @config_text
+            - @text_reparser.lock
+            - @text_reparser_collection
+        calls:
+            - [set_name, [cron.task.text_reparser.pm_text]]
+            - [set_reparser, [text_reparser.pm_text]]
+        tags:
+            - { name: cron.task }
+
+    cron.task.text_reparser.poll_option:
+        class: phpbb\cron\task\text_reparser\reparser
+        arguments:
+            - @config
+            - @config_text
+            - @text_reparser.lock
+            - @text_reparser_collection
+        calls:
+            - [set_name, [cron.task.text_reparser.poll_option]]
+            - [set_reparser, [text_reparser.poll_option]]
+        tags:
+            - { name: cron.task }
+
+    cron.task.text_reparser.poll_title:
+        class: phpbb\cron\task\text_reparser\reparser
+        arguments:
+            - @config
+            - @config_text
+            - @text_reparser.lock
+            - @text_reparser_collection
+        calls:
+            - [set_name, [cron.task.text_reparser.poll_title]]
+            - [set_reparser, [text_reparser.poll_title]]
+        tags:
+            - { name: cron.task }
+
+    cron.task.text_reparser.post_text:
+        class: phpbb\cron\task\text_reparser\reparser
+        arguments:
+            - @config
+            - @config_text
+            - @text_reparser.lock
+            - @text_reparser_collection
+        calls:
+            - [set_name, [cron.task.text_reparser.post_text]]
+            - [set_reparser, [text_reparser.post_text]]
+        tags:
+            - { name: cron.task }
+
+    cron.task.text_reparser.user_signature:
+        class: phpbb\cron\task\text_reparser\reparser
+        arguments:
+            - @config
+            - @config_text
+            - @text_reparser.lock
+            - @text_reparser_collection
+        calls:
+            - [set_name, [cron.task.text_reparser.user_signature]]
+            - [set_reparser, [text_reparser.user_signature]]
+        tags:
+            - { name: cron.task }

--- a/phpBB/config/default/container/services_cron.yml
+++ b/phpBB/config/default/container/services_cron.yml
@@ -153,6 +153,7 @@ services:
             - @config
             - @config_text
             - @text_reparser.lock
+            - @text_reparser.manager
             - @text_reparser_collection
         calls:
             - [set_name, [cron.task.text_reparser.pm_text]]
@@ -166,6 +167,7 @@ services:
             - @config
             - @config_text
             - @text_reparser.lock
+            - @text_reparser.manager
             - @text_reparser_collection
         calls:
             - [set_name, [cron.task.text_reparser.poll_option]]
@@ -179,6 +181,7 @@ services:
             - @config
             - @config_text
             - @text_reparser.lock
+            - @text_reparser.manager
             - @text_reparser_collection
         calls:
             - [set_name, [cron.task.text_reparser.poll_title]]
@@ -192,6 +195,7 @@ services:
             - @config
             - @config_text
             - @text_reparser.lock
+            - @text_reparser.manager
             - @text_reparser_collection
         calls:
             - [set_name, [cron.task.text_reparser.post_text]]
@@ -205,6 +209,7 @@ services:
             - @config
             - @config_text
             - @text_reparser.lock
+            - @text_reparser.manager
             - @text_reparser_collection
         calls:
             - [set_name, [cron.task.text_reparser.user_signature]]

--- a/phpBB/config/default/container/services_text_reparser.yml
+++ b/phpBB/config/default/container/services_text_reparser.yml
@@ -1,4 +1,11 @@
 services:
+    text_reparser.lock:
+        class: phpbb\lock\db
+        arguments:
+            - reparse_lock
+            - @config
+            - @dbal.conn
+
     text_reparser_collection:
         class: phpbb\di\service_collection
         arguments:

--- a/phpBB/config/default/container/services_text_reparser.yml
+++ b/phpBB/config/default/container/services_text_reparser.yml
@@ -1,4 +1,11 @@
 services:
+    text_reparser.manager:
+        class: phpbb\textreparser\manager
+        arguments:
+            - @config
+            - @config_text
+            - @text_reparser_collection
+
     text_reparser.lock:
         class: phpbb\lock\db
         arguments:

--- a/phpBB/language/en/acp/common.php
+++ b/phpBB/language/en/acp/common.php
@@ -289,6 +289,7 @@ $lang = array_merge($lang, array(
 	'PROCEED_TO_ACP'					=> '%sProceed to the ACP%s',
 
 	'REMIND'							=> 'Remind',
+	'REPARSE_LOCK_ERROR'				=> 'Could not obtain reparse lock.',
 	'RESYNC'							=> 'Resynchronise',
 
 	'RUNNING_TASK'			=> 'Running task: %s.',

--- a/phpBB/language/en/acp/common.php
+++ b/phpBB/language/en/acp/common.php
@@ -289,7 +289,7 @@ $lang = array_merge($lang, array(
 	'PROCEED_TO_ACP'					=> '%sProceed to the ACP%s',
 
 	'REMIND'							=> 'Remind',
-	'REPARSE_LOCK_ERROR'				=> 'Could not obtain reparse lock.',
+	'REPARSE_LOCK_ERROR'				=> 'Reparsing is already in progress by another process.',
 	'RESYNC'							=> 'Resynchronise',
 
 	'RUNNING_TASK'			=> 'Running task: %s.',

--- a/phpBB/phpbb/console/command/reparser/reparse.php
+++ b/phpBB/phpbb/console/command/reparser/reparse.php
@@ -61,9 +61,9 @@ class reparse extends \phpbb\console\command\command
 	* Constructor
 	*
 	* @param \phpbb\user $user
-	* @param \phpbb\di\service_collection $reparsers
-	* @param \phpbb\config\db_text $config_text
 	* @param \phpbb\lock\db $reparse_lock
+	* @param \phpbb\textreparser\manager $reparser_manager
+	* @param \phpbb\di\service_collection $reparsers
 	*/
 	public function __construct(\phpbb\user $user, \phpbb\lock\db $reparse_lock, \phpbb\textreparser\manager $reparser_manager, \phpbb\di\service_collection $reparsers)
 	{

--- a/phpBB/phpbb/console/command/reparser/reparse.php
+++ b/phpBB/phpbb/console/command/reparser/reparse.php
@@ -174,36 +174,34 @@ class reparse extends \phpbb\console\command\command
 
 		if (!$this->reparse_lock->acquire())
 		{
-			$this->load_resume_data();
+			throw new runtime_exception('REPARSE_LOCK_ERROR', array(), null, 1);
+		}
 
-			$name = $input->getArgument('reparser-name');
-			if (isset($name))
+		$this->load_resume_data();
+
+		$name = $input->getArgument('reparser-name');
+		if (isset($name))
+		{
+			// Allow "post_text" to be an alias for "text_reparser.post_text"
+			if (!isset($this->reparsers[$name]))
 			{
-				// Allow "post_text" to be an alias for "text_reparser.post_text"
-				if (!isset($this->reparsers[$name]))
-				{
-					$name = 'text_reparser.' . $name;
-				}
-				$this->reparse($name);
+				$name = 'text_reparser.' . $name;
 			}
-			else
-			{
-				foreach ($this->reparsers as $name => $service)
-				{
-					$this->reparse($name);
-				}
-			}
-
-			$this->io->success($this->user->lang('CLI_REPARSER_REPARSE_SUCCESS'));
-
-			$this->reparse_lock->release();
-
-			return 0;
+			$this->reparse($name);
 		}
 		else
 		{
-			throw new runtime_exception('REPARSE_LOCK_ERROR', array(), null, 1);
+			foreach ($this->reparsers as $name => $service)
+			{
+				$this->reparse($name);
+			}
 		}
+
+		$this->io->success($this->user->lang('CLI_REPARSER_REPARSE_SUCCESS'));
+
+		$this->reparse_lock->release();
+
+		return 0;
 	}
 
 	/**

--- a/phpBB/phpbb/console/command/reparser/reparse.php
+++ b/phpBB/phpbb/console/command/reparser/reparse.php
@@ -53,7 +53,7 @@ class reparse extends \phpbb\console\command\command
 	protected $reparsers;
 
 	/**
-	* @var array Reparser names as keys, and their last $current ID as values
+	* @var array The reparser's last $current ID as values
 	*/
 	protected $resume_data;
 
@@ -208,27 +208,18 @@ class reparse extends \phpbb\console\command\command
 	* Will use the last saved value if --resume is set and the option was not specified
 	* on the command line
 	*
-	* @param  string  $reparser_name Reparser name
 	* @param  string  $option_name   Option name
 	* @return integer
 	*/
-	protected function get_option($reparser_name, $option_name)
+	protected function get_option($option_name)
 	{
 		// Return the option from the resume_data if applicable
-		if ($this->input->getOption('resume') && isset($this->resume_data[$reparser_name][$option_name]) && !$this->input->hasParameterOption('--' . $option_name))
+		if ($this->input->getOption('resume') && isset($this->resume_data[$option_name]) && !$this->input->hasParameterOption('--' . $option_name))
 		{
-			return $this->resume_data[$reparser_name][$option_name];
+			return $this->resume_data[$option_name];
 		}
 
-		$value = $this->input->getOption($option_name);
-
-		// range-max has no default value, it must be computed for each reparser
-		if ($option_name === 'range-max' && $value === null)
-		{
-			$value = $this->reparsers[$reparser_name]->get_max_id();
-		}
-
-		return $value;
+		return $this->input->getOption($option_name);
 	}
 
 	/**
@@ -250,9 +241,15 @@ class reparse extends \phpbb\console\command\command
 		}
 
 		// Start at range-max if specified or at the highest ID otherwise
-		$max  = $this->get_option($name, 'range-max');
-		$min  = $this->get_option($name, 'range-min');
-		$size = $this->get_option($name, 'range-size');
+		$max  = $this->get_option('range-max');
+		$min  = $this->get_option('range-min');
+		$size = $this->get_option('range-size');
+
+		// range-max has no default value, it must be computed for each reparser
+		if ($max == null)
+		{
+			$max = $reparser->get_max_id();
+		}
 
 		if ($max < $min)
 		{

--- a/phpBB/phpbb/cron/task/text_reparser/reparser.php
+++ b/phpBB/phpbb/cron/task/text_reparser/reparser.php
@@ -1,0 +1,197 @@
+<?php
+/**
+ *
+ * This file is part of the phpBB Forum Software package.
+ *
+ * @copyright (c) phpBB Limited <https://www.phpbb.com>
+ * @license GNU General Public License, version 2 (GPL-2.0)
+ *
+ * For full copyright and license information, please see
+ * the docs/CREDITS.txt file.
+ *
+ */
+
+namespace phpbb\cron\task\text_reparser;
+
+/**
+ * Reparse text cron task
+ */
+class reparser extends \phpbb\cron\task\base
+{
+	const MIN = 1;
+	const SIZE = 100;
+
+	/**
+	 * @var \phpbb\config\config
+	 */
+	protected $config;
+
+	/**
+	 * @var \phpbb\config\db_text
+	 */
+	protected $config_text;
+
+	/**
+	 * @var \phpbb\lock\db
+	 */
+	protected $reparse_lock;
+
+	/**
+	 * @var \phpbb\di\service_collection
+	 */
+	protected $reparsers;
+
+	/**
+	 * @var string
+	 */
+	protected $reparser_name;
+
+	/**
+	 * @var array
+	 */
+	protected $resume_data;
+
+	/**
+	 * Constructor
+	 *
+	 * @param \phpbb\config\config			$config
+	 * @param \phpbb\config\db_text			$config_text
+	 * @param \phpbb\lock\db				$reparse_lock
+	 * @param \phpbb\di\service_collection	$reparsers
+	 */
+	public function __construct(\phpbb\config\config $config, \phpbb\config\db_text $config_text, \phpbb\lock\db $reparse_lock, \phpbb\di\service_collection $reparsers)
+	{
+		$this->config = $config;
+		$this->config_text = $config_text;
+		$this->reparse_lock = $reparse_lock;
+		$this->reparsers = $reparsers;
+	}
+
+	/**
+	 * Sets the reparser for this cron task
+	 *
+	 * @param string	$reparser
+	 */
+	public function set_reparser($reparser)
+	{
+		if (isset($this->reparsers[$reparser]))
+		{
+			$this->reparser_name = preg_replace('(^text_reparser\\.)', '', $reparser);
+		}
+		else if (isset($this->reparsers['text_reparser.' . $reparser]))
+		{
+			$this->reparser_name = $reparser;
+		}
+
+		if ($this->resume_data === null)
+		{
+			$this->load_resume_data();
+		}
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function is_runnable()
+	{
+		if ($this->resume_data === null)
+		{
+			$this->load_resume_data();
+		}
+
+		if (empty($this->resume_data[$this->reparser_name]['range-max']) || $this->resume_data[$this->reparser_name]['range-max'] === $this->resume_data[$this->reparser_name]['range-min'])
+		{
+			return true;
+		}
+
+		return false;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function should_run()
+	{
+		if (!empty($this->config['reparse_lock']))
+		{
+			$last_run = explode(' ', $this->config['reparse_lock']);
+
+			if ($last_run[0] + 3600 >= time())
+			{
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function run()
+	{
+		if ($this->reparse_lock->acquire())
+		{
+			if ($this->resume_data === null)
+			{
+				$this->load_resume_data();
+			}
+
+			/**
+			 * @var \phpbb\textreparser\reparser_interface $reparser
+			 */
+			$reparser = isset($this->reparsers[$this->reparser_name]) ? $this->reparsers[$this->reparser_name] : $this->reparsers['text_reparser.' . $this->reparser_name];
+
+			$min = !empty($this->resume_data[$this->reparser_name]['range-min']) ? $this->resume_data[$this->reparser_name]['range-min'] : self::MIN;
+			$current = !empty($this->resume_data[$this->reparser_name]['range-max']) ? $this->resume_data[$this->reparser_name]['range-max'] : $reparser->get_max_id();
+			$size = !empty($this->resume_data[$this->reparser_name]['range-size']) ? $this->resume_data[$this->reparser_name]['range-size'] : self::SIZE;
+
+			if ($current >= $min)
+			{
+				$start = max($min, $current + 1 - $size);
+				$end = max($min, $current);
+
+				$reparser->reparse_range($start, $end);
+
+				$this->update_resume_data($this->reparser_name, $min, $start - 1, $size);
+			}
+
+			$this->reparse_lock->release();
+		}
+	}
+
+	/**
+	 * Load the resume data from the database
+	 */
+	protected function load_resume_data()
+	{
+		$resume_data = $this->config_text->get('reparser_resume');
+		$this->resume_data = (empty($resume_data)) ? array() : unserialize($resume_data);
+	}
+
+	/**
+	 * Save the resume data to the database
+	 */
+	protected function save_resume_data()
+	{
+		$this->config_text->set('reparser_resume', serialize($this->resume_data));
+	}
+
+	/**
+	 * Save the resume data to the database
+	 *
+	 * @param string	$name		Reparser name
+	 * @param int		$min		Lowest record ID
+	 * @param int		$current	Current ID
+	 * @param int		$size		Number of records to process at a time
+	 */
+	protected function update_resume_data($name, $min, $current, $size)
+	{
+		$this->resume_data[$name] = array(
+			'range-min'  => $min,
+			'range-max'  => $current,
+			'range-size' => $size,
+		);
+		$this->save_resume_data();
+	}
+}

--- a/phpBB/phpbb/cron/task/text_reparser/reparser.php
+++ b/phpBB/phpbb/cron/task/text_reparser/reparser.php
@@ -122,7 +122,7 @@ class reparser extends \phpbb\cron\task\base
 			}
 		}
 
-		if ($this->config[$this->reparser_name . '_cron_interval'] != -1)
+		if ($this->config[$this->reparser_name . '_cron_interval'])
 		{
 			return $this->config[$this->reparser_name . '_last_cron'] < time() - $this->config[$this->reparser_name . '_cron_interval'];
 		}

--- a/phpBB/phpbb/cron/task/text_reparser/reparser.php
+++ b/phpBB/phpbb/cron/task/text_reparser/reparser.php
@@ -99,7 +99,7 @@ class reparser extends \phpbb\cron\task\base
 			$this->load_resume_data();
 		}
 
-		if (empty($this->resume_data[$this->reparser_name]['range-max']) || $this->resume_data[$this->reparser_name]['range-max'] === $this->resume_data[$this->reparser_name]['range-min'])
+		if (empty($this->resume_data[$this->reparser_name]['range-max']) || $this->resume_data[$this->reparser_name]['range-max'] >= $this->resume_data[$this->reparser_name]['range-min'])
 		{
 			return true;
 		}

--- a/phpBB/phpbb/db/migration/data/v320/reparse_fast.php
+++ b/phpBB/phpbb/db/migration/data/v320/reparse_fast.php
@@ -1,0 +1,87 @@
+<?php
+/**
+ *
+ * This file is part of the phpBB Forum Software package.
+ *
+ * @copyright (c) phpBB Limited <https://www.phpbb.com>
+ * @license GNU General Public License, version 2 (GPL-2.0)
+ *
+ * For full copyright and license information, please see
+ * the docs/CREDITS.txt file.
+ *
+ */
+
+namespace phpbb\db\migration\data\v320;
+
+class reparse_fast extends \phpbb\db\migration\container_aware_migration
+{
+	static public function depends_on()
+	{
+		return array('\phpbb\db\migration\data\v310\contact_admin_form');
+	}
+
+	public function effectively_installed()
+	{
+		return isset($this->config['reparse_lock']);
+	}
+
+	public function update_data()
+	{
+		return array(
+			array('config.add', array('reparse_lock', 0, true)),
+			array('custom', array(array($this, 'reparse'))),
+		);
+	}
+
+	public function reparse($resume_data)
+	{
+		// Somtimes a cron job is too much
+		$limit = 200;
+		$fast_reparsers = array(
+			'text_reparser.contact_admin_info',
+			'text_reparser.forum_description',
+			'text_reparser.forum_rules',
+			'text_reparser.group_description',
+		);
+
+		if (!is_array($resume_data))
+		{
+			$resume_data = array(
+				'reparser'	=> 0,
+				'current'	=> $this->container->get($fast_reparsers[0])->get_max_id(),
+			);
+		}
+
+		$fast_reparsers_size = sizeof($fast_reparsers);
+		$processed_records = 0;
+		while ($processed_records < $limit && $resume_data['reparser'] < $fast_reparsers_size)
+		{
+			$reparser = $this->container->get($fast_reparsers[$resume_data['reparser']]);
+
+			// New reparser
+			if ($resume_data['current'] === 0)
+			{
+				$resume_data['current'] = $reparser->get_max_id();
+			}
+
+			$start = max(1, $resume_data['current'] + 1 - ($limit - $processed_records));
+			$end = max(1, $resume_data['current']);
+			$reparser->reparse_range($start, $end);
+
+			$processed_records = $end - $start + 1;
+			$resume_data['current'] = $start - 1;
+
+			if ($start === 1)
+			{
+				$resume_data['reparser']++;
+			}
+		}
+
+		if ($resume_data['reparser'] === $fast_reparsers_size)
+		{
+			return true;
+		}
+
+		return $resume_data;
+	}
+}

--- a/phpBB/phpbb/db/migration/data/v320/text_reparser.php
+++ b/phpBB/phpbb/db/migration/data/v320/text_reparser.php
@@ -29,15 +29,15 @@ class text_reparser extends \phpbb\db\migration\container_aware_migration
 	{
 		return array(
 			array('config.add', array('reparse_lock', 0, true)),
-			array('config.add', array('text_reparser.pm_text_cron_interval', 0)),
+			array('config.add', array('text_reparser.pm_text_cron_interval', 10)),
 			array('config.add', array('text_reparser.pm_text_last_cron', 0)),
-			array('config.add', array('text_reparser.poll_option_cron_interval', 0)),
+			array('config.add', array('text_reparser.poll_option_cron_interval', 10)),
 			array('config.add', array('text_reparser.poll_option_last_cron', 0)),
-			array('config.add', array('text_reparser.poll_title_cron_interval', 0)),
+			array('config.add', array('text_reparser.poll_title_cron_interval', 10)),
 			array('config.add', array('text_reparser.poll_title_last_cron', 0)),
-			array('config.add', array('text_reparser.post_text_cron_interval', 0)),
+			array('config.add', array('text_reparser.post_text_cron_interval', 10)),
 			array('config.add', array('text_reparser.post_text_last_cron', 0)),
-			array('config.add', array('text_reparser.user_signature_cron_interval', 0)),
+			array('config.add', array('text_reparser.user_signature_cron_interval', 10)),
 			array('config.add', array('text_reparser.user_signature_last_cron', 0)),
 			array('custom', array(array($this, 'reparse'))),
 		);

--- a/phpBB/phpbb/db/migration/data/v320/text_reparser.php
+++ b/phpBB/phpbb/db/migration/data/v320/text_reparser.php
@@ -13,7 +13,7 @@
 
 namespace phpbb\db\migration\data\v320;
 
-class reparse_fast extends \phpbb\db\migration\container_aware_migration
+class text_reparser extends \phpbb\db\migration\container_aware_migration
 {
 	static public function depends_on()
 	{
@@ -29,6 +29,16 @@ class reparse_fast extends \phpbb\db\migration\container_aware_migration
 	{
 		return array(
 			array('config.add', array('reparse_lock', 0, true)),
+			array('config.add', array('text_reparser.pm_text_cron_interval', 0)),
+			array('config.add', array('text_reparser.pm_text_last_cron', 0)),
+			array('config.add', array('text_reparser.poll_option_cron_interval', 0)),
+			array('config.add', array('text_reparser.poll_option_last_cron', 0)),
+			array('config.add', array('text_reparser.poll_title_cron_interval', 0)),
+			array('config.add', array('text_reparser.poll_title_last_cron', 0)),
+			array('config.add', array('text_reparser.post_text_cron_interval', 0)),
+			array('config.add', array('text_reparser.post_text_last_cron', 0)),
+			array('config.add', array('text_reparser.user_signature_cron_interval', 0)),
+			array('config.add', array('text_reparser.user_signature_last_cron', 0)),
 			array('custom', array(array($this, 'reparse'))),
 		);
 	}
@@ -36,7 +46,7 @@ class reparse_fast extends \phpbb\db\migration\container_aware_migration
 	public function reparse($resume_data)
 	{
 		// Somtimes a cron job is too much
-		$limit = 200;
+		$limit = 100;
 		$fast_reparsers = array(
 			'text_reparser.contact_admin_info',
 			'text_reparser.forum_description',
@@ -73,6 +83,10 @@ class reparse_fast extends \phpbb\db\migration\container_aware_migration
 
 			if ($start === 1)
 			{
+				// Prevent CLI command from running these reparsers again
+				$reparser_manager = $this->container->get('text_reparser.manager');
+				$reparser_manager->update_resume_data($fast_reparsers[$resume_data['reparser']], 1, 0, $limit);
+
 				$resume_data['reparser']++;
 			}
 		}

--- a/phpBB/phpbb/textreparser/manager.php
+++ b/phpBB/phpbb/textreparser/manager.php
@@ -1,0 +1,128 @@
+<?php
+/**
+ *
+ * This file is part of the phpBB Forum Software package.
+ *
+ * @copyright (c) phpBB Limited <https://www.phpbb.com>
+ * @license GNU General Public License, version 2 (GPL-2.0)
+ *
+ * For full copyright and license information, please see
+ * the docs/CREDITS.txt file.
+ *
+ */
+
+namespace phpbb\textreparser;
+
+class manager
+{
+	/**
+	 * @var \phpbb\config\config
+	 */
+	protected $config;
+
+	/**
+	 * @var \phpbb\config\db_text
+	 */
+	protected $config_text;
+
+	/**
+	 * @var \phpbb\di\service_collection
+	 */
+	protected $reparsers;
+
+	/**
+	 * @var array
+	 */
+	protected $resume_data;
+
+	/**
+	 * Constructor
+	 *
+	 * @param \phpbb\config\config			$config
+	 * @param \phpbb\config\db_text			$config_text
+	 * @param \phpbb\di\service_collection	$reparsers
+	 */
+	public function __construct(\phpbb\config\config $config, \phpbb\config\db_text $config_text, \phpbb\di\service_collection $reparsers)
+	{
+		$this->config = $config;
+		$this->config_text = $config_text;
+		$this->reparsers = $reparsers;
+	}
+
+	/**
+	 * Loads resume data from the database
+	 *
+	 * @param string	$name	Name of the reparser to which the resume data belongs
+	 *
+	 * @return array
+	 */
+	public function get_resume_data($name)
+	{
+		if ($this->resume_data === null)
+		{
+			$resume_data = $this->config_text->get('reparser_resume');
+			$this->resume_data = !empty($resume_data) ? unserialize($resume_data) : array();
+		}
+
+		return isset($this->resume_data[$name]) ? $this->resume_data[$name] : array();
+	}
+
+	/**
+	 * Updates the resume data in the database
+	 *
+	 * @param string	$name		Name of the reparser to which the resume data belongs
+	 * @param int		$min		Lowest record ID
+	 * @param int		$current	Current record ID
+	 * @param int		$size		Number of records to process at a time
+	 * @param bool		$update_db	True if the resume data should be written to the database, false if not. (default: true)
+	 */
+	public function update_resume_data($name, $min, $current, $size, $update_db = true)
+	{
+		// Prevent overwriting the old, stored array
+		if ($this->resume_data === null)
+		{
+			$this->get_resume_data('');
+		}
+
+		$this->resume_data[$name] = array(
+			'range-min'		=> $min,
+			'range-max'		=> $current,
+			'range-size'	=> $size,
+		);
+
+		if ($update_db)
+		{
+			$this->config_text->set('reparser_resume', serialize($this->resume_data));
+		}
+	}
+
+	/**
+	 * Sets the interval for a text_reparser cron task
+	 *
+	 * @param string	$name		Name of the reparser to schedule
+	 * @param int		$interval	Interval in seconds, -1 to disable the cron task
+	 */
+	public function schedule($name, $interval)
+	{
+		if (isset($this->reparsers[$name]) && isset($this->config[$name . '_cron_interval']))
+		{
+			$this->config->set($name . '_cron_interval', $interval);
+		}
+	}
+
+	/**
+	 * Sets the interval for all text_reparser cron tasks
+	 *
+	 * @param int	$interval	Interval in seconds, -1 to disable the cron task
+	 */
+	public function schedule_all($interval)
+	{
+		// This way we don't construct every registered reparser
+		$reparser_array = array_keys($this->reparsers->getArrayCopy());
+
+		foreach ($reparser_array as $reparser)
+		{
+			$this->schedule($reparser, $interval);
+		}
+	}
+}

--- a/phpBB/phpbb/textreparser/manager.php
+++ b/phpBB/phpbb/textreparser/manager.php
@@ -100,7 +100,7 @@ class manager
 	 * Sets the interval for a text_reparser cron task
 	 *
 	 * @param string	$name		Name of the reparser to schedule
-	 * @param int		$interval	Interval in seconds, -1 to disable the cron task
+	 * @param int		$interval	Interval in seconds, 0 to disable the cron task
 	 */
 	public function schedule($name, $interval)
 	{
@@ -113,7 +113,7 @@ class manager
 	/**
 	 * Sets the interval for all text_reparser cron tasks
 	 *
-	 * @param int	$interval	Interval in seconds, -1 to disable the cron task
+	 * @param int	$interval	Interval in seconds, 0 to disable the cron task
 	 */
 	public function schedule_all($interval)
 	{

--- a/tests/text_reparser/fixtures/config_text.xml
+++ b/tests/text_reparser/fixtures/config_text.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<dataset>
+	<table name="phpbb_config_text">
+		<column>config_name</column>
+		<column>config_value</column>
+	</table>
+</dataset>

--- a/tests/text_reparser/manager_test.php
+++ b/tests/text_reparser/manager_test.php
@@ -1,0 +1,117 @@
+<?php
+/**
+ *
+ * This file is part of the phpBB Forum Software package.
+ *
+ * @copyright (c) phpBB Limited <https://www.phpbb.com>
+ * @license GNU General Public License, version 2 (GPL-2.0)
+ *
+ * For full copyright and license information, please see
+ * the docs/CREDITS.txt file.
+ *
+ */
+
+require_once __DIR__ . '/../mock/container_builder.php';
+require_once __DIR__ . '/../test_framework/phpbb_database_test_case.php';
+
+class phpbb_text_reparser_manager_test extends phpbb_database_test_case
+{
+	/** @var \phpbb\config\config */
+	protected $config;
+
+	/** @var \phpbb\config\db_text */
+	protected $config_text;
+
+	/** @var \phpbb\textreparser\manager */
+	protected $reparser_manager;
+
+	public function getDataSet()
+	{
+		return $this->createXMLDataSet(dirname(__FILE__) . '/fixtures/config_text.xml');
+	}
+
+	public function setUp()
+	{
+		parent::setUp();
+
+		$this->config = new \phpbb\config\config(array(
+			'test_reparser_cron_interval'	=> 0,
+			'my_reparser_cron_interval'		=> 100,
+		));
+
+		$db = $this->new_dbal();
+		$this->config_text = new \phpbb\config\db_text($db, 'phpbb_config_text');
+
+		$service_collection = new \phpbb\di\service_collection(new phpbb_mock_container_builder());
+		$service_collection->add('test_reparser');
+		$service_collection->add('another_reparser');
+		$service_collection->add('my_reparser');
+
+		$this->reparser_manager = new \phpbb\textreparser\manager($this->config, $this->config_text, $service_collection);
+	}
+
+	public function test_get_resume_data()
+	{
+		$resume_data = array(
+			'test_reparser'	=> array(
+				'range-min'		=> 0,
+				'range-max'		=> 100,
+				'range-size'	=> 50,
+			),
+		);
+		$this->config_text->set('reparser_resume', serialize($resume_data));
+
+		$this->assert_array_content_equals($resume_data['test_reparser'], $this->reparser_manager->get_resume_data('test_reparser'));
+		$this->assertEmpty($this->reparser_manager->get_resume_data('another_reparser'));
+	}
+
+	public function test_update_resume_data()
+	{
+		$resume_data = array(
+			'test_reparser'	=> array(
+				'range-min'		=> 0,
+				'range-max'		=> 100,
+				'range-size'	=> 50,
+			),
+		);
+		$this->config_text->set('reparser_resume', serialize($resume_data));
+
+		$this->reparser_manager->update_resume_data('another_reparser', 5, 20, 10, false);
+		$this->assert_array_content_equals($resume_data, unserialize($this->config_text->get('reparser_resume')));
+
+		$this->reparser_manager->update_resume_data('test_reparser', 0, 50, 50);
+		$resume_data = array(
+			'test_reparser'	=> array(
+				'range-min'		=> 0,
+				'range-max'		=> 50,
+				'range-size'	=> 50,
+			),
+			'another_reparser'	=> array(
+				'range-min'		=> 5,
+				'range-max'		=> 20,
+				'range-size'	=> 10,
+			),
+		);
+		$this->assert_array_content_equals($resume_data, unserialize($this->config_text->get('reparser_resume')));
+	}
+
+	public function test_schedule()
+	{
+		$this->reparser_manager->schedule('no_reparser', 21);
+		$this->assertArrayNotHasKey('no_reparser_cron_interval', $this->config);
+
+		$this->reparser_manager->schedule('another_reparser', 42);
+		$this->assertArrayNotHasKey('another_reparser_cron_interval', $this->config);
+
+		$this->reparser_manager->schedule('test_reparser', 20);
+		$this->assertEquals(20, $this->config['test_reparser_cron_interval']);
+	}
+
+	public function test_schedule_all()
+	{
+		$this->reparser_manager->schedule_all(180);
+		$this->assertEquals(180, $this->config['test_reparser_cron_interval']);
+		$this->assertEquals(180, $this->config['my_reparser_cron_interval']);
+		$this->assertArrayNotHasKey('another_reparser_cron_interval', $this->config);
+	}
+}


### PR DESCRIPTION
One new cron task for each reparser.
Advantage of this approach is that the decision which reparser will run in the cron job is made before running it.
Disadvantage is that extension authors have to create their own cron task but since they only have to define that in the services.yml and they have to create their own reparser class anyway, I don't think this is a big issue.
So basically no disadvantages. :grinning: 

Cron job and console command can't interfere with eachother because the reparser acquires a lock, of course.
However, cron job and console command will be synced. So the console command can resume where the cron job stopped and vice versa.

This also means unfortunately that an administator can set weird values by using the console command (weird start, end, size IDs) which might lead to an unfinished reparsing. I don't know if this is something we have to care about?

And since this is your baby, @JoshyPHP, please have a look as well. :) ;) Thank you! :)

[PHPBB3-14257](https://tracker.phpbb.com/browse/PHPBB3-14257)