### PR TITLE
[ticket/14372] Include functions_content.php into phpBB/bin/phpbbcli.php

### DIFF
--- a/phpBB/bin/phpbbcli.php
+++ b/phpBB/bin/phpbbcli.php
@@ -35,6 +35,7 @@ extract($phpbb_config_php_file->get_all());
 require($phpbb_root_path . 'includes/constants.' . $phpEx);
 require($phpbb_root_path . 'includes/functions.' . $phpEx);
 require($phpbb_root_path . 'includes/functions_admin.' . $phpEx);
+require($phpbb_root_path . 'includes/functions_content.' . $phpEx);
 require($phpbb_root_path . 'includes/utf/utf_tools.' . $phpEx);
 
 $phpbb_container_builder = new \phpbb\di\container_builder($phpbb_config_php_file, $phpbb_root_path, $phpEx);


### PR DESCRIPTION
functions_content.php is needed for the cases phpbbcli is used to run
cron tasks from extensions when the latter are using methods from it.

<a href="https://tracker.phpbb.com/browse/PHPBB3-14372">PHPBB3-14372</a>.