### PR TITLE
[ticket/14876] Allows multibyte strings for exception messages

### DIFF
--- a/phpBB/phpbb/event/kernel_exception_subscriber.php
+++ b/phpBB/phpbb/event/kernel_exception_subscriber.php
@@ -61,7 +61,7 @@ class kernel_exception_subscriber implements EventSubscriberInterface
 		$exception = $event->getException();
 
 		$message = $exception->getMessage();
-		$this->type_caster->set_var($message, $message, 'string', false, false);
+		$this->type_caster->set_var($message, $message, 'string', true, false);
 
 		if ($exception instanceof \phpbb\exception\exception_interface)
 		{


### PR DESCRIPTION
Checklist:

- [x] Correct branch: master for new features; 3.2.x, 3.1.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master / 3.2.x](https://area51.phpbb.com/docs/master/coding-guidelines.html), [3.1.x](https://area51.phpbb.com/docs/31x/coding-guidelines.html)
- [x] Commit follows commit message [format](https://wiki.phpbb.com/Git#Commit_Messages)

https://tracker.phpbb.com/browse/PHPBB3-14876

All exception messages are sanitized via type_caster::set_var()
which is called with $multibyte = false.
This commit allows to pass multibyte messages as well.

PHPBB3-14876