### PR TITLE
[ticket/14717] Quote strings beginning with @ or % in yaml definitions

### DIFF
--- a/phpBB/config/default/container/services_auth.yml
+++ b/phpBB/config/default/container/services_auth.yml
@@ -103,7 +103,7 @@ services:
     auth.provider.oauth.service.twitter:
         class: phpbb\auth\provider\oauth\service\twitter
         arguments:
-            - @config
-            - @request
+            - '@config'
+            - '@request'
         tags:
             - { name: auth.provider.oauth.service }

--- a/tests/di/fixtures/config/production/container/environment.yml
+++ b/tests/di/fixtures/config/production/container/environment.yml
@@ -8,7 +8,7 @@ services:
     dbal.conn:
         class: phpbb\db\driver\factory
         arguments:
-            - @service_container
+            - '@service_container'
 
     dispatcher:
         class: phpbb\db\driver\container_mock

--- a/tests/di/fixtures/config/test/container/environment.yml
+++ b/tests/di/fixtures/config/test/container/environment.yml
@@ -8,7 +8,7 @@ services:
     dbal.conn:
         class: phpbb\db\driver\factory
         arguments:
-            - @service_container
+            - '@service_container'
 
     dispatcher:
         class: phpbb\db\driver\container_mock

--- a/tests/di/fixtures/other_config/production/container/environment.yml
+++ b/tests/di/fixtures/other_config/production/container/environment.yml
@@ -8,7 +8,7 @@ services:
     dbal.conn:
         class: phpbb\db\driver\factory
         arguments:
-            - @service_container
+            - '@service_container'
 
     dispatcher:
         class: phpbb\db\driver\container_mock

--- a/tests/di/fixtures/other_config/test/container/environment.yml
+++ b/tests/di/fixtures/other_config/test/container/environment.yml
@@ -8,7 +8,7 @@ services:
     dbal.conn:
         class: phpbb\db\driver\factory
         arguments:
-            - @service_container
+            - '@service_container'
 
     dispatcher:
         class: phpbb\db\driver\container_mock

--- a/tests/functional/fixtures/ext/foo/bar/config/services.yml
+++ b/tests/functional/fixtures/ext/foo/bar/config/services.yml
@@ -2,13 +2,13 @@ services:
     foo_bar.controller:
         class: foo\bar\controller\controller
         arguments:
-            - @controller.helper
-            - @path_helper
-            - @template
-            - @config
-            - @user
-            - %core.root_path%
-            - %core.php_ext%
+            - '@controller.helper'
+            - '@path_helper'
+            - '@template'
+            - '@config'
+            - '@user'
+            - '%core.root_path%'
+            - '%core.php_ext%'
 
     foo_bar.listener.permission:
         class: foo\bar\event\permission


### PR DESCRIPTION
Checklist:

- [x] Correct branch: master for new features; 3.2.x, 3.1.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master / 3.2.x](https://area51.phpbb.com/docs/master/coding-guidelines.html), [3.1.x](https://area51.phpbb.com/docs/31x/coding-guidelines.html)
- [x] Commit follows commit message [format](https://wiki.phpbb.com/Git#Commit_Messages)

Tracker ticket (set the ticket ID to **your ticket ID**):

https://tracker.phpbb.com/browse/PHPBB3-14717

This type of use was deprecated in symfony 2.8 and will be dropped in 3.x.
Also see: https://github.com/symfony/symfony/pull/16285

PHPBB3-14717