### PR TITLE
[ticket/14395] Add event core.viewtopic_add_quickmod_option_before

### DIFF
--- a/phpBB/viewtopic.php
+++ b/phpBB/viewtopic.php
@@ -592,7 +592,7 @@ $quickmod_array = array(
 * Event to modify data in the quickmod_array before it gets sent to the
 * phpbb_add_quickmod_option function.
 *
-* @event core.viewtopic_add_quickmod_option_before
+* @event core.viewtopic_add_quickmod_option_after
 * @var	int		forum_id			Forum ID
 * @var	int		post_id				Post ID
 * @var	array	quickmod_array		Array with quick moderation options data

--- a/phpBB/viewtopic.php
+++ b/phpBB/viewtopic.php
@@ -588,14 +588,6 @@ $quickmod_array = array(
 	'topic_logs'			=> array('VIEW_TOPIC_LOGS', $auth->acl_get('m_', $forum_id)),
 );
 
-foreach ($quickmod_array as $option => $qm_ary)
-{
-	if (!empty($qm_ary[1]))
-	{
-		phpbb_add_quickmod_option($s_quickmod_action, $option, $qm_ary[0]);
-	}
-}
-
 // Navigation links
 generate_forum_nav($topic_data);
 
@@ -666,6 +658,14 @@ $vars = array(
 	'viewtopic_url',
 );
 extract($phpbb_dispatcher->trigger_event('core.viewtopic_assign_template_vars_before', compact($vars)));
+
+foreach ($quickmod_array as $option => $qm_ary)
+{
+	if (!empty($qm_ary[1]))
+	{
+		phpbb_add_quickmod_option($s_quickmod_action, $option, $qm_ary[0]);
+	}
+}
 
 $pagination->generate_template_pagination($base_url, 'pagination', 'start', $total_posts, $config['posts_per_page'], $start);
 

--- a/phpBB/viewtopic.php
+++ b/phpBB/viewtopic.php
@@ -611,7 +611,7 @@ $vars = array(
 	'topic_id',
 	'topic_tracking_info',
 	'viewtopic_url',
-  'allow_change_type',
+	'allow_change_type',
 );
 extract($phpbb_dispatcher->trigger_event('core.viewtopic_add_quickmod_option_after', compact($vars)));
 

--- a/phpBB/viewtopic.php
+++ b/phpBB/viewtopic.php
@@ -588,6 +588,41 @@ $quickmod_array = array(
 	'topic_logs'			=> array('VIEW_TOPIC_LOGS', $auth->acl_get('m_', $forum_id)),
 );
 
+/**
+* Event to modify data in the quickmod_array before it gets sent to the
+* phpbb_add_quickmod_option function.
+*
+* @event core.viewtopic_add_quickmod_option_before
+* @var	int		forum_id			Forum ID
+* @var	int		post_id				Post ID
+* @var	array	quickmod_array		Array with quick moderation options data
+* @var	array	topic_data			Array with topic data
+* @var	int		topic_id			Topic ID
+* @var	array	topic_tracking_info	Array with topic tracking data
+* @var	string	viewtopic_url		URL to the topic page
+* @var  bool  allow_change_type   Topic change permissions check
+* @since 3.1.8-RC1
+*/
+$vars = array(
+	'forum_id',
+	'post_id',
+	'quickmod_array',
+	'topic_data',
+	'topic_id',
+	'topic_tracking_info',
+	'viewtopic_url',
+  'allow_change_type',
+);
+extract($phpbb_dispatcher->trigger_event('core.viewtopic_add_quickmod_option_after', compact($vars)));
+
+foreach ($quickmod_array as $option => $qm_ary)
+{
+	if (!empty($qm_ary[1]))
+	{
+		phpbb_add_quickmod_option($s_quickmod_action, $option, $qm_ary[0]);
+	}
+}
+
 // Navigation links
 generate_forum_nav($topic_data);
 
@@ -658,14 +693,6 @@ $vars = array(
 	'viewtopic_url',
 );
 extract($phpbb_dispatcher->trigger_event('core.viewtopic_assign_template_vars_before', compact($vars)));
-
-foreach ($quickmod_array as $option => $qm_ary)
-{
-	if (!empty($qm_ary[1]))
-	{
-		phpbb_add_quickmod_option($s_quickmod_action, $option, $qm_ary[0]);
-	}
-}
 
 $pagination->generate_template_pagination($base_url, 'pagination', 'start', $total_posts, $config['posts_per_page'], $start);
 

--- a/phpBB/viewtopic.php
+++ b/phpBB/viewtopic.php
@@ -592,7 +592,7 @@ $quickmod_array = array(
 * Event to modify data in the quickmod_array before it gets sent to the
 * phpbb_add_quickmod_option function.
 *
-* @event core.viewtopic_add_quickmod_option_after
+* @event core.viewtopic_add_quickmod_option_before
 * @var	int		forum_id			Forum ID
 * @var	int		post_id				Post ID
 * @var	array	quickmod_array		Array with quick moderation options data
@@ -601,7 +601,7 @@ $quickmod_array = array(
 * @var	array	topic_tracking_info	Array with topic tracking data
 * @var	string	viewtopic_url		URL to the topic page
 * @var  bool  allow_change_type   Topic change permissions check
-* @since 3.1.8-RC1
+* @since 3.1.9-RC1
 */
 $vars = array(
 	'forum_id',
@@ -613,7 +613,7 @@ $vars = array(
 	'viewtopic_url',
 	'allow_change_type',
 );
-extract($phpbb_dispatcher->trigger_event('core.viewtopic_add_quickmod_option_after', compact($vars)));
+extract($phpbb_dispatcher->trigger_event('core.viewtopic_add_quickmod_option_before', compact($vars)));
 
 foreach ($quickmod_array as $option => $qm_ary)
 {

--- a/phpBB/viewtopic.php
+++ b/phpBB/viewtopic.php
@@ -593,14 +593,14 @@ $quickmod_array = array(
 * phpbb_add_quickmod_option function.
 *
 * @event core.viewtopic_add_quickmod_option_before
-* @var	int			forum_id								Forum ID
-* @var	int			post_id									Post ID
-* @var	array		quickmod_array					Array with quick moderation options data
-* @var	array		topic_data							Array with topic data
-* @var	int			topic_id								Topic ID
-* @var	array		topic_tracking_info			Array with topic tracking data
-* @var	string	viewtopic_url						URL to the topic page
-* @var	bool		allow_change_type				Topic change permissions check
+* @var	int				forum_id				Forum ID
+* @var	int				post_id					Post ID
+* @var	array			quickmod_array			Array with quick moderation options data
+* @var	array			topic_data				Array with topic data
+* @var	int				topic_id				Topic ID
+* @var	array			topic_tracking_info		Array with topic tracking data
+* @var	string			viewtopic_url			URL to the topic page
+* @var	bool			allow_change_type		Topic change permissions check
 * @since 3.1.9-RC1
 */
 $vars = array(

--- a/phpBB/viewtopic.php
+++ b/phpBB/viewtopic.php
@@ -593,14 +593,14 @@ $quickmod_array = array(
 * phpbb_add_quickmod_option function.
 *
 * @event core.viewtopic_add_quickmod_option_before
-* @var	int		forum_id			Forum ID
-* @var	int		post_id				Post ID
-* @var	array	quickmod_array		Array with quick moderation options data
-* @var	array	topic_data			Array with topic data
-* @var	int		topic_id			Topic ID
-* @var	array	topic_tracking_info	Array with topic tracking data
-* @var	string	viewtopic_url		URL to the topic page
-* @var  bool  allow_change_type   Topic change permissions check
+* @var	int			forum_id								Forum ID
+* @var	int			post_id									Post ID
+* @var	array		quickmod_array					Array with quick moderation options data
+* @var	array		topic_data							Array with topic data
+* @var	int			topic_id								Topic ID
+* @var	array		topic_tracking_info			Array with topic tracking data
+* @var	string	viewtopic_url						URL to the topic page
+* @var	bool		allow_change_type				Topic change permissions check
 * @since 3.1.9-RC1
 */
 $vars = array(


### PR DESCRIPTION
Moved the call to function phpbb_add_quickmod_option to being under the core
event core.viewtopic_assign_template_vars_before so as to enable the
modification of elements in the  BEFORE they are assigned to the
template, so that removed elements don't show up in a non-functional state.
Allows the user to perform additional permissions checks on the items within the
array.

PHPBB3-14395