### PR TITLE
[ticket/14660] Fix parsing board email messages through template engine.

### DIFF
--- a/phpBB/includes/acp/acp_board.php
+++ b/phpBB/includes/acp/acp_board.php
@@ -642,6 +642,9 @@ class acp_board
 				$messenger->template('test');
 				$messenger->set_addresses($user->data);
 				$messenger->anti_abuse_headers($config, $user);
+				$messenger->assign_vars(array(
+					'USERNAME'	=> htmlspecialchars_decode($user->data['username']),
+				));
 				$messenger->send(NOTIFY_EMAIL);
 
 				trigger_error($user->lang('TEST_EMAIL_SENT') . adm_back_link($this->u_action));

--- a/phpBB/includes/functions_messenger.php
+++ b/phpBB/includes/functions_messenger.php
@@ -624,31 +624,34 @@ class messenger
 	*/
 	protected function setup_template()
 	{
-		global $phpbb_extension_manager, $phpbb_container, $phpbb_filesystem;
+		global $phpbb_container;
 
 		if ($this->template instanceof \phpbb\template\template)
 		{
 			return;
 		}
 
+		$template_environment = new \phpbb\template\twig\environment(
+			$phpbb_container->get('config'),
+			$phpbb_container->get('filesystem'),
+			$phpbb_container->get('path_helper'),
+			$phpbb_container->getParameter('core.template.cache_path'),
+			$phpbb_container->get('ext.manager'),
+			new \phpbb\template\twig\loader(
+				$phpbb_container->get('filesystem')
+			)
+		);
+		$template_environment->setLexer($phpbb_container->get('template.twig.lexer'));
+
 		$this->template = new \phpbb\template\twig\twig(
 			$phpbb_container->get('path_helper'),
 			$phpbb_container->get('config'),
 			new \phpbb\template\context(),
-			new \phpbb\template\twig\environment(
-				$phpbb_container->get('config'),
-				$phpbb_container->get('filesystem'),
-				$phpbb_container->get('path_helper'),
-				$phpbb_container->getParameter('core.cache_dir'),
-				$phpbb_container->get('ext.manager'),
-				new \phpbb\template\twig\loader(
-					$phpbb_filesystem
-				)
-			),
-			$phpbb_container->getParameter('core.cache_dir'),
+			$template_environment,
+			$phpbb_container->getParameter('core.template.cache_path'),
 			$phpbb_container->get('user'),
 			$phpbb_container->get('template.twig.extensions.collection'),
-			$phpbb_extension_manager
+			$phpbb_container->get('ext.manager')
 		);
 	}
 

--- a/phpBB/language/en/email/forum_notify.txt
+++ b/phpBB/language/en/email/forum_notify.txt
@@ -2,7 +2,7 @@ Subject: Forum post notification - "{FORUM_NAME}"
 
 Hello {USERNAME},
 
-You are receiving this notification because you are watching the forum "{FORUM_NAME}" at "{SITENAME}". This forum has received a new reply to the topic "{TOPIC_TITLE}"<!-- IF AUTHOR_NAME !== '' --> by {AUTHOR_NAME}<!-- ENDIF --> since your last visit. You can use the following link to view the last unread reply, no more notifications will be sent until you visit the topic.
+You are receiving this notification because you are watching the forum "{FORUM_NAME}" at "{SITENAME}". This forum has received a new reply to the topic "{TOPIC_TITLE}"<!-- IF AUTHOR_NAME != '' --> by {AUTHOR_NAME}<!-- ENDIF --> since your last visit. You can use the following link to view the last unread reply, no more notifications will be sent until you visit the topic.
 
 {U_NEWEST_POST}
 

--- a/phpBB/language/en/email/newtopic_notify.txt
+++ b/phpBB/language/en/email/newtopic_notify.txt
@@ -2,7 +2,7 @@ Subject: New topic notification - "{FORUM_NAME}"
 
 Hello {USERNAME},
 
-You are receiving this notification because you are watching the forum "{FORUM_NAME}" at "{SITENAME}". This forum has received a new topic<!-- IF AUTHOR_NAME !== '' --> by {AUTHOR_NAME}<!-- ENDIF --> since your last visit, "{TOPIC_TITLE}". You can use the following link to view the forum, no more notifications will be sent until you visit the forum.
+You are receiving this notification because you are watching the forum "{FORUM_NAME}" at "{SITENAME}". This forum has received a new topic<!-- IF AUTHOR_NAME != '' --> by {AUTHOR_NAME}<!-- ENDIF --> since your last visit, "{TOPIC_TITLE}". You can use the following link to view the forum, no more notifications will be sent until you visit the forum.
 
 {U_FORUM}
 

--- a/phpBB/language/en/email/short/newtopic_notify.txt
+++ b/phpBB/language/en/email/short/newtopic_notify.txt
@@ -2,7 +2,7 @@ Subject: New topic notification - "{FORUM_NAME}"
 
 Hello {USERNAME},
 
