### PR TITLE
[ticket/14540] Adjust recursive_dot_prefix_filter_iterator for performance

### DIFF
--- a/phpBB/phpbb/recursive_dot_prefix_filter_iterator.php
+++ b/phpBB/phpbb/recursive_dot_prefix_filter_iterator.php
@@ -25,6 +25,6 @@ class recursive_dot_prefix_filter_iterator extends \RecursiveFilterIterator
 	public function accept()
 	{
 		$filename = $this->current()->getFilename();
-		return !$this->current()->isDir() || $filename[0] !== '.';
+		return $filename[0] !== '.' || !$this->current()->isDir();
 	}
 }


### PR DESCRIPTION
Swapping conditions in the function accept() of the class
\phpbb\recursive_dot_prefix_filter_iterator saves a lot of isDir() calls which
is more expensive than $filename[0] checks.

<a href="https://tracker.phpbb.com/browse/PHPBB3-14540">PHPBB3-14540</a>.