### PR TITLE
[ticket/14286] Move create_thumbnail() into classes and split resize into own class

### DIFF
--- a/phpBB/config/default/container/services_attachment.yml
+++ b/phpBB/config/default/container/services_attachment.yml
@@ -23,14 +23,20 @@ services:
         arguments:
             - '@dbal.conn'
 
-    attachment.thumbnail:
-        class: phpbb\attachment\thumbnail
+    attachment.resize:
+        class: phpbb\attachment\resize
         scope: prototype
         arguments:
             - '@config'
             - '@filesystem'
             - '@php_ini'
             - '@upload_imagesize'
+
+    attachment.resync:
+        class: phpbb\attachment\resync
+        scope: prototype
+        arguments:
+            - '@dbal.conn'
 
     attachment.upload:
         class: phpbb\attachment\upload
@@ -46,5 +52,5 @@ services:
             - '@plupload'
             - '@storage.attachment'
             - '@filesystem.temp'
-            - '@attachment.thumbnail'
+            - '@attachment.resize'
             - '@user'

--- a/phpBB/config/default/container/services_attachment.yml
+++ b/phpBB/config/default/container/services_attachment.yml
@@ -9,6 +9,9 @@ services:
             - '@attachment.resync'
             - '@storage.attachment'
 
+    attachment.image_helper:
+        class: phpbb\attachment\image_helper
+
     attachment.manager:
         class: phpbb\attachment\manager
         shared: false
@@ -27,8 +30,8 @@ services:
         class: phpbb\attachment\resize
         scope: prototype
         arguments:
-            - '@config'
             - '@filesystem'
+            - '@attachment.image_helper'
             - '@php_ini'
             - '@upload_imagesize'
 

--- a/phpBB/config/default/container/services_attachment.yml
+++ b/phpBB/config/default/container/services_attachment.yml
@@ -28,7 +28,6 @@ services:
 
     attachment.resize:
         class: phpbb\attachment\resize
-        scope: prototype
         arguments:
             - '@filesystem'
             - '@attachment.image_helper'
@@ -40,6 +39,12 @@ services:
         scope: prototype
         arguments:
             - '@dbal.conn'
+
+    attachment.thumbnail:
+        class: phpbb\attachment\thumbnail
+        arguments:
+            - '@config'
+            - '@attachment.resize'
 
     attachment.upload:
         class: phpbb\attachment\upload

--- a/phpBB/config/default/container/services_attachment.yml
+++ b/phpBB/config/default/container/services_attachment.yml
@@ -23,6 +23,14 @@ services:
         arguments:
             - '@dbal.conn'
 
+    attachment.thumbnail:
+        class: phpbb\attachment\thumbnail
+        scope: prototype
+        arguments:
+            - @config
+            - @filesystem
+            - @upload_imagesize
+
     attachment.upload:
         class: phpbb\attachment\upload
         shared: false

--- a/phpBB/config/default/container/services_attachment.yml
+++ b/phpBB/config/default/container/services_attachment.yml
@@ -27,10 +27,10 @@ services:
         class: phpbb\attachment\thumbnail
         scope: prototype
         arguments:
-            - @config
-            - @filesystem
-            - @php_ini
-            - @upload_imagesize
+            - '@config'
+            - '@filesystem'
+            - '@php_ini'
+            - '@upload_imagesize'
 
     attachment.upload:
         class: phpbb\attachment\upload
@@ -46,4 +46,5 @@ services:
             - '@plupload'
             - '@storage.attachment'
             - '@filesystem.temp'
+            - '@attachment.thumbnail'
             - '@user'

--- a/phpBB/config/default/container/services_attachment.yml
+++ b/phpBB/config/default/container/services_attachment.yml
@@ -55,5 +55,5 @@ services:
             - '@plupload'
             - '@storage.attachment'
             - '@filesystem.temp'
-            - '@attachment.resize'
+            - '@attachment.thumbnail'
             - '@user'

--- a/phpBB/config/default/container/services_attachment.yml
+++ b/phpBB/config/default/container/services_attachment.yml
@@ -29,6 +29,7 @@ services:
         arguments:
             - @config
             - @filesystem
+            - @php_ini
             - @upload_imagesize
 
     attachment.upload:

--- a/phpBB/config/default/container/services_console.yml
+++ b/phpBB/config/default/container/services_console.yml
@@ -265,7 +265,7 @@ services:
             - '@user'
             - '@dbal.conn'
             - '@cache'
-            - '@attachment.resize'
+            - '@attachment.thumbnail'
             - '%core.root_path%'
             - '%core.php_ext%'
         tags:

--- a/phpBB/config/default/container/services_console.yml
+++ b/phpBB/config/default/container/services_console.yml
@@ -265,6 +265,7 @@ services:
             - '@user'
             - '@dbal.conn'
             - '@cache'
+            - '@attachment.resize'
             - '%core.root_path%'
             - '%core.php_ext%'
         tags:

--- a/phpBB/includes/acp/acp_attachments.php
+++ b/phpBB/includes/acp/acp_attachments.php
@@ -243,9 +243,9 @@ class acp_attachments
 					}
 				}
 
-				/** @var \phpbb\attachment\resize $attachment_resize */
-				$attachment_resize = $phpbb_container->get('attachment.resize');
-				$supported_types = $attachment_resize->get_supported_image_types();
+				/** @var \phpbb\attachment\image_helper $image_helper */
+				$image_helper = new \phpbb\attachment\image_helper();
+				$supported_types = $image_helper->get_supported_image_types();
 
 				// Check Thumbnail Support
 				if (!$this->new_config['img_imagick'] && (!isset($supported_types['format']) || !count($supported_types['format'])))

--- a/phpBB/includes/acp/acp_attachments.php
+++ b/phpBB/includes/acp/acp_attachments.php
@@ -113,12 +113,6 @@ class acp_attachments
 		switch ($mode)
 		{
 			case 'attach':
-
-				if (!function_exists('get_supported_image_types'))
-				{
-					include($phpbb_root_path . 'includes/functions_posting.' . $phpEx);
-				}
-
 				$sql = 'SELECT group_name, cat_id
 					FROM ' . EXTENSION_GROUPS_TABLE . '
 					WHERE cat_id > 0
@@ -249,7 +243,9 @@ class acp_attachments
 					}
 				}
 
-				$supported_types = get_supported_image_types();
+				/** @var \phpbb\attachment\thumbnail $attachment_thumbnail */
+				$attachment_thumbnail = $phpbb_container->get('attachment.thumbnail');
+				$supported_types = $attachment_thumbnail->get_supported_image_types();
 
 				// Check Thumbnail Support
 				if (!$this->new_config['img_imagick'] && (!isset($supported_types['format']) || !count($supported_types['format'])))

--- a/phpBB/includes/acp/acp_attachments.php
+++ b/phpBB/includes/acp/acp_attachments.php
@@ -243,9 +243,9 @@ class acp_attachments
 					}
 				}
 
-				/** @var \phpbb\attachment\thumbnail $attachment_thumbnail */
-				$attachment_thumbnail = $phpbb_container->get('attachment.thumbnail');
-				$supported_types = $attachment_thumbnail->get_supported_image_types();
+				/** @var \phpbb\attachment\resize $attachment_resize */
+				$attachment_resize = $phpbb_container->get('attachment.resize');
+				$supported_types = $attachment_resize->get_supported_image_types();
 
 				// Check Thumbnail Support
 				if (!$this->new_config['img_imagick'] && (!isset($supported_types['format']) || !count($supported_types['format'])))

--- a/phpBB/includes/functions_posting.php
+++ b/phpBB/includes/functions_posting.php
@@ -397,28 +397,19 @@ function posting_gen_topic_types($forum_id, $cur_topic_type = POST_NORMAL)
 //
 /**
 * Calculate the needed size for Thumbnail
+*
+* @deprecated 3.2.0-a3 (To be removed: 3.4.0)
 */
 function get_img_size_format($width, $height)
 {
 	global $config;
 
+	$image_helper = new \phpbb\attachment\image_helper();
+
 	// Maximum Width the Image can take
 	$max_width = ($config['img_max_thumb_width']) ? $config['img_max_thumb_width'] : 400;
 
-	if ($width > $height)
-	{
-		return array(
-			round($width * ($max_width / $width)),
-			round($height * ($max_width / $width))
-		);
-	}
-	else
-	{
-		return array(
-			round($width * ($max_width / $height)),
-			round($height * ($max_width / $height))
-		);
-	}
+	return $image_helper->get_img_size_format($width, $height, $max_width);
 }
 
 /**
@@ -430,10 +421,10 @@ function get_supported_image_types($type = false)
 {
 	global $phpbb_container;
 
-	/** @var \phpbb\attachment\resize $attachment_resize */
-	$attachment_resize = $phpbb_container->get('attachment.resize');
+	/** @var \phpbb\attachment\image_helper $attachment_resize */
+	$image_helper = $phpbb_container->get('attachment.image_helper');
 
-	return $attachment_resize->get_supported_image_types($type);
+	return $image_helper->get_supported_image_types($type);
 }
 
 /**

--- a/phpBB/includes/functions_posting.php
+++ b/phpBB/includes/functions_posting.php
@@ -419,10 +419,8 @@ function get_img_size_format($width, $height)
 */
 function get_supported_image_types($type = false)
 {
-	global $phpbb_container;
-
-	/** @var \phpbb\attachment\image_helper $attachment_resize */
-	$image_helper = $phpbb_container->get('attachment.image_helper');
+	/** @var \phpbb\attachment\image_helper $image_helper */
+	$image_helper = new \phpbb\attachment\image_helper();
 
 	return $image_helper->get_supported_image_types($type);
 }

--- a/phpBB/includes/functions_posting.php
+++ b/phpBB/includes/functions_posting.php
@@ -423,67 +423,17 @@ function get_img_size_format($width, $height)
 
 /**
 * Return supported image types
+*
+* @deprecated 3.2.0-a3 (To be removed: 3.4.0)
 */
 function get_supported_image_types($type = false)
 {
-	if (@extension_loaded('gd'))
-	{
-		$format = imagetypes();
-		$new_type = 0;
+	global $phpbb_container;
 
-		if ($type !== false)
-		{
-			// Type is one of the IMAGETYPE constants - it is fetched from getimagesize()
-			switch ($type)
-			{
-				// GIF
-				case IMAGETYPE_GIF:
-					$new_type = ($format & IMG_GIF) ? IMG_GIF : false;
-				break;
+	/** @var \phpbb\attachment\thumbnail $attachment_thumbnail */
+	$attachment_thumbnail = $phpbb_container->get('attachment.thumbnail');
 
-				// JPG, JPC, JP2
-				case IMAGETYPE_JPEG:
-				case IMAGETYPE_JPC:
-				case IMAGETYPE_JPEG2000:
-				case IMAGETYPE_JP2:
-				case IMAGETYPE_JPX:
-				case IMAGETYPE_JB2:
-					$new_type = ($format & IMG_JPG) ? IMG_JPG : false;
-				break;
-
-				// PNG
-				case IMAGETYPE_PNG:
-					$new_type = ($format & IMG_PNG) ? IMG_PNG : false;
-				break;
-
-				// WBMP
-				case IMAGETYPE_WBMP:
-					$new_type = ($format & IMG_WBMP) ? IMG_WBMP : false;
-				break;
-			}
-		}
-		else
-		{
-			$new_type = array();
-			$go_through_types = array(IMG_GIF, IMG_JPG, IMG_PNG, IMG_WBMP);
-
-			foreach ($go_through_types as $check_type)
-			{
-				if ($format & $check_type)
-				{
-					$new_type[] = $check_type;
-				}
-			}
-		}
-
-		return array(
-			'gd'		=> ($new_type) ? true : false,
-			'format'	=> $new_type,
-			'version'	=> (function_exists('imagecreatetruecolor')) ? 2 : 1
-		);
-	}
-
-	return array('gd' => false);
+	return $attachment_thumbnail->get_supported_image_types($type);
 }
 
 /**

--- a/phpBB/includes/functions_posting.php
+++ b/phpBB/includes/functions_posting.php
@@ -430,10 +430,10 @@ function get_supported_image_types($type = false)
 {
 	global $phpbb_container;
 
-	/** @var \phpbb\attachment\thumbnail $attachment_thumbnail */
-	$attachment_thumbnail = $phpbb_container->get('attachment.thumbnail');
+	/** @var \phpbb\attachment\resize $attachment_resize */
+	$attachment_resize = $phpbb_container->get('attachment.resize');
 
