### PR TITLE
[ticket/14136] Add back X-UA-Compatible meta tag

### DIFF
--- a/phpBB/adm/style/installer_header.html
+++ b/phpBB/adm/style/installer_header.html
@@ -2,6 +2,7 @@
 <html dir="{S_CONTENT_DIRECTION}" lang="{S_USER_LANG}">
 <head>
 	<meta charset="utf-8">
+	<meta http-equiv="X-UA-Compatible" content="IE=edge">
 	<meta name="viewport" content="width=device-width, initial-scale=1" />
 	<!-- IF META -->{META}<!-- ENDIF -->
 	<title>{PAGE_TITLE}</title>

--- a/phpBB/adm/style/overall_header.html
+++ b/phpBB/adm/style/overall_header.html
@@ -2,6 +2,7 @@
 <html dir="{S_CONTENT_DIRECTION}" lang="{S_USER_LANG}">
 <head>
 <meta charset="utf-8">
+<meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 <!-- IF META -->{META}<!-- ENDIF -->
 <title>{PAGE_TITLE}</title>

--- a/phpBB/adm/style/simple_header.html
+++ b/phpBB/adm/style/simple_header.html
@@ -2,6 +2,7 @@
 <html dir="{S_CONTENT_DIRECTION}" lang="{S_USER_LANG}">
 <head>
 <meta charset="utf-8">
+<meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 <!-- IF META -->{META}<!-- ENDIF -->
 <title>{PAGE_TITLE}</title>

--- a/phpBB/docs/CHANGELOG.html
+++ b/phpBB/docs/CHANGELOG.html
@@ -2,6 +2,7 @@
 <html dir="ltr" lang="en">
 <head>
 <meta charset="utf-8">
+<meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="keywords" content="" />
 <meta name="description" content="phpBB 3.1.x Changelog" />
 <title>phpBB &bull; Changelog</title>

--- a/phpBB/docs/FAQ.html
+++ b/phpBB/docs/FAQ.html
@@ -2,6 +2,7 @@
 <html dir="ltr" lang="en">
 <head>
 <meta charset="utf-8">
+<meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="keywords" content="" />
 <meta name="description" content="phpBB 3.1.x frequently asked questions" />
 <title>phpBB &bull; FAQ</title>

--- a/phpBB/docs/INSTALL.html
+++ b/phpBB/docs/INSTALL.html
@@ -2,6 +2,7 @@
 <html dir="ltr" lang="en">
 <head>
 <meta charset="utf-8">
+<meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="keywords" content="" />
 <meta name="description" content="phpBB 3.1.x Installation, updating and conversion informations" />
 <title>phpBB &bull; Install</title>

--- a/phpBB/docs/README.html
+++ b/phpBB/docs/README.html
@@ -2,6 +2,7 @@
 <html dir="ltr" lang="en">
 <head>
 <meta charset="utf-8">
+<meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="keywords" content="" />
 <meta name="description" content="phpBB 3.1.x Readme" />
 <title>phpBB &bull; Readme</title>

--- a/phpBB/docs/auth_api.html
+++ b/phpBB/docs/auth_api.html
@@ -2,6 +2,7 @@
 <html dir="ltr" lang="en">
 <head>
 <meta charset="utf-8">
+<meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="keywords" content="" />
 <meta name="description" content="This is an explanation of how to use the phpBB auth/acl API" />
 <title>phpBB3 &bull; Auth API</title>

--- a/phpBB/docs/coding-guidelines.html
+++ b/phpBB/docs/coding-guidelines.html
@@ -2,6 +2,7 @@
 <html dir="ltr" lang="en">
 <head>
 <meta charset="utf-8">
+<meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="keywords" content="" />
 <meta name="description" content="Ascraeus coding guidelines document" />
 <title>phpBB3 &bull; Coding Guidelines</title>

--- a/phpBB/includes/functions.php
+++ b/phpBB/includes/functions.php
@@ -1813,6 +1813,7 @@ function redirect($url, $return = false, $disable_cd_check = false)
 		echo '<html dir="' . $user->lang['DIRECTION'] . '" lang="' . $user->lang['USER_LANG'] . '">';
 		echo '<head>';
 		echo '<meta charset="utf-8">';
+		echo '<meta http-equiv="X-UA-Compatible" content="IE=edge">';
 		echo '<meta http-equiv="refresh" content="0; url=' . str_replace('&', '&amp;', $url) . '" />';
 		echo '<title>' . $user->lang['REDIRECT'] . '</title>';
 		echo '</head>';
@@ -3322,6 +3323,7 @@ function msg_handler($errno, $msg_text, $errfile, $errline)
 			echo '<html dir="ltr">';
 			echo '<head>';
 			echo '<meta charset="utf-8">';