-You are receiving this notification because you are watching the forum "{FORUM_NAME}" at "{SITENAME}". This forum has received a new topic<!-- IF AUTHOR_NAME !== '' --> by {AUTHOR_NAME}<!-- ENDIF --> since your last visit, "{TOPIC_TITLE}". You can use the following link to view the forum, no more notifications will be sent until you visit the forum.
+You are receiving this notification because you are watching the forum "{FORUM_NAME}" at "{SITENAME}". This forum has received a new topic<!-- IF AUTHOR_NAME != '' --> by {AUTHOR_NAME}<!-- ENDIF --> since your last visit, "{TOPIC_TITLE}". You can use the following link to view the forum, no more notifications will be sent until you visit the forum.
 
 {U_FORUM}
 

--- a/phpBB/language/en/email/short/topic_notify.txt
+++ b/phpBB/language/en/email/short/topic_notify.txt
@@ -2,7 +2,7 @@ Subject: Topic reply notification - "{TOPIC_TITLE}"
 
 Hello {USERNAME},
 
-You are receiving this notification because you are watching the topic "{TOPIC_TITLE}" at "{SITENAME}". This topic has received a reply<!-- IF AUTHOR_NAME !== '' --> by {AUTHOR_NAME}<!-- ENDIF --> since your last visit. You can use the following link to view the replies made, no more notifications will be sent until you visit the topic.
+You are receiving this notification because you are watching the topic "{TOPIC_TITLE}" at "{SITENAME}". This topic has received a reply<!-- IF AUTHOR_NAME != '' --> by {AUTHOR_NAME}<!-- ENDIF --> since your last visit. You can use the following link to view the replies made, no more notifications will be sent until you visit the topic.
 
 If you want to view the newest post made since your last visit, click the following link:
 {U_NEWEST_POST}

--- a/phpBB/language/en/email/topic_notify.txt
+++ b/phpBB/language/en/email/topic_notify.txt
@@ -2,7 +2,7 @@ Subject: Topic reply notification - "{TOPIC_TITLE}"
 
 Hello {USERNAME},
 
-You are receiving this notification because you are watching the topic "{TOPIC_TITLE}" at "{SITENAME}". This topic has received a reply<!-- IF AUTHOR_NAME !== '' --> by {AUTHOR_NAME}<!-- ENDIF --> since your last visit. No more notifications will be sent until you visit the topic.
+You are receiving this notification because you are watching the topic "{TOPIC_TITLE}" at "{SITENAME}". This topic has received a reply<!-- IF AUTHOR_NAME != '' --> by {AUTHOR_NAME}<!-- ENDIF --> since your last visit. No more notifications will be sent until you visit the topic.
 
 If you want to view the newest post made since your last visit, click the following link:
 {U_NEWEST_POST}

