### PR TITLE
[ticket/14387] Allow extending avatars by extensions in ACP

### DIFF
--- a/phpBB/includes/acp/acp_groups.php
+++ b/phpBB/includes/acp/acp_groups.php
@@ -672,9 +672,8 @@ class acp_groups
 						$driver = $phpbb_avatar_manager->get_driver($current_driver);
 
 						$avatars_enabled = true;
-						$template_name = $phpbb_avatar_manager->get_driver_template_name($driver);
 						$template->set_filenames(array(
-							'avatar' => $template_name,
+							'avatar' => $driver->get_acp_template_name(),
 						));
 
 						if ($driver->prepare_form($request, $template, $user, $avatar_data, $avatar_error))

--- a/phpBB/includes/acp/acp_groups.php
+++ b/phpBB/includes/acp/acp_groups.php
@@ -672,9 +672,9 @@ class acp_groups
 						$driver = $phpbb_avatar_manager->get_driver($current_driver);
 
 						$avatars_enabled = true;
-						$config_name = $phpbb_avatar_manager->get_driver_config_name($driver);
+						$template_name = $phpbb_avatar_manager->get_driver_template_name($driver);
 						$template->set_filenames(array(
-							'avatar' => "acp_avatar_options_{$config_name}.html",
+							'avatar' => $template_name,
 						));
 
 						if ($driver->prepare_form($request, $template, $user, $avatar_data, $avatar_error))

--- a/phpBB/includes/acp/acp_users.php
+++ b/phpBB/includes/acp/acp_users.php
@@ -1878,9 +1878,8 @@ class acp_users
 						$driver = $phpbb_avatar_manager->get_driver($current_driver);
 
 						$avatars_enabled = true;
-						$template_name = $phpbb_avatar_manager->get_driver_template_name($driver);
 						$template->set_filenames(array(
-							'avatar' => $template_name,
+							'avatar' => $driver->get_acp_template_name(),
 						));
 
 						if ($driver->prepare_form($request, $template, $user, $avatar_data, $error))

--- a/phpBB/includes/acp/acp_users.php
+++ b/phpBB/includes/acp/acp_users.php
@@ -1878,9 +1878,9 @@ class acp_users
 						$driver = $phpbb_avatar_manager->get_driver($current_driver);
 
 						$avatars_enabled = true;
-						$config_name = $phpbb_avatar_manager->get_driver_config_name($driver);
+						$template_name = $phpbb_avatar_manager->get_driver_template_name($driver);
 						$template->set_filenames(array(
-							'avatar' => "acp_avatar_options_{$config_name}.html",
+							'avatar' => $template_name,
 						));
 
 						if ($driver->prepare_form($request, $template, $user, $avatar_data, $error))

--- a/phpBB/phpbb/avatar/driver/driver.php
+++ b/phpBB/phpbb/avatar/driver/driver.php
@@ -128,6 +128,14 @@ abstract class driver implements \phpbb\avatar\driver\driver_interface
 	}
 
 	/**
+	* {@inheritdoc}
+	*/
+	public function get_acp_template_name()
+	{
+		return 'acp_avatar_options_' . $this->get_config_name() . '.html';
+	}
+
+	/**
 	* Sets the name of the driver.
 	*
 	* @param string	$name Driver name

--- a/phpBB/phpbb/avatar/driver/driver.php
+++ b/phpBB/phpbb/avatar/driver/driver.php
@@ -120,6 +120,14 @@ abstract class driver implements \phpbb\avatar\driver\driver_interface
 	}
 
 	/**
+	* {@inheritdoc}
+	*/
+	public function get_config_name()
+	{
+		return preg_replace('#^phpbb\\\\avatar\\\\driver\\\\#', '', get_class($this));
+	}
+
+	/**
 	* Sets the name of the driver.
 	*
 	* @param string	$name Driver name

--- a/phpBB/phpbb/avatar/driver/driver_interface.php
+++ b/phpBB/phpbb/avatar/driver/driver_interface.php
@@ -117,4 +117,11 @@ interface driver_interface
 	* @return string Avatar driver's template name
 	*/
 	public function get_template_name();
+
+	/**
+	* Get the avatar driver's template name (ACP)
+	*
+	* @return string Avatar driver's template name
+	*/
+	public function get_acp_template_name();
 }

