### PR TITLE
[ticket/14614] Allow usage of language keys in composer.json

### DIFF
--- a/phpBB/includes/acp/acp_extensions.php
+++ b/phpBB/includes/acp/acp_extensions.php
@@ -75,6 +75,7 @@ class acp_extensions
 			try
 			{
 				$md_manager->get_metadata('all');
+				$md_manager->load_info_language_file();
 			}
 			catch (\phpbb\extension\exception $e)
 			{

--- a/phpBB/phpbb/extension/manager.php
+++ b/phpBB/phpbb/extension/manager.php
@@ -146,6 +146,53 @@ class manager
 	}
 
 	/**
+	 * Add custom Extension info language file
+	 */
+	public function add_ext_info()
+	{
+		$finder = $this->get_finder(true);
+		// We grab the language files from the default, English and user's language.
+		// So we can fall back to the other files like we do when using add_lang()
+		$default_lang_files = $english_lang_files = $user_lang_files = array();
+
+		// Search for board default language if it's not the user language
+		if ($this->config['default_lang'] != $this->user->lang_name)
+		{
+			$default_lang_files = $finder
+				->prefix('info_ext_')
+				->suffix('.' . $this->php_ext)
+				->extension_directory('/language/' . basename($this->config['default_lang']))
+				->core_path('language/' . basename($this->config['default_lang']) . '/mods/')
+				->find();
+		}
+
+		// Search for english, if its not the default or user language
+		if ($this->config['default_lang'] != 'en' && $this->user->lang_name != 'en')
+		{
+			$english_lang_files = $finder
+				->prefix('info_ext_')
+				->suffix('.' . $this->php_ext)
+				->extension_directory('/language/en')
+				->core_path('language/en/mods/')
+				->find();
+		}
+
+		// Find files in the user's language
+		$user_lang_files = $finder
+			->prefix('info_ext_')
+			->suffix('.' . $this->php_ext)
+			->extension_directory('/language/' . $this->user->lang_name)
+			->core_path('language/' . $this->user->lang_name . '/mods/')
+			->find();
+
+		$lang_files = array_merge($english_lang_files, $default_lang_files, $user_lang_files);
+		foreach ($lang_files as $lang_file => $ext_name)
+		{
+			$this->user->add_lang_ext($ext_name, $lang_file);
+		}
+	}
+
+	/**
 	* Instantiates the metadata manager for the extension with the given name
 	*
 	* @param string $name The extension name

--- a/phpBB/phpbb/extension/metadata_manager.php
+++ b/phpBB/phpbb/extension/metadata_manager.php
@@ -136,6 +136,15 @@ class metadata_manager
 	}
 
 	/**
+	 * Loads the extension info language file
+	 */
+	public function load_info_language_file()
+	{
+		$this->extension_manager->add_ext_info();
+	}
+
+
+	/**
 	* Sets the filepath of the metadata file
 	*
 	* @throws \phpbb\extension\exception
@@ -349,9 +358,9 @@ class metadata_manager
 	public function output_template_data()
 	{
 		$this->template->assign_vars(array(
-			'META_NAME'			=> $this->metadata['name'],
+			'META_NAME'			=> $this->get_metadata_language_key($this->metadata['name']),
 			'META_TYPE'			=> $this->metadata['type'],
-			'META_DESCRIPTION'	=> (isset($this->metadata['description'])) ? $this->metadata['description'] : '',
+			'META_DESCRIPTION'	=> (isset($this->metadata['description'])) ? $this->get_metadata_language_key($this->metadata['description']) : '',
 			'META_HOMEPAGE'		=> (isset($this->metadata['homepage'])) ? $this->metadata['homepage'] : '',
 			'META_VERSION'		=> (isset($this->metadata['version'])) ? $this->metadata['version'] : '',
 			'META_TIME'			=> (isset($this->metadata['time'])) ? $this->metadata['time'] : '',
@@ -372,8 +381,23 @@ class metadata_manager
 				'AUTHOR_NAME'		=> $author['name'],
 				'AUTHOR_EMAIL'		=> (isset($author['email'])) ? $author['email'] : '',
 				'AUTHOR_HOMEPAGE'	=> (isset($author['homepage'])) ? $author['homepage'] : '',
-				'AUTHOR_ROLE'		=> (isset($author['role'])) ? $author['role'] : '',
+				'AUTHOR_ROLE'		=> (isset($author['role'])) ? $this->get_metadata_language_key($author['role']) : '',
 			));
 		}
+	}
+
+	/**
+	 * Returns the language key if exists
+	 *
+	 * @return string
+	 */
+	private function get_metadata_language_key($lang_key)
+	{
+		if (isset($this->user->lang[$lang_key]))
+		{
+			return $this->user->lang[$lang_key];
+		}
+
+		return $lang_key;
 	}
 }


### PR DESCRIPTION
These changes allow to use language keys in composer.json to translate the name and description of the extension and also the Author Role.

https://tracker.phpbb.com/browse/PHPBB3-14614

PHPBB3-14614