### PR TITLE
[ticket/14678] Forum title hidden on viewforum without f_list permission

### DIFF
--- a/phpBB/includes/functions_display.php
+++ b/phpBB/includes/functions_display.php
@@ -754,7 +754,7 @@ function generate_forum_nav(&$forum_data_ary)
 	global $template, $auth, $config;
 	global $phpEx, $phpbb_root_path, $phpbb_dispatcher;
 
-	if (!$auth->acl_get('f_list', $forum_data_ary['forum_id']))
+	if (!$auth->acl_get('f_read', $forum_data_ary['forum_id']))
 	{
 		return;
 	}
@@ -774,7 +774,7 @@ function generate_forum_nav(&$forum_data_ary)
 			list($parent_name, $parent_type) = array_values($parent_data);
 
 			// Skip this parent if the user does not have the permission to view it
-			if (!$auth->acl_get('f_list', $parent_forum_id))
+			if (!$auth->acl_get('f_read', $parent_forum_id))
 			{
 				continue;
 			}


### PR DESCRIPTION
If a user has f_read permission, but doesn't have f_list permission, they can read a forum but not see it in lists.
However when they read a forum, the title and navigation is hidden. I think they should be able to read the forum title.

More info here: https://tracker.phpbb.com/browse/PHPBB3-14678