### PR TITLE
[ticket/13202] Remove old and unsed code from session_begin()

### DIFF
--- a/phpBB/phpbb/session.php
+++ b/phpBB/phpbb/session.php
@@ -465,15 +465,6 @@ class session
 
 							$db->sql_return_on_error(false);
 
-							// If the database is not yet updated, there will be an error due to the session_forum_id
-							// @todo REMOVE for 3.0.2
-							if ($result === false)
-							{
-								unset($sql_ary['session_forum_id']);
-
-								$this->update_session($sql_ary);
-							}
-
 							if ($this->data['user_id'] != ANONYMOUS && !empty($config['new_member_post_limit']) && $this->data['user_new'] && $config['new_member_post_limit'] <= $this->data['user_posts'])
 							{
 								$this->leave_newly_registered();


### PR DESCRIPTION
This code was to be removed in 3.0.2. So, I think that we can safely remove it in 3.2.x.

Also, the `$result` variable doesn't longer defined by update_session(), so the variable come from a `SELECT` query few lines above and this condition is always false.

[PHPBB3-13202](https://tracker.phpbb.com/browse/PHPBB3-13202)