### PR TITLE
[ticket/14532] Do not escape column default in mssql

### DIFF
--- a/phpBB/phpbb/db/tools.php
+++ b/phpBB/phpbb/db/tools.php
@@ -2340,7 +2340,7 @@ class tools
 				if (!empty($column_data['default']))
 				{
 					// Add new default value constraint
-					$statements[] = 'ALTER TABLE [' . $table_name . '] ADD CONSTRAINT [DF_' . $table_name . '_' . $column_name . '_1] ' . $this->db->sql_escape($column_data['default']) . ' FOR [' . $column_name . ']';
+					$statements[] = 'ALTER TABLE [' . $table_name . '] ADD CONSTRAINT [DF_' . $table_name . '_' . $column_name . '_1] ' . $column_data['default'] . ' FOR [' . $column_name . ']';
 				}
 
 				if (!empty($indexes))


### PR DESCRIPTION
The column default shouldn't be escaped for mssql. This is a regression
from 743d816631292a2081af4c5f7fc2fad2aff17c58. Prior to that commit, the
default value for the column was not escaped. Escaping it will cause SQL
errors while altering columns.

Ticket: https://tracker.phpbb.com/browse/PHPBB3-14532