### PR TITLE
[ticket/14888] Missing check for disabled profile field types

### DIFF
--- a/phpBB/includes/acp/acp_profile.php
+++ b/phpBB/includes/acp/acp_profile.php
@@ -752,6 +752,10 @@ class acp_profile
 				$s_one_need_edit = true;
 			}
 
+			if (!isset($this->type_collection[$row['field_type']]))
+			{
+				continue;
+			}
 			$profile_field = $this->type_collection[$row['field_type']];
 			$template->assign_block_vars('fields', array(
 				'FIELD_IDENT'		=> $row['field_ident'],


### PR DESCRIPTION
Checks if a profile field type is enabled before using it.

Checklist:

- [ ] Correct branch: master for new features; 3.2.x, 3.1.x for fixes
- [ ] Tests pass
- [ ] Code follows coding guidelines: [master / 3.2.x](https://area51.phpbb.com/docs/master/coding-guidelines.html), [3.1.x](https://area51.phpbb.com/docs/31x/coding-guidelines.html)
- [ ] Commit follows commit message [format](https://wiki.phpbb.com/Git#Commit_Messages)

Tracker ticket:

https://tracker.phpbb.com/browse/PHPBB3-14888
