### PR TITLE
[ticket/14869] Allows DEBUG and DEBUG_ERROR_LEVEL to be used

### DIFF
--- a/phpBB/common.php
+++ b/phpBB/common.php
@@ -96,9 +96,10 @@ include($phpbb_root_path . 'includes/functions_compatibility.' . $phpEx);
 require($phpbb_root_path . 'includes/constants.' . $phpEx);
 require($phpbb_root_path . 'includes/utf/utf_tools.' . $phpEx);
 
-if (PHPBB_ENVIRONMENT === 'development' || DEBUG === true)
+if (PHPBB_ENVIRONMENT === 'development' || (defined('DEBUG') && DEBUG === true) )
 {
-	\phpbb\debug\debug::enable(DEBUG_ERROR_LEVEL);
+	$log_level = (defined('DEBUG_PHP_ERROR_LEVEL') ? constant('DEBUG_PHP_ERROR_LEVEL') : null);
+	\phpbb\debug\debug::enable($log_level);
 }
 else
 {

--- a/phpBB/common.php
+++ b/phpBB/common.php
@@ -96,9 +96,9 @@ include($phpbb_root_path . 'includes/functions_compatibility.' . $phpEx);
 require($phpbb_root_path . 'includes/constants.' . $phpEx);
 require($phpbb_root_path . 'includes/utf/utf_tools.' . $phpEx);
 
-if (PHPBB_ENVIRONMENT === 'development')
+if (PHPBB_ENVIRONMENT === 'development' || DEBUG === true)
 {
-	\phpbb\debug\debug::enable();
+	\phpbb\debug\debug::enable(DEBUG_ERROR_LEVEL);
 }
 else
 {


### PR DESCRIPTION
Checklist:

- [x] Correct branch: master for new features; 3.2.x, 3.1.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master / 3.2.x](https://area51.phpbb.com/docs/master/coding-guidelines.html), [3.1.x](https://area51.phpbb.com/docs/31x/coding-guidelines.html)
- [x] Commit follows commit message [format](https://wiki.phpbb.com/Git#Commit_Messages)

Tracker ticket (set the ticket ID to **your ticket ID**):

https://tracker.phpbb.com/browse/PHPBB3-14869

Currently debug is enabled by default based off environment with no way to set log level