### PR TITLE
[ticket/14536] Force unix time stamps to be integer

### DIFF
--- a/phpBB/phpbb/user.php
+++ b/phpBB/phpbb/user.php
@@ -725,7 +725,7 @@ class user extends \phpbb\session
 			$utc = new \DateTimeZone('UTC');
 		}
 
-		$time = new $this->datetime($this, "@$gmepoch", $utc);
+		$time = new $this->datetime($this, '@' . (int) $gmepoch, $utc);
 		$time->setTimezone($this->timezone);
 
 		return $time->format($format, $forcedate);


### PR DESCRIPTION
This will ensure to prevent PHP fatal errors in case the passed timestamp
is an empty string or does not evaluate to an integer (i.e. strings like
foobar).

Ticket: https://tracker.phpbb.com/browse/PHPBB3-14536