### PR TITLE
[ticket/14529] Stop using --prefer-source for composer

### DIFF
--- a/travis/setup-phpbb.sh
+++ b/travis/setup-phpbb.sh
@@ -37,5 +37,5 @@ then
 fi
 
 cd phpBB
-php ../composer.phar install --dev --no-interaction --prefer-source
+php ../composer.phar install --dev --no-interaction
 cd ..


### PR DESCRIPTION
The api rate limit has been removed by github. Therefore,
we no longer need --prefer-source

Ticket: https://tracker.phpbb.com/browse/PHPBB3-14529