+			echo '<meta http-equiv="X-UA-Compatible" content="IE=edge">';
 			echo '<title>' . $msg_title . '</title>';
 			echo '<style type="text/css">' . "\n" . '/* <![CDATA[ */' . "\n";
 			echo '* { margin: 0; padding: 0; } html { font-size: 100%; height: 100%; margin-bottom: 1px; background-color: #E4EDF0; } body { font-family: "Lucida Grande", Verdana, Helvetica, Arial, sans-serif; color: #536482; background: #E4EDF0; font-size: 62.5%; margin: 0; } ';

--- a/phpBB/includes/functions_download.php
+++ b/phpBB/includes/functions_download.php
@@ -108,6 +108,7 @@ function wrap_img_in_html($src, $title)
 	echo '<html>';
 	echo '<head>';
 	echo '<meta charset="utf-8">';
+	echo '<meta http-equiv="X-UA-Compatible" content="IE=edge">';
 	echo '<title>' . $title . '</title>';
 	echo '</head>';
 	echo '<body>';

--- a/phpBB/phpbb/db/driver/driver.php
+++ b/phpBB/phpbb/db/driver/driver.php
@@ -1041,6 +1041,7 @@ abstract class driver implements driver_interface
 					<html dir="ltr">
 					<head>
 						<meta charset="utf-8">
+						<meta http-equiv="X-UA-Compatible" content="IE=edge">
 						<title>SQL Report</title>
 						<link href="' . htmlspecialchars($phpbb_path_helper->update_web_root_path($phpbb_root_path) . $phpbb_path_helper->get_adm_relative_path()) . 'style/admin.css" rel="stylesheet" type="text/css" media="screen" />
 					</head>

--- a/phpBB/styles/prosilver/template/overall_header.html
+++ b/phpBB/styles/prosilver/template/overall_header.html
@@ -2,6 +2,7 @@
 <html dir="{S_CONTENT_DIRECTION}" lang="{S_USER_LANG}">
 <head>
 <meta charset="utf-8" />
+<meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 {META}
 <title><!-- IF UNREAD_NOTIFICATIONS_COUNT -->({UNREAD_NOTIFICATIONS_COUNT}) <!-- ENDIF --><!-- IF not S_VIEWTOPIC and not S_VIEWFORUM -->{SITENAME} - <!-- ENDIF --><!-- IF S_IN_MCP -->{L_MCP} - <!-- ELSEIF S_IN_UCP -->{L_UCP} - <!-- ENDIF -->{PAGE_TITLE}<!-- IF S_VIEWTOPIC or S_VIEWFORUM --> - {SITENAME}<!-- ENDIF --></title>

--- a/phpBB/styles/prosilver/template/simple_header.html
+++ b/phpBB/styles/prosilver/template/simple_header.html
@@ -2,6 +2,7 @@
 <html dir="{S_CONTENT_DIRECTION}" lang="{S_USER_LANG}">
 <head>
 <meta charset="utf-8" />
+<meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 {META}
 <title>{SITENAME} &bull; <!-- IF S_IN_MCP -->{L_MCP} &bull; <!-- ELSEIF S_IN_UCP -->{L_UCP} &bull; <!-- ENDIF -->{PAGE_TITLE}</title>

--- a/phpBB/styles/prosilver/template/ucp_pm_viewmessage_print.html
+++ b/phpBB/styles/prosilver/template/ucp_pm_viewmessage_print.html
@@ -2,6 +2,7 @@
 <html dir="{S_CONTENT_DIRECTION}" lang="{S_USER_LANG}">
 <head>
 <meta charset="utf-8" />
+<meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="robots" content="noindex" />
 {META}
 <title>{SITENAME} &bull; {PAGE_TITLE}</title>

--- a/phpBB/styles/prosilver/template/viewtopic_print.html
+++ b/phpBB/styles/prosilver/template/viewtopic_print.html
@@ -2,6 +2,7 @@
 <html dir="{S_CONTENT_DIRECTION}" lang="{S_USER_LANG}">
 <head>
 <meta charset="utf-8" />
+<meta http-equiv="X-UA-Compatible" content="IE=edge">
 <meta name="robots" content="noindex" />
 {META}
 <title>{SITENAME} &bull; {PAGE_TITLE}</title>


### PR DESCRIPTION
This was previously removed without needing to. Adding it back to force
users to not emulate the page for previous versions of IE. The
imagetoolbar http-equiv tag was not restored as IE does not contain that
anymore since IE7. Also, the chome=1 has been removed from the
X-UA-Compatible content as ChromeFrame does not receive any further
updates since 2014 and is potentially broken.

3.2.x version of #4242 

Ticket: https://tracker.phpbb.com/browse/PHPBB3-14136