### PR TITLE
[ticket/9674] Use poster auth instead of current user auth

### DIFF
--- a/phpBB/includes/functions_posting.php
+++ b/phpBB/includes/functions_posting.php
@@ -1535,7 +1535,7 @@ function delete_post($forum_id, $topic_id, $post_id, &$data, $is_soft = false, $
 */
 function submit_post($mode, $subject, $username, $topic_type, &$poll, &$data, $update_message = true, $update_search_index = true)
 {
-	global $db, $auth, $user, $config, $phpEx, $template, $phpbb_root_path, $phpbb_container, $phpbb_dispatcher;
+	global $db, $user, $config, $phpEx, $template, $phpbb_root_path, $phpbb_container, $phpbb_dispatcher;
 
 	/**
 	* Modify the data for post submitting
@@ -1562,6 +1562,24 @@ function submit_post($mode, $subject, $username, $topic_type, &$poll, &$data, $u
 		'update_search_index',
 	);
 	extract($phpbb_dispatcher->trigger_event('core.modify_submit_post_data', compact($vars)));
+
+	// Use poster auth instead of current user auth.
+	// Without this alteration, moderator who edits unapproved post from user without
+	// f_postcount permission disarrays post counts.
+	if ($user->data['user_id'] == $data['poster_id'])
+	{
+		global $auth;
+	}
+	else
+	{
+		$auth = new phpbb\auth\auth();
+		$sql = 'SELECT user_id, user_permissions, user_type
+				FROM ' . USERS_TABLE . '
+				WHERE user_id = ' . (int) $data['poster_id'];
+		$result = $db->sql_query($sql);
+		$userdata = $db->sql_fetchrow($result);
+		$auth->acl($userdata);
+	}
 
 	// We do not handle erasing posts here
 	if ($mode == 'delete')

--- a/tests/notification/submit_post_type_bookmark_test.php
+++ b/tests/notification/submit_post_type_bookmark_test.php
@@ -64,7 +64,7 @@ class phpbb_notification_submit_post_type_bookmark_test extends phpbb_notificati
 			*	7	=> Bookmarked, option set to default, should receive a notification
 			*/
 			array(
-				array(),
+				array('poster_id' => 2),
 				array(
 					array('user_id' => 5, 'item_id' => 1, 'item_parent_id' => 1),
 				),
@@ -81,7 +81,7 @@ class phpbb_notification_submit_post_type_bookmark_test extends phpbb_notificati
 			* No new notifications
 			*/
 			array(
-				array('force_approved_state' => false),
+				array('force_approved_state' => false, 'poster_id' => 2),
 				array(
 					array('user_id' => 5, 'item_id' => 1, 'item_parent_id' => 1),
 				),

--- a/tests/notification/submit_post_type_post_in_queue_test.php
+++ b/tests/notification/submit_post_type_post_in_queue_test.php
@@ -71,7 +71,7 @@ class phpbb_notification_submit_post_type_post_in_queue_test extends phpbb_notif
 			* No new notifications
 			*/
 			array(
-				array(),
+				array('poster_id' => 2),
 				array(
 					array('user_id' => 6, 'item_id' => 1, 'item_parent_id' => 1),
 				),
@@ -94,7 +94,7 @@ class phpbb_notification_submit_post_type_post_in_queue_test extends phpbb_notif
 			*	9	=> Moderator, has only global mod permissions, should receive a notification
 			*/
 			array(
-				array('force_approved_state' => false),
+				array('force_approved_state' => false, 'poster_id' => 2),
 				array(
 					array('user_id' => 6, 'item_id' => 1, 'item_parent_id' => 1),
 				),

--- a/tests/notification/submit_post_type_post_test.php
+++ b/tests/notification/submit_post_type_post_test.php
@@ -65,7 +65,7 @@ class phpbb_notification_submit_post_type_post_test extends phpbb_notification_s
 			*	8	=> Forum subscribed, but already notified, should NOT receive a new notification
 			*/
 			array(
-				array(),
+				array('poster_id' => 2),
 				array(
 					array('user_id' => 5, 'item_id' => 1, 'item_parent_id' => 1),
 					array('user_id' => 8, 'item_id' => 1, 'item_parent_id' => 1),
@@ -85,7 +85,7 @@ class phpbb_notification_submit_post_type_post_test extends phpbb_notification_s
 			* No new notifications
 			*/
 			array(
-				array('force_approved_state' => false),
+				array('force_approved_state' => false, 'poster_id' => 2),
 				array(
 					array('user_id' => 5, 'item_id' => 1, 'item_parent_id' => 1),
 					array('user_id' => 8, 'item_id' => 1, 'item_parent_id' => 1),

--- a/tests/notification/submit_post_type_quote_test.php
+++ b/tests/notification/submit_post_type_quote_test.php
@@ -65,6 +65,7 @@ class phpbb_notification_submit_post_type_quote_test extends phpbb_notification_
 			*/
 			array(
 				array(
+					'poster_id'			=> 2,
 					'message'			=> implode(' ', array(
 						'[quote=&quot;poster&quot;:uid]poster should not be notified[/quote:uid]',
 						'[quote=&quot;test&quot;:uid]test should be notified[/quote:uid]',
@@ -94,6 +95,7 @@ class phpbb_notification_submit_post_type_quote_test extends phpbb_notification_
 			*/
 			array(
 				array(
+					'poster_id'			=> 2,
 					'message'			=> implode(' ', array(
 						'[quote=&quot;poster&quot;:uid]poster should not be notified[/quote:uid]',
 						'[quote=&quot;test&quot;:uid]test should be notified[/quote:uid]',

--- a/tests/notification/submit_post_type_topic_test.php
+++ b/tests/notification/submit_post_type_topic_test.php
@@ -64,7 +64,7 @@ class phpbb_notification_submit_post_type_topic_test extends phpbb_notification_
 			*	8	=> Forum subscribed, but already notified, should NOT receive a new notification
 			*/
 			array(
-				array(),
+				array('poster_id' => 2),
 				array(
 					array('user_id' => 8, 'item_id' => 1, 'item_parent_id' => 1),
 				),
@@ -81,7 +81,7 @@ class phpbb_notification_submit_post_type_topic_test extends phpbb_notification_
 			* No new notifications
 			*/
 			array(
-				array('force_approved_state' => false),
+				array('force_approved_state' => false, 'poster_id' => 2),
 				array(
 					array('user_id' => 8, 'item_id' => 1, 'item_parent_id' => 1),
 				),
@@ -121,7 +121,7 @@ class phpbb_notification_submit_post_type_topic_test extends phpbb_notification_
 			return;
 		}
 
-		$reply_data = array_merge($this->post_data, array(
+		$reply_data = array_merge($this->post_data, $additional_post_data, array(
 			'topic_id'		=> 2,
 		));
 		$url = submit_post('reply', '', 'poster-name', POST_NORMAL, $poll_data, $reply_data, false, false);


### PR DESCRIPTION
[PHPBB3-9674](https://tracker.phpbb.com/browse/PHPBB3-9674)

Side effect of this modification is, that post awaiting approval edited by moderator does not get approved automatically upon editing. But imho this is desired behaviour, just ignored by everyone till now.