-	return $attachment_thumbnail->get_supported_image_types($type);
+	return $attachment_resize->get_supported_image_types($type);
 }
 
 /**
@@ -445,10 +445,10 @@ function create_thumbnail($source, $destination, $mimetype)
 {
 	global $phpbb_container;
 
-	/** @var \phpbb\attachment\thumbnail $attachment_thumbnail */
-	$attachment_thumbnail = $phpbb_container->get('attachment.thumbnail');
+	/** @var \phpbb\attachment\resize $attachment_resize */
+	$attachment_resize = $phpbb_container->get('attachment.resize');
 
-	return $attachment_thumbnail->create($source, $destination, $mimetype);
+	return $attachment_resize->create($source, $destination, $mimetype);
 }
 
 /**

--- a/phpBB/phpbb/attachment/image_helper.php
+++ b/phpBB/phpbb/attachment/image_helper.php
@@ -1,0 +1,126 @@
+<?php
+/**
+ *
+ * This file is part of the phpBB Forum Software package.
+ *
+ * @copyright (c) phpBB Limited <https://www.phpbb.com>
+ * @license GNU General Public License, version 2 (GPL-2.0)
+ *
+ * For full copyright and license information, please see
+ * the docs/CREDITS.txt file.
+ *
+ */
+
+namespace phpbb\attachment;
+
+use phpbb\config\config;
+use phpbb\filesystem\filesystem_interface;
+use bantu\IniGetWrapper\IniGetWrapper;
+use FastImageSize\FastImageSize;
+
+/**
+ * Attachment image helper class
+ */
+class image_helper
+{
+	/**
+	 * Get supported image types
+	 *
+	 * @param bool|int $type Image type constant
+	 * @return array An Array containing whether gd is enabled and supported
+	 *		image types
+	 */
+	public function get_supported_image_types($type = false)
+	{
+		if (@extension_loaded('gd'))
+		{
+			$format = imagetypes();
+			$new_type = 0;
+
+			if ($type !== false)
+			{
+				// Type is one of the IMAGETYPE constants - it is fetched from getimagesize()
+				switch ($type)
+				{
+					// GIF
+					case IMAGETYPE_GIF:
+						$new_type = ($format & IMG_GIF) ? IMG_GIF : false;
+					break;
+
+					// JPG, JPC, JP2
+					case IMAGETYPE_JPEG:
+					case IMAGETYPE_JPC:
+					case IMAGETYPE_JPEG2000:
+					case IMAGETYPE_JP2:
+					case IMAGETYPE_JPX:
+					case IMAGETYPE_JB2:
+						$new_type = ($format & IMG_JPG) ? IMG_JPG : false;
+					break;
+
+					// PNG
+					case IMAGETYPE_PNG:
+						$new_type = ($format & IMG_PNG) ? IMG_PNG : false;
+					break;
+
+					// WBMP
+					case IMAGETYPE_WBMP:
+						$new_type = ($format & IMG_WBMP) ? IMG_WBMP : false;
+					break;
+				}
+			}
+			else
+			{
+				$new_type = array();
+				$go_through_types = array(IMG_GIF, IMG_JPG, IMG_PNG, IMG_WBMP);
+
+				foreach ($go_through_types as $check_type)
+				{
+					if ($format & $check_type)
+					{
+						$new_type[] = $check_type;
+					}
+				}
+			}
+
+			return array(
+				'gd'		=> ($new_type) ? true : false,
+				'format'	=> $new_type,
+				'version'	=> (function_exists('imagecreatetruecolor')) ? 2 : 1
+			);
+		}
+
+		return array('gd' => false);
+	}
+
+	/**
+	 * Calculate the needed size for Thumbnail
+	 *
+	 * @param int $width Image width
+	 * @param int $height Image height
+	 * @param int $max_target_width Maximum image width. Defaults to 400px
+	 * @param int $max_target_height Maximum image height. Defaults to 400px
+	 *
+	 * @return array An array with target width and height
+	 */
+	public function get_img_size_format($width, $height, $max_target_width = 400, $max_target_height = 400)
+	{
+		$target_ratio = ($max_target_height != 0) ? $max_target_width / $max_target_height : 1;
+		$image_ratio = ($height != 0) ? $width / $height : 1;
+
+		// Check if size is limited by width or height
+		if ($image_ratio >= $target_ratio)
+		{
+			return array(
+				round($width * ($max_target_width / $width)),
+				round($height * ($max_target_width / $width))
+			);
+		}
+		else
+		{
+			return array(
+				round($width * ($max_target_height / $height)),
+				round($height * ($max_target_height / $height))
+			);
+		}
+	}
+}

--- a/phpBB/phpbb/attachment/image_helper.php
+++ b/phpBB/phpbb/attachment/image_helper.php
@@ -13,11 +13,6 @@
 
 namespace phpbb\attachment;
 
-use phpbb\config\config;
-use phpbb\filesystem\filesystem_interface;
-use bantu\IniGetWrapper\IniGetWrapper;
-use FastImageSize\FastImageSize;
-
 /**
  * Attachment image helper class
  */

--- a/phpBB/phpbb/attachment/resize.php
+++ b/phpBB/phpbb/attachment/resize.php
@@ -64,7 +64,7 @@ class resize
 	/** @var int Minimum target file size */
 	protected $target_min_size;
 
-	/** @var bool Flag whether thumbnail was created */
+	/** @var bool Flag whether image was resized */
 	private $resize_created = false;
 
 	/** @var string Imagemagick path */
@@ -91,6 +91,7 @@ class resize
 	 *
 	 * @param int $target_width
 	 * @param int $target_height
+	 *
 	 * @return resize Returns self for allowing chained calls
 	 */
 	public function set_target_size($target_width, $target_height)
@@ -105,6 +106,7 @@ class resize
 	 * Set target minimum file size in bytes
 	 *
 	 * @param int $min_size
+	 *
 	 * @return resize Returns self for allowing chained calls
 	 */
 	public function set_min_file_size($min_size)
@@ -118,6 +120,7 @@ class resize
 	 * Enable imagemagick support
 	 *
 	 * @param string $path Imagemagick path
+	 *
 	 * @return resize Returns self for allowing chained calls
 	 */
 	public function set_imagick_path($path)
@@ -134,7 +137,7 @@ class resize
 	 * @param string $destination Destination file path
 	 * @param string $mime_type File mime type
 	 *
-	 * @return bool True if thumbnail was created, false if not
+	 * @return bool True if image was resized, false if not
 	 */
 	public function create($source, $destination, $mime_type)
 	{
@@ -216,7 +219,7 @@ class resize
 			$this->target_height
 		);
 
