### PR TITLE
[ticket/14261] Move the update of session informations to page_footer()

### DIFF
--- a/phpBB/includes/functions.php
+++ b/phpBB/includes/functions.php
@@ -5395,6 +5395,8 @@ function page_footer($run_cron = true, $display_template = true, $exit_handler =
 		return;
 	}
 
+	$user->update_session_infos();
+
 	phpbb_check_and_display_sql_report($request, $auth, $db);
 
 	$template->assign_vars(array(

--- a/phpBB/includes/functions_acp.php
+++ b/phpBB/includes/functions_acp.php
@@ -164,6 +164,8 @@ function adm_page_footer($copyright_html = true)
 		return;
 	}
 
+	$user->update_session_infos();
+
 	phpbb_check_and_display_sql_report($request, $auth, $db);
 
 	$template->assign_vars(array(

--- a/phpBB/phpbb/session.php
+++ b/phpBB/phpbb/session.php
@@ -1583,15 +1583,6 @@ class session
 
 			$db->sql_return_on_error(false);
 
-			// If the database is not yet updated, there will be an error due to the session_forum_id
-			// @todo REMOVE for 3.0.2
-			if ($result === false)
-			{
-				unset($sql_ary['session_forum_id']);
-
-				$this->update_session($sql_ary);
-			}
-
 			if ($this->data['user_id'] != ANONYMOUS && !empty($config['new_member_post_limit']) && $this->data['user_new'] && $config['new_member_post_limit'] <= $this->data['user_posts'])
 			{
 				$this->leave_newly_registered();


### PR DESCRIPTION
Currently, the unique way to disable the update of session_page is to pass `false` to the parameter of `session_begin()`. This method is directly called in `app.php`, so pages served from the routing system can't disable the update of session informations.

By moving the update to `page_footer`, we can allow controllers to tell to the session manager that we don't want to update the session infos.

[PHPBB3-14261](https://tracker.phpbb.com/browse/PHPBB3-14261)