### PR TITLE
[ticket/11483] Generate user act key if database entry is empty

### DIFF
--- a/phpBB/includes/acp/acp_users.php
+++ b/phpBB/includes/acp/acp_users.php
@@ -373,11 +373,6 @@ class acp_users
 								if ($user_row['user_type'] == USER_NORMAL)
 								{
 									user_active_flip('deactivate', $user_id, INACTIVE_REMIND);
-
-									$sql = 'UPDATE ' . USERS_TABLE . "
-										SET user_actkey = '" . $db->sql_escape($user_actkey) . "'
-										WHERE user_id = $user_id";
-									$db->sql_query($sql);
 								}
 								else
 								{
@@ -386,8 +381,18 @@ class acp_users
 										FROM ' . USERS_TABLE . '
 										WHERE user_id = ' . $user_id;
 									$result = $db->sql_query($sql);
-									$user_actkey = (string) $db->sql_fetchfield('user_actkey');
+									$user_activation_key = (string) $db->sql_fetchfield('user_actkey');
 									$db->sql_freeresult($result);
+
+									$user_actkey = empty($user_activation_key) ? $user_actkey : $user_activation_key;
+								}
+
+								if ($user_row['user_type'] == USER_NORMAL || empty($user_activation_key))
+								{
+									$sql = 'UPDATE ' . USERS_TABLE . "
+										SET user_actkey = '" . $db->sql_escape($user_actkey) . "'
+										WHERE user_id = $user_id";
+									$db->sql_query($sql);
 								}
 
 								$messenger = new messenger(false);


### PR DESCRIPTION
Checklist:
- [x] Correct branch: master for new features; 3.2.x, 3.1.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master / 3.2.x](https://area51.phpbb.com/docs/master/coding-guidelines.html), [3.1.x](https://area51.phpbb.com/docs/31x/coding-guidelines.html)
- [x] Commit follows commit message [format](https://wiki.phpbb.com/Git#Commit_Messages)

Tracker ticket (set the ticket ID to **your ticket ID**):

https://tracker.phpbb.com/browse/PHPBB3-11483

The force reactivation action in the ACP will no longer overwrite the
generated activation key in case the key stored in the database is empty.
It will also save the generated key back to the database to actually allow
the activation by the user.

PHPBB3-11483
