### PR TITLE
[ticket/14562] Language fallback for extension permissions

### DIFF
--- a/phpBB/includes/functions_admin.php
+++ b/phpBB/includes/functions_admin.php
@@ -3081,17 +3081,46 @@ function tidy_database()
 */
 function add_permission_language()
 {
-	global $user, $phpEx, $phpbb_extension_manager;
+	global $config, $user, $phpEx, $phpbb_extension_manager;
 
 	// add permission language files from extensions
 	$finder = $phpbb_extension_manager->get_finder();
 
-	$lang_files = $finder
+	// We grab the language files from the default, English and user's language.
+	// So we can fall back to the other files like we do when using add_lang()
+	$default_lang_files = $english_lang_files = $user_lang_files = array();
+
+	// Search for board default language if it's not the user language
+	if ($config['default_lang'] != $user->lang_name)
+	{
+		$default_lang_files = $finder
+			->prefix('permissions_')
+			->suffix(".$phpEx")
+			->core_path('language/' . basename($config['default_lang']) . '/')
+			->extension_directory('/language/' . basename($config['default_lang']))
+			->find();
+	}
+
+	// Search for english, if its not the default or user language
+	if ($config['default_lang'] != 'en' && $user->lang_name != 'en')
+	{
+		$english_lang_files = $finder
+			->prefix('permissions_')
+			->suffix(".$phpEx")
+			->core_path('language/en/')
+			->extension_directory('/language/en')
+			->find();
+	}
+
+	// Find files in the user's language
+	$user_lang_files = $finder
 		->prefix('permissions_')
 		->suffix(".$phpEx")
 		->core_path('language/' . $user->lang_name . '/')
 		->extension_directory('/language/' . $user->lang_name)
 		->find();
+
+	$lang_files = array_merge($english_lang_files, $default_lang_files, $user_lang_files);
 
 	foreach ($lang_files as $lang_file => $ext_name)
 	{


### PR DESCRIPTION
The code was copied and adjusted from `add_mod_info()` in `includes/functions_module.php` which already has language fallback.

PHPBB3-14562