### PR TITLE
[ticket/14831] Make sure migrations always start with backslash

### DIFF
--- a/phpBB/phpbb/db/migration/data/v31x/migrations_deduplicate_entries.php
+++ b/phpBB/phpbb/db/migration/data/v31x/migrations_deduplicate_entries.php
@@ -55,21 +55,21 @@ class migrations_deduplicate_entries extends \phpbb\db\migration\migration
 			$prepended_name = preg_replace('#^(?!\\\)#', '\\\$0', $name);
 			$prefixless_name = preg_replace('#(^\\\)([^\\\].+)#', '$2', $name);
 
-			if ($prepended_name !== $name && isset($migration_state[$prepended_name]) && $migration_state[$prepended_name] === $migration_state[$name])
+			if ($prepended_name != $name && isset($migration_state[$prepended_name]) && $migration_state[$prepended_name]['migration_depends_on'] == $migration_state[$name]['migration_depends_on'])
 			{
 				$duplicate_migrations[] = $name;
 				unset($migration_state[$prepended_name]);
 			}
-			else if ($prefixless_name !== $name && isset($migration_state[$prefixless_name]) && $migration_state[$prefixless_name] === $migration_state[$name])
+			else if ($prefixless_name != $name && isset($migration_state[$prefixless_name]) && $migration_state[$prefixless_name]['migration_depends_on'] == $migration_state[$name]['migration_depends_on'])
 			{
-				$duplicate_migrations[] = $name;
+				$duplicate_migrations[] = $prefixless_name;
 				unset($migration_state[$prefixless_name]);
 			}
 		}
 
 		if (count($duplicate_migrations))
 		{
-			$sql = 'DELETE *
+			$sql = 'DELETE
 				FROM ' . $this->table_prefix . 'migrations
 				WHERE '  . $this->db->sql_in_set('migration_name', $duplicate_migrations);
 			$this->db->sql_query($sql);

--- a/phpBB/phpbb/db/migration/data/v31x/migrations_deduplicate_entries.php
+++ b/phpBB/phpbb/db/migration/data/v31x/migrations_deduplicate_entries.php
@@ -1,0 +1,78 @@
+<?php
+
+/**
+ *
+ * This file is part of the phpBB Forum Software package.
+ *
+ * @copyright (c) phpBB Limited <https://www.phpbb.com>
+ * @license GNU General Public License, version 2 (GPL-2.0)
+ *
+ * For full copyright and license information, please see
+ * the docs/CREDITS.txt file.
+ *
+ */
+
+namespace phpbb\db\migration\data\v31x;
+
+class migrations_deduplicate_entries extends \phpbb\db\migration\migration
+{
+	static public function depends_on()
+	{
+		return array('\phpbb\db\migration\data\v31x\v3110');
+	}
+
+	public function update_data()
+	{
+		return array(
+			array('custom', array(array($this, 'deduplicate_entries'))),
+		);
+	}
+
+	public function deduplicate_entries()
+	{
+		$migration_state = array();
+		$duplicate_migrations = array();
+
+		$sql = "SELECT *
+			FROM " . $this->table_prefix . 'migrations';
+		$result = $this->db->sql_query($sql);
+
+		if (!$this->db->get_sql_error_triggered())
+		{
+			while ($migration = $this->db->sql_fetchrow($result))
+			{
+				$migration_state[$migration['migration_name']] = $migration;
+
+				$migration_state[$migration['migration_name']]['migration_depends_on'] = unserialize($migration['migration_depends_on']);
+				$migration_state[$migration['migration_name']]['migration_data_state'] = !empty($migration['migration_data_state']) ? unserialize($migration['migration_data_state']) : '';
+			}
+		}
+
+		$this->db->sql_freeresult($result);
+
+		foreach ($migration_state as $name => $migration)
+		{
+			$prepended_name = preg_replace('#^(?!\\\)#', '\\\$0', $name);
+			$prefixless_name = preg_replace('#(^\\\)([^\\\].+)#', '$2', $name);
+
+			if ($prepended_name !== $name && isset($migration_state[$prepended_name]) && $migration_state[$prepended_name] === $migration_state[$name])
+			{
+				$duplicate_migrations[] = $name;
+				unset($migration_state[$prepended_name]);
+			}
+			else if ($prefixless_name !== $name && isset($migration_state[$prefixless_name]) && $migration_state[$prefixless_name] === $migration_state[$name])
+			{
+				$duplicate_migrations[] = $name;
+				unset($migration_state[$prefixless_name]);
+			}
+		}
+
+		if (count($duplicate_migrations))
+		{
+			$sql = 'DELETE *
+				FROM ' . $this->table_prefix . 'migrations
+				WHERE '  . $this->db->sql_in_set('migration_name', $duplicate_migrations);
+			$this->db->sql_query($sql);
+		}
+	}
+}

--- a/phpBB/phpbb/db/migration/data/v31x/remove_duplicate_migrations.php
+++ b/phpBB/phpbb/db/migration/data/v31x/remove_duplicate_migrations.php
@@ -14,7 +14,7 @@
 
 namespace phpbb\db\migration\data\v31x;
 
-class migrations_deduplicate_entries extends \phpbb\db\migration\migration
+class remove_duplicate_migrations extends \phpbb\db\migration\migration
 {
 	static public function depends_on()
 	{
@@ -44,7 +44,6 @@ class migrations_deduplicate_entries extends \phpbb\db\migration\migration
 				$migration_state[$migration['migration_name']] = $migration;
 
 				$migration_state[$migration['migration_name']]['migration_depends_on'] = unserialize($migration['migration_depends_on']);
-				$migration_state[$migration['migration_name']]['migration_data_state'] = !empty($migration['migration_data_state']) ? unserialize($migration['migration_data_state']) : '';
 			}
 		}
 
@@ -52,8 +51,8 @@ class migrations_deduplicate_entries extends \phpbb\db\migration\migration
 
 		foreach ($migration_state as $name => $migration)
 		{
-			$prepended_name = preg_replace('#^(?!\\\)#', '\\\$0', $name);
-			$prefixless_name = preg_replace('#(^\\\)([^\\\].+)#', '$2', $name);
+			$prepended_name = ($name[0] == '\\' ? '' : '\\') . $name;
+			$prefixless_name = $name[0] == '\\' ? substr($name, 1) : $name;
 
 			if ($prepended_name != $name && isset($migration_state[$prepended_name]) && $migration_state[$prepended_name]['migration_depends_on'] == $migration_state[$name]['migration_depends_on'])
 			{

--- a/phpBB/phpbb/db/migrator.php
+++ b/phpBB/phpbb/db/migrator.php
@@ -201,6 +201,34 @@ class migrator
 	}
 
 	/**
+	 * Get a valid migration name from the migration state array in case the
+	 * supplied name is not in the migration state list.
+	 *
+	 * @param string $name Migration name
+	 * @return string Migration name
+	 */
+	protected function get_valid_name($name)
+	{
+		// Try falling back to a valid migration name with or without leading backslash
+		if (!isset($this->migration_state[$name]))
+		{
+			$appended_name = preg_replace('#^(?!\\\)#', '\\\$0', $name);
+			$prefixless_name = preg_replace('#(^\\\)([^\\\].+)#', '$2', $name);
+
+			if (isset($this->migration_state[$appended_name]))
+			{
+				$name = $appended_name;
+			}
+			else if (isset($this->migration_state[$prefixless_name]))
+			{
+				$name = $prefixless_name;
+			}
+		}
+
+		return $name;
+	}
+
+	/**
 	 * Effectively runs a single update step from the next migration to be applied.
 	 *
 	 * @return null
@@ -209,18 +237,7 @@ class migrator
 	{
 		foreach ($this->migrations as $name)
 		{
-			// Try falling back to a valid migration name with or without leading backslash
-			if (!isset($this->migration_state[$name]))
-			{
-				if (isset($this->migration_state[preg_replace('#^(?!\\\)#', '\\\$0', $name)]))
-				{
-					$name = preg_replace('#^(?!\\\)#', '\\\$0', $name);
-				}
-				else if (isset($this->migration_state[preg_replace('#(^\\\)([^\\\].+)#', '$2', $name)]))
-				{
-					$name = preg_replace('#(^\\\)([^\\\].+)#', '$2', $name);
-				}
-			}
+			$name = $this->get_valid_name($name);
 
 			if (!isset($this->migration_state[$name]) ||
 				!$this->migration_state[$name]['migration_schema_done'] ||
@@ -277,22 +294,10 @@ class migrator
 
 		foreach ($state['migration_depends_on'] as $depend)
 		{
-			// Try falling back to a valid migration name with or without leading backslash
-			if (!isset($this->migration_state[$name]))
-			{
-				if (isset($this->migration_state[preg_replace('#^(?!\\\)#', '\\\$0', $name)]))
-				{
-					$name = preg_replace('#^(?!\\\)#', '\\\$0', $name);
-				}
-				else if (isset($this->migration_state[preg_replace('#(^\\\)([^\\\].+)#', '$2', $name)]))
-				{
-					$name = preg_replace('#(^\\\)([^\\\].+)#', '$2', $name);
-				}
-			}
+			$depend = $this->get_valid_name($depend);
 
 			// Test all possible namings before throwing exception
-			if ($this->unfulfillable($depend) !== false && $this->unfulfillable(preg_replace('#(^\\\)([^\\\].+)#', '$2', $depend)) !== false &&
-				$this->unfulfillable(preg_replace('#^(?!\\\)#', '\\\$0', $name)))
+			if ($this->unfulfillable($depend) !== false)
 			{
 				throw new \phpbb\db\migration\exception('MIGRATION_NOT_FULFILLABLE', $name, $depend);
 			}
@@ -770,6 +775,8 @@ class migrator
 	*/
 	public function unfulfillable($name)
 	{
+		$name = $this->get_valid_name($name);
+
 		if (isset($this->migration_state[$name]) || isset($this->fulfillable_migrations[$name]))
 		{
 			return false;
@@ -785,6 +792,7 @@ class migrator
 
 		foreach ($depends as $depend)
 		{
+			$depend = $this->get_valid_name($depend);
 			$unfulfillable = $this->unfulfillable($depend);
 			if ($unfulfillable !== false)
 			{

--- a/phpBB/phpbb/db/migrator.php
+++ b/phpBB/phpbb/db/migrator.php
@@ -212,8 +212,8 @@ class migrator
 		// Try falling back to a valid migration name with or without leading backslash
 		if (!isset($this->migration_state[$name]))
 		{
-			$prepended_name = preg_replace('#^(?!\\\)#', '\\\$0', $name);
-			$prefixless_name = preg_replace('#(^\\\)([^\\\].+)#', '$2', $name);
+			$prepended_name = ($name[0] == '\\' ? '' : '\\') . $name;
+			$prefixless_name = $name[0] == '\\' ? substr($name, 1) : $name;
 
 			if (isset($this->migration_state[$prepended_name]))
 			{

--- a/phpBB/phpbb/db/migrator.php
+++ b/phpBB/phpbb/db/migrator.php
@@ -212,12 +212,12 @@ class migrator
 		// Try falling back to a valid migration name with or without leading backslash
 		if (!isset($this->migration_state[$name]))
 		{
-			$appended_name = preg_replace('#^(?!\\\)#', '\\\$0', $name);
+			$prepended_name = preg_replace('#^(?!\\\)#', '\\\$0', $name);
 			$prefixless_name = preg_replace('#(^\\\)([^\\\].+)#', '$2', $name);
 
-			if (isset($this->migration_state[$appended_name]))
+			if (isset($this->migration_state[$prepended_name]))
 			{
-				$name = $appended_name;
+				$name = $prepended_name;
 			}
 			else if (isset($this->migration_state[$prefixless_name]))
 			{

--- a/phpBB/phpbb/db/migrator.php
+++ b/phpBB/phpbb/db/migrator.php
@@ -264,6 +264,9 @@ class migrator
 
 		foreach ($state['migration_depends_on'] as $depend)
 		{
+			// Make sure migration starts with backslash
+			$depend = $depend[0] == '\\' ? $depend : '\\' . $depend;
+
 			if ($this->unfulfillable($depend) !== false)
 			{
 				throw new \phpbb\db\migration\exception('MIGRATION_NOT_FULFILLABLE', $name, $depend);


### PR DESCRIPTION
Checklist:
- [x] Correct branch: master for new features; 3.2.x, 3.1.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master / 3.2.x](https://area51.phpbb.com/docs/master/coding-guidelines.html), [3.1.x](https://area51.phpbb.com/docs/31x/coding-guidelines.html)
- [x] Commit follows commit message [format](https://wiki.phpbb.com/Git#Commit_Messages)

Tracker ticket (set the ticket ID to **your ticket ID**):

https://tracker.phpbb.com/browse/PHPBB3-14831

The migration system expects every migration to start with a backslash.
If depends on definitions do not supply that leading backslash, we should
make sure it's added manually before calling the depends on migration.

PHPBB3-14831
