### PR TITLE
[ticket/14796] Use log_table class member instead of table constant

### DIFF
--- a/phpBB/phpbb/log/log.php
+++ b/phpBB/phpbb/log/log.php
@@ -402,7 +402,7 @@ class log implements \phpbb\log\log_interface
 			}
 		}
 
-		$sql = 'DELETE FROM ' . LOG_TABLE . "
+		$sql = 'DELETE FROM ' . $this->log_table . "
 					$sql_where";
 		$this->db->sql_query($sql);
 


### PR DESCRIPTION
Checklist:

- [x] Correct branch: master for new features; 3.2.x, 3.1.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master / 3.2.x](https://area51.phpbb.com/docs/master/coding-guidelines.html), [3.1.x](https://area51.phpbb.com/docs/31x/coding-guidelines.html)
- [x] Commit follows commit message [format](https://wiki.phpbb.com/Git#Commit_Messages)

Replaces https://github.com/phpbb/phpbb/pull/4393

https://tracker.phpbb.com/browse/PHPBB3-14796

Was still using the old LOG_TABLE constant in the delete method.

PHPBB3-14796