### PR TITLE
[ticket/14415] Adds data-ajax="mark_topics_read" to link "mark_all_read"

### DIFF
--- a/phpBB/styles/prosilver/template/search_results.html
+++ b/phpBB/styles/prosilver/template/search_results.html
@@ -33,7 +33,7 @@
 		<!-- EVENT search_results_searchbox_after -->
 
 		<div class="pagination">
-			<!-- IF U_MARK_ALL_READ --><a href="{U_MARK_ALL_READ}" class="mark-read" accesskey="m">{L_MARK_ALL_READ}</a> &bull;<!-- ENDIF -->
+			<!-- IF U_MARK_ALL_READ --><a href="{U_MARK_ALL_READ}" class="mark-read" accesskey="m" data-ajax="mark_topics_read">{L_MARK_ALL_READ}</a> &bull;<!-- ENDIF -->
 			{SEARCH_MATCHES}
 			<!-- IF .pagination -->
 				<!-- INCLUDE pagination.html -->


### PR DESCRIPTION
The link in the search-results of "unread posts" will now work with AJAX. I think it is okay to use the existing function from "mark_topics_read" instead of creating a new, very similar function for "mark_all_read" instead. 

PHPBB3-14415 https://tracker.phpbb.com/projects/PHPBB3/issues/PHPBB3-14415 