### PR TITLE
[ticket/14774] Support partial downloads of attachments

### DIFF
--- a/tests/download/http_byte_range_test.php
+++ b/tests/download/http_byte_range_test.php
@@ -45,23 +45,71 @@ class phpbb_download_http_byte_range_test extends phpbb_test_case
 	public function parse_range_request_data()
 	{
 		return array(
-			// Does not read until the end of file.
+            // Valid request
 			array(
 				array('3-4'),
 				10,
-				false,
+				array(
+					'byte_pos_start'	=> 3,
+					'byte_pos_end'		=> 4,
+					'bytes_requested'	=> 2,
+					'bytes_total'		=> 10,
+				),
 			),
 
-			// Valid request, handle second range.
+            // Get the beginning
+			array(
+				array('-5'),
+				10,
+				array(
+					'byte_pos_start'	=> 0,
+					'byte_pos_end'		=> 5,
+					'bytes_requested'	=> 6,
+					'bytes_total'		=> 10,
+				),
+			),
+
+            // Get the end
+			array(
+				array('5-'),
+				10,
+				array(
+					'byte_pos_start'	=> 5,
+					'byte_pos_end'		=> 9,
+					'bytes_requested'	=> 5,
+					'bytes_total'		=> 10,
+				),
+			),
+
+            // Overlong request
+			array(
+				array('3-20'),
+				10,
+				array(
+					'byte_pos_start'	=> 3,
+					'byte_pos_end'		=> 9,
+					'bytes_requested'	=> 7,
+					'bytes_total'		=> 10,
+				),
+			),
+
+			// Multiple, contiguous range
+			array(
+				array('10-20', '21-30'),
+				125,
+				array(
+					'byte_pos_start'	=> 10,
+					'byte_pos_end'		=> 30,
+					'bytes_requested'	=> 21,
+					'bytes_total'		=> 125,
+				)
+			),
+
+			// We don't do multiple, non-contiguous range
 			array(
 				array('0-0', '120-125'),
 				125,
-				array(
-					'byte_pos_start'	=> 120,
-					'byte_pos_end'		=> 124,
-					'bytes_requested'	=> 5,
-					'bytes_total'		=> 125,
-				)
+				false,
 			),
 		);
 	}


### PR DESCRIPTION
Checklist:

- [x] Correct branch: master for new features; 3.2.x, 3.1.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master / 3.2.x](https://area51.phpbb.com/docs/master/coding-guidelines.html), [3.1.x](https://area51.phpbb.com/docs/31x/coding-guidelines.html)
- [x] Commit follows commit message [format](https://wiki.phpbb.com/Git#Commit_Messages)

Tracker ticket (set the ticket ID to **your ticket ID**):

https://tracker.phpbb.com/browse/PHPBB3-14774

phpBB already had limited support for partial downloads, but only for
resuming downloads, disregarding any range ending before EOF.

WebKit on iOS and OS X uses partial downloads when fetching media
files. Previously, only MP3 attachments could play directly in the
browser, reported as a live stream, but with this change, all
supported media formats should render as expected.

Tested using cURL by verifying that partial downloads give exactly the
same results compared to Apache.

PHPBB3-14774