### PR TITLE
[ticket/14381] Set the mode in message parser to "reparse"

### DIFF
--- a/phpBB/phpbb/textreparser/base.php
+++ b/phpBB/phpbb/textreparser/base.php
@@ -230,7 +230,8 @@ abstract class base implements reparser_interface
 			$unparsed['enable_img_bbcode'],
 			$unparsed['enable_flash_bbcode'],
 			$unparsed['enable_quote_bbcode'],
-			$unparsed['enable_url_bbcode']
+			$unparsed['enable_url_bbcode'],
+			'reparse'
 		);
 
 		// Save the new text if it has changed and it's not a dry run

--- a/tests/text_reparser/base_test.php
+++ b/tests/text_reparser/base_test.php
@@ -1,0 +1,70 @@
+<?php
+/**
+*
+* This file is part of the phpBB Forum Software package.
+*
+* @copyright (c) phpBB Limited <https://www.phpbb.com>
+* @license GNU General Public License, version 2 (GPL-2.0)
+*
+* For full copyright and license information, please see
+* the docs/CREDITS.txt file.
+*
+*/
+require_once __DIR__ . '/../../phpBB/includes/functions.php';
+require_once __DIR__ . '/../../phpBB/includes/functions_content.php';
+require_once __DIR__ . '/../test_framework/phpbb_database_test_case.php';
+
+class phpbb_textreparser_base_test extends phpbb_database_test_case
+{
+	protected $db;
+
+	public function setUp()
+	{
+		global $config;
+		if (!isset($config))
+		{
+			$config = new \phpbb\config\config(array());
+		}
+		$this->get_test_case_helpers()->set_s9e_services();
+		$this->db = $this->new_dbal();
+		parent::setUp();
+	}
+
+	public function getDataSet()
+	{
+		return $this->createXMLDataSet(__DIR__ . '/fixtures/base.xml');
+	}
+
+	protected function get_reparser()
+	{
+		return new \phpbb\textreparser\plugins\post_text($this->db, POSTS_TABLE);
+	}
+
+	protected function get_rows(array $ids)
+	{
+		$sql = 'SELECT post_id AS id, post_text AS text
+			FROM ' . POSTS_TABLE . '
+			WHERE ' . $this->db->sql_in_set('post_id', $ids) . '
+			ORDER BY id';
+		$result = $this->db->sql_query($sql);
+		$rows = $this->db->sql_fetchrowset($result);
+		$this->db->sql_freeresult($result);
+
+		return $rows;
+	}
+
+	public function test_reparse_empty()
+	{
+		$this->get_reparser()->reparse_range(1, 1);
+
+		$this->assertEquals(
+			array(
+				array(
+					'id'   => 1,
+					'text' => '<t></t>'
+				)
+			),
+			$this->get_rows(array(1))
+		);
+	}
+}

--- a/tests/text_reparser/fixtures/base.xml
+++ b/tests/text_reparser/fixtures/base.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<dataset>
+	<table name="phpbb_posts">
+		<column>post_id</column>
+		<column>enable_bbcode</column>
+		<column>enable_smilies</column>
+		<column>enable_magic_url</column>
+		<column>post_text</column>
+		<column>bbcode_uid</column>
+		<row>
+			<value>1</value>
+			<value>1</value>
+			<value>1</value>
+			<value>1</value>
+			<value></value>
+			<value>abcd1234</value>
+		</row>
+	</table>
+</dataset>


### PR DESCRIPTION
The default mode is "post". By setting it to something else,
all limits pertaining to posts (min/max length, etc...) should
be disabled.

PHPBB3-14381