### PR TITLE
[ticket/14310] Put progress percentage inside span and make more visible

### DIFF
--- a/phpBB/adm/style/admin.css
+++ b/phpBB/adm/style/admin.css
@@ -2566,6 +2566,7 @@ fieldset.permissions .padding {
 	text-align: center;
 	line-height: 25px;
 	font-weight: bold;
+	color: #fff;
 }
 
 #progress-bar #progress-bar-filler {

--- a/phpBB/assets/javascript/installer.js
+++ b/phpBB/assets/javascript/installer.js
@@ -191,12 +191,12 @@
 				$progressText.attr('id', 'progress-bar-text');
 				$progressFiller = $('<span />');
 				$progressFiller.attr('id', 'progress-bar-filler');
+				$progressFiller.html($progressText);
 
 				$statusText = $('<p />');
 				$statusText.attr('id', 'progress-status-text');
 
 				$progressBar.append($progressFiller);
-				$progressBar.append($progressText);
 
 				$progressBarWrapper.append($statusText);
 				$progressBarWrapper.append($progressBar);


### PR DESCRIPTION
The progress bar percentage is hardly readable during the installation once the filler passes the text.
This change will take care of this (see pictures below).
![install_percent_50](https://cloud.githubusercontent.com/assets/394418/11631680/6e9a1dde-9d03-11e5-913d-515c70febc16.png)

![install_percent_80](https://cloud.githubusercontent.com/assets/394418/11631689/7b9638b0-9d03-11e5-83a0-c5fdbd840ce0.png)
The text will always be inside the filler.

Ticket: https://tracker.phpbb.com/browse/PHPBB3-14310