### PR TITLE
[ticket/14645] Language pack not reconised when using a symlink

### DIFF
--- a/phpBB/phpbb/language/language_file_helper.php
+++ b/phpBB/phpbb/language/language_file_helper.php
@@ -47,6 +47,7 @@ class language_file_helper
 		$finder->files()
 			->name('iso.txt')
 			->depth('== 1')
+			->followLinks()
 			->in($this->phpbb_root_path . 'language');
 
 		$available_languages = array();


### PR DESCRIPTION
Symfony finder does not follow symlinks by default.
With this change it does, so a user is able to have the language pack outside
the phpBB directory, and linked with a symlink into phpBB/language/

PHPBB3-14645