### PR TITLE
[ticket/13757] Properly fix bug with negative PM count

### DIFF
--- a/phpBB/includes/functions_privmsgs.php
+++ b/phpBB/includes/functions_privmsgs.php
@@ -889,7 +889,8 @@ function update_unread_status($unread, $msg_id, $user_id, $folder_id)
 		SET pm_unread = 0
 		WHERE msg_id = $msg_id
 			AND user_id = $user_id
-			AND folder_id = $folder_id";
+			AND folder_id = $folder_id
+			AND pm_unread = 1";
 	$db->sql_query($sql);
 
 	// If the message is already marked as read, we just skip the rest to avoid negative PM count


### PR DESCRIPTION
Checklist:

- [x] Correct branch: master for new features; 3.2.x, 3.1.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master / 3.2.x](https://area51.phpbb.com/docs/master/coding-guidelines.html), [3.1.x](https://area51.phpbb.com/docs/31x/coding-guidelines.html)
- [x] Commit follows commit message [format](https://wiki.phpbb.com/Git#Commit_Messages)

Tracker ticket (set the ticket ID to **your ticket ID**):

https://tracker.phpbb.com/browse/PHPBB3-13757

The fix from PR #4548 doesn't work as expected because
in phpBB the sql_affectedrows() method always returns
a count of matched rows instead of affected rows.
This commit fixes bug properly.

PHPBB3-13757