### PR TITLE
[ticket/14340] Revert fix for segmentation fault error on phpBB 3.2 PHP7 tests

### DIFF
--- a/tests/datetime/from_format_test.php
+++ b/tests/datetime/from_format_test.php
@@ -113,10 +113,6 @@ class phpbb_datetime_from_format_test extends phpbb_test_case
 	{
 		global $phpbb_root_path, $phpEx;
 
-		// This magically fixes the segmentation fault error on PHP7 tests
-		// while date_default_timezone_set('UTC') does not
-		date_default_timezone_set('Europe/Paris');
-
 		$lang_loader = new \phpbb\language\language_file_loader($phpbb_root_path, $phpEx);
 		$lang = new \phpbb\language\language($lang_loader);
 		$user = new \phpbb\user($lang, '\phpbb\datetime');


### PR DESCRIPTION
The fix was introduced with #3826, now the PHP core bug has been fixed:
https://bugs.php.net/bug.php?id=70249
Original fix ticket: <a href="https://tracker.phpbb.com/browse/PHPBB3-14094">PHPBB3-14094</a>.

<a href="https://tracker.phpbb.com/browse/PHPBB3-14340">PHPBB3-14340</a>.