### PR TITLE
[ticket/14433] Purge cache setting up extension functional tests

### DIFF
--- a/tests/test_framework/phpbb_functional_test_case.php
+++ b/tests/test_framework/phpbb_functional_test_case.php
@@ -94,6 +94,8 @@ class phpbb_functional_test_case extends phpbb_test_case
 
 		foreach (static::setup_extensions() as $extension)
 		{
+			$this->purge_cache();
+
 			$sql = 'SELECT ext_active
 				FROM ' . EXT_TABLE . "
 				WHERE ext_name = '" . $db->sql_escape($extension). "'";


### PR DESCRIPTION
Cache still needs purging in functional tests, but only when setting up for testing extensions. This is __not__ a reversion of https://github.com/phpbb/phpbb/pull/4111 and only affects extensions running functional tests.
https://tracker.phpbb.com/browse/PHPBB3-14433

PHPBB3-14433