### PR TITLE
[ticket/14706] Updated [list] BBCode to automatically create a list item

### DIFF
--- a/phpBB/composer.json
+++ b/phpBB/composer.json
@@ -33,7 +33,7 @@
 		"marc1706/fast-image-size": "1.1.*",
 		"paragonie/random_compat": "^1.2",
 		"patchwork/utf8": "1.1.*",
-		"s9e/text-formatter": "^0.4.2",
+		"s9e/text-formatter": "^0.5.4",
 		"symfony/config": "2.8.*",
 		"symfony/console": "2.8.*",
 		"symfony/debug": "2.8.*",

--- a/phpBB/composer.lock
+++ b/phpBB/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "0a51a3b7218cbf3a5fe6621729b72c05",
-    "content-hash": "396082a59d972dd35293fe73b0615e79",
+    "hash": "b0bb6560f0982ecfc8867e762faa3847",
+    "content-hash": "322b621681118fa67925d35030625dae",
     "packages": [
         {
             "name": "bantu/ini-get-wrapper",
@@ -647,16 +647,16 @@
         },
         {
             "name": "s9e/text-formatter",
-            "version": "0.4.11",
+            "version": "0.5.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/s9e/TextFormatter.git",
-                "reference": "e6dc4615081b1668742076aa05d11aa0f7b00103"
+                "reference": "e9363a0d2d6ddef40200854207557c648d36d925"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/s9e/TextFormatter/zipball/e6dc4615081b1668742076aa05d11aa0f7b00103",
-                "reference": "e6dc4615081b1668742076aa05d11aa0f7b00103",
+                "url": "https://api.github.com/repos/s9e/TextFormatter/zipball/e9363a0d2d6ddef40200854207557c648d36d925",
+                "reference": "e9363a0d2d6ddef40200854207557c648d36d925",
                 "shasum": ""
             },
             "require": {
@@ -703,7 +703,7 @@
                 "parser",
                 "shortcodes"
             ],
-            "time": "2016-02-21 20:38:42"
+            "time": "2016-07-08 05:19:02"
         },
         {
             "name": "symfony/config",

--- a/phpBB/phpbb/textformatter/s9e/factory.php
+++ b/phpBB/phpbb/textformatter/s9e/factory.php
@@ -82,7 +82,7 @@ class factory implements \phpbb\textformatter\cache_interface
 		'flash' => '[FLASH={NUMBER1},{NUMBER2} width={NUMBER1;postFilter=#flashwidth} height={NUMBER2;postFilter=#flashheight} url={URL;useContent} /]',
 		'i'     => '[I]{TEXT}[/I]',
 		'img'   => '[IMG src={IMAGEURL;useContent}]',
-		'list'  => '[LIST type={HASHMAP=1:decimal,a:lower-alpha,A:upper-alpha,i:lower-roman,I:upper-roman;optional;postFilter=#simpletext}]{TEXT}[/LIST]',
+		'list'  => '[LIST type={HASHMAP=1:decimal,a:lower-alpha,A:upper-alpha,i:lower-roman,I:upper-roman;optional;postFilter=#simpletext} #createChild=LI]{TEXT}[/LIST]',
 		'li'    => '[* $tagName=LI]{TEXT}[/*]',
 		'quote' =>
 			"[QUOTE

--- a/tests/text_formatter/s9e/default_formatting_test.php
+++ b/tests/text_formatter/s9e/default_formatting_test.php
@@ -86,7 +86,7 @@ class phpbb_textformatter_s9e_default_formatting_test extends phpbb_test_case
 			),
 			array(
 				'[list]no item[/list]',
-				'<ul>no item</ul>'
+				'<ul><li>no item</li></ul>'
 			),
 			array(
 				'[*]unparsed',

--- a/tests/text_processing/tickets_data/PHPBB3-14706.html
+++ b/tests/text_processing/tickets_data/PHPBB3-14706.html
@@ -1,0 +1,1 @@
+<ul><li><ol style="list-style-type: lower-alpha"><li>a</li><li>b</li><li>c</li><li>d</li><li>e</li></ol></li><li>outer</li></ul>

--- a/tests/text_processing/tickets_data/PHPBB3-14706.txt
+++ b/tests/text_processing/tickets_data/PHPBB3-14706.txt
@@ -1,0 +1,1 @@
+[list][list=a][*]a[*]b[*]c[*]d[*]e[/list][*]outer[/list]


### PR DESCRIPTION
Renders `[list]text[/list]` into `<ul><li>text</li></ul>`. Fixes issues with missing list items. Produces valid HTML. The updated BBCode definition requires [s9e\TextFormatter v0.5.4](https://github.com/s9e/TextFormatter/releases/tag/0.5.4) or newer.

http://area51.phpbb.com/phpBB/viewtopic.php?f=126&p=293551

Checklist:

- [x] Correct branch: master for new features; 3.2.x, 3.1.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master / 3.2.x](https://area51.phpbb.com/docs/master/coding-guidelines.html), [3.1.x](https://area51.phpbb.com/docs/31x/coding-guidelines.html)
- [x] Commit follows commit message [format](https://wiki.phpbb.com/Git#Commit_Messages)

Tracker ticket (set the ticket ID to **your ticket ID**):

https://tracker.phpbb.com/browse/PHPBB3-12345

PHPBB3-14706