### PR TITLE
[ticket/14901] Remove notice for extension without version check

### DIFF
--- a/phpBB/adm/style/acp_ext_details.html
+++ b/phpBB/adm/style/acp_ext_details.html
@@ -7,19 +7,17 @@
 	<h1>{L_EXTENSIONS_ADMIN}</h1>
 
 	<!-- IF S_VERSIONCHECK -->
-	<div class="<!-- IF S_UP_TO_DATE -->successbox<!-- ELSE -->errorbox<!-- ENDIF -->">
-		<p>{UP_TO_DATE_MSG} - <a href="{U_VERSIONCHECK_FORCE}">{L_VERSIONCHECK_FORCE_UPDATE}</a></p>
-	</div>
-	<!-- ELSE IF S_VERSIONCHECK_STATUS == 0 -->
-	<div class="errorbox notice">
-		<p>{L_VERSIONCHECK_FAIL}</p>
-		<p>{VERSIONCHECK_FAIL_REASON}</p>
-		<p><a href="{U_VERSIONCHECK_FORCE}">{L_VERSIONCHECK_FORCE_UPDATE}</a></p>
-	</div>
-	<!-- ELSE IF S_VERSIONCHECK_STATUS == 1 -->
-	<div class="errorbox notice">
-		<p>{VERSIONCHECK_FAIL_REASON}</p>
-	</div>
+		<!-- IF S_VERSIONCHECK_FAIL -->
+		<div class="errorbox notice">
+			<p>{L_VERSIONCHECK_FAIL}</p>
+			<p>{VERSIONCHECK_FAIL_REASON}</p>
+			<p><a href="{U_VERSIONCHECK_FORCE}">{L_VERSIONCHECK_FORCE_UPDATE}</a></p>
+		</div>
+		<!-- ELSE -->
+		<div class="<!-- IF S_UP_TO_DATE -->successbox<!-- ELSE -->errorbox<!-- ENDIF -->">
+			<p>{UP_TO_DATE_MSG} - <a href="{U_VERSIONCHECK_FORCE}">{L_VERSIONCHECK_FORCE_UPDATE}</a></p>
+		</div>
+		<!-- ENDIF -->
 	<!-- ENDIF -->
 
 	<fieldset>

--- a/phpBB/includes/acp/acp_extensions.php
+++ b/phpBB/includes/acp/acp_extensions.php
@@ -308,29 +308,37 @@ class acp_extensions
 				// Output it to the template
 				$md_manager->output_template_data($template);
 
-				try
+				$meta = $md_manager->get_metadata('all');
+				if (isset($meta['extra']['version-check']))
 				{
-					$updates_available = $phpbb_extension_manager->version_check($md_manager, $request->variable('versioncheck_force', false), $this->config['extension_force_unstable'] ? 'unstable' : null);
-
-					$template->assign_vars(array(
-						'S_UP_TO_DATE'		=> empty($updates_available),
-						'S_VERSIONCHECK'	=> true,
-						'UP_TO_DATE_MSG'	=> $this->user->lang(empty($updates_available) ? 'UP_TO_DATE' : 'NOT_UP_TO_DATE', $md_manager->get_metadata('display-name')),
-					));
-
-					foreach ($updates_available as $branch => $version_data)
+					try
 					{
-						$template->assign_block_vars('updates_available', $version_data);
-					}
-				}
-				catch (exception_interface $e)
-				{
-					$message = call_user_func_array(array($this->user, 'lang'), array_merge(array($e->getMessage()), $e->get_parameters()));
+						$updates_available = $phpbb_extension_manager->version_check($md_manager, $request->variable('versioncheck_force', false), $this->config['extension_force_unstable'] ? 'unstable' : null);
 
-					$template->assign_vars(array(
-						'S_VERSIONCHECK_STATUS'			=> $e->getCode(),
-						'VERSIONCHECK_FAIL_REASON'		=> ($e->getMessage() !== 'VERSIONCHECK_FAIL') ? $message : '',
-					));
+						$template->assign_vars(array(
+							'S_UP_TO_DATE' => empty($updates_available),
+							'UP_TO_DATE_MSG' => $this->user->lang(empty($updates_available) ? 'UP_TO_DATE' : 'NOT_UP_TO_DATE', $md_manager->get_metadata('display-name')),
+						));
+
+						foreach ($updates_available as $branch => $version_data)
+						{
+							$template->assign_block_vars('updates_available', $version_data);
+						}
+					}
+					catch (exception_interface $e)
+					{
+						$message = call_user_func_array(array($this->user, 'lang'), array_merge(array($e->getMessage()), $e->get_parameters()));
+
+						$template->assign_vars(array(
+							'S_VERSIONCHECK_FAIL' => true,
+							'VERSIONCHECK_FAIL_REASON' => ($e->getMessage() !== 'VERSIONCHECK_FAIL') ? $message : '',
+						));
+					}
+					$template->assign_var('S_VERSIONCHECK', true);
+				}
+				else
+				{
+					$template->assign_var('S_VERSIONCHECK', false);
 				}
 
 				$template->assign_vars(array(


### PR DESCRIPTION
Checklist:

- [x] Correct branch: master for new features; 3.2.x, 3.1.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master / 3.2.x](https://area51.phpbb.com/docs/master/coding-guidelines.html), [3.1.x](https://area51.phpbb.com/docs/31x/coding-guidelines.html)
- [x] Commit follows commit message [format](https://wiki.phpbb.com/Git#Commit_Messages)

Tracker ticket

https://tracker.phpbb.com/browse/PHPBB3-14901

Extensions without version check should not display a notice on the
details page in the ACP.

PHPBB3-14901