### PR TITLE
[ticket/14821] Replace escaped strong tags with actual tags

### DIFF
--- a/phpBB/phpbb/event/kernel_exception_subscriber.php
+++ b/phpBB/phpbb/event/kernel_exception_subscriber.php
@@ -69,7 +69,7 @@ class kernel_exception_subscriber implements EventSubscriberInterface
 		}
 
 		// Show <strong> text in bold
-		$message = preg_replace('#&lt;(/?)(strong)&gt;#i', '<$1$2>', $message);
+		$message = preg_replace('#&lt;(/?strong)&gt;#i', '<$1>', $message);
 
 		if (!$event->getRequest()->isXmlHttpRequest())
 		{

--- a/phpBB/phpbb/event/kernel_exception_subscriber.php
+++ b/phpBB/phpbb/event/kernel_exception_subscriber.php
@@ -68,6 +68,9 @@ class kernel_exception_subscriber implements EventSubscriberInterface
 			$message = call_user_func_array(array($this->user, 'lang'), array_merge(array($message), $exception->get_parameters()));
 		}
 
+		// Show <strong> text in bold
+		$message = preg_replace('#&lt;(/?)(strong)&gt;#i', '<$1$2>', $message);
+
 		if (!$event->getRequest()->isXmlHttpRequest())
 		{
 			page_header($this->user->lang('INFORMATION'));


### PR DESCRIPTION
Checklist:

- [x] Correct branch: master for new features; 3.2.x, 3.1.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master / 3.2.x](https://area51.phpbb.com/docs/master/coding-guidelines.html), [3.1.x](https://area51.phpbb.com/docs/31x/coding-guidelines.html)
- [x] Commit follows commit message [format](https://wiki.phpbb.com/Git#Commit_Messages)

Tracker ticket (set the ticket ID to **your ticket ID**):

https://tracker.phpbb.com/browse/PHPBB3-14821

Everything else will still be escaped. This will however add back support for
bold text in exception messages.

PHPBB3-14821