### PR TITLE
[ticket/14692] Remove duplicate subexpression in questionnaire.php

### DIFF
--- a/phpBB/includes/questionnaire/questionnaire.php
+++ b/phpBB/includes/questionnaire/questionnaire.php
@@ -190,7 +190,6 @@ class phpbb_questionnaire_system_data_provider
 			// - 192.168.0.0/16
 			if ($ip_address_ary[0] == '10' ||
 				($ip_address_ary[0] == '172' && intval($ip_address_ary[1]) > 15 && intval($ip_address_ary[1]) < 32) ||
-				($ip_address_ary[0] == '192' && $ip_address_ary[1] == '168') ||
 				($ip_address_ary[0] == '192' && $ip_address_ary[1] == '168'))
 			{
 				return true;


### PR DESCRIPTION
Checklist:

- [x] Correct branch: master for new features; 3.2.x, 3.1.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master / 3.2.x](https://area51.phpbb.com/docs/master/coding-guidelines.html), [3.1.x](https://area51.phpbb.com/docs/31x/coding-guidelines.html)
- [x] Commit follows commit message [format](https://wiki.phpbb.com/Git#Commit_Messages)

Tracker ticket (set the ticket ID to **your ticket ID**):

https://tracker.phpbb.com/browse/PHPBB3-14692

Subexpression `($ip_address_ary[0] == '192' && $ip_address_ary[1] == '168')`
is repeated.

PHPBB3-14692

Replaces https://github.com/phpbb/phpbb/pull/4369