### PR TITLE
Display pending group requests on ACP group summary page

### DIFF
--- a/phpBB/adm/style/acp_groups.html
+++ b/phpBB/adm/style/acp_groups.html
@@ -266,11 +266,12 @@
 	<form id="acp_groups" method="post" action="{U_ACTION}">
 
 	<table class="table1">
-		<col class="col1" /><col class="col1" /><col class="col2" /><col class="col2" /><col class="col2" />
+		<col class="col1" /><col class="col1" /><col class="col1" /><col class="col2" /><col class="col2" /><col class="col2" />
 	<thead>
 	<tr>
 		<th style="width: 50%">{L_GROUP}</th>
 		<th>{L_TOTAL_MEMBERS}</th>
+		<th>{L_PENDING_MEMBERS}</th>
 		<th colspan="2">{L_OPTIONS}</th>
 		<th>{L_ACTION}</th>
 	</tr>
@@ -280,7 +281,7 @@
 		<!-- IF groups.S_SPECIAL -->
 		<!-- IF groups.S_FIRST_ROW -->
 			<tr>
-				<td colspan="5" class="row3">{L_NO_GROUPS_CREATED}</td>
+				<td colspan="6" class="row3">{L_NO_GROUPS_CREATED}</td>
 			</tr>
 		<!-- ENDIF -->
 	</tbody>
@@ -300,11 +301,12 @@
 	<p>{L_SPECIAL_GROUPS_EXPLAIN}</p>
 
 	<table class="table1">
-		<col class="col1" /><col class="col1" /><col class="col2" /><col class="col2" /><col class="col2" />
+		<col class="col1" /><col class="col1" /><col class="col1" /><col class="col2" /><col class="col2" />
 	<thead>
 	<tr>
 		<th style="width: 50%">{L_GROUP}</th>
 		<th>{L_TOTAL_MEMBERS}</th>
+		<th>{L_PENDING_MEMBERS}</th>
 		<th colspan="2">{L_OPTIONS}</th>
 		<th>{L_ACTION}</th>
 	</tr>
@@ -314,6 +316,7 @@
 		<tr>
 			<td><strong>{groups.GROUP_NAME}</strong></td>
 			<td style="text-align: center;">{groups.TOTAL_MEMBERS}</td>
+			<td style="text-align: center;">{groups.PENDING_MEMBERS}</td>
 			<td style="text-align: center;"><a href="{groups.U_EDIT}">{L_SETTINGS}</a></td>
 			<td style="text-align: center;"><a href="{groups.U_LIST}">{L_MEMBERS}</a></td>
 			<td style="text-align: center;"><!-- IF not groups.S_GROUP_SPECIAL and groups.U_DELETE --><a href="{groups.U_DELETE}" data-ajax="row_delete">{L_DELETE}</a><!-- ELSE -->{L_DELETE}<!-- ENDIF --></td>

--- a/phpBB/includes/acp/acp_groups.php
+++ b/phpBB/includes/acp/acp_groups.php
@@ -933,6 +933,7 @@ class acp_groups
 			// used for easy access to the data within a group
 			$cached_group_data[$type][$row['group_id']] = $row;
 			$cached_group_data[$type][$row['group_id']]['total_members'] = 0;
+			$cached_group_data[$type][$row['group_id']]['pending_members'] = 0;
 		}
 		$db->sql_freeresult($result);
 

--- a/phpBB/includes/acp/acp_groups.php
+++ b/phpBB/includes/acp/acp_groups.php
@@ -938,7 +938,7 @@ class acp_groups
 		$db->sql_freeresult($result);
 
 		// How many people are in which group?
-		$sql = 'SELECT COUNT(ug.user_id) AS total_members, ug.group_id
+		$sql = 'SELECT COUNT(ug.user_id) AS total_members, SUM(ug.user_pending) AS pending_members, ug.group_id
 			FROM ' . USER_GROUP_TABLE . ' ug
 			WHERE ' . $db->sql_in_set('ug.group_id', array_keys($lookup)) . '
 			GROUP BY ug.group_id';
@@ -948,6 +948,7 @@ class acp_groups
 		{
 			$type = $lookup[$row['group_id']];
 			$cached_group_data[$type][$row['group_id']]['total_members'] = $row['total_members'];
+			$cached_group_data[$type][$row['group_id']]['pending_members'] = $row['pending_members'];
 		}
 		$db->sql_freeresult($result);
 
@@ -976,6 +977,7 @@ class acp_groups
 
 					'GROUP_NAME'	=> $group_name,
 					'TOTAL_MEMBERS'	=> $row['total_members'],
+					'PENDING_MEMBERS' => $row['pending_members']
 				));
 			}
 		}

--- a/phpBB/language/en/acp/groups.php
+++ b/phpBB/language/en/acp/groups.php
@@ -130,6 +130,8 @@ $lang = array_merge($lang, array(
 	'NO_USERS_ADDED'			=> 'No users were added to the group.',
 	'NO_VALID_USERS'			=> 'You haven’t entered any users eligible for that action.',
 
+	'PENDING_MEMBERS'			=> 'Pending',
+
 	'SELECT_GROUP'				=> 'Select a group',
 	'SPECIAL_GROUPS'			=> 'Pre-defined groups',
 	'SPECIAL_GROUPS_EXPLAIN'	=> 'Pre-defined groups are special groups, they cannot be deleted or directly modified. However you can still add users and alter basic settings.',


### PR DESCRIPTION
Currenty, you need to open each existing group in ACP to know if there are pending group requests or not. Doing so is really boring and annoying... :/
This patch displays the number of pending group requests at the ACP groups summary page.

https://tracker.phpbb.com/browse/PHPBB3-14253