### PR TITLE
[ticket/13853] Flexible schema for profilefields step 1 configuration

### DIFF
--- a/phpBB/adm/style/acp_profile.html
+++ b/phpBB/adm/style/acp_profile.html
@@ -104,31 +104,13 @@
 			<dt><label for="lang_explain">{L_FIELD_DESCRIPTION}{L_COLON}</label><br /><span>{L_FIELD_DESCRIPTION_EXPLAIN}</span></dt>
 			<dd><textarea id="lang_explain" name="lang_explain" rows="3" cols="80">{LANG_EXPLAIN}</textarea></dd>
 		</dl>
-		<!-- IF S_TEXT or S_STRING -->
+		<!-- BEGIN option -->
 			<dl>
-				<dt><label for="lang_default_value">{L_DEFAULT_VALUE}{L_COLON}</label><br /><span>{L_DEFAULT_VALUE_EXPLAIN}</span></dt>
-				<dd><!-- IF S_STRING --><input class="text medium" type="text" id="lang_default_value" name="lang_default_value" value="{LANG_DEFAULT_VALUE}" /><!-- ELSE --><textarea id="lang_default_value" name="lang_default_value" rows="5" cols="80">{LANG_DEFAULT_VALUE}</textarea><!-- ENDIF --></dd>
+				<dt><label>{option.TITLE}{L_COLON}</label><!-- IF option.EXPLAIN --><br /><span>{option.EXPLAIN}</span><!-- ENDIF --></dt>
+				<dd>{option.FIELD}</dd>
 			</dl>
-		<!-- ENDIF -->
-		<!-- IF S_BOOL or S_DROPDOWN -->
-			<dl>
-				<dt><label for="lang_options">{L_ENTRIES}{L_COLON}</label>
-					<!-- IF S_EDIT_MODE and S_DROPDOWN -->
-						<br /><span>{L_EDIT_DROPDOWN_LANG_EXPLAIN}</span>
-					<!-- ELSE -->
-						<br /><span>{L_LANG_OPTIONS_EXPLAIN}</span>
-					<!-- ENDIF -->
-				</dt>
-			<!-- IF S_DROPDOWN -->
-				<dd><textarea id="lang_options" name="lang_options" rows="5" cols="80">{LANG_OPTIONS}</textarea></dd>
-			<!-- ELSE -->
-				<dd><input class="medium" id="lang_options" name="lang_options[0]" value="{FIRST_LANG_OPTION}" /> {L_FIRST_OPTION}</dd>
-				<dd><input class="medium" name="lang_options[1]" value="{SECOND_LANG_OPTION}" /> {L_SECOND_OPTION}</dd>
-			<!-- ENDIF -->
-			</dl>
-		<!-- ENDIF -->
+		<!-- END option -->
 		</fieldset>
-
 		<fieldset class="quick">
 			{S_HIDDEN_FIELDS}
 			{S_FORM_TOKEN}

--- a/phpBB/includes/acp/acp_profile.php
+++ b/phpBB/includes/acp/acp_profile.php
@@ -625,7 +625,7 @@ class acp_profile
 				{
 					// Create basic options - only small differences between field types
 					case 1:
-						$template_vars = array(
+						$template->assign_vars(array(
 							'S_STEP_ONE'		=> true,
 							'S_FIELD_REQUIRED'	=> ($cp->vars['field_required']) ? true : false,
 							'S_FIELD_SHOW_NOVALUE'=> ($cp->vars['field_show_novalue']) ? true : false,
@@ -645,22 +645,26 @@ class acp_profile
 							'FIELD_IDENT'		=> $cp->vars['field_ident'],
 							'LANG_NAME'			=> $cp->vars['lang_name'],
 							'LANG_EXPLAIN'		=> $cp->vars['lang_explain'],
-						);
+						));
 
+						// Build options based on profile type
 						$field_data = $cp->vars;
-						$profile_field->display_options($template_vars, $field_data);
+						$options = $profile_field->display_options($action, $field_data);
 						$cp->vars = $field_data;
 
-						// Build common create options
-						$template->assign_vars($template_vars);
+						foreach ($options as $num => $option_ary)
+						{
+							$template->assign_block_vars('option', $option_ary);
+						}
+
 					break;
 
 					case 2:
 
 						$template->assign_vars(array(
 							'S_STEP_TWO'		=> true,
-							'L_NEXT_STEP'			=> (sizeof($this->lang_defs['iso']) == 1) ? $user->lang['SAVE'] : $user->lang['PROFILE_LANG_OPTIONS'])
-						);
+							'L_NEXT_STEP'		=> (sizeof($this->lang_defs['iso']) == 1) ? $user->lang['SAVE'] : $user->lang['PROFILE_LANG_OPTIONS'],
+						));
 
 						// Build options based on profile type
 						$options = $profile_field->get_options($this->lang_defs['iso'][$config['default_lang']], $cp->vars);