--- a/tests/email/email_parsing_test.php
+++ b/tests/email/email_parsing_test.php
@@ -1,0 +1,138 @@
+<?php
+/**
+ *
+ * This file is part of the phpBB Forum Software package.
+ *
+ * @copyright (c) phpBB Limited <https://www.phpbb.com>
+ * @license GNU General Public License, version 2 (GPL-2.0)
+ *
+ * For full copyright and license information, please see
+ * the docs/CREDITS.txt file.
+ *
+ */
+
+class phpbb_email_parsing_test extends phpbb_test_case
+{
+	static protected $reflection;
+	protected $messenger;
+	protected $reflection_template_property;
+
+	public function setUp()
+	{
+		global $phpbb_container, $config, $phpbb_root_path, $phpEx, $request, $user; 
+
+		$phpbb_container = new phpbb_mock_container_builder;
+
+		$config = new \phpbb\config\config(array());
+		$default_config = array(
+			'board_email_sig'     => '-- Thanks, The Management',
+			'sitename' 			=> 'yourdomain.com',
+			'default_lang'		=> 'en',
+		);
+		foreach ($default_config as $config_name => $config_value)
+		{
+			if (!isset($config[$config_name]))
+			{
+				$config[$config_name] = $config_value;
+			}
+		}
+		$phpbb_container->set('config', $config, phpbb_mock_container_builder::SCOPE_PROTOTYPE);
+
+		$request = new phpbb_mock_request;
+		$symfony_request = new \phpbb\symfony_request(
+			$request
+		);
+		$filesystem = new \phpbb\filesystem\filesystem();
+		$phpbb_path_helper = new \phpbb\path_helper(
+			$symfony_request,
+			$filesystem,
+			$request,
+			$phpbb_root_path,
+			$phpEx
+		);
+		$phpbb_container->set('path_helper', $phpbb_path_helper, phpbb_mock_container_builder::SCOPE_PROTOTYPE);
+		$phpbb_container->set('filesystem', $filesystem, phpbb_mock_container_builder::SCOPE_PROTOTYPE);
+
+		$cache_path = 'cache/' . PHPBB_ENVIRONMENT . '/twig';
+		$phpbb_container->setParameter('core.template.cache_path', $cache_path, phpbb_mock_container_builder::SCOPE_PROTOTYPE);
+
+		$lang_loader = new \phpbb\language\language_file_loader($phpbb_root_path, $phpEx);
+		$lang = new \phpbb\language\language($lang_loader);
+		$user = new \phpbb\user($lang, '\phpbb\datetime');
+		$phpbb_container->set('user', $user, phpbb_mock_container_builder::SCOPE_PROTOTYPE);
+		$extension_manager = new phpbb_mock_extension_manager(
+			dirname(__FILE__) . '/',
+			array(
+				'vendor2/foo' => array(
+					'ext_name' => 'vendor2/foo',
+					'ext_active' => '1',
+					'ext_path' => 'ext/vendor2/foo/',
+				),
+			)
+		);
+		$phpbb_container->set('ext.manager', $extension_manager, phpbb_mock_container_builder::SCOPE_PROTOTYPE);
+
+		$context = new \phpbb\template\context();
+		$phpbb_container->set('template.twig.extensions.collection', array(new \phpbb\template\twig\extension($context, $user)), phpbb_mock_container_builder::SCOPE_PROTOTYPE);
+
+		$twig = new \phpbb\template\twig\environment(
+			$config,
+			$filesystem,
+			$phpbb_path_helper,
+			$cache_path,
+			null,
+			new \phpbb\template\twig\loader($filesystem, ''),
+			array(
+				'cache'			=> false,
+				'debug'			=> false,
+				'auto_reload'	=> true,
+				'autoescape'	=> false,
+			)
+		);
+		$phpbb_container->set('template.twig.lexer', new \phpbb\template\twig\lexer($twig), phpbb_mock_container_builder::SCOPE_PROTOTYPE);
+
+		if (!class_exists('messenger'))
+		{
+			include($phpbb_root_path . 'includes/functions_messenger.' . $phpEx);
+		}
+		
+		$this->messenger = new \messenger();
+
+		$reflection = new ReflectionObject($this->messenger);
+		$this->reflection_template_property = $reflection->getProperty('template');
+		$this->reflection_template_property->setAccessible(true);
+	}
+
+	public function test_email_parsing()
+	{
+		global $phpbb_container, $config, $phpbb_root_path, $phpEx, $user, $request; 
+
+		$this->messenger->set_addresses($user->data);
+
+		$this->messenger->assign_vars(array(
+			'EMAIL_SIG'	=> str_replace('<br />', "\n", "-- \n" . htmlspecialchars_decode($config['board_email_sig'])),
+			'SITENAME'	=> htmlspecialchars_decode($config['sitename']),
+
+			'AUTHOR_NAME'				=> 'Author username',
+			'FORUM_NAME'				=> 'Any forum',
+			'TOPIC_TITLE'				=> 'The topic title',
+			'USERNAME'					=> 'Dear user',
+
+			'U_FORUM'					=> generate_board_url() . "/viewforum.{$phpEx}?f=1",
+			'U_STOP_WATCHING_FORUM'		=> generate_board_url() . "/viewforum.{$phpEx}?uid=2&f=1&unwatch=forum",
+		));
+		$this->messenger->template('newtopic_notify', $user->data['user_lang'], '', '');
+
+		$reflection_template = $this->reflection_template_property->getValue($this->messenger);
+		$msg = trim($reflection_template->assign_display('body'));
+
+		$this->assertContains('Author username', $msg);
+		$this->assertContains('Any forum', $msg);
+		$this->assertContains('The topic title', $msg);
+		$this->assertContains('Dear user', $msg);
+		$this->assertContains(htmlspecialchars_decode($config['sitename']), $msg);
+		$this->assertContains(str_replace('<br />', "\n", "-- \n" . htmlspecialchars_decode($config['board_email_sig'])), $msg);
+		$this->assertNotContains('EMAIL_SIG', $msg);
+		$this->assertNotContains('U_STOP_WATCHING_FORUM', $msg);
+	}
+}


### PR DESCRIPTION
The fix is for 3.2.x/master only.

Checklist:

- [x] Correct branch: master for new features; 3.2.x, 3.1.x for fixes
- [ ] Tests pass
- [x] Code follows coding guidelines: [master / 3.2.x](https://area51.phpbb.com/docs/master/coding-guidelines.html), [3.1.x](https://area51.phpbb.com/docs/31x/coding-guidelines.html)
- [x] Commit follows commit message [format](https://wiki.phpbb.com/Git#Commit_Messages)

<a href="https://tracker.phpbb.com/browse/PHPBB3-14660">PHPBB3-14660</a>.