### PR TITLE
[ticket/14740] Added support for quoted attributes in BBCode definitions

### DIFF
--- a/phpBB/composer.lock
+++ b/phpBB/composer.lock
@@ -641,16 +641,16 @@
         },
         {
             "name": "s9e/text-formatter",
-            "version": "0.6.1",
+            "version": "0.6.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/s9e/TextFormatter.git",
-                "reference": "dd0ec47d1ffb5ed5a3eb4e3adbc33db6e0057420"
+                "reference": "99d6b5799387dddfdd00b5a76bb83a15dda586e3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/s9e/TextFormatter/zipball/dd0ec47d1ffb5ed5a3eb4e3adbc33db6e0057420",
-                "reference": "dd0ec47d1ffb5ed5a3eb4e3adbc33db6e0057420",
+                "url": "https://api.github.com/repos/s9e/TextFormatter/zipball/99d6b5799387dddfdd00b5a76bb83a15dda586e3",
+                "reference": "99d6b5799387dddfdd00b5a76bb83a15dda586e3",
                 "shasum": ""
             },
             "require": {
@@ -697,7 +697,7 @@
                 "parser",
                 "shortcodes"
             ],
-            "time": "2016-07-30 01:50:02"
+            "time": "2016-08-09 14:16:45"
         },
         {
             "name": "symfony/config",

--- a/tests/text_processing/tickets_data/PHPBB3-14740.html
+++ b/tests/text_processing/tickets_data/PHPBB3-14740.html
@@ -1,0 +1,2 @@
+<div id="modremark"><div id="modremarkexclamation">!</div><div><div id="moderemarktitle">Moderatoropmerking from: neufke</div><div id="moderemarktext">Mod Remark</div></div></div>
+<div id="modremark"><div id="modremarkexclamation">!</div><div><div id="moderemarktitle">Moderatoropmerking from: neufke</div><div id="moderemarktext">Mod Remark</div></div></div>

--- a/tests/text_processing/tickets_data/PHPBB3-14740.txt
+++ b/tests/text_processing/tickets_data/PHPBB3-14740.txt
@@ -1,0 +1,2 @@
+[mod=neufke]Mod Remark[/mod]
+[mod="neufke"]Mod Remark[/mod]

--- a/tests/text_processing/tickets_data/PHPBB3-14740.xml
+++ b/tests/text_processing/tickets_data/PHPBB3-14740.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<dataset>
+	<table name="phpbb_bbcodes">
+		<column>bbcode_id</column>
+		<column>bbcode_tag</column>
+		<column>bbcode_helpline</column>
+		<column>display_on_posting</column>
+		<column>bbcode_match</column>
+		<column>bbcode_tpl</column>
+		<column>first_pass_match</column>
+		<column>first_pass_replace</column>
+		<column>second_pass_match</column>
+		<column>second_pass_replace</column>
+
+		<row>
+			<value>13</value>
+			<value>mod=</value>
+			<value></value>
+			<value>1</value>
+			<value>[mod=&quot;{TEXT1}&quot;]{TEXT2}[/mod]</value>
+			<value><![CDATA[<div id="modremark">
+	<div id="modremarkexclamation">!</div>
+	<div>
+		<div id="moderemarktitle">Moderatoropmerking {L_FROM}{L_COLON} {TEXT1}</div>
+		<div id="moderemarktext">{TEXT2}</div>
+	</div>
+</div>]]></value>
+			<value>!\[mod\=&quot;(.*?)&quot;\](.*?)\[/mod\]!ies</value>
+			<value>'[mod=&quot;'.str_replace(array("\r\n", '\"', '\'', '(', ')'), array("\n", '"', '&#39;', '&#40;', '&#41;'), trim('${1}')).'&quot;:$uid]'.str_replace(array("\r\n", '\"', '\'', '(', ')'), array("\n", '"', '&#39;', '&#40;', '&#41;'), trim('${2}')).'[/mod:$uid]'</value>
+			<value>!\[mod\=&quot;(.*?)&quot;:$uid\](.*?)\[/mod:$uid\]!s</value>
+			<value><![CDATA[<div id="modremark">
+	<div id="modremarkexclamation">!</div>
+	<div>
+		<div id="moderemarktitle">Moderatoropmerking {L_FROM}{L_COLON} ${1}</div>
+		<div id="moderemarktext">${2}</div>
+	</div>
+</div>]]></value>
+		</row>
+	</table>
+</dataset>


### PR DESCRIPTION
Allows defining a BBCode as `[foo="{TEXT}"]` in addition to the usual `[foo={TEXT}]`

The syntax is not explicitly defined in [the phpBB docs](https://www.phpbb.com/support/docs/en/3.1/kb/article/adding-custom-bbcodes-in-phpbb3/) but it's apparently allowed and in use.

The actual feature/fix was implemented in https://github.com/s9e/TextFormatter/commit/c8253c9249f19ff18721de69241b485033ed38d5, this PR only contains the updated `composer.json` and a regression test.

Checklist:

- [x] Correct branch: master for new features; 3.2.x, 3.1.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master / 3.2.x](https://area51.phpbb.com/docs/master/coding-guidelines.html), [3.1.x](https://area51.phpbb.com/docs/31x/coding-guidelines.html)
- [x] Commit follows commit message [format](https://wiki.phpbb.com/Git#Commit_Messages)

https://tracker.phpbb.com/browse/PHPBB3-14740

PHPBB3-14740