### PR TITLE
 twig extension for template name

### DIFF
--- a/phpBB/includes/functions_module.php
+++ b/phpBB/includes/functions_module.php
@@ -953,7 +953,7 @@ class p_master
 	*/
 	function get_tpl_name()
 	{
-		return $this->module->tpl_name . '.html';
+		return strpos($this->module->tpl_name,'.twig')?$this->module->tpl_name:$this->module->tpl_name . '.html';
 	}
 
 	/**


### PR DESCRIPTION
Allow twig extension for template name for better IDE support.

https://tracker.phpbb.com/browse/PHPBB3-14421