--- a/phpBB/phpbb/avatar/driver/driver_interface.php
+++ b/phpBB/phpbb/avatar/driver/driver_interface.php
@@ -26,6 +26,13 @@ interface driver_interface
 	public function get_name();
 
 	/**
+	* Returns the config name of the driver. To be used in accessing the CONFIG variables.
+	*
+	* @return string	Config name of driver.
+	*/
+	public function get_config_name();
+
+	/**
 	* Get the avatar url and dimensions
 	*
 	* @param array	$row User data or group data that has been cleaned with

--- a/phpBB/phpbb/avatar/manager.php
+++ b/phpBB/phpbb/avatar/manager.php
@@ -280,6 +280,18 @@ class manager
 	}
 
 	/**
+	* Get the template name of an avatar driver
+	*
+	* @param object $driver Avatar driver object
+	*
+	* @return string Avatar driver template name
+	*/
+	public function get_driver_template_name($driver)
+	{
+		return $driver->get_acp_template_name();
+	}
+
+	/**
 	* Replace "error" strings with their real, localized form
 	*
 	* @param \phpbb\user phpBB User object

--- a/phpBB/phpbb/avatar/manager.php
+++ b/phpBB/phpbb/avatar/manager.php
@@ -246,7 +246,7 @@ class manager
 	*/
 	public function is_enabled($driver)
 	{
-		$config_name = $this->get_driver_config_name($driver);
+		$config_name = $driver->get_config_name();
 
 		return $this->config["allow_avatar_{$config_name}"];
 	}
@@ -260,35 +260,11 @@ class manager
 	*/
 	public function get_avatar_settings($driver)
 	{
-		$config_name = $this->get_driver_config_name($driver);
+		$config_name = $driver->get_config_name();
 
 		return array(
 			'allow_avatar_' . $config_name	=> array('lang' => 'ALLOW_' . strtoupper(str_replace('\\', '_', $config_name)),		'validate' => 'bool',	'type' => 'radio:yes_no', 'explain' => false),
 		);
-	}
-
-	/**
-	* Get the config name of an avatar driver
-	*
-	* @param object $driver Avatar driver object
-	*
-	* @return string Avatar driver config name
-	*/
-	public function get_driver_config_name($driver)
-	{
-		return $driver->get_config_name();
-	}
-
-	/**
-	* Get the template name of an avatar driver
-	*
-	* @param object $driver Avatar driver object
-	*
-	* @return string Avatar driver template name
-	*/
-	public function get_driver_template_name($driver)
-	{
-		return $driver->get_acp_template_name();
 	}
 
 	/**

--- a/phpBB/phpbb/avatar/manager.php
+++ b/phpBB/phpbb/avatar/manager.php
@@ -276,7 +276,7 @@ class manager
 	*/
 	public function get_driver_config_name($driver)
 	{
-		return preg_replace('#^phpbb\\\\avatar\\\\driver\\\\#', '', get_class($driver));
+		return $driver->get_config_name();
 	}
 
 	/**

--- a/tests/avatar/manager_test.php
+++ b/tests/avatar/manager_test.php
@@ -64,10 +64,13 @@ class phpbb_avatar_manager_test extends \phpbb_database_test_case
 			->method('get_name')
 			->will($this->returnValue('avatar.driver.foobar'));
 		// barfoo driver can't be mocked with constructor arguments
-		$this->avatar_barfoo = $this->getMock('\phpbb\avatar\driver\barfoo', array('get_name'));
+		$this->avatar_barfoo = $this->getMock('\phpbb\avatar\driver\barfoo', array('get_name', 'get_config_name'));
 		$this->avatar_barfoo->expects($this->any())
 			->method('get_name')
 			->will($this->returnValue('avatar.driver.barfoo'));
+		$this->avatar_barfoo->expects($this->any())
+			->method('get_config_name')
+			->will($this->returnValue('barfoo'));
 		$avatar_drivers = array($this->avatar_foobar, $this->avatar_barfoo);
 
 		foreach ($this->avatar_drivers() as $driver)


### PR DESCRIPTION
Create a driver method to provide the driver config name, and use it
within the manager method. Default driver config name is the same as now.
But new drivers are able to override the config name with their own.

Ticket: https://tracker.phpbb.com/browse/PHPBB3-14387

PHPBB3-14387