### PR TITLE
[ticket/14426] Fixed undefined offset error

### DIFF
--- a/phpBB/includes/bbcode.php
+++ b/phpBB/includes/bbcode.php
@@ -226,6 +226,11 @@ class bbcode
 						),
 						'preg' => array(
 							'#\[quote(?:=&quot;(.*?)&quot;)?:$uid\]((?!\[quote(?:=&quot;.*?&quot;)?:$uid\]).)?#is'	=> function ($match) {
+								if (!isset($match[2]))
+								{
+									$match[2] = '';
+								}
+
 								return $this->bbcode_second_pass_quote($match[1], $match[2]);
 							},
 						)


### PR DESCRIPTION
It's just an undefined offset error that was introduced in 3106195cddec48ec779282d03f2c54c88fc66511. The second capture is optional and since it's the last capture it will be omitted from `$match` rather than set to an empty string.

No test attached because there's no support for running "second pass" tests on the old BBCode engine.

PHPBB3-14426