### PR TITLE
[ticket/14366] Add core events to the function decode_message()

### DIFF
--- a/phpBB/includes/functions_content.php
+++ b/phpBB/includes/functions_content.php
@@ -392,7 +392,7 @@ function phpbb_clean_search_string($search_string)
 */
 function decode_message(&$message, $bbcode_uid = '')
 {
-	global $config;
+	global $config, $phpbb_dispatcher;
 
 	if ($bbcode_uid)
 	{
@@ -405,12 +405,38 @@ function decode_message(&$message, $bbcode_uid = '')
 		$replace = array("\n");
 	}
 
+	/**
+	* Use this event to modify the message before it is decoded
+	*
+	* @event core.decode_message_before
+	* @var string	message			The message content
+	* @var string	bbcode_uid		The message BBCode UID
+	* @var string	match			Match pattern to replace
+	* @var int		replace			Replacement for the matched text
+	* @since 3.1.8-RC1
+	*/
+	$vars = array('message', 'bbcode_uid', 'match', 'replace');
+	extract($phpbb_dispatcher->trigger_event('core.decode_message_before', compact($vars)));
+
 	$message = str_replace($match, $replace, $message);
 
 	$match = get_preg_expression('bbcode_htm');
 	$replace = array('\1', '\1', '\2', '\1', '', '');
 
 	$message = preg_replace($match, $replace, $message);
+
+	/**
+	* Use this event to modify the message after it is decoded
+	*
+	* @event core.decode_message_after
+	* @var string	message			The message content
+	* @var string	bbcode_uid		The message BBCode UID
+	* @var string	match			Match pattern to replace
+	* @var int		replace			Replacement for the matched text
+	* @since 3.1.8-RC1
+	*/
+	$vars = array('message', 'bbcode_uid', 'match', 'replace');
+	extract($phpbb_dispatcher->trigger_event('core.decode_message_after', compact($vars)));
 }
 
 /**

--- a/phpBB/includes/functions_content.php
+++ b/phpBB/includes/functions_content.php
@@ -409,14 +409,14 @@ function decode_message(&$message, $bbcode_uid = '')
 	* Use this event to modify the message before it is decoded
 	*
 	* @event core.decode_message_before
-	* @var string	message			The message content
+	* @var string	message_text	The message content
 	* @var string	bbcode_uid		The message BBCode UID
-	* @var string	match			Match pattern to replace
-	* @var int		replace			Replacement for the matched text
-	* @since 3.1.8-RC1
+	* @since 3.1.9-RC1
 	*/
-	$vars = array('message', 'bbcode_uid', 'match', 'replace');
+	$message_text = $message;
+	$vars = array('message_text', 'bbcode_uid');
 	extract($phpbb_dispatcher->trigger_event('core.decode_message_before', compact($vars)));
+	$message = $message_text;
 
 	$message = str_replace($match, $replace, $message);
 
@@ -429,14 +429,14 @@ function decode_message(&$message, $bbcode_uid = '')
 	* Use this event to modify the message after it is decoded
 	*
 	* @event core.decode_message_after
-	* @var string	message			The message content
+	* @var string	message_text	The message content
 	* @var string	bbcode_uid		The message BBCode UID
-	* @var string	match			Match pattern to replace
-	* @var int		replace			Replacement for the matched text
-	* @since 3.1.8-RC1
+	* @since 3.1.9-RC1
 	*/
-	$vars = array('message', 'bbcode_uid', 'match', 'replace');
+	$message_text = $message;
+	$vars = array('message_text', 'bbcode_uid');
 	extract($phpbb_dispatcher->trigger_event('core.decode_message_after', compact($vars)));
+	$message = $message_text;
 }
 
 /**


### PR DESCRIPTION
Add core event to the function decode_message() in
includes/functions_content.php to allow extensions performing additional
message handling before/after decoding.

<a href="https://tracker.phpbb.com/browse/PHPBB3-14366">PHPBB3-14366</a>.