### PR TITLE
[ticket/14530] Only generate text again if sig was parsed for storage

### DIFF
--- a/phpBB/includes/acp/acp_users.php
+++ b/phpBB/includes/acp/acp_users.php
@@ -2073,7 +2073,10 @@ class acp_users
 				// Replace "error" strings with their real, localised form
 				$error = array_map(array($user, 'lang'), $error);
 
-				$decoded_message = generate_text_for_edit($signature, $bbcode_uid, $bbcode_bitfield);
+				if ($request->is_set_post('preview'))
+				{
+					$decoded_message = generate_text_for_edit($signature, $bbcode_uid, $bbcode_bitfield);
+				}
 
 				/** @var \phpbb\controller\helper $controller_helper */
 				$controller_helper = $phpbb_container->get('controller.helper');

--- a/phpBB/includes/ucp/ucp_profile.php
+++ b/phpBB/includes/ucp/ucp_profile.php
@@ -544,7 +544,10 @@ class ucp_profile
 				// Replace "error" strings with their real, localised form
 				$error = array_map(array($user, 'lang'), $error);
 
-				$decoded_message = generate_text_for_edit($signature, $bbcode_uid, $bbcode_bitfield);
+				if ($request->is_set_post('preview'))
+				{
+					$decoded_message = generate_text_for_edit($signature, $bbcode_uid, $bbcode_flags);
+				}
 
 				/** @var \phpbb\controller\helper $controller_helper */
 				$controller_helper = $phpbb_container->get('controller.helper');

--- a/phpBB/viewtopic.php
+++ b/phpBB/viewtopic.php
@@ -1597,6 +1597,7 @@ for ($i = 0, $end = sizeof($post_list); $i < $end; ++$i)
 	{
 		$parse_flags = ($user_cache[$poster_id]['sig_bbcode_bitfield'] ? OPTION_FLAG_BBCODE : 0) | OPTION_FLAG_SMILIES;
 		$user_cache[$poster_id]['sig'] = generate_text_for_display($user_cache[$poster_id]['sig'], $user_cache[$poster_id]['sig_bbcode_uid'], $user_cache[$poster_id]['sig_bbcode_bitfield'],  $parse_flags, true);
+		$user_cache[$poster_id]['sig_parsed'] = true;
 	}
 
 	// Parse the message and subject


### PR DESCRIPTION
Otherwise data like the bbcode ID and the flags will not be set which will cause improper generation of text for edit by users.

Ticket: https://tracker.phpbb.com/browse/PHPBB3-14530