@@ -950,7 +954,6 @@ class acp_profile
 			'profile_fields',
 		);
 		extract($phpbb_dispatcher->trigger_event('core.acp_profile_create_edit_save_before', compact($vars)));
-
 		if ($action == 'create')
 		{
 			$profile_fields += array(

--- a/phpBB/phpbb/profilefields/type/type_base.php
+++ b/phpBB/phpbb/profilefields/type/type_base.php
@@ -177,9 +177,9 @@ abstract class type_base implements type_interface
 	/**
 	* {@inheritDoc}
 	*/
-	public function display_options(&$template_vars, &$field_data)
+	public function display_options($action, &$field_data)
 	{
-		return;
+		return array();
 	}
 
 	/**

--- a/phpBB/phpbb/profilefields/type/type_bool.php
+++ b/phpBB/phpbb/profilefields/type/type_bool.php
@@ -395,7 +395,7 @@ class type_bool extends type_base
 	/**
 	* {@inheritDoc}
 	*/
-	public function display_options(&$template_vars, &$field_data)
+	public function display_options($action, &$field_data)
 	{
 		// Initialize these array elements if we are creating a new field
 		if (!sizeof($field_data['lang_options']))
@@ -405,11 +405,14 @@ class type_bool extends type_base
 			$field_data['lang_options'][1] = '';
 		}
 
-		$template_vars = array_merge($template_vars, array(
-			'S_BOOL'					=> true,
-			'L_LANG_OPTIONS_EXPLAIN'	=> $this->user->lang['BOOL_ENTRIES_EXPLAIN'],
-			'FIRST_LANG_OPTION'			=> $field_data['lang_options'][0],
-			'SECOND_LANG_OPTION'		=> $field_data['lang_options'][1],
-		));
+		$doptions = array(
+			0 => array(
+					'TITLE' => $this->user->lang['ENTRIES'],
+					'EXPLAIN' => $this->user->lang['BOOL_ENTRIES_EXPLAIN'],
+					'FIELD' => '<input class="medium" id="lang_options" name="lang_options[0]" value="' . $field_data['lang_options'][0] . '" /> ' . $this->user->lang['FIRST_OPTION'] . '</dd><dd><input class="medium" name="lang_options[1]" value="' . $field_data['lang_options'][1] . '" /> ' . $this->user->lang['SECOND_OPTION']
+				),
+		);
+
+		return $doptions;
 	}
 }

--- a/phpBB/phpbb/profilefields/type/type_dropdown.php
+++ b/phpBB/phpbb/profilefields/type/type_dropdown.php
@@ -307,7 +307,7 @@ class type_dropdown extends type_base
 	/**
 	* {@inheritDoc}
 	*/
-	public function display_options(&$template_vars, &$field_data)
+	public function display_options($action, &$field_data)
 	{
 		// Initialize these array elements if we are creating a new field
 		if (!sizeof($field_data['lang_options']))
@@ -316,10 +316,14 @@ class type_dropdown extends type_base
 			$field_data['lang_options'] = array();
 		}
 
-		$template_vars = array_merge($template_vars, array(
-			'S_DROPDOWN'				=> true,
-			'L_LANG_OPTIONS_EXPLAIN'	=> $this->user->lang['DROPDOWN_ENTRIES_EXPLAIN'],
-			'LANG_OPTIONS'				=> implode("\n", $field_data['lang_options']),
-		));
+		$doptions = array(
+			0 => array(
+					'TITLE' => $this->user->lang['ENTRIES'],
+					'EXPLAIN' => $this->user->lang[($action == 'edit') ? 'EDIT_DROPDOWN_LANG_EXPLAIN' : 'DROPDOWN_ENTRIES_EXPLAIN'],
+					'FIELD' => '<textarea id="lang_options" name="lang_options" rows="5" cols="80">' . implode("\n", $field_data['lang_options']) . '</textarea>'
+				),
+		);
+
+		return $doptions;
 	}
 }

--- a/phpBB/phpbb/profilefields/type/type_interface.php
+++ b/phpBB/phpbb/profilefields/type/type_interface.php
@@ -134,6 +134,14 @@ interface type_interface
 	public function get_field_ident($field_data);
 
 	/**
+	* Get the localized name of the field
+	*
+	* @param string $field_name		Unlocalized name of this field
+	* @return string 	Localized name of the field
+	*/
+	public function get_field_name($field_name);
+
+	/**
 	* Get the column type for the database
 	*
 	* @return string	Returns the database column type
@@ -200,11 +208,11 @@ interface type_interface
 	/**
 	* Allows assigning of additional template variables
 	*
-	* @param array	$template_vars	Template variables we are going to assign
+	* @param string	$action			Currently performed action (create|edit)
 	* @param array	$field_data		Array with data for this field
-	* @return null
+	* @return array	with the acp options for step 1
 	*/
