### PR TITLE
[ticket/14795] Use maximum topic views instead of adding up views in merge

### DIFF
--- a/phpBB/includes/mcp/mcp_forum.php
+++ b/phpBB/includes/mcp/mcp_forum.php
@@ -424,7 +424,7 @@ function merge_topics($forum_id, $topic_ids, $to_topic_id)
 	foreach ($topic_data as $data)
 	{
 		$sync_forums[$data['forum_id']] = $data['forum_id'];
-		$topic_views += $data['topic_views'];
+		$topic_views = max($topic_views, $data['topic_views']);
 	}
 
 	$topic_data = $topic_data[$to_topic_id];


### PR DESCRIPTION
Checklist:
- [x] Correct branch: master for new features; 3.2.x, 3.1.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master / 3.2.x](https://area51.phpbb.com/docs/master/coding-guidelines.html), [3.1.x](https://area51.phpbb.com/docs/31x/coding-guidelines.html)
- [x] Commit follows commit message [format](https://wiki.phpbb.com/Git#Commit_Messages)

Tracker ticket (set the ticket ID to **your ticket ID**):

https://tracker.phpbb.com/browse/PHPBB3-14795

Merging topics should not result in topic views being added up but rather in
the highest topic view showing up for the merged topic.

PHPBB3-14795
