### PR TITLE
[ticket/13630] Prevent empty parameter select_single

### DIFF
--- a/phpBB/includes/ucp/ucp_pm_compose.php
+++ b/phpBB/includes/ucp/ucp_pm_compose.php
@@ -154,7 +154,7 @@ function compose_pm($id, $mode, $action, $user_folders = array())
 			'S_SHOW_PM_BOX'		=> true,
 			'S_ALLOW_MASS_PM'	=> ($config['allow_mass_pm'] && $auth->acl_get('u_masspm')) ? true : false,
 			'S_GROUP_OPTIONS'	=> ($config['allow_mass_pm'] && $auth->acl_get('u_masspm_group')) ? $group_options : '',
-			'U_FIND_USERNAME'	=> append_sid("{$phpbb_root_path}memberlist.$phpEx", "mode=searchuser&amp;form=postform&amp;field=username_list&amp;select_single=$select_single"),
+			'U_FIND_USERNAME'	=> append_sid("{$phpbb_root_path}memberlist.$phpEx", "mode=searchuser&amp;form=postform&amp;field=username_list&amp;select_single=" . (int) $select_single),
 		));
 	}
 

--- a/phpBB/memberlist.php
+++ b/phpBB/memberlist.php
@@ -1277,7 +1277,8 @@ switch ($mode)
 			}
 
 			$param = call_user_func_array('request_var', $call);
-			$param = urlencode($key) . '=' . ((is_string($param)) ? urlencode($param) : $param);
+			// Encode strings, convert everything else to int in order to prevent empty parameters.
+			$param = urlencode($key) . '=' . ((is_string($param)) ? urlencode($param) : (int) $param);
 			$params[] = $param;
 
 			if ($key != 'first_char')


### PR DESCRIPTION
[PHPBB3-13630](https://tracker.phpbb.com/browse/PHPBB3-13630)

Please note, that this is probably only one of many problematic parameters. For example, when you submit member search for every user that starts with "a", this URL is generated:
`http://localhost/phpbb/phpBB/memberlist.php?sk=c&sd=a&username=a&email=&search_group_id=0&joined_select=lt&active_select=lt&count_select=eq&joined=&active=&count=&ip=`
Apache's mod_security has no knowledge, that this URL was generated by browser's form instead of classical anchor. Further inspection is required.