### PR TITLE
invalid redirect login or logout from HTTPS page

### DIFF
--- a/phpBB/includes/functions.php
+++ b/phpBB/includes/functions.php
@@ -2266,7 +2266,7 @@ function generate_board_url($without_script_path = false)
 		// HTTP HOST can carry a port number (we fetch $user->host, but for old versions this may be true)
 		if (strpos($server_name, ':') === false)
 		{
-			$url .= ':' . $server_port;
+			$url .= ':' . $config['server_port'];
 		}
 	}
 


### PR DESCRIPTION
when user login or logout from HTTPS page then phpBB do invalid redirect to `https://...:80`, althoughin in board settings Server Port: 443
> ENVIRONMENT:
> 
> Apache 2.2
> PHP 5.4
> phpBB 3.1.9
> 
> 
> BOARD SETTINGS
> 
> Cookies settings
> Secure cookie [https]: Enabled
> 
> Server Settings - URL Server Settings
> Server Protocol: https://
> Server Port: 443
> The path to the conference: /

https://tracker.phpbb.com/browse/PHPBB3-14617