### PR TITLE
[ticket/14241] Prevent empty q&a as a result of improper settings

### DIFF
--- a/phpBB/language/en/acp/common.php
+++ b/phpBB/language/en/acp/common.php
@@ -594,6 +594,7 @@ $lang = array_merge($lang, array(
 
 	'LOG_ERROR_JABBER'		=> '<strong>Jabber error</strong><br />» %s',
 	'LOG_ERROR_EMAIL'		=> '<strong>Email error</strong><br />» %s',
+	'LOG_ERROR_CAPTCHA'		=> '<strong>CAPTCHA error</strong><br />» %s',
 
 	'LOG_FORUM_ADD'							=> '<strong>Created new forum</strong><br />» %s',
 	'LOG_FORUM_COPIED_PERMISSIONS'			=> '<strong>Copied forum permissions</strong> from %1$s<br />» %2$s',

--- a/phpBB/language/en/captcha_qa.php
+++ b/phpBB/language/en/captcha_qa.php
@@ -40,6 +40,7 @@ $lang = array_merge($lang, array(
 	'CAPTCHA_QA'				=> 'Q&amp;A',
 	'CONFIRM_QUESTION_EXPLAIN'	=> 'This question is a means of preventing automated form submissions by spambots.',
 	'CONFIRM_QUESTION_WRONG'	=> 'You have provided an invalid answer to the question.',
+	'CONFIRM_QUESTION_MISSING'	=> 'Questions for the captcha could not be retrieved. Please contact a board administrator.',
 
 	'QUESTION_ANSWERS'			=> 'Answers',
 	'ANSWERS_EXPLAIN'			=> 'Please enter valid answers to the question, one per line.',
@@ -60,5 +61,4 @@ $lang = array_merge($lang, array(
 
 	'QA_ERROR_MSG'				=> 'Please fill in all fields and enter at least one answer.',
 	'QA_LAST_QUESTION'			=> 'You cannot delete all questions while the plugin is active.',
-
 ));

--- a/phpBB/phpbb/captcha/plugins/qa.php
+++ b/phpBB/phpbb/captcha/plugins/qa.php
@@ -220,10 +220,12 @@ class qa
 	*/
 	function get_template()
 	{
-		global $template;
+		global $phpbb_log, $template, $user;
 
-		if ($this->is_solved() || !count($this->question_ids))
+		if ($this->is_solved() || empty($this->question_text) || !count($this->question_ids))
 		{
+			/** @var \phpbb\log\log_interface $phpbb_log */
+			$phpbb_log->add('critical', $user->data['user_id'], $user->ip, 'LOG_ERROR_CAPTCHA', time(), array($user->lang('CONFIRM_QUESTION_MISSING')));
 			return false;
 		}
 		else
@@ -386,13 +388,15 @@ class qa
 	*/
 	function validate()
 	{
-		global $user;
+		global $phpbb_log, $user;
 
 		$error = '';
 
 		if (!sizeof($this->question_ids))
 		{
-			return $user->lang['CONFIRM_QUESTION_MISSING'];
+			/** @var \phpbb\log\log_interface $phpbb_log */
+			$phpbb_log->add('critical', $user->data['user_id'], $user->ip, 'LOG_ERROR_CAPTCHA', time(), array($user->lang('CONFIRM_QUESTION_MISSING')));
+			return $user->lang('CONFIRM_QUESTION_MISSING');
 		}
 
 		if (!$this->confirm_id)

--- a/phpBB/phpbb/captcha/plugins/qa.php
+++ b/phpBB/phpbb/captcha/plugins/qa.php
@@ -100,6 +100,28 @@ class qa
 			$db->sql_freeresult($result);
 		}
 
+		// final fallback to any language
+		if (!sizeof($this->question_ids))
+		{
+			$this->question_lang = '';
+
+			$sql = 'SELECT q.question_id, q.lang_iso
+				FROM ' . $this->table_captcha_questions . ' q, ' . $this->table_captcha_answers . ' a
+				WHERE q.question_id = a.question_id
+				GROUP BY lang_iso';
+			$result = $db->sql_query($sql, 7200);
+
+			while ($row = $db->sql_fetchrow($result))
+			{
+				if (empty($this->question_lang))
+				{
+					$this->question_lang = $row['lang_iso'];
+				}
+				$this->question_ids[$row['question_id']] = $row['question_id'];
+			}
+			$db->sql_freeresult($result);
+		}
+
 		// okay, if there is a confirm_id, we try to load that confirm's state. If not, we try to find one
 		if (!$this->load_answer() && (!$this->load_confirm_id() || !$this->load_answer()))
 		{
@@ -200,7 +222,7 @@ class qa
 	{
 		global $template;
 
-		if ($this->is_solved())
+		if ($this->is_solved() || !count($this->question_ids))
 		{
 			return false;
 		}
@@ -370,7 +392,7 @@ class qa
 
 		if (!sizeof($this->question_ids))
 		{
-			return false;
+			return $user->lang['CONFIRM_QUESTION_MISSING'];
 		}
 
 		if (!$this->confirm_id)


### PR DESCRIPTION
Improper setup of the q&a captcha in combination with the admin choosing a
default language that does not have any questions and answers set might
result in the user being presented empty questions and answers. This
change will try to fall back to any question in case the admin incorrectly
set the default language and has no questions & answers set. If that does
not work, the captcha will not allow passing it and suggest to contact the
board admin to resolve this issue.

Ticket: https://tracker.phpbb.com/browse/PHPBB3-14241