### PR TITLE
[ticket/14287] Always remove loading indicator after confirming action.

### DIFF
--- a/phpBB/assets/javascript/core.js
+++ b/phpBB/assets/javascript/core.js
@@ -303,6 +303,10 @@ phpbb.ajaxify = function(options) {
 					alert = phpbb.alert(res.MESSAGE_TITLE, res.MESSAGE_TEXT);
 				} else {
 					$dark.fadeOut(phpbb.alertTime);
+
+					if ($loadingIndicator) {
+						$loadingIndicator.fadeOut(phpbb.alertTime);
+					}
 				}
 
 				if (typeof phpbb.ajaxCallbacks[callback] === 'function') {


### PR DESCRIPTION
If there is no success message after the action is confirmed, the indicator
is not currently removed.

[PHPBB3-14287](https://tracker.phpbb.com/browse/PHPBB3-14287)

Test script since this situation currently does not present itself in the core.
https://gist.github.com/prototech/8363883637fa78785887

Insert this into any template to call the script.
```
<a href="./confirm.php?mode=without" data-ajax="true">Without success message</a>
<a href="./confirm.php?mode=with" data-ajax="true">With success message</a>
```

