### PR TITLE
[ticket/13757] Prevents the count of unread PMs from being negative

### DIFF
--- a/phpBB/includes/functions_privmsgs.php
+++ b/phpBB/includes/functions_privmsgs.php
@@ -892,6 +892,14 @@ function update_unread_status($unread, $msg_id, $user_id, $folder_id)
 			AND folder_id = $folder_id";
 	$db->sql_query($sql);
 
+	$affected_rows = $db->sql_affectedrows();
+
+	// If the message is already marked as read, we just skip the rest to avoid negative PM count
+	if (!$affected_rows)
+	{
+		return;
+	}
+
 	$sql = 'UPDATE ' . USERS_TABLE . "
 		SET user_unread_privmsg = user_unread_privmsg - 1
 		WHERE user_id = $user_id";


### PR DESCRIPTION
Checklist:

- [ ] Correct branch: master for new features; 3.2.x, 3.1.x for fixes
- [ ] Tests pass
- [ ] Code follows coding guidelines: [master / 3.2.x](https://area51.phpbb.com/docs/master/coding-guidelines.html), [3.1.x](https://area51.phpbb.com/docs/31x/coding-guidelines.html)
- [ ] Commit follows commit message [format](https://wiki.phpbb.com/Git#Commit_Messages)

Tracker ticket (set the ticket ID to **your ticket ID**):

https://tracker.phpbb.com/browse/PHPBB3-13757

Sometimes the user_unread_privmsg flag in users table can become negative.
It happens when the unread message is requested by simultaneous concurrent
requests. Both requests will decrement the value of the flag.
This commit prevents updating the flag if the message already marked as read.

PHPBB3-13757