-	public function display_options(&$template_vars, &$field_data);
+	public function display_options($action, &$field_data);
 
 	/**
 	* Return templated value/field. Possible values for $mode are:

--- a/phpBB/phpbb/profilefields/type/type_string.php
+++ b/phpBB/phpbb/profilefields/type/type_string.php
@@ -63,7 +63,7 @@ class type_string extends type_string_common
 		$options = array(
 			0 => array('TITLE' => $this->user->lang['FIELD_LENGTH'],		'FIELD' => '<input type="number" min="0" max="99999" name="field_length" value="' . $field_data['field_length'] . '" />'),
 			1 => array('TITLE' => $this->user->lang['MIN_FIELD_CHARS'],	'FIELD' => '<input type="number" min="0" max="99999" name="field_minlen" value="' . $field_data['field_minlen'] . '" />'),
-			2 => array('TITLE' => $this->user->lang['MAX_FIELD_CHARS'],	'FIELD' => '<input type="number" min="0 max="99999"" name="field_maxlen" value="' . $field_data['field_maxlen'] . '" />'),
+			2 => array('TITLE' => $this->user->lang['MAX_FIELD_CHARS'],	'FIELD' => '<input type="number" min="0" max="99999" name="field_maxlen" value="' . $field_data['field_maxlen'] . '" />'),
 			3 => array('TITLE' => $this->user->lang['FIELD_VALIDATION'],	'FIELD' => '<select name="field_validation">' . $this->validate_options($field_data) . '</select>'),
 		);
 
@@ -148,12 +148,16 @@ class type_string extends type_string_common
 	/**
 	* {@inheritDoc}
 	*/
-	public function display_options(&$template_vars, &$field_data)
+	public function display_options($action, &$field_data)
 	{
-		$template_vars = array_merge($template_vars, array(
-			'S_STRING'					=> true,
-			'L_DEFAULT_VALUE_EXPLAIN'	=> $this->user->lang['STRING_DEFAULT_VALUE_EXPLAIN'],
-			'LANG_DEFAULT_VALUE'		=> $field_data['lang_default_value'],
-		));
+		$doptions = array(
+			0 => array(
+					'TITLE' => $this->user->lang['DEFAULT_VALUE'],
+					'EXPLAIN' => $this->user->lang['TEXT_DEFAULT_VALUE_EXPLAIN'],
+					'FIELD' => '<textarea id="lang_default_value" name="lang_default_value" rows="5" cols="80">' . $field_data['lang_default_value'] . '</textarea>'
+				),
+		);
+
+		return $doptions;
 	}
 }

--- a/phpBB/phpbb/profilefields/type/type_text.php
+++ b/phpBB/phpbb/profilefields/type/type_text.php
@@ -193,12 +193,16 @@ class type_text extends type_string_common
 	/**
 	* {@inheritDoc}
 	*/
-	public function display_options(&$template_vars, &$field_data)
+	public function display_options($action, &$field_data)
 	{
-		$template_vars = array_merge($template_vars, array(
-			'S_TEXT'					=> true,
-			'L_DEFAULT_VALUE_EXPLAIN'	=> $this->user->lang['TEXT_DEFAULT_VALUE_EXPLAIN'],
-			'LANG_DEFAULT_VALUE'		=> $field_data['lang_default_value'],
-		));
+		$doptions = array(
+			0 => array(
+					'TITLE' => $this->user->lang['DEFAULT_VALUE'],
+					'EXPLAIN' => $this->user->lang['TEXT_DEFAULT_VALUE_EXPLAIN'],
+					'FIELD' => '<input class="text medium" type="text" id="lang_default_value" name="lang_default_value" value="' . $field_data['lang_default_value'] . '" />'
+				),
+		);
+
+		return $doptions;
 	}
 }


### PR DESCRIPTION
Modify the way adm/style/acp_profile.html STEP 1 (lines 106 to 128)
is coded to make it flexible and expandable to other new types of
profile fields, rather than the current mechanism, hardcoded for
the default types.

A flexible mechanism similar to the one used of STEP 2 is used.

This required a slight modification of the type_interface, and
corresponding modifications to all implementations of that interface.

Includes a fix in the type_interface, missing a required method.

Checklist:

- [ ] Correct branch: master for new features; 3.2.x, 3.1.x for fixes
- [ ] Tests pass
- [ ] Code follows coding guidelines: [master / 3.2.x](https://area51.phpbb.com/docs/master/coding-guidelines.html), [3.1.x](https://area51.phpbb.com/docs/31x/coding-guidelines.html)
- [ ] Commit follows commit message [format](https://wiki.phpbb.com/Git#Commit_Messages)

Tracker ticket:

https://tracker.phpbb.com/browse/PHPBB3-13853
