### PR TITLE
[ticket/14648] Fix bug where default notifications stop working if another setting is set.

### DIFF
--- a/phpBB/phpbb/notification/type/base.php
+++ b/phpBB/phpbb/notification/type/base.php
@@ -487,7 +487,7 @@ abstract class base implements \phpbb\notification\type\type_interface
 
 		foreach ($user_ids as $user_id)
 		{
-			if (isset($options['ignore_users'][$user_id])) 
+			if (isset($options['ignore_users'][$user_id]))
 			{
 				continue;
 			}


### PR DESCRIPTION
When a new user signs up, they have an email preference set but no board notification preference set. The default board preference should work. Also when a user checks the email box for any notification preference, the default board preference should still work.

PHPBB3-14648