-		// Do not create a thumbnail if the resulting width/height is bigger than the original one
+		// Do not resize image if the resulting width/height is bigger than the original one
 		if ($this->new_width >= $this->width && $this->new_height >= $this->height)
 		{
 			return false;
@@ -230,7 +233,6 @@ class resize
 	 */
 	protected function create_imagick()
 	{
-		// Only use imagemagick if defined and the passthru function not disabled
 		if ($this->imagick_path && function_exists('passthru'))
 		{
 			if (substr($this->imagick_path, -1) !== '/')
@@ -238,7 +240,7 @@ class resize
 				$this->imagick_path .= '/';
 			}
 
-			// Make sure we don't try to use bogus here
+			// Make sure we only use existing paths here
 			if (!is_dir($this->imagick_path))
 			{
 				return;
@@ -256,7 +258,7 @@ class resize
 	/**
 	 * Create resized image using GD
 	 *
-	 * @return bool True if thumbnail might have been created, false if not
+	 * @return bool True if image was resized, false if not
 	 */
 	protected function create_gd()
 	{
@@ -264,7 +266,7 @@ class resize
 
 		if ($type['gd'])
 		{
-			// If the type is not supported, we are not able to create a thumbnail
+			// If the type is not supported, we are not able to resize an image
 			if ($type['format'] === false)
 			{
 				return false;

--- a/phpBB/phpbb/attachment/resize.php
+++ b/phpBB/phpbb/attachment/resize.php
@@ -200,7 +200,7 @@ class resize
 
 		$dimension = $this->image_size->getImageSize($this->source, $mime_type);
 
-		if ($dimension === false || empty($dimension['width'] || empty($dimension['height'])))
+		if ($dimension === false || empty($dimension['width']) || empty($dimension['height']))
 		{
 			return false;
 		}

--- a/phpBB/phpbb/attachment/resize.php
+++ b/phpBB/phpbb/attachment/resize.php
@@ -322,12 +322,6 @@ class resize
 				imagecopyresampled($new_image, $image, 0, 0, 0, 0, $this->new_width, $this->new_height, $this->width, $this->height);
 			}
 
-			// If we are in safe mode create the destination file prior to using the gd functions to circumvent a PHP bug
-			if ($this->php_ini->getBool('safe_mode'))
-			{
-				$this->filesystem->touch($this->destination);
-			}
-
 			switch ($type['format'])
 			{
 				case IMG_GIF:

--- a/phpBB/phpbb/attachment/resize.php
+++ b/phpBB/phpbb/attachment/resize.php
@@ -19,7 +19,7 @@ use bantu\IniGetWrapper\IniGetWrapper;
 use FastImageSize\FastImageSize;
 
 /**
- * Attachment thumbnail class
+ * Attachment resize class
  */
 class resize
 {
@@ -57,10 +57,10 @@ class resize
 	protected $new_width;
 
 	/** @var bool Flag whether thumbnail was created */
-	private $thumbnail_created = false;
+	private $resize_created = false;
 
 	/**
-	 * Thumbnail constructor
+	 * Resize constructor
 	 *
 	 * @param config $config phpBB config
 	 * @param filesystem_interface $filesystem phpBB filesystem
@@ -76,7 +76,7 @@ class resize
 	}
 
 	/**
-	 * Create Thumbnail
+	 * Create resized image
 	 *
 	 * @param string $source Source file path
 	 * @param string $destination Destination file path
@@ -87,7 +87,7 @@ class resize
 	public function create($source, $destination, $mime_type)
 	{
 		$this->set_paths($source, $destination);
-		$this->thumbnail_created = false;
+		$this->resize_created = false;
 
 		if (!$this->set_size($mime_type))
 		{
@@ -96,7 +96,7 @@ class resize
 
 		$this->create_imagick();
 
-		if (!$this->thumbnail_created && !$this->create_gd())
+		if (!$this->resize_created && !$this->create_gd())
 		{
 			return false;
 		}
@@ -169,7 +169,7 @@ class resize
 	}
 
 	/**
-	 * Create thumbnail using imagemagick
+	 * Create resized image using imagemagick
 	 */
 	protected function create_imagick()
 	{
@@ -185,7 +185,7 @@ class resize
 
 			if (file_exists($this->destination))
 			{
-				$this->thumbnail_created = true;
+				$this->resize_created = true;
 			}
 		}
 	}
@@ -260,7 +260,7 @@ class resize
 	}
 
 	/**
-	 * Create thumbnail using GD
+	 * Create resized image using GD
 	 *
 	 * @return bool True if thumbnail might have been created, false if not
 	 */

--- a/phpBB/phpbb/attachment/resize.php
+++ b/phpBB/phpbb/attachment/resize.php
@@ -21,7 +21,7 @@ use FastImageSize\FastImageSize;
 /**
  * Attachment thumbnail class
  */
-class thumbnail
+class resize
 {
 	/** @var config phpBB config */
 	protected $config;

--- a/phpBB/phpbb/attachment/thumbnail.php
+++ b/phpBB/phpbb/attachment/thumbnail.php
@@ -31,6 +31,12 @@ class thumbnail
 	/** @var FastImageSize */
 	protected $image_size;
 
+	/** @var string Source file path */
+	protected $source;
+
+	/** @var string Destination file path */
+	protected $destination;
+
 	/** @var int Source image height */
 	protected $height;
 
@@ -45,6 +51,9 @@ class thumbnail
 
 	/** @var int Source image width */
 	protected $new_width;
+
+	/** @var bool Flag whether thumbnail was created */
+	private $thumbnail_created = false;
 
 	/**
 	 * Thumbnail constructor
@@ -71,134 +80,29 @@ class thumbnail
 	 */
 	function create($source, $destination, $mime_type)
 	{
-		if (!$this->set_size($source, $mime_type))
+		$this->set_paths($source, $destination);
+		$this->thumbnail_created = false;
+
+		if (!$this->set_size($mime_type))
 		{
 			return false;
 		}
 
-		$used_imagick = false;
+		$this->create_imagick();
 
-		// Only use imagemagick if defined and the passthru function not disabled
-		if ($this->config['img_imagick'] && function_exists('passthru'))
+		if (!$this->thumbnail_created && !$this->create_gd())
 		{
-			if (substr($this->config['img_imagick'], -1) !== '/')
-			{
-				$this->config['img_imagick'] .= '/';
-			}
-
-			@passthru(escapeshellcmd($this->config['img_imagick']) . 'convert' . ((defined('PHP_OS') && preg_match('#^win#i', PHP_OS)) ? '.exe' : '') . ' -quality 85 -geometry ' . $this->new_width . 'x' . $this->new_height . ' "' . str_replace('\\', '/', $source) . '" "' . str_replace('\\', '/', $destination) . '"');
-
-			if (file_exists($destination))
-			{
-				$used_imagick = true;
-			}
+			return false;
 		}
 
-		if (!$used_imagick)
-		{
-			$type = get_supported_image_types($this->type);
-
-			if ($type['gd'])
-			{
-				// If the type is not supported, we are not able to create a thumbnail
-				if ($type['format'] === false)
-				{
-					return false;
-				}
-
-				switch ($type['format'])
-				{
-					case IMG_GIF:
-						$image = @imagecreatefromgif($source);
-						break;
-
-					case IMG_JPG:
-						@ini_set('gd.jpeg_ignore_warning', 1);
-						$image = @imagecreatefromjpeg($source);
-						break;
-
-					case IMG_PNG:
-						$image = @imagecreatefrompng($source);
-						break;
-
-					case IMG_WBMP:
-						$image = @imagecreatefromwbmp($source);
-						break;
-				}
-
-				if (empty($image))
-				{
-					return false;
-				}
-
-				if ($type['version'] == 1)
-				{
-					$new_image = imagecreate($this->new_width, $this->new_height);
-
-					if ($new_image === false)
-					{
-						return false;
-					}
-
-					imagecopyresized($new_image, $image, 0, 0, 0, 0, $this->new_width, $this->new_height, $this->width, $this->height);
-				}
-				else
-				{
-					$new_image = imagecreatetruecolor($this->new_width, $this->new_height);
-
-					if ($new_image === false)
-					{
-						return false;
-					}
-
-					// Preserve alpha transparency (png for example)
-					@imagealphablending($new_image, false);
-					@imagesavealpha($new_image, true);
-
-					imagecopyresampled($new_image, $image, 0, 0, 0, 0, $this->new_width, $this->new_height, $this->width, $this->height);
-				}
-
-				// If we are in safe mode create the destination file prior to using the gd functions to circumvent a PHP bug
-				if (@ini_get('safe_mode') || @strtolower(ini_get('safe_mode')) == 'on')
-				{
-					@touch($destination);
-				}
-
-				switch ($type['format'])
-				{
-					case IMG_GIF:
-						imagegif($new_image, $destination);
-						break;
-
-					case IMG_JPG:
-						imagejpeg($new_image, $destination, 90);
-						break;
-
-					case IMG_PNG:
-						imagepng($new_image, $destination);
-						break;
-
-					case IMG_WBMP:
-						imagewbmp($new_image, $destination);
-						break;
-				}
-
-				imagedestroy($new_image);
-			}
-			else
-			{
-				return false;
-			}
-		}
-
-		if (!file_exists($destination))
+		if (!file_exists($this->destination))
 		{
 			return false;
 		}
 
 		try
 		{
-			$this->filesystem->phpbb_chmod($destination, CHMOD_READ | CHMOD_WRITE);
+			$this->filesystem->phpbb_chmod($this->destination, CHMOD_READ | CHMOD_WRITE);
 		}
 		catch (\phpbb\filesystem\exception\filesystem_exception $e)
 		{
@@ -209,23 +113,34 @@ class thumbnail
 	}
 
 	/**
-	 * Set image size info
+	 * Set file paths
 	 *
 	 * @param string $source Source file path
+	 * @param string $destination Destination file path
+	 */
+	protected function set_paths($source, $destination)
+	{
+		$this->source = $source;
+		$this->destination = $destination;
+	}
+
+	/**
+	 * Set image size info
+	 *
 	 * @param string $mime_type Image mime type
 	 *
 	 * @return bool True if valid size could be set, false if not
 	 */
-	protected function set_size($source, $mime_type)
+	protected function set_size($mime_type)
 	{
-		$img_filesize = (file_exists($source)) ? @filesize($source) : false;
+		$img_filesize = (file_exists($this->source)) ? @filesize($this->source) : false;
 
 		if (!$img_filesize || $img_filesize <= (int) $this->config['img_min_thumb_filesize'])
 		{
 			return false;
 		}
 
-		$dimension = $this->image_size->getImageSize($source, $mime_type);
+		$dimension = $this->image_size->getImageSize($this->source, $mime_type);
 
 		if ($dimension === false)
 		{
@@ -243,6 +158,132 @@ class thumbnail
 
 		// Do not create a thumbnail if the resulting width/height is bigger than the original one
 		if ($this->new_width >= $this->width && $this->new_height >= $this->height)
+		{
+			return false;
+		}
+
+		return true;
+	}
+
+	/**
+	 * Create thumbnail using imagemagick
+	 */
+	protected function create_imagick()
+	{
+		// Only use imagemagick if defined and the passthru function not disabled
+		if ($this->config['img_imagick'] && function_exists('passthru'))
+		{
+			if (substr($this->config['img_imagick'], -1) !== '/')
+			{
+				$this->config['img_imagick'] .= '/';
+			}
+
+			@passthru(escapeshellcmd($this->config['img_imagick']) . 'convert' . ((defined('PHP_OS') && preg_match('#^win#i', PHP_OS)) ? '.exe' : '') . ' -quality 85 -geometry ' . $this->new_width . 'x' . $this->new_height . ' "' . str_replace('\\', '/', $this->source) . '" "' . str_replace('\\', '/', $this->destination) . '"');
+
+			if (file_exists($this->destination))
+			{
+				$this->thumbnail_created = true;
+			}
+		}
+	}
+
+	/**
+	 * Create thumbnail using GD
+	 *
+	 * @return bool True if thumbnail might have been created, false if not
+	 */
+	protected function create_gd()
+	{
+		$type = get_supported_image_types($this->type);
+
+		if ($type['gd'])
+		{
+			// If the type is not supported, we are not able to create a thumbnail
+			if ($type['format'] === false)
+			{
+				return false;
+			}
+
+			switch ($type['format'])
+			{
+				case IMG_GIF:
+					$image = @imagecreatefromgif($this->source);
+				break;
+
+				case IMG_JPG:
+					@ini_set('gd.jpeg_ignore_warning', 1);
+					$image = @imagecreatefromjpeg($this->source);
+				break;
+
+				case IMG_PNG:
+					$image = @imagecreatefrompng($this->source);
+				break;
+
+				case IMG_WBMP:
+					$image = @imagecreatefromwbmp($this->source);
+				break;
+			}
+
+			if (empty($image))
+			{
+				return false;
+			}
+
+			if ($type['version'] == 1)
+			{
+				$new_image = imagecreate($this->new_width, $this->new_height);
+
+				if ($new_image === false)
+				{
+					return false;
+				}
+
+				imagecopyresized($new_image, $image, 0, 0, 0, 0, $this->new_width, $this->new_height, $this->width, $this->height);
+			}
+			else
+			{
+				$new_image = imagecreatetruecolor($this->new_width, $this->new_height);
+
+				if ($new_image === false)
+				{
+					return false;
+				}
+
+				// Preserve alpha transparency (png for example)
+				@imagealphablending($new_image, false);
+				@imagesavealpha($new_image, true);
+
+				imagecopyresampled($new_image, $image, 0, 0, 0, 0, $this->new_width, $this->new_height, $this->width, $this->height);
+			}
+
+			// If we are in safe mode create the destination file prior to using the gd functions to circumvent a PHP bug
+			if (@ini_get('safe_mode') || @strtolower(ini_get('safe_mode')) == 'on')
+			{
+				@touch($this->destination);
+			}
+
+			switch ($type['format'])
+			{
+				case IMG_GIF:
+					imagegif($new_image, $this->destination);
+				break;
+
+				case IMG_JPG:
+					imagejpeg($new_image, $this->destination, 90);
+				break;
+
+				case IMG_PNG:
+					imagepng($new_image, $this->destination);
+				break;
+
+				case IMG_WBMP:
+					imagewbmp($new_image, $this->destination);
+				break;
+			}
+
+			imagedestroy($new_image);
+		}
+		else
 		{
 			return false;
 		}

--- a/phpBB/phpbb/attachment/thumbnail.php
+++ b/phpBB/phpbb/attachment/thumbnail.php
@@ -84,7 +84,7 @@ class thumbnail
 	 *
 	 * @return bool True if thumbnail was created, false if not
 	 */
-	function create($source, $destination, $mime_type)
+	public function create($source, $destination, $mime_type)
 	{
 		$this->set_paths($source, $destination);
 		$this->thumbnail_created = false;
@@ -197,6 +197,11 @@ class thumbnail
 	 */
 	protected function create_gd()
 	{
+		if ($this->thumbnail_created)
+		{
+			return true;
+		}
+
 		$type = get_supported_image_types($this->type);
 
 		if ($type['gd'])

--- a/phpBB/phpbb/attachment/thumbnail.php
+++ b/phpBB/phpbb/attachment/thumbnail.php
@@ -191,6 +191,75 @@ class thumbnail
 	}
 
 	/**
+	 * Get supported image types
+	 *
+	 * @param bool|int $type Image type constant
+	 * @return array An Array containing whether gd is enabled and supported
+	 *		image types
+	 */
+	public function get_supported_image_types($type = false)
+	{
+		if (@extension_loaded('gd'))
+		{
+			$format = imagetypes();
+			$new_type = 0;
+
+			if ($type !== false)
+			{
+				// Type is one of the IMAGETYPE constants - it is fetched from getimagesize()
+				switch ($type)
+				{
+					// GIF
+					case IMAGETYPE_GIF:
+						$new_type = ($format & IMG_GIF) ? IMG_GIF : false;
+					break;
+
+					// JPG, JPC, JP2
+					case IMAGETYPE_JPEG:
+					case IMAGETYPE_JPC:
+					case IMAGETYPE_JPEG2000:
+					case IMAGETYPE_JP2:
+					case IMAGETYPE_JPX:
+					case IMAGETYPE_JB2:
+						$new_type = ($format & IMG_JPG) ? IMG_JPG : false;
+					break;
+
+					// PNG
+					case IMAGETYPE_PNG:
+						$new_type = ($format & IMG_PNG) ? IMG_PNG : false;
+					break;
+
+					// WBMP
+					case IMAGETYPE_WBMP:
+						$new_type = ($format & IMG_WBMP) ? IMG_WBMP : false;
+					break;
+				}
+			}
+			else
+			{
+				$new_type = array();
+				$go_through_types = array(IMG_GIF, IMG_JPG, IMG_PNG, IMG_WBMP);
+
+				foreach ($go_through_types as $check_type)
+				{
+					if ($format & $check_type)
+					{
+						$new_type[] = $check_type;
+					}
+				}
+			}
+
+			return array(
+				'gd'		=> ($new_type) ? true : false,
+				'format'	=> $new_type,
+				'version'	=> (function_exists('imagecreatetruecolor')) ? 2 : 1
+			);
+		}
+
+		return array('gd' => false);
+	}
+
+	/**
 	 * Create thumbnail using GD
 	 *
 	 * @return bool True if thumbnail might have been created, false if not
@@ -202,7 +271,7 @@ class thumbnail
 			return true;
 		}
 
-		$type = get_supported_image_types($this->type);
+		$type = $this->get_supported_image_types($this->type);
 
 		if ($type['gd'])
 		{

--- a/phpBB/phpbb/attachment/thumbnail.php
+++ b/phpBB/phpbb/attachment/thumbnail.php
@@ -148,17 +148,14 @@ class thumbnail
 
 		$dimension = $this->image_size->getImageSize($this->source, $mime_type);
 
-		if ($dimension === false)
+		if ($dimension === false || empty($dimension['width'] || empty($dimension['height'])))
 		{
 			return false;
 		}
 
-		list($this->width, $this->height, $this->type, ) = $dimension;
-
-		if (empty($this->width) || empty($this->height))
-		{
-			return false;
-		}
+		$this->width = $dimension['width'];
+		$this->height = $dimension['height'];
+		$this->type = $dimension['type'];
 
 		list($this->new_width, $this->new_height) = get_img_size_format($this->width, $this->height);
 

--- a/phpBB/phpbb/attachment/thumbnail.php
+++ b/phpBB/phpbb/attachment/thumbnail.php
@@ -1,0 +1,220 @@
+<?php
+/**
+ *
+ * This file is part of the phpBB Forum Software package.
+ *
+ * @copyright (c) phpBB Limited <https://www.phpbb.com>
+ * @license GNU General Public License, version 2 (GPL-2.0)
+ *
+ * For full copyright and license information, please see
+ * the docs/CREDITS.txt file.
+ *
+ */
+
+namespace phpbb\attachment;
+
+use phpbb\config\config;
+use phpbb\filesystem\filesystem;
+use FastImageSize\FastImageSize;
+
+/**
+ * Attachment thumbnail class
+ */
+class thumbnail
+{
+	/** @var config phpBB config */
+	protected $config;
+
+	/** @var filesystem phpBB filesystem */
+	protected $filesystem;
+
+	/** @var FastImageSize */
+	protected $image_size;
+
+	/**
+	 * Thumbnail constructor
+	 *
+	 * @param config $config phpBB config
+	 * @param filesystem $filesystem phpBB filesystem
+	 * @param FastImageSize $image_size FastImageSize library
+	 */
+	public function __construct(config $config, filesystem $filesystem, FastImageSize $image_size)
+	{
+		$this->config = $config;
+		$this->filesystem = $filesystem;
+		$this->imagesize = $image_size;
+	}
+
+	/**
+	 * Create Thumbnail
+	 *
+	 * @param string $source Source file path
+	 * @param string $destination Destination file path
+	 * @param string $mime_type File mime type
+	 *
+	 * @return bool True if thumbnail was created, false if not
+	 */
+	function create($source, $destination, $mime_type)
+	{
+		$min_filesize = (int) $this->config['img_min_thumb_filesize'];
+		$img_filesize = (file_exists($source)) ? @filesize($source) : false;
+
+		if (!$img_filesize || $img_filesize <= $min_filesize)
+		{
+			return false;
+		}
+
+		$dimension = $this->image_size->getImageSize($source, $mime_type);
+
+		if ($dimension === false)
+		{
+			return false;
+		}
+
+		list($width, $height, $type, ) = $dimension;
+
+		if (empty($width) || empty($height))
+		{
+			return false;
+		}
+
+		list($new_width, $new_height) = get_img_size_format($width, $height);
+
+		// Do not create a thumbnail if the resulting width/height is bigger than the original one
+		if ($new_width >= $width && $new_height >= $height)
+		{
+			return false;
+		}
+
+		$used_imagick = false;
+
+		// Only use imagemagick if defined and the passthru function not disabled
+		if ($this->config['img_imagick'] && function_exists('passthru'))
+		{
+			if (substr($this->config['img_imagick'], -1) !== '/')
+			{
+				$this->config['img_imagick'] .= '/';
+			}
+
+			@passthru(escapeshellcmd($this->config['img_imagick']) . 'convert' . ((defined('PHP_OS') && preg_match('#^win#i', PHP_OS)) ? '.exe' : '') . ' -quality 85 -geometry ' . $new_width . 'x' . $new_height . ' "' . str_replace('\\', '/', $source) . '" "' . str_replace('\\', '/', $destination) . '"');
+
+			if (file_exists($destination))
+			{
+				$used_imagick = true;
+			}
+		}
+
+		if (!$used_imagick)
+		{
+			$type = get_supported_image_types($type);
+
+			if ($type['gd'])
+			{
+				// If the type is not supported, we are not able to create a thumbnail
+				if ($type['format'] === false)
+				{
+					return false;
+				}
+
+				switch ($type['format'])
+				{
+					case IMG_GIF:
+						$image = @imagecreatefromgif($source);
+						break;
+
+					case IMG_JPG:
+						@ini_set('gd.jpeg_ignore_warning', 1);
+						$image = @imagecreatefromjpeg($source);
+						break;
+
+					case IMG_PNG:
+						$image = @imagecreatefrompng($source);
+						break;
+
+					case IMG_WBMP:
+						$image = @imagecreatefromwbmp($source);
+						break;
+				}
+
+				if (empty($image))
+				{
+					return false;
+				}
+
+				if ($type['version'] == 1)
+				{
+					$new_image = imagecreate($new_width, $new_height);
+
+					if ($new_image === false)
+					{
+						return false;
+					}
+
+					imagecopyresized($new_image, $image, 0, 0, 0, 0, $new_width, $new_height, $width, $height);
+				}
+				else
+				{
+					$new_image = imagecreatetruecolor($new_width, $new_height);
+
+					if ($new_image === false)
+					{
+						return false;
+					}
+
+					// Preserve alpha transparency (png for example)
+					@imagealphablending($new_image, false);
+					@imagesavealpha($new_image, true);
+
+					imagecopyresampled($new_image, $image, 0, 0, 0, 0, $new_width, $new_height, $width, $height);
+				}
+
+				// If we are in safe mode create the destination file prior to using the gd functions to circumvent a PHP bug
+				if (@ini_get('safe_mode') || @strtolower(ini_get('safe_mode')) == 'on')
+				{
+					@touch($destination);
+				}
+
+				switch ($type['format'])
+				{
+					case IMG_GIF:
+						imagegif($new_image, $destination);
+						break;
+
+					case IMG_JPG:
+						imagejpeg($new_image, $destination, 90);
+						break;
+
+					case IMG_PNG:
+						imagepng($new_image, $destination);
+						break;
+
+					case IMG_WBMP:
+						imagewbmp($new_image, $destination);
+						break;
+				}
+
+				imagedestroy($new_image);
+			}
+			else
+			{
+				return false;
+			}
+		}
+
+		if (!file_exists($destination))
+		{
+			return false;
+		}
+
+		try
+		{
+			$this->filesystem->phpbb_chmod($destination, CHMOD_READ | CHMOD_WRITE);
+		}
+		catch (\phpbb\filesystem\exception\filesystem_exception $e)
+		{
+			// Do nothing
+		}
+
+		return true;
+	}
+}

--- a/phpBB/phpbb/attachment/thumbnail.php
+++ b/phpBB/phpbb/attachment/thumbnail.php
@@ -14,7 +14,8 @@
 namespace phpbb\attachment;
 
 use phpbb\config\config;
-use phpbb\filesystem\filesystem;
+use phpbb\filesystem\filesystem_interface;
+use bantu\IniGetWrapper\IniGetWrapper;
 use FastImageSize\FastImageSize;
 
 /**
@@ -25,8 +26,11 @@ class thumbnail
 	/** @var config phpBB config */
 	protected $config;
 
-	/** @var filesystem phpBB filesystem */
+	/** @var filesystem_interface phpBB filesystem */
 	protected $filesystem;
+
+	/** @var IniGetWrapper */
+	protected $php_ini;
 
 	/** @var FastImageSize */
 	protected $image_size;
@@ -59,13 +63,15 @@ class thumbnail
 	 * Thumbnail constructor
 	 *
 	 * @param config $config phpBB config
-	 * @param filesystem $filesystem phpBB filesystem
+	 * @param filesystem_interface $filesystem phpBB filesystem
+	 * @param IniGetWrapper $php_ini ini_get() wrapper
 	 * @param FastImageSize $image_size FastImageSize library
 	 */
-	public function __construct(config $config, filesystem $filesystem, FastImageSize $image_size)
+	public function __construct(config $config, filesystem_interface $filesystem, IniGetWrapper $php_ini, FastImageSize $image_size)
 	{
 		$this->config = $config;
 		$this->filesystem = $filesystem;
+		$this->php_ini = $php_ini;
 		$this->imagesize = $image_size;
 	}
 
@@ -257,9 +263,9 @@ class thumbnail
 			}
 
 			// If we are in safe mode create the destination file prior to using the gd functions to circumvent a PHP bug
-			if (@ini_get('safe_mode') || @strtolower(ini_get('safe_mode')) == 'on')
+			if ($this->php_ini->getBool('safe_mode'))
 			{
-				@touch($this->destination);
+				$this->filesystem->touch($this->destination);
 			}
 
 			switch ($type['format'])

--- a/phpBB/phpbb/attachment/thumbnail.php
+++ b/phpBB/phpbb/attachment/thumbnail.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ *
+ * This file is part of the phpBB Forum Software package.
+ *
+ * @copyright (c) phpBB Limited <https://www.phpbb.com>
+ * @license GNU General Public License, version 2 (GPL-2.0)
+ *
+ * For full copyright and license information, please see
+ * the docs/CREDITS.txt file.
+ *
+ */
+
+namespace phpbb\attachment;
+
+use phpbb\config\config;
+use phpbb\filesystem\filesystem_interface;
+use bantu\IniGetWrapper\IniGetWrapper;
+use FastImageSize\FastImageSize;
+
+/**
+ * Attachment thumbnail class
+ */
+class thumbnail
+{
+	/** @var config phpBB config */
+	protected $config;
+
+	/** @var resize Resize class */
+	protected $resize;
+
+	/**
+	 * Thumbnail constructor
+	 *
+	 * @param config $config phpBB config
+	 */
+	public function __construct(config $config, resize $resize)
+	{
+		$this->config = $config;
+		$this->resize = $resize;
+	}
+
+	/**
+	 * Create resized image
+	 *
+	 * @param string $source Source file path
+	 * @param string $destination Destination file path
+	 * @param string $mime_type File mime type
+	 *
+	 * @return bool True if thumbnail was created, false if not
+	 */
+	public function create($source, $destination, $mime_type)
+	{
+		$this->resize
+			->set_min_file_size($this->config['img_min_thumb_filesize'])
+			->set_target_size($this->config['img_max_thumb_width'], $this->config['img_max_thumb_width']);
+
+		if ($this->config['img_imagick'])
+		{
+			$this->resize->set_imagick_path($this->config['img_imagick']);
+		}
+
+		return $this->resize->create($source, $destination, $mime_type);
+	}
+}

--- a/phpBB/phpbb/attachment/thumbnail.php
+++ b/phpBB/phpbb/attachment/thumbnail.php
@@ -72,7 +72,7 @@ class thumbnail
 		$this->config = $config;
 		$this->filesystem = $filesystem;
 		$this->php_ini = $php_ini;
-		$this->imagesize = $image_size;
+		$this->image_size = $image_size;
 	}
 
 	/**

--- a/phpBB/phpbb/attachment/thumbnail.php
+++ b/phpBB/phpbb/attachment/thumbnail.php
@@ -56,10 +56,9 @@ class thumbnail
 	 */
 	function create($source, $destination, $mime_type)
 	{
-		$min_filesize = (int) $this->config['img_min_thumb_filesize'];
 		$img_filesize = (file_exists($source)) ? @filesize($source) : false;
 
-		if (!$img_filesize || $img_filesize <= $min_filesize)
+		if (!$img_filesize || $img_filesize <= (int) $this->config['img_min_thumb_filesize'])
 		{
 			return false;
 		}

--- a/phpBB/phpbb/attachment/thumbnail.php
+++ b/phpBB/phpbb/attachment/thumbnail.php
@@ -266,11 +266,6 @@ class thumbnail
 	 */
 	protected function create_gd()
 	{
-		if ($this->thumbnail_created)
-		{
-			return true;
-		}
-
 		$type = $this->get_supported_image_types($this->type);
 
 		if ($type['gd'])

--- a/phpBB/phpbb/attachment/thumbnail.php
+++ b/phpBB/phpbb/attachment/thumbnail.php
@@ -14,9 +14,6 @@
 namespace phpbb\attachment;
 
 use phpbb\config\config;
-use phpbb\filesystem\filesystem_interface;
-use bantu\IniGetWrapper\IniGetWrapper;
-use FastImageSize\FastImageSize;
 
 /**
  * Attachment thumbnail class

--- a/phpBB/phpbb/attachment/thumbnail.php
+++ b/phpBB/phpbb/attachment/thumbnail.php
@@ -30,6 +30,7 @@ class thumbnail
 	 * Thumbnail constructor
 	 *
 	 * @param config $config phpBB config
+	 * @param resize $resize Resize class
 	 */
 	public function __construct(config $config, resize $resize)
 	{

--- a/phpBB/phpbb/attachment/thumbnail.php
+++ b/phpBB/phpbb/attachment/thumbnail.php
@@ -39,7 +39,7 @@ class thumbnail
 	}
 
 	/**
-	 * Create resized image
+	 * Create thumbnail for image
 	 *
 	 * @param string $source Source file path
 	 * @param string $destination Destination file path

--- a/phpBB/phpbb/attachment/upload.php
+++ b/phpBB/phpbb/attachment/upload.php
@@ -59,8 +59,8 @@ class upload
 	/** @var temp */
 	protected $temp;
 
-	/** @var resize Resize class */
-	protected $resize;
+	/** @var thumbnail Resize class */
+	protected $thumbnail;
 
 	/** @var user */
 	protected $user;
@@ -89,10 +89,10 @@ class upload
 	 * @param plupload $plupload
 	 * @param storage $storage
 	 * @param temp $temp
-	 * @param resize $resize
+	 * @param thumbnail $thumbnail
 	 * @param user $user
 	 */
-	public function __construct(auth $auth, service $cache, config $config, \phpbb\files\upload $files_upload, language $language, guesser $mimetype_guesser, dispatcher $phpbb_dispatcher, plupload $plupload, storage $storage, temp $temp, resize $resize, user $user)
+	public function __construct(auth $auth, service $cache, config $config, \phpbb\files\upload $files_upload, language $language, guesser $mimetype_guesser, dispatcher $phpbb_dispatcher, plupload $plupload, storage $storage, temp $temp, thumbnail $thumbnail, user $user)
 	{
 		$this->auth = $auth;
 		$this->cache = $cache;
@@ -104,7 +104,7 @@ class upload
 		$this->plupload = $plupload;
 		$this->storage = $storage;
 		$this->temp = $temp;
-		$this->resize = $resize;
+		$this->thumbnail = $thumbnail;
 		$this->user = $user;
 	}
 
@@ -249,7 +249,7 @@ class upload
 			$destination_name = 'thumb_' . $this->file->get('realname');
 			$destination = $this->temp->get_dir() . '/' . $destination_name;
 
-			if ($this->resize->create($source, $destination, $this->file->get('mimetype')))
+			if ($this->thumbnail->create($source, $destination, $this->file->get('mimetype')))
 			{
 				// Move the thumbnail from temp folder to the storage
 				$fp = fopen($destination, 'rb');

--- a/phpBB/phpbb/attachment/upload.php
+++ b/phpBB/phpbb/attachment/upload.php
@@ -59,7 +59,7 @@ class upload
 	/** @var temp */
 	protected $temp;
 
-	/** @var thumbnail Resize class */
+	/** @var thumbnail Thumbnail class */
 	protected $thumbnail;
 
 	/** @var user */

--- a/phpBB/phpbb/attachment/upload.php
+++ b/phpBB/phpbb/attachment/upload.php
@@ -59,8 +59,8 @@ class upload
 	/** @var temp */
 	protected $temp;
 
-	/** @var thumbnail Thumbnail class */
-	protected $thumbnail;
+	/** @var resize Resize class */
+	protected $resize;
 
 	/** @var user */
 	protected $user;
@@ -89,10 +89,10 @@ class upload
 	 * @param plupload $plupload
 	 * @param storage $storage
 	 * @param temp $temp
-	 * @param $thumbnail $thumbnail
+	 * @param resize $resize
 	 * @param user $user
 	 */
-	public function __construct(auth $auth, service $cache, config $config, \phpbb\files\upload $files_upload, language $language, guesser $mimetype_guesser, dispatcher $phpbb_dispatcher, plupload $plupload, storage $storage, temp $temp, thumbnail $thumbnail, user $user)
+	public function __construct(auth $auth, service $cache, config $config, \phpbb\files\upload $files_upload, language $language, guesser $mimetype_guesser, dispatcher $phpbb_dispatcher, plupload $plupload, storage $storage, temp $temp, resize $resize, user $user)
 	{
 		$this->auth = $auth;
 		$this->cache = $cache;
@@ -104,7 +104,7 @@ class upload
 		$this->plupload = $plupload;
 		$this->storage = $storage;
 		$this->temp = $temp;
-		$this->thumbnail = $thumbnail;
+		$this->resize = $resize;
 		$this->user = $user;
 	}
 
@@ -249,7 +249,7 @@ class upload
 			$destination_name = 'thumb_' . $this->file->get('realname');
 			$destination = $this->temp->get_dir() . '/' . $destination_name;
 
-			if ($this->thumbnail->create($source, $destination, $this->file->get('mimetype')))
+			if ($this->resize->create($source, $destination, $this->file->get('mimetype')))
 			{
 				// Move the thumbnail from temp folder to the storage
 				$fp = fopen($destination, 'rb');

--- a/phpBB/phpbb/attachment/upload.php
+++ b/phpBB/phpbb/attachment/upload.php
@@ -59,6 +59,9 @@ class upload
 	/** @var temp */
 	protected $temp;
 
+	/** @var thumbnail Thumbnail class */
+	protected $thumbnail;
+
 	/** @var user */
 	protected $user;
 
@@ -84,10 +87,12 @@ class upload
 	 * @param guesser $mimetype_guesser
 	 * @param dispatcher $phpbb_dispatcher
 	 * @param plupload $plupload
+	 * @param storage $storage
 	 * @param temp $temp
+	 * @param $thumbnail $thumbnail
 	 * @param user $user
 	 */
-	public function __construct(auth $auth, service $cache, config $config, \phpbb\files\upload $files_upload, language $language, guesser $mimetype_guesser, dispatcher $phpbb_dispatcher, plupload $plupload, storage $storage, temp $temp, user $user)
+	public function __construct(auth $auth, service $cache, config $config, \phpbb\files\upload $files_upload, language $language, guesser $mimetype_guesser, dispatcher $phpbb_dispatcher, plupload $plupload, storage $storage, temp $temp, thumbnail $thumbnail, user $user)
 	{
 		$this->auth = $auth;
 		$this->cache = $cache;
@@ -99,6 +104,7 @@ class upload
 		$this->plupload = $plupload;
 		$this->storage = $storage;
 		$this->temp = $temp;
+		$this->thumbnail = $thumbnail;
 		$this->user = $user;
 	}
 
@@ -243,7 +249,7 @@ class upload
 			$destination_name = 'thumb_' . $this->file->get('realname');
 			$destination = $this->temp->get_dir() . '/' . $destination_name;
 
-			if (create_thumbnail($source, $destination, $this->file->get('mimetype')))
+			if ($this->thumbnail->create($source, $destination, $this->file->get('mimetype')))
 			{
 				// Move the thumbnail from temp folder to the storage
 				$fp = fopen($destination, 'rb');

--- a/phpBB/phpbb/console/command/thumbnail/generate.php
+++ b/phpBB/phpbb/console/command/thumbnail/generate.php
@@ -30,6 +30,11 @@ class generate extends \phpbb\console\command\command
 	protected $cache;
 
 	/**
+	 * @var \phpbb\attachment\thumbnail
+	 */
+	protected $thumbnail;
+
+	/**
 	* phpBB root path
 	* @var string
 	*/
@@ -48,13 +53,15 @@ class generate extends \phpbb\console\command\command
 	* @param \phpbb\user $user The user object (used to get language information)
 	* @param \phpbb\db\driver\driver_interface $db Database connection
 	* @param \phpbb\cache\service $cache The cache service
+	* @param \phpbb\attachment\thumbnail $thumbnail Thumbnail service
 	* @param string $phpbb_root_path Root path
 	* @param string $php_ext PHP extension
 	*/
-	public function __construct(\phpbb\user $user, \phpbb\db\driver\driver_interface $db, \phpbb\cache\service $cache, $phpbb_root_path, $php_ext)
+	public function __construct(\phpbb\user $user, \phpbb\db\driver\driver_interface $db, \phpbb\cache\service $cache, \phpbb\attachment\thumbnail $thumbnail, $phpbb_root_path, $php_ext)
 	{
 		$this->db = $db;
 		$this->cache = $cache;
+		$this->thumbnail = $thumbnail;
 		$this->phpbb_root_path = $phpbb_root_path;
 		$this->php_ext = $php_ext;
 
@@ -110,11 +117,6 @@ class generate extends \phpbb\console\command\command
 			WHERE thumbnail = 0';
 		$result = $this->db->sql_query($sql);
 
-		if (!function_exists('create_thumbnail'))
-		{
-			require($this->phpbb_root_path . 'includes/functions_posting.' . $this->php_ext);
-		}
-
 		$progress = $this->create_progress_bar($nb_missing_thumbnails, $io, $output);
 
 		$progress->setMessage($this->user->lang('CLI_THUMBNAIL_GENERATING'));
@@ -129,7 +131,7 @@ class generate extends \phpbb\console\command\command
 				$source = $this->phpbb_root_path . 'files/' . $row['physical_filename'];
 				$destination = $this->phpbb_root_path . 'files/thumb_' . $row['physical_filename'];
 
-				if (create_thumbnail($source, $destination, $row['mimetype']))
+				if ($this->thumbnail->create($source, $destination, $row['mimetype']))
 				{
 					$thumbnail_created[] = (int) $row['attach_id'];
 

--- a/phpBB/phpbb/console/command/thumbnail/generate.php
+++ b/phpBB/phpbb/console/command/thumbnail/generate.php
@@ -30,9 +30,9 @@ class generate extends \phpbb\console\command\command
 	protected $cache;
 
 	/**
-	 * @var \phpbb\attachment\resize
+	 * @var \phpbb\attachment\thumbnail
 	 */
-	protected $resize;
+	protected $thumbnail;
 
 	/**
 	* phpBB root path
@@ -53,15 +53,15 @@ class generate extends \phpbb\console\command\command
 	* @param \phpbb\user $user The user object (used to get language information)
 	* @param \phpbb\db\driver\driver_interface $db Database connection
 	* @param \phpbb\cache\service $cache The cache service
-	* @param \phpbb\attachment\resize $resize Thumbnail service
+	* @param \phpbb\attachment\thumbnail $thumbnail Thumbnail service
 	* @param string $phpbb_root_path Root path
 	* @param string $php_ext PHP extension
 	*/
-	public function __construct(\phpbb\user $user, \phpbb\db\driver\driver_interface $db, \phpbb\cache\service $cache, \phpbb\attachment\resize $resize, $phpbb_root_path, $php_ext)
+	public function __construct(\phpbb\user $user, \phpbb\db\driver\driver_interface $db, \phpbb\cache\service $cache, \phpbb\attachment\thumbnail $thumbnail, $phpbb_root_path, $php_ext)
 	{
 		$this->db = $db;
 		$this->cache = $cache;
-		$this->resize = $resize;
+		$this->thumbnail = $thumbnail;
 		$this->phpbb_root_path = $phpbb_root_path;
 		$this->php_ext = $php_ext;
 
@@ -136,7 +136,7 @@ class generate extends \phpbb\console\command\command
 				$source = $this->phpbb_root_path . 'files/' . $row['physical_filename'];
 				$destination = $this->phpbb_root_path . 'files/thumb_' . $row['physical_filename'];
 
-				if ($this->resize->create($source, $destination, $row['mimetype']))
+				if ($this->thumbnail->create($source, $destination, $row['mimetype']))
 				{
 					$thumbnail_created[] = (int) $row['attach_id'];
 

--- a/phpBB/phpbb/console/command/thumbnail/generate.php
+++ b/phpBB/phpbb/console/command/thumbnail/generate.php
@@ -30,9 +30,9 @@ class generate extends \phpbb\console\command\command
 	protected $cache;
 
 	/**
-	 * @var \phpbb\attachment\thumbnail
+	 * @var \phpbb\attachment\resize
 	 */
-	protected $thumbnail;
+	protected $resize;
 
 	/**
 	* phpBB root path
@@ -53,15 +53,15 @@ class generate extends \phpbb\console\command\command
 	* @param \phpbb\user $user The user object (used to get language information)
 	* @param \phpbb\db\driver\driver_interface $db Database connection
 	* @param \phpbb\cache\service $cache The cache service
-	* @param \phpbb\attachment\thumbnail $thumbnail Thumbnail service
+	* @param \phpbb\attachment\resize $resize Thumbnail service
 	* @param string $phpbb_root_path Root path
 	* @param string $php_ext PHP extension
 	*/
-	public function __construct(\phpbb\user $user, \phpbb\db\driver\driver_interface $db, \phpbb\cache\service $cache, \phpbb\attachment\thumbnail $thumbnail, $phpbb_root_path, $php_ext)
+	public function __construct(\phpbb\user $user, \phpbb\db\driver\driver_interface $db, \phpbb\cache\service $cache, \phpbb\attachment\resize $resize, $phpbb_root_path, $php_ext)
 	{
 		$this->db = $db;
 		$this->cache = $cache;
-		$this->thumbnail = $thumbnail;
+		$this->resize = $resize;
 		$this->phpbb_root_path = $phpbb_root_path;
 		$this->php_ext = $php_ext;
 
@@ -136,7 +136,7 @@ class generate extends \phpbb\console\command\command
 				$source = $this->phpbb_root_path . 'files/' . $row['physical_filename'];
 				$destination = $this->phpbb_root_path . 'files/thumb_' . $row['physical_filename'];
 
-				if ($this->thumbnail->create($source, $destination, $row['mimetype']))
+				if ($this->resize->create($source, $destination, $row['mimetype']))
 				{
 					$thumbnail_created[] = (int) $row['attach_id'];
 

--- a/phpBB/phpbb/console/command/thumbnail/generate.php
+++ b/phpBB/phpbb/console/command/thumbnail/generate.php
@@ -117,11 +117,6 @@ class generate extends \phpbb\console\command\command
 			WHERE thumbnail = 0';
 		$result = $this->db->sql_query($sql);
 
-		if (!function_exists('get_img_size_format'))
-		{
-			require($this->phpbb_root_path . 'includes/functions_posting.' . $this->php_ext);
-		}
-
 		$progress = $this->create_progress_bar($nb_missing_thumbnails, $io, $output);
 
 		$progress->setMessage($this->user->lang('CLI_THUMBNAIL_GENERATING'));

--- a/phpBB/phpbb/console/command/thumbnail/generate.php
+++ b/phpBB/phpbb/console/command/thumbnail/generate.php
@@ -117,6 +117,11 @@ class generate extends \phpbb\console\command\command
 			WHERE thumbnail = 0';
 		$result = $this->db->sql_query($sql);
 
+		if (!function_exists('get_img_size_format'))
+		{
+			require($this->phpbb_root_path . 'includes/functions_posting.' . $this->php_ext);
+		}
+
 		$progress = $this->create_progress_bar($nb_missing_thumbnails, $io, $output);
 
 		$progress->setMessage($this->user->lang('CLI_THUMBNAIL_GENERATING'));

--- a/tests/attachment/resize_test.php
+++ b/tests/attachment/resize_test.php
@@ -11,8 +11,6 @@
 *
 */
 
-require_once dirname(__FILE__) . '/../../phpBB/includes/functions_posting.php';
-
 class phpbb_attachment_resize_test extends \phpbb_test_case
 {
 	/** @var \phpbb\attachment\resize */

--- a/tests/attachment/resize_test.php
+++ b/tests/attachment/resize_test.php
@@ -150,7 +150,7 @@ class phpbb_attachment_resize_test extends \phpbb_test_case
 
 		/** @var \phpbb\attachment\resize $resize_mock */
 		$resize_mock = $this->getMock(
-			'\phpbb\attachment\thumbnail',
+			'\phpbb\attachment\resize',
 			array('get_supported_image_types'),
 			array(
 				$this->config,
@@ -170,7 +170,7 @@ class phpbb_attachment_resize_test extends \phpbb_test_case
 
 		/** @var \phpbb\attachment\resize $thumbnail_mock */
 		$resize_mock = $this->getMock(
-			'\phpbb\attachment\thumbnail',
+			'\phpbb\attachment\resize',
 			array('create_gd'),
 			array(
 				$this->config,

--- a/tests/attachment/resize_test.php
+++ b/tests/attachment/resize_test.php
@@ -362,4 +362,34 @@ class phpbb_attachment_resize_test extends \phpbb_test_case
 			unlink($this->phpbb_root_path . '../tests/upload/fixture/meh');
 		}
 	}
+
+	public function data_get_img_size_format()
+	{
+		return array(
+			array(200, 100, 50, 20, array(
+				40.0,
+				20.0,
+			)),
+			array(200, 100, 50, '', array(
+				50.0,
+				25.0,
+			)),
+			array(200, 100, 50, 40, array(
+				50.0,
+				25.0,
+			)),
+			array(200, 100, 50, 25, array(
+				50.0,
+				25.0,
+			)),
+		);
+	}
+
+	/**
+	 * @dataProvider data_get_img_size_format
+	 */
+	public function test_get_img_size_format($width, $height, $target_width, $target_height, $expected)
+	{
+		$this->assertSame($expected, $this->image_helper->get_img_size_format($width, $height, $target_width, $target_height));
+	}
 }

--- a/tests/attachment/resize_test.php
+++ b/tests/attachment/resize_test.php
@@ -249,6 +249,32 @@ class phpbb_attachment_resize_test extends \phpbb_test_case
 	/**
 	 * @dataProvider data_create_gd
 	 */
+	public function test_create_thumbnail($mimetype, $type, $source, $expected)
+	{
+		$this->image_size = $this->getMock('\FastImageSize\FastImageSize', array('getImageSize'));
+		$this->image_size->expects($this->any())
+			->method('getImageSize')
+			->with($this->anything())
+			->willReturn(array(
+				'width'		=> 500,
+				'height'	=> 500,
+				'type'		=> $type,
+			));
+		$this->config->set('img_min_thumb_filesize', 0);
+		$this->config->set('img_max_thumb_width', 200);
+		$this->config->set('img_max_thumb_height', 200);
+
+		$this->get_resize();
+		$thumbnail_class = new \phpbb\attachment\thumbnail($this->config, $this->resize);
+
+		$this->assertEquals($expected, $thumbnail_class->create($this->phpbb_root_path . '../tests/upload/fixture/' . $source, $this->phpbb_root_path . '../tests/upload/fixture/meh', $mimetype));
+
+		$this->image_size = new \FastImageSize\FastImageSize();
+	}
+
+	/**
+	 * @dataProvider data_create_gd
+	 */
 	public function test_create_gd($mimetype, $type, $source, $expected)
 	{
 		$this->image_size = $this->getMock('\FastImageSize\FastImageSize', array('getImageSize'));
@@ -306,6 +332,30 @@ class phpbb_attachment_resize_test extends \phpbb_test_case
 		$this->get_resize();
 
 		$this->assertEquals($expected, $this->resize->create($this->phpbb_root_path . '../tests/upload/fixture/png', $this->phpbb_root_path . '../tests/upload/fixture/meh', 'image/png'));
+
+		$this->image_size = new \FastImageSize\FastImageSize();
+	}
+
+	public function test_create_thumbnail_imagick()
+	{
+		$this->image_size = $this->getMock('\FastImageSize\FastImageSize', array('getImageSize'));
+		$this->image_size->expects($this->any())
+			->method('getImageSize')
+			->with($this->anything())
+			->willReturn(array(
+				'width'		=> 500,
+				'height'	=> 500,
+				'type'		=> IMAGETYPE_PNG,
+			));
+		$this->config->set('img_min_thumb_filesize', 0);
+		$this->config->set('img_max_thumb_width', 200);
+		$this->config->set('img_max_thumb_height', 200);
+		$this->config->set('img_imagick', '/usr/bin');
+
+		$this->get_resize();
+		$thumbnail_class = new \phpbb\attachment\thumbnail($this->config, $this->resize);
+
+		$this->assertEquals(true, $thumbnail_class->create($this->phpbb_root_path . '../tests/upload/fixture/png', $this->phpbb_root_path . '../tests/upload/fixture/meh', 'image/png'));
 
 		$this->image_size = new \FastImageSize\FastImageSize();
 

--- a/tests/attachment/thumbnail_test.php
+++ b/tests/attachment/thumbnail_test.php
@@ -58,16 +58,16 @@ class phpbb_attachment_thumbnail_test extends \phpbb_test_case
 	public function data_get_size()
 	{
 		return array(
-			array('foobar', 'meh', 'image/png', false),
-			array('../tests/upload/fixture/png', 'meh', 'image/png', false,
+			array('foobar', '../tests/upload/fixture/meh', 'image/png', false),
+			array('../tests/upload/fixture/png', '../tests/upload/fixture/meh', 'image/png', false,
 				array('img_min_thumb_filesize' => 500)
 			),
-			array('../tests/upload/fixture/png', 'meh', 'image/png', false,
+			array('../tests/upload/fixture/png', '../tests/upload/fixture/meh', 'image/png', false,
 				array('img_min_thumb_filesize' => 0),
 				true,
 				false
 			),
-			array('../tests/upload/fixture/png', 'meh', 'image/png', false,
+			array('../tests/upload/fixture/png', '../tests/upload/fixture/meh', 'image/png', false,
 				array(
 					'img_min_thumb_filesize'	=> 0,
 					'img_max_thumb_width'		=> 200,
@@ -80,7 +80,7 @@ class phpbb_attachment_thumbnail_test extends \phpbb_test_case
 					'type'		=> IMAGETYPE_PNG,
 				)
 			),
-			array('../tests/upload/fixture/png', 'meh', 'image/png', true,
+			array('../tests/upload/fixture/png', '../tests/upload/fixture/meh', 'image/png', true,
 				array(
 					'img_min_thumb_filesize'	=> 0,
 					'img_max_thumb_width'		=> 200,
@@ -117,8 +117,13 @@ class phpbb_attachment_thumbnail_test extends \phpbb_test_case
 
 		$this->get_thumbnail();
 
-		$this->assertSame($expected, $this->thumbnail->create($this->phpbb_root_path . $source, $destination, $type));
+		$this->assertSame($expected, $this->thumbnail->create($this->phpbb_root_path . $source, $this->phpbb_root_path . $destination, $type));
 
 		$this->image_size = new \FastImageSize\FastImageSize();
+
+		if (file_exists($this->phpbb_root_path . $destination))
+		{
+			unlink($this->phpbb_root_path . $destination);
+		}
 	}
 }

--- a/tests/attachment/thumbnail_test.php
+++ b/tests/attachment/thumbnail_test.php
@@ -1,0 +1,124 @@
+<?php
+/**
+*
+* This file is part of the phpBB Forum Software package.
+*
+* @copyright (c) phpBB Limited <https://www.phpbb.com>
+* @license GNU General Public License, version 2 (GPL-2.0)
+*
+* For full copyright and license information, please see
+* the docs/CREDITS.txt file.
+*
+*/
+
+require_once dirname(__FILE__) . '/../../phpBB/includes/functions_posting.php';
+
+class phpbb_attachment_thumbnail_test extends \phpbb_test_case
+{
+	/** @var \phpbb\attachment\thumbnail */
+	protected $thumbnail;
+
+	/** @var \phpbb\config\config */
+	protected $config;
+
+	/** @var \phpbb\filesystem\filesystem_interface */
+	protected $filesystem;
+
+	/** @var \bantu\IniGetWrapper\IniGetWrapper */
+	protected $php_ini;
+
+	/** @var \FastImageSize\FastImageSize */
+	protected $image_size;
+
+	public function setUp()
+	{
+		global $phpbb_root_path;
+
+		parent::setUp();
+
+		$this->config = new \phpbb\config\config(array());
+		$this->filesystem = new \phpbb\filesystem\filesystem();
+		$this->php_ini = new \bantu\IniGetWrapper\IniGetWrapper();
+		$this->image_size = new \FastImageSize\FastImageSize();
+		$this->phpbb_root_path = $phpbb_root_path;
+
+		$this->get_thumbnail();
+	}
+
+	private function get_thumbnail()
+	{
+		$this->thumbnail = new \phpbb\attachment\thumbnail(
+			$this->config,
+			$this->filesystem,
+			$this->php_ini,
+			$this->image_size
+		);
+	}
+
+	public function data_get_size()
+	{
+		return array(
+			array('foobar', 'meh', 'image/png', false),
+			array('../tests/upload/fixture/png', 'meh', 'image/png', false,
+				array('img_min_thumb_filesize' => 500)
+			),
+			array('../tests/upload/fixture/png', 'meh', 'image/png', false,
+				array('img_min_thumb_filesize' => 0),
+				true,
+				false
+			),
+			array('../tests/upload/fixture/png', 'meh', 'image/png', false,
+				array(
+					'img_min_thumb_filesize'	=> 0,
+					'img_max_thumb_width'		=> 200,
+					'img_max_thumb_height'		=> 200,
+				),
+				true,
+				array(
+					'width'		=> 2,
+					'height'	=> 2,
+					'type'		=> IMAGETYPE_PNG,
+				)
+			),
+			array('../tests/upload/fixture/png', 'meh', 'image/png', true,
+				array(
+					'img_min_thumb_filesize'	=> 0,
+					'img_max_thumb_width'		=> 200,
+					'img_max_thumb_height'		=> 200,
+				),
+				true,
+				array(
+					'width'		=> 500,
+					'height'	=> 500,
+					'type'		=> IMAGETYPE_PNG,
+				)
+			),
+		);
+	}
+
+	/**
+	 * @dataProvider data_get_size
+	 */
+	public function test_set_size($source, $destination, $type, $expected, $config_data = array(), $mock_image_size = false, $mock_image_size_return = false)
+	{
+		foreach ($config_data as $key => $value)
+		{
+			$this->config->set($key, $value);
+		}
+
+		if ($mock_image_size)
+		{
+			$this->image_size = $this->getMock('\FastImageSize\FastImageSize', array('getImageSize'));
+			$this->image_size->expects($this->any())
+				->method('getImageSize')
+				->with($this->anything())
+				->willReturn($mock_image_size_return);
+		}
+
+		$this->get_thumbnail();
+
+		$this->assertSame($expected, $this->thumbnail->create($this->phpbb_root_path . $source, $destination, $type));
+
+		$this->image_size = new \FastImageSize\FastImageSize();
+	}
+}

--- a/tests/attachment/thumbnail_test.php
+++ b/tests/attachment/thumbnail_test.php
@@ -229,4 +229,37 @@ class phpbb_attachment_thumbnail_test extends \phpbb_test_case
 	{
 		$this->assertSame($expected, $this->thumbnail->get_supported_image_types($input));
 	}
+
+	public function data_create_gd()
+	{
+		return array(
+			array('image/iff', IMAGETYPE_IFF, 'png', false),
+			array('image/gif', IMAGETYPE_GIF, 'png', false),
+			array('image/gif', IMAGETYPE_GIF, 'gif', true),
+			array('image/jpg', IMAGETYPE_JPEG, 'jpg', true),
+			array('image/wbmp', IMAGETYPE_WBMP, 'wbmp', true),
+		);
+	}
+
+	/**
+	 * @dataProvider data_create_gd
+	 */
+	public function test_create_gd($mimetype, $type, $source, $expected)
+	{
+		$this->image_size = $this->getMock('\FastImageSize\FastImageSize', array('getImageSize'));
+		$this->image_size->expects($this->any())
+			->method('getImageSize')
+			->with($this->anything())
+			->willReturn(array(
+				'width'		=> 500,
+				'height'	=> 500,
+				'type'		=> $type,
+			));
+
+		$this->get_thumbnail();
+
+		$this->assertEquals($expected, $this->thumbnail->create($this->phpbb_root_path . '../tests/upload/fixture/' . $source, $this->phpbb_root_path . '../tests/upload/fixture/meh', $mimetype));
+
+		$this->image_size = new \FastImageSize\FastImageSize();
+	}
 }

--- a/tests/attachment/thumbnail_test.php
+++ b/tests/attachment/thumbnail_test.php
@@ -182,5 +182,51 @@ class phpbb_attachment_thumbnail_test extends \phpbb_test_case
 			->willReturn(true);
 
 		$this->assertSame(false, $thumbnail_mock->create($this->phpbb_root_path . '../tests/upload/fixture/png', $this->phpbb_root_path . '../tests/upload/fixture/meh', 'image/png'));
+
+		$this->image_size = new \FastImageSize\FastImageSize();
+	}
+
+	public function data_get_supported_image_types()
+	{
+		return array(
+			array(-1, array(
+				'gd'		=> false,
+				'format'	=> 0,
+				'version'	=> (function_exists('imagecreatetruecolor')) ? 2 : 1,
+			)),
+			array(false, array(
+				'gd'		=> true,
+				'format'	=> array(
+					IMG_GIF,
+					IMG_JPG,
+					IMG_PNG,
+					IMG_WBMP,
+				),
+				'version'	=> (function_exists('imagecreatetruecolor')) ? 2 : 1,
+			)),
+			array(IMAGETYPE_GIF, array(
+				'gd'		=> true,
+				'format'	=> IMG_GIF,
+				'version'	=> (function_exists('imagecreatetruecolor')) ? 2 : 1,
+			)),
+			array(IMAGETYPE_JPEG, array(
+				'gd'		=> true,
+				'format'	=> IMG_JPEG,
+				'version'	=> (function_exists('imagecreatetruecolor')) ? 2 : 1,
+			)),
+			array(IMAGETYPE_WBMP, array(
+				'gd'		=> true,
+				'format'	=> IMG_WBMP,
+				'version'	=> (function_exists('imagecreatetruecolor')) ? 2 : 1,
+			)),
+		);
+	}
+
+	/**
+	 * @dataProvider data_get_supported_image_types
+	 */
+	public function test_get_supported_image_types($input, $expected)
+	{
+		$this->assertSame($expected, $this->thumbnail->get_supported_image_types($input));
 	}
 }

--- a/tests/attachment/thumbnail_test.php
+++ b/tests/attachment/thumbnail_test.php
@@ -262,4 +262,34 @@ class phpbb_attachment_thumbnail_test extends \phpbb_test_case
 
 		$this->image_size = new \FastImageSize\FastImageSize();
 	}
+
+	public function test_create_imagick()
+	{
+		if (!file_exists('/usr/bin/convert'))
+		{
+			$this->markTestSkipped('Unable to test imagick which non-existent imagick');
+		}
+
+		$this->image_size = $this->getMock('\FastImageSize\FastImageSize', array('getImageSize'));
+		$this->image_size->expects($this->any())
+			->method('getImageSize')
+			->with($this->anything())
+			->willReturn(array(
+				'width'		=> 500,
+				'height'	=> 500,
+				'type'		=> IMAGETYPE_PNG,
+			));
+		$this->config->set('img_imagick', '/usr/bin');
+
+		$this->get_thumbnail();
+
+		$this->assertEquals(true, $this->thumbnail->create($this->phpbb_root_path . '../tests/upload/fixture/png', $this->phpbb_root_path . '../tests/upload/fixture/meh', 'image/png'));
+
+		$this->image_size = new \FastImageSize\FastImageSize();
+
+		if (file_exists($this->phpbb_root_path . '../tests/upload/fixture/meh'))
+		{
+			unlink($this->phpbb_root_path . '../tests/upload/fixture/meh');
+		}
+	}
 }

--- a/tests/attachment/upload_test.php
+++ b/tests/attachment/upload_test.php
@@ -72,6 +72,9 @@ class phpbb_attachment_upload_test extends \phpbb_database_test_case
 	/** @var \bantu\IniGetWrapper\IniGetWrapper */
 	protected $php_ini;
 
+	/** @var \phpbb\attachment\thumbnail */
+	protected $thumbnail;
+
 	public function getDataSet()
 	{
 		return $this->createXMLDataSet(dirname(__FILE__) . '/fixtures/resync.xml');
@@ -149,7 +152,8 @@ class phpbb_attachment_upload_test extends \phpbb_database_test_case
 		$this->phpbb_dispatcher = new phpbb_mock_event_dispatcher();
 		$this->temp = new \phpbb\filesystem\temp($this->filesystem, '');
 		$this->user = new \phpbb\user($this->language, '\phpbb\datetime');
-		$this->resize = new \phpbb\attachment\resize($this->config, new \phpbb\filesystem\filesystem(), $this->php_ini, new \FastImageSize\FastImageSize());
+		$this->resize = new \phpbb\attachment\resize(new \phpbb\filesystem\filesystem(), new \phpbb\attachment\image_helper(), $this->php_ini, new \FastImageSize\FastImageSize());
+		$this->thumbnail = new \phpbb\attachment\thumbnail($this->config, $this->resize);
 
 		$this->upload = new \phpbb\attachment\upload(
 			$this->auth,
@@ -162,7 +166,7 @@ class phpbb_attachment_upload_test extends \phpbb_database_test_case
 			$this->plupload,
 			$this->storage,
 			$this->temp,
-			$this->resize,
+			$this->thumbnail,
 			$this->user,
 			$this->phpbb_root_path
 		);
@@ -257,7 +261,7 @@ class phpbb_attachment_upload_test extends \phpbb_database_test_case
 			$this->plupload,
 			$this->storage,
 			$this->temp,
-			$this->resize,
+			$this->thumbnail,
 			$this->user,
 			$this->phpbb_root_path
 		);
@@ -424,7 +428,7 @@ class phpbb_attachment_upload_test extends \phpbb_database_test_case
 			$plupload,
 			$this->storage,
 			$this->temp,
-			$this->resize,
+			$this->thumbnail,
 			$this->user,
 			$this->phpbb_root_path
 		);

--- a/tests/attachment/upload_test.php
+++ b/tests/attachment/upload_test.php
@@ -42,8 +42,8 @@ class phpbb_attachment_upload_test extends \phpbb_database_test_case
 	/** @var \phpbb\storage\storage */
 	protected $storage;
 
-	/** @var \phpbb\attachment\thumbnail */
-	protected $thumbnail;
+	/** @var \phpbb\attachment\resize */
+	protected $resize;
 
 	/** @var \phpbb\user */
 	protected $user;
@@ -149,7 +149,7 @@ class phpbb_attachment_upload_test extends \phpbb_database_test_case
 		$this->phpbb_dispatcher = new phpbb_mock_event_dispatcher();
 		$this->temp = new \phpbb\filesystem\temp($this->filesystem, '');
 		$this->user = new \phpbb\user($this->language, '\phpbb\datetime');
-		$this->thumbnail = new \phpbb\attachment\thumbnail($this->config, new \phpbb\filesystem\filesystem(), $this->php_ini, new \FastImageSize\FastImageSize());
+		$this->resize = new \phpbb\attachment\resize($this->config, new \phpbb\filesystem\filesystem(), $this->php_ini, new \FastImageSize\FastImageSize());
 
 		$this->upload = new \phpbb\attachment\upload(
 			$this->auth,
@@ -162,7 +162,7 @@ class phpbb_attachment_upload_test extends \phpbb_database_test_case
 			$this->plupload,
 			$this->storage,
 			$this->temp,
-			$this->thumbnail,
+			$this->resize,
 			$this->user,
 			$this->phpbb_root_path
 		);
@@ -257,7 +257,7 @@ class phpbb_attachment_upload_test extends \phpbb_database_test_case
 			$this->plupload,
 			$this->storage,
 			$this->temp,
-			$this->thumbnail,
+			$this->resize,
 			$this->user,
 			$this->phpbb_root_path
 		);
@@ -424,7 +424,7 @@ class phpbb_attachment_upload_test extends \phpbb_database_test_case
 			$plupload,
 			$this->storage,
 			$this->temp,
-			$this->thumbnail,
+			$this->resize,
 			$this->user,
 			$this->phpbb_root_path
 		);

--- a/tests/attachment/upload_test.php
+++ b/tests/attachment/upload_test.php
@@ -42,6 +42,9 @@ class phpbb_attachment_upload_test extends \phpbb_database_test_case
 	/** @var \phpbb\storage\storage */
 	protected $storage;
 
+	/** @var \phpbb\attachment\thumbnail */
+	protected $thumbnail;
+
 	/** @var \phpbb\user */
 	protected $user;
 
@@ -146,6 +149,7 @@ class phpbb_attachment_upload_test extends \phpbb_database_test_case
 		$this->phpbb_dispatcher = new phpbb_mock_event_dispatcher();
 		$this->temp = new \phpbb\filesystem\temp($this->filesystem, '');
 		$this->user = new \phpbb\user($this->language, '\phpbb\datetime');
+		$this->thumbnail = new \phpbb\attachment\thumbnail($this->config, new \phpbb\filesystem\filesystem(), $this->php_ini, new \FastImageSize\FastImageSize());
 
 		$this->upload = new \phpbb\attachment\upload(
 			$this->auth,
@@ -158,7 +162,9 @@ class phpbb_attachment_upload_test extends \phpbb_database_test_case
 			$this->plupload,
 			$this->storage,
 			$this->temp,
-			$this->user
+			$this->thumbnail,
+			$this->user,
+			$this->phpbb_root_path
 		);
 	}
 
@@ -251,7 +257,9 @@ class phpbb_attachment_upload_test extends \phpbb_database_test_case
 			$this->plupload,
 			$this->storage,
 			$this->temp,
-			$this->user
+			$this->thumbnail,
+			$this->user,
+			$this->phpbb_root_path
 		);
 
 		$filedata = $this->upload->upload('foobar', 1, true);
@@ -416,7 +424,9 @@ class phpbb_attachment_upload_test extends \phpbb_database_test_case
 			$plupload,
 			$this->storage,
 			$this->temp,
-			$this->user
+			$this->thumbnail,
+			$this->user,
+			$this->phpbb_root_path
 		);
 
 		$filedata = $this->upload->upload('foobar', 1, true, '', false, array(

--- a/tests/console/thumbnail_test.php
+++ b/tests/console/thumbnail_test.php
@@ -67,10 +67,11 @@ class phpbb_console_command_thumbnail_test extends phpbb_database_test_case
 
 		$phpbb_filesystem = new \phpbb\filesystem\filesystem();
 
-		$this->resize = new \phpbb\attachment\resize($config, $phpbb_filesystem, new \bantu\IniGetWrapper\IniGetWrapper(), new \FastImageSize\FastImageSize());
+		$this->resize = new \phpbb\attachment\resize($phpbb_filesystem, new \phpbb\attachment\image_helper(), new \bantu\IniGetWrapper\IniGetWrapper(), new \FastImageSize\FastImageSize());
+		$this->thumbnail = new \phpbb\attachment\thumbnail($config, $this->resize);
 
 		$this->application = new Application();
-		$this->application->add(new generate($this->user, $this->db, $this->cache, $this->resize, $this->phpbb_root_path, $this->phpEx));
+		$this->application->add(new generate($this->user, $this->db, $this->cache, $this->thumbnail, $this->phpbb_root_path, $this->phpEx));
 		$this->application->add(new delete($this->user, $this->db, $this->phpbb_root_path));
 		$this->application->add(new recreate($this->user));
 

--- a/tests/console/thumbnail_test.php
+++ b/tests/console/thumbnail_test.php
@@ -13,7 +13,7 @@
 
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
-use phpbb\attachment\thumbnail;
+use phpbb\attachment\resize;
 use phpbb\console\command\thumbnail\generate;
 use phpbb\console\command\thumbnail\delete;
 use phpbb\console\command\thumbnail\recreate;
@@ -27,7 +27,7 @@ class phpbb_console_command_thumbnail_test extends phpbb_database_test_case
 	protected $phpEx;
 	protected $phpbb_root_path;
 	protected $application;
-	protected $thumbnail;
+	protected $resize;
 
 	public function getDataSet()
 	{
@@ -67,10 +67,10 @@ class phpbb_console_command_thumbnail_test extends phpbb_database_test_case
 
 		$phpbb_filesystem = new \phpbb\filesystem\filesystem();
 
-		$this->thumbnail = new \phpbb\attachment\thumbnail($config, $phpbb_filesystem, new \bantu\IniGetWrapper\IniGetWrapper(), new \FastImageSize\FastImageSize());
+		$this->resize = new \phpbb\attachment\resize($config, $phpbb_filesystem, new \bantu\IniGetWrapper\IniGetWrapper(), new \FastImageSize\FastImageSize());
 
 		$this->application = new Application();
-		$this->application->add(new generate($this->user, $this->db, $this->cache, $this->thumbnail, $this->phpbb_root_path, $this->phpEx));
+		$this->application->add(new generate($this->user, $this->db, $this->cache, $this->resize, $this->phpbb_root_path, $this->phpEx));
 		$this->application->add(new delete($this->user, $this->db, $this->phpbb_root_path));
 		$this->application->add(new recreate($this->user));
 

--- a/tests/console/thumbnail_test.php
+++ b/tests/console/thumbnail_test.php
@@ -13,6 +13,7 @@
 
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
+use phpbb\attachment\thumbnail;
 use phpbb\console\command\thumbnail\generate;
 use phpbb\console\command\thumbnail\delete;
 use phpbb\console\command\thumbnail\recreate;
@@ -26,6 +27,7 @@ class phpbb_console_command_thumbnail_test extends phpbb_database_test_case
 	protected $phpEx;
 	protected $phpbb_root_path;
 	protected $application;
+	protected $thumbnail;
 
 	public function getDataSet()
 	{
@@ -63,12 +65,14 @@ class phpbb_console_command_thumbnail_test extends phpbb_database_test_case
 			'txt' => array('display_cat' => ATTACHMENT_CATEGORY_NONE),
 		)));
 
+		$phpbb_filesystem = new \phpbb\filesystem\filesystem();
+
+		$this->thumbnail = new \phpbb\attachment\thumbnail($config, $phpbb_filesystem, new \bantu\IniGetWrapper\IniGetWrapper(), new \FastImageSize\FastImageSize());
+
 		$this->application = new Application();
-		$this->application->add(new generate($this->user, $this->db, $this->cache, $this->phpbb_root_path, $this->phpEx));
+		$this->application->add(new generate($this->user, $this->db, $this->cache, $this->thumbnail, $this->phpbb_root_path, $this->phpEx));
 		$this->application->add(new delete($this->user, $this->db, $this->phpbb_root_path));
 		$this->application->add(new recreate($this->user));
-
-		$phpbb_filesystem = new \phpbb\filesystem\filesystem();
 
 		copy(dirname(__FILE__) . '/fixtures/png.png', $this->phpbb_root_path . 'files/test_png_1');
 		copy(dirname(__FILE__) . '/fixtures/png.png', $this->phpbb_root_path . 'files/test_png_2');


### PR DESCRIPTION
This will move the create_thumbnail() into its own class(es).

Current goals:
- [x] Refactor create_thumbnail() into class
- [x] Create class for resize
  - [x] Make resize class also usable for avatars
  - [x] Split thumbnail class into wrapper
- [x] Add helper class for image functions like get_supported_image_types()
- [x] Improve test coverage of image_helper

Ticket: https://tracker.phpbb.com/browse/PHPBB3-14286
