### PR TITLE
[ticket/14859] Send notifications for PM reports to all users with correct permissions

### DIFF
--- a/phpBB/phpbb/notification/type/report_pm.php
+++ b/phpBB/phpbb/notification/type/report_pm.php
@@ -52,7 +52,7 @@ class report_pm extends \phpbb\notification\type\pm
 	*
 	* @var string Permission name
 	*/
-	protected $permission = 'm_report';
+	protected $permission = 'm_pm_report';
 
 	/**
 	* Notification option data (for outputting to the user)


### PR DESCRIPTION
Tracker ticket (set the ticket ID to your ticket ID):

https://tracker.phpbb.com/browse/PHPBB3-14859

This addresses the problem that notifications of new PM reports were not sent out to moderators that weren't global moderators but did have the permission "Can close/delete PM reports". 

PHPBB3-14859