### PR TITLE
[ticket/14306] Automatically enable a safe mode when container building fails

### DIFF
--- a/phpBB/adm/style/overall_header.html
+++ b/phpBB/adm/style/overall_header.html
@@ -149,8 +149,7 @@ function popup(url, width, height, name)
 							<!-- IF CONTAINER_EXCEPTION !== false -->
 							<div class="errorbox">
 								<p>{L_CONTAINER_EXCEPTION}</p>
-								<p>{L_CONTAINER_EXCEPTION_DETAIL}</p>
-								<p>Exception message: {{ CONTAINER_EXCEPTION.getMessage() }}</p>
+								<p>{L_EXCEPTION}{L_COLON} {{ CONTAINER_EXCEPTION.getMessage() }}</p>
 								<pre>{{ CONTAINER_EXCEPTION.getTraceAsString() }}</pre>
 							</div>
 							<!-- ENDIF -->

--- a/phpBB/adm/style/overall_header.html
+++ b/phpBB/adm/style/overall_header.html
@@ -49,7 +49,7 @@ function marklist(id, name, state)
 	}
 
 	var rb = parent.getElementsByTagName('input');
-	
+
 	for (var r = 0; r < rb.length; r++)
 	{
 		if (rb[r].name.substr(0, name.length) == name)
@@ -103,7 +103,7 @@ function popup(url, width, height, name)
 		<p><a href="{U_ADM_INDEX}">{L_ADMIN_INDEX}</a> &bull; <a href="{U_INDEX}">{L_FORUM_INDEX}</a></p>
 		<p id="skip"><a href="#acp">{L_SKIP}</a></p>
 	</div>
-	
+
 	<div id="page-body">
 		<div id="tabs">
 			<ul>
@@ -120,7 +120,7 @@ function popup(url, width, height, name)
 						<!-- DEFINE $LI_USED = 0 -->
 						<!-- BEGIN l_block1 -->
 							<!-- IF l_block1.S_SELECTED -->
-	
+
 						<!-- BEGIN l_block2 -->
 							<!-- IF .l_block1.l_block2.l_block3 -->
 							<!-- IF $LI_USED --></ul></div><!-- ENDIF -->
@@ -129,13 +129,13 @@ function popup(url, width, height, name)
 								<ul>
 							<!-- DEFINE $LI_USED = 1 -->
 							<!-- ENDIF -->
-	
+
 							<!-- BEGIN l_block3 -->
 								<li<!-- IF l_block1.l_block2.l_block3.S_SELECTED --> id="activemenu"<!-- ENDIF -->><a href="{l_block1.l_block2.l_block3.U_TITLE}"><span>{l_block1.l_block2.l_block3.L_TITLE}</span></a></li>
 								<!-- DEFINE $LI_USED = 1 -->
 							<!-- END l_block3 -->
 						<!-- END l_block2 -->
-						
+
 							<!-- ENDIF -->
 						<!-- END l_block1 -->
 						<!-- IF $LI_USED -->
@@ -143,6 +143,14 @@ function popup(url, width, height, name)
 							</div>
 						<!-- ENDIF -->
 					</div>
-	
+
 					<div id="main">
 						<div class="main">
+							<!-- IF CONTAINER_EXCEPTION !== false -->
+							<div class="errorbox">
+								<p>{L_CONTAINER_EXCEPTION}</p>
+								<p>{L_CONTAINER_EXCEPTION_DETAIL}</p>
+								<p>Exception message: {{ CONTAINER_EXCEPTION.getMessage() }}</p>
+								<pre>{{ CONTAINER_EXCEPTION.getTraceAsString() }}</pre>
+							</div>
+							<!-- ENDIF -->

--- a/phpBB/adm/style/overall_header.html
+++ b/phpBB/adm/style/overall_header.html
@@ -146,10 +146,10 @@ function popup(url, width, height, name)
 
 					<div id="main">
 						<div class="main">
-							<!-- IF CONTAINER_EXCEPTION !== false -->
+							{% if CONTAINER_EXCEPTION !== false %}
 							<div class="errorbox">
-								<p>{L_CONTAINER_EXCEPTION}</p>
-								<p>{L_EXCEPTION}{L_COLON} {{ CONTAINER_EXCEPTION.getMessage() }}</p>
+								<p>{{ lang('CONTAINER_EXCEPTION') }}</p>
+								<p>{{ lang('EXCEPTION') }}{{ lang('COLON') }} {{ CONTAINER_EXCEPTION.getMessage() }}</p>
 								<pre>{{ CONTAINER_EXCEPTION.getTraceAsString() }}</pre>
 							</div>
-							<!-- ENDIF -->
+							{% endif %}

--- a/phpBB/adm/style/overall_header.html
+++ b/phpBB/adm/style/overall_header.html
@@ -148,7 +148,7 @@ function popup(url, width, height, name)
 						<div class="main">
 							{% if CONTAINER_EXCEPTION !== false %}
 							<div class="errorbox">
-								<p>{{ lang('CONTAINER_EXCEPTION') }}</p>
+								<p>{{ lang('CONTAINER_EXCEPTION') }}</p><br />
 								<p>{{ lang('EXCEPTION') }}{{ lang('COLON') }} {{ CONTAINER_EXCEPTION.getMessage() }}</p>
 								<pre>{{ CONTAINER_EXCEPTION.getTraceAsString() }}</pre>
 							</div>

--- a/phpBB/includes/functions_acp.php
+++ b/phpBB/includes/functions_acp.php
@@ -26,7 +26,7 @@ function adm_page_header($page_title)
 {
 	global $config, $db, $user, $template;
 	global $phpbb_root_path, $phpbb_admin_path, $phpEx, $SID, $_SID;
-	global $phpbb_dispatcher;
+	global $phpbb_dispatcher, $phpbb_container;
 
 	if (defined('HEADER_INC'))
 	{
@@ -105,6 +105,8 @@ function adm_page_header($page_title)
 		'S_CONTENT_ENCODING'	=> 'UTF-8',
 		'S_CONTENT_FLOW_BEGIN'	=> ($user->lang['DIRECTION'] == 'ltr') ? 'left' : 'right',
 		'S_CONTENT_FLOW_END'	=> ($user->lang['DIRECTION'] == 'ltr') ? 'right' : 'left',
+
+		'CONTAINER_EXCEPTION'	=> $phpbb_container->hasParameter('container_exception') ? $phpbb_container->getParameter('container_exception') : false,
 	));
 
 	// An array of http headers that phpbb will set. The following event may override these.

--- a/phpBB/language/en/acp/common.php
+++ b/phpBB/language/en/acp/common.php
@@ -225,7 +225,7 @@ $lang = array_merge($lang, array(
 
 	'BACK'					=> 'Back',
 
-	'CONTAINER_EXCEPTION' => 'phpBB encountered an error building the container due to an installed extension. For this reason, all extensions have been temporarily disabled. Please try purging your forum cache. All extensions will automatically be re-enabled once the container error is resolved. If this error continues, please visit phpBB.com for support.',
+	'CONTAINER_EXCEPTION' => 'phpBB encountered an error building the container due to an installed extension. For this reason, all extensions have been temporarily disabled. Please try purging your forum cache. All extensions will automatically be re-enabled once the container error is resolved. If this error continues, please visit <a href="https://www.phpbb.com/support">phpBB.com</a> for support.',
 	'EXCEPTION' => 'Exception',
 
 	'COLOUR_SWATCH'			=> 'Web-safe colour swatch',

--- a/phpBB/language/en/acp/common.php
+++ b/phpBB/language/en/acp/common.php
@@ -225,6 +225,9 @@ $lang = array_merge($lang, array(
 
 	'BACK'					=> 'Back',
 
+	'CONTAINER_EXCEPTION' => 'phpBB encountered an error building the container due to an installed extension. For this reason, all extensions have been temporarily disabled. Please try purging your forum cache. All extensions will automatically be re-enabled once the container error is resolved. If this error continues, please visit phpBB.com for support.',
+	'EXCEPTION' => 'Exception',
+
 	'COLOUR_SWATCH'			=> 'Web-safe colour swatch',
 	'CONFIG_UPDATED'		=> 'Configuration updated successfully.',
 	'CRON_LOCK_ERROR'		=> 'Could not obtain cron lock.',

--- a/phpBB/phpbb/di/container_builder.php
+++ b/phpBB/phpbb/di/container_builder.php
@@ -90,7 +90,7 @@ class container_builder
 	 *
 	 * @var array
 	 */
-	protected $custom_parameters = null;
+	protected $custom_parameters = [];
 
 	/**
 	 * @var \phpbb\config_php_file
@@ -126,67 +126,80 @@ class container_builder
 	 */
 	public function get_container()
 	{
-		$container_filename = $this->get_container_filename();
-		$config_cache = new ConfigCache($container_filename, defined('DEBUG'));
-		if ($this->use_cache && $config_cache->isFresh())
-		{
-			require($config_cache->getPath());
-			$this->container = new \phpbb_cache_container();
-		}
-		else
-		{
-			$this->container_extensions = array(new extension\core($this->get_config_path()));
-
-			if ($this->use_extensions)
+		try {
+			$container_filename = $this->get_container_filename();
+			$config_cache = new ConfigCache($container_filename, defined('DEBUG'));
+			if ($this->use_cache && $config_cache->isFresh())
 			{
-				$this->load_extensions();
+				require($config_cache->getPath());
+				$this->container = new \phpbb_cache_container();
 			}
-
-			// Inject the config
-			if ($this->config_php_file)
+			else
 			{
-				$this->container_extensions[] = new extension\config($this->config_php_file);
-			}
+				$this->container_extensions = array(new extension\core($this->get_config_path()));
 
-			$this->container = $this->create_container($this->container_extensions);
-
-			// Easy collections through tags
-			$this->container->addCompilerPass(new pass\collection_pass());
-
-			// Event listeners "phpBB style"
-			$this->container->addCompilerPass(new RegisterListenersPass('dispatcher', 'event.listener_listener', 'event.listener'));
-
-			// Event listeners "Symfony style"
-			$this->container->addCompilerPass(new RegisterListenersPass('dispatcher'));
-
-			if ($this->use_extensions)
-			{
-				$this->register_ext_compiler_pass();
-			}
-
-			$filesystem = new filesystem();
-			$loader     = new YamlFileLoader($this->container, new FileLocator($filesystem->realpath($this->get_config_path())));
-			$loader->load($this->container->getParameter('core.environment') . '/config.yml');
-
-			$this->inject_custom_parameters();
-
-			if ($this->compile_container)
-			{
-				$this->container->compile();
-
-				if ($this->use_cache)
+				if ($this->use_extensions)
 				{
-					$this->dump_container($config_cache);
+					$this->load_extensions();
+				}
+
+				// Inject the config
+				if ($this->config_php_file)
+				{
+					$this->container_extensions[] = new extension\config($this->config_php_file);
+				}
+
+				$this->container = $this->create_container($this->container_extensions);
+
+				// Easy collections through tags
+				$this->container->addCompilerPass(new pass\collection_pass());
+
+				// Event listeners "phpBB style"
+				$this->container->addCompilerPass(new RegisterListenersPass('dispatcher', 'event.listener_listener', 'event.listener'));
+
+				// Event listeners "Symfony style"
+				$this->container->addCompilerPass(new RegisterListenersPass('dispatcher'));
+
+				if ($this->use_extensions)
+				{
+					$this->register_ext_compiler_pass();
+				}
+
+				$filesystem = new filesystem();
+				$loader     = new YamlFileLoader($this->container, new FileLocator($filesystem->realpath($this->get_config_path())));
+				$loader->load($this->container->getParameter('core.environment') . '/config.yml');
+
+				$this->inject_custom_parameters();
+
+				if ($this->compile_container)
+				{
+					$this->container->compile();
+
+					if ($this->use_cache)
+					{
+						$this->dump_container($config_cache);
+					}
 				}
 			}
-		}
 
-		if ($this->compile_container && $this->config_php_file)
+			if ($this->compile_container && $this->config_php_file)
+			{
+				$this->container->set('config.php', $this->config_php_file);
+			}
+
+			return $this->container;
+		}
+		catch (\Exception $e)
 		{
-			$this->container->set('config.php', $this->config_php_file);
+			return $this
+				->without_extensions()
+				->without_cache()
+				->with_custom_parameters(array_merge($this->custom_parameters, [
+					'container_exception' => $e,
+				]))
+				->get_container()
+			;
 		}
-
-		return $this->container;
 	}
 
 	/**
@@ -451,13 +464,11 @@ class container_builder
 	 */
 	protected function inject_custom_parameters()
 	{
-		if ($this->custom_parameters !== null)
+		foreach ($this->custom_parameters as $key => $value)
 		{
-			foreach ($this->custom_parameters as $key => $value)
-			{
-				$this->container->setParameter($key, $value);
-			}
+			$this->container->setParameter($key, $value);
 		}
+
 	}
 
 	/**

--- a/phpBB/phpbb/di/container_builder.php
+++ b/phpBB/phpbb/di/container_builder.php
@@ -107,6 +107,9 @@ class container_builder
 	 */
 	private $container_extensions;
 
+	/** @var \Exception */
+	private $build_exception;
+
 	/**
 	 * Constructor
 	 *
@@ -126,7 +129,8 @@ class container_builder
 	 */
 	public function get_container()
 	{
-		try {
+		try
+		{
 			$container_filename = $this->get_container_filename();
 			$config_cache = new ConfigCache($container_filename, defined('DEBUG'));
 			if ($this->use_cache && $config_cache->isFresh())
@@ -197,8 +201,10 @@ class container_builder
 				throw $e;
 			}
 
-			try
+			if ($this->build_exception === null)
 			{
+				$this->build_exception = $e;
+
 				return $this
 					->without_extensions()
 					->without_cache()
@@ -207,10 +213,10 @@ class container_builder
 					]))
 					->get_container();
 			}
-			catch (\Exception $_)
+			else
 			{
 				// Rethrow the original exception if it's still failing
-				throw $e;
+				throw $this->build_exception;
 			}
 		}
 	}

--- a/phpBB/phpbb/di/container_builder.php
+++ b/phpBB/phpbb/di/container_builder.php
@@ -113,7 +113,7 @@ class container_builder
 	 * @param string $phpbb_root_path Path to the phpbb includes directory.
 	 * @param string $php_ext php file extension
 	 */
-	function __construct($phpbb_root_path, $php_ext)
+	public function __construct($phpbb_root_path, $php_ext)
 	{
 		$this->phpbb_root_path = $phpbb_root_path;
 		$this->php_ext = $php_ext;
@@ -191,14 +191,26 @@ class container_builder
 		}
 		catch (\Exception $e)
 		{
-			return $this
-				->without_extensions()
-				->without_cache()
-				->with_custom_parameters(array_merge($this->custom_parameters, [
-					'container_exception' => $e,
-				]))
-				->get_container()
-			;
+			// Don't try to recover if we are in the development environment
+			if ($this->get_environment() === 'development') {
+				throw $e;
+			}
+
+			try
+			{
+				return $this
+					->without_extensions()
+					->without_cache()
+					->with_custom_parameters(array_merge($this->custom_parameters, [
+						'container_exception' => $e,
+					]))
+					->get_container();
+			}
+			catch (\Exception $_)
+			{
+				// Rethrow the original exception if it's still failing
+				throw $e;
+			}
 		}
 	}
 

--- a/phpBB/phpbb/di/container_builder.php
+++ b/phpBB/phpbb/di/container_builder.php
@@ -192,7 +192,8 @@ class container_builder
 		catch (\Exception $e)
 		{
 			// Don't try to recover if we are in the development environment
-			if ($this->get_environment() === 'development') {
+			if ($this->get_environment() === 'development')
+			{
 				throw $e;
 			}
 


### PR DESCRIPTION
Automatically try to use a safe mode (no cached container, no extensions) when we fail to build the container and display the exception on every page in the ACP (do not display anything outside of the ACP).

PHPBB3-14306