### PR TITLE
Duplicate subexpression in questionnaire.php

### DIFF
--- a/phpBB/includes/questionnaire/questionnaire.php
+++ b/phpBB/includes/questionnaire/questionnaire.php
@@ -190,7 +190,6 @@ class phpbb_questionnaire_system_data_provider
 			// - 192.168.0.0/16
 			if ($ip_address_ary[0] == '10' ||
 				($ip_address_ary[0] == '172' && intval($ip_address_ary[1]) > 15 && intval($ip_address_ary[1]) < 32) ||
-				($ip_address_ary[0] == '192' && $ip_address_ary[1] == '168') ||
 				($ip_address_ary[0] == '192' && $ip_address_ary[1] == '168'))
 			{
 				return true;


### PR DESCRIPTION
[3.2.x] Subexpression `($ip_address_ary[0] == '192' && $ip_address_ary[1] == '168')` is repeated.

https://tracker.phpbb.com/browse/PHPBB3-14692