### PR TITLE
[ticket/14132] Use transaction for adding notifications to type table

### DIFF
--- a/phpBB/phpbb/notification/manager.php
+++ b/phpBB/phpbb/notification/manager.php
@@ -923,6 +923,8 @@ class manager
 	{
 		$notification_type_ids = $this->cache->get('notification_type_ids');
 
+		$this->db->sql_transaction('begin');
+
 		if ($notification_type_ids === false)
 		{
 			$notification_type_ids = array();
@@ -956,6 +958,8 @@ class manager
 
 			$this->cache->put('notification_type_ids', $notification_type_ids);
 		}
+
+		$this->db->sql_transaction('commit');
 
 		return $notification_type_ids[$notification_type_name];
 	}


### PR DESCRIPTION
This will prevent a race condition that might occur by two posts being
submitted at the same time with the notification type IDs not being
cached.

Ticket: https://tracker.phpbb.com/browse/PHPBB3-14132