### PR TITLE
[ticket/14489] Fix bug where extension custom compiler pass cannot be found

### DIFF
--- a/phpBB/phpbb/di/container_builder.php
+++ b/phpBB/phpbb/di/container_builder.php
@@ -589,7 +589,7 @@ class container_builder
 			->ignoreUnreadableDirs(true)
 			->ignoreVCS(true)
 			->followLinks()
-			->in($this->phpbb_root_path . 'ext/')
+			->in($this->phpbb_root_path . 'ext')
 		;
 
 		/** @var \SplFileInfo $pass */


### PR DESCRIPTION
This is returning an extra / on my machine which throws off the next code block, and then the class can't be found.

PHPBB3-14489