### PR TITLE
[ticket/14051] Restore accidentally removed $topics_count value

### DIFF
--- a/phpBB/viewforum.php
+++ b/phpBB/viewforum.php
@@ -308,7 +308,10 @@ if ($sort_days)
 		'sql_array',
 	);
 	extract($phpbb_dispatcher->trigger_event('core.viewforum_modify_sort_data_sql', compact($vars)));
+
 	$result = $db->sql_query($db->sql_build_query('SELECT', $sql_array));
+	$topics_count = (int) $db->sql_fetchfield('num_topics');
+	$db->sql_freeresult($result);
 
 	if (isset($_POST['sort']))
 	{


### PR DESCRIPTION
$topics_count value was accidentally removed by #4238. Restore it.
<a href="https://tracker.phpbb.com/browse/PHPBB3-14051">PHPBB3-14051</a>.