### PR TITLE
[ticket/14581] Add core events to content_visibility

### DIFF
--- a/phpBB/phpbb/content_visibility.php
+++ b/phpBB/phpbb/content_visibility.php
@@ -428,7 +428,35 @@ class content_visibility
 			'post_delete_time'		=> ((int) $time) ?: time(),
 			'post_delete_reason'	=> truncate_string($reason, 255, 255, false),
 		);
-
+		/**
+		 * Perform actions right before the query to change post visibility
+		 *
+		 * @event core.set_post_visibility_before_sql
+		 * @var			int			visibility		Element of {ITEM_APPROVED, ITEM_DELETED, ITEM_REAPPROVE}
+		 * @var			array		post_id			Array containing all post IDs to be modified. If blank, all posts within the topic are modified.
+		 * @var			int			topic_id		Topic of the post IDs to be modified.
+		 * @var			int			forum_id		Forum ID that the topic_id resides in.
+		 * @var			int			user_id			User ID doing this action.
+		 * @var			int			timestamp		Timestamp of this action.
+		 * @var			string		reason			Reason specified by the user for this change.
+		 * @var			bool		is_starter		Are we changing the topic's starter?
+		 * @var			bool		is_latest		Are we changing the topic's latest post?
+		 * @var			array		data			The data array for this action.
+		 * @since 3.1.10-RC1
+		 */
+		$vars = array(
+			'visibility',
+			'post_id',
+			'topic_id',
+			'forum_id',
+			'user_id',
+			'timestamp',
+			'reason',
+			'is_starter',
+			'is_latest',
+			'data',
+		);
+		extract($this->phpbb_dispatcher->trigger_event('core.set_post_visibility_before_sql', compact($vars)));
 		$sql = 'UPDATE ' . $this->posts_table . '
 			SET ' . $this->db->sql_build_array('UPDATE', $data) . '
 			WHERE ' . $this->db->sql_in_set('post_id', $post_ids);
@@ -585,7 +613,35 @@ class content_visibility
 				WHERE topic_id = ' . (int) $topic_id;
 			$this->db->sql_query($sql);
 		}
-
+		/**
+		 * Perform actions after all steps to changing post visibility
+		 *
+		 * @event core.set_post_visibility_after
+		 * @var			int			visibility		Element of {ITEM_APPROVED, ITEM_DELETED, ITEM_REAPPROVE}
+		 * @var			array		post_id			Array containing all post IDs to be modified. If blank, all posts within the topic are modified.
+		 * @var			int			topic_id		Topic of the post IDs to be modified.
+		 * @var			int			forum_id		Forum ID that the topic_id resides in.
+		 * @var			int			user_id			User ID doing this action.
+		 * @var			int			timestamp		Timestamp of this action.
+		 * @var			string		reason			Reason specified by the user for this change.
+		 * @var			bool		is_starter		Are we changing the topic's starter?
+		 * @var			bool		is_latest		Are we changing the topic's latest post?
+		 * @var			array		data			The data array for this action.
+		 * @since 3.1.10-RC1
+		 */
+		$vars = array(
+			'visibility',
+			'post_id',
+			'topic_id',
+			'forum_id',
+			'user_id',
+			'timestamp',
+			'reason',
+			'is_starter',
+			'is_latest',
+			'data',
+		);
+		extract($this->phpbb_dispatcher->trigger_event('core.set_post_visibility_after', compact($vars)));
 		return $data;
 	}
 
@@ -645,7 +701,31 @@ class content_visibility
 			'topic_delete_time'		=> ((int) $time) ?: time(),
 			'topic_delete_reason'	=> truncate_string($reason, 255, 255, false),
 		);
-
+		/**
+		 * Perform actions right before the query to change topic visibility
+		 *
+		 * @event core.set_topic_visibility_before_sql
+		 * @var			int			visibility			Element of {ITEM_APPROVED, ITEM_DELETED, ITEM_REAPPROVE}
+		 * @var			int			topic_id			Topic of the post IDs to be modified.
+		 * @var			int			forum_id			Forum ID that the topic_id resides in.
+		 * @var			int			user_id				User ID doing this action.
+		 * @var			int			timestamp			Timestamp of this action.
+		 * @var			string		reason				Reason specified by the user for this change.
+		 * @var			bool		force_update_all	Force an update on all posts within the topic, regardless of their current approval state.
+		 * @var			array		data				The data array for this action.
+		 * @since 3.1.10-RC1
+		 */
+		$vars = array(
+			'visibility',
+			'topic_id',
+			'forum_id',
+			'user_id',
+			'timestamp',
+			'reason',
+			'force_update_all',
+			'data',
+		);
+		extract($this->phpbb_dispatcher->trigger_event('core.set_topic_visibility_before_sql', compact($vars)));
 		$sql = 'UPDATE ' . $this->topics_table . '
 			SET ' . $this->db->sql_build_array('UPDATE', $data) . '
 			WHERE topic_id = ' . (int) $topic_id;
@@ -670,7 +750,31 @@ class content_visibility
 		{
 			$this->set_post_visibility($visibility, false, $topic_id, $forum_id, $user_id, $time, '', true, true);
 		}
-
+		/**
+		 * Perform actions after all steps to changing topic visibility
+		 *
+		 * @event core.set_topic_visibility_after
+		 * @var			int			visibility			Element of {ITEM_APPROVED, ITEM_DELETED, ITEM_REAPPROVE}
+		 * @var			int			topic_id			Topic of the post IDs to be modified.
+		 * @var			int			forum_id			Forum ID that the topic_id resides in.
+		 * @var			int			user_id				User ID doing this action.
+		 * @var			int			timestamp			Timestamp of this action.
+		 * @var			string		reason				Reason specified by the user for this change.
+		 * @var			bool		force_update_all	Force an update on all posts within the topic, regardless of their current approval state.
+		 * @var			array		data				The data array for this action.
+		 * @since 3.1.10-RC1
+		 */
+		$vars = array(
+			'visibility',
+			'topic_id',
+			'forum_id',
+			'user_id',
+			'timestamp',
+			'reason',
+			'force_update_all',
+			'data',
+		);
+		extract($this->phpbb_dispatcher->trigger_event('core.set_topic_visibility_after', compact($vars)));
 		return $data;
 	}
 


### PR DESCRIPTION
Checklist:

- [x] Correct branch: master for new features; 3.2.x, 3.1.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master / 3.2.x](https://area51.phpbb.com/docs/master/coding-guidelines.html), [3.1.x](https://area51.phpbb.com/docs/31x/coding-guidelines.html)
- [x] Commit follows commit message [format](https://wiki.phpbb.com/Git#Commit_Messages)

Events added for both changing the content visibility for both posts and topics,
executing right before and after the SQL UPDATE query for setting the
visibillity.

https://tracker.phpbb.com/browse/PHPBB3-14581

PHPBB3-14581