### PR TITLE
[ticket/12133] fix download file names for WebKit-derived browsers

### DIFF
--- a/phpBB/includes/functions_download.php
+++ b/phpBB/includes/functions_download.php
@@ -284,7 +284,7 @@ function header_filename($file)
 
 	// There be dragons here.
 	// Not many follows the RFC...
-	if (strpos($user_agent, 'MSIE') !== false || strpos($user_agent, 'Safari') !== false || strpos($user_agent, 'Konqueror') !== false)
+	if (strpos($user_agent, 'MSIE') !== false || strpos($user_agent, 'Konqueror') !== false)
 	{
 		return "filename=" . rawurlencode($file);
 	}


### PR DESCRIPTION
Checklist:

- [x] Correct branch: master for new features; 3.2.x, 3.1.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master / 3.2.x](https://area51.phpbb.com/docs/master/coding-guidelines.html), [3.1.x](https://area51.phpbb.com/docs/31x/coding-guidelines.html)
- [x] Commit follows commit message [format](https://wiki.phpbb.com/Git#Commit_Messages)

Tracker ticket (set the ticket ID to **your ticket ID**):

https://tracker.phpbb.com/browse/PHPBB3-12133

All browser engines that descend from WebKit declare themselves as
Safari in the user agent, including Chrome. Currently, the code
assumes that any Safari-like browser cannot handle the RFC-compliant
filename syntax. At least for recent versions of Safari, this is no
longer the case, and the legacy syntax results in URI-quoted
filenames. Using the standard syntax works as expected in both Safari
9 and Chrome 45.

The ticket reporting this issue is from January 2014, so we can safely
ignore compatibility: any browser still relying on the previous
behaviour is unlikely to receive security updates.

PHPBB3-12133