### PR TITLE
[ticket/14938] Inconsistency in ext_mgr all_available vs is_available

### DIFF
--- a/phpBB/phpbb/extension/manager.php
+++ b/phpBB/phpbb/extension/manager.php
@@ -433,25 +433,11 @@ class manager
 			if ($file_info->isFile() && $file_info->getFilename() == 'composer.json')
 			{
 				$ext_name = $iterator->getInnerIterator()->getSubPath();
-				$composer_file = $iterator->getPath() . '/composer.json';
-
-				// Ignore the extension if there is no composer.json.
-				if (!is_readable($composer_file) || !($ext_info = file_get_contents($composer_file)))
-				{
-					continue;
-				}
-
-				$ext_info = json_decode($ext_info, true);
 				$ext_name = str_replace(DIRECTORY_SEPARATOR, '/', $ext_name);
-
-				// Ignore the extension if directory depth is not correct or if the directory structure
-				// does not match the name value specified in composer.json.
-				if (substr_count($ext_name, '/') !== 1 || !isset($ext_info['name']) || $ext_name != $ext_info['name'])
+				if ($this->is_available($ext_name))
 				{
-					continue;
+					$available[$ext_name] = $this->phpbb_root_path . 'ext/' . $ext_name . '/';
 				}
-
-				$available[$ext_name] = $this->phpbb_root_path . 'ext/' . $ext_name . '/';
 			}
 		}
 		ksort($available);
@@ -530,7 +516,7 @@ class manager
 			return false;
 		}
 
-		$composer_file = $this->get_extension_path($name, true) . '/composer.json';
+		$composer_file = $this->get_extension_path($name, true) . 'composer.json';
 
 		// Not available if there is no composer.json.
 		if (!is_readable($composer_file) || !($ext_info = file_get_contents($composer_file)))

--- a/phpBB/phpbb/extension/manager.php
+++ b/phpBB/phpbb/extension/manager.php
@@ -510,29 +510,15 @@ class manager
 	*/
 	public function is_available($name)
 	{
-		// Not available if the folder does not exist
-		if (!file_exists($this->get_extension_path($name, true)))
+		$md_manager = $this->create_extension_metadata_manager($name, $this->container->get('template'));
+		try
+		{
+			return $md_manager->get_metadata('all') && $md_manager->validate_enable();
+		}
+		catch (\phpbb\extension\exception $e)
 		{
 			return false;
 		}
-
-		$composer_file = $this->get_extension_path($name, true) . 'composer.json';
-
-		// Not available if there is no composer.json.
-		if (!is_readable($composer_file) || !($ext_info = file_get_contents($composer_file)))
-		{
-			return false;
-		}
-		$ext_info = json_decode($ext_info, true);
-
-		// Not available if malformed name or if the directory structure
-		// does not match the name value specified in composer.json.
-		if (substr_count($name, '/') !== 1 || !isset($ext_info['name']) || $name != $ext_info['name'])
-		{
-			return false;
-		}
-
-		return true;
 	}
 
 	/**

--- a/phpBB/phpbb/extension/manager.php
+++ b/phpBB/phpbb/extension/manager.php
@@ -524,7 +524,29 @@ class manager
 	*/
 	public function is_available($name)
 	{
-		return file_exists($this->get_extension_path($name, true));
+		// Not available if the folder does not exist
+		if (!file_exists($this->get_extension_path($name, true)))
+		{
+			return false;
+		}
+
+		$composer_file = $this->get_extension_path($name, true) . '/composer.json';
+
+		// Not available if there is no composer.json.
+		if (!is_readable($composer_file) || !($ext_info = file_get_contents($composer_file)))
+		{
+			return false;
+		}
+		$ext_info = json_decode($ext_info, true);
+
+		// Not available if malformed name or if the directory structure
+		// does not match the name value specified in composer.json.
+		if (substr_count($name, '/') !== 1 || !isset($ext_info['name']) || $name != $ext_info['name'])
+		{
+			return false;
+		}
+
+		return true;
 	}
 
 	/**

--- a/phpBB/phpbb/extension/manager.php
+++ b/phpBB/phpbb/extension/manager.php
@@ -149,10 +149,10 @@ class manager
 	* Instantiates the metadata manager for the extension with the given name
 	*
 	* @param string $name The extension name
-	* @param \phpbb\template\template $template The template manager
+	* @param \phpbb\template\template $template The template manager or null
 	* @return \phpbb\extension\metadata_manager Instance of the metadata manager
 	*/
-	public function create_extension_metadata_manager($name, \phpbb\template\template $template)
+	public function create_extension_metadata_manager($name, \phpbb\template\template $template = null)
 	{
 		return new \phpbb\extension\metadata_manager($name, $this->config, $this, $template, $this->user, $this->phpbb_root_path);
 	}
@@ -510,7 +510,7 @@ class manager
 	*/
 	public function is_available($name)
 	{
-		$md_manager = $this->create_extension_metadata_manager($name, $this->container->get('template'));
+		$md_manager = $this->create_extension_metadata_manager($name);
 		try
 		{
 			return $md_manager->get_metadata('all') && $md_manager->validate_enable();

--- a/phpBB/phpbb/extension/metadata_manager.php
+++ b/phpBB/phpbb/extension/metadata_manager.php
@@ -72,11 +72,11 @@ class metadata_manager
 	* @param string				$ext_name			Name (including vendor) of the extension
 	* @param \phpbb\config\config		$config				phpBB Config instance
 	* @param \phpbb\extension\manager	$extension_manager	An instance of the phpBB extension manager
-	* @param \phpbb\template\template	$template			phpBB Template instance
+	* @param \phpbb\template\template	$template			phpBB Template instance or null
 	* @param \phpbb\user 		$user 				User instance
 	* @param string				$phpbb_root_path	Path to the phpbb includes directory.
 	*/
-	public function __construct($ext_name, \phpbb\config\config $config, \phpbb\extension\manager $extension_manager, \phpbb\template\template $template, \phpbb\user $user, $phpbb_root_path)
+	public function __construct($ext_name, \phpbb\config\config $config, \phpbb\extension\manager $extension_manager, \phpbb\template\template $template = null, \phpbb\user $user, $phpbb_root_path)
 	{
 		$this->config = $config;
 		$this->extension_manager = $extension_manager;

--- a/tests/mock/extension_manager.php
+++ b/tests/mock/extension_manager.php
@@ -20,5 +20,7 @@ class phpbb_mock_extension_manager extends \phpbb\extension\manager
 		$this->extensions = $extensions;
 		$this->filesystem = new \phpbb\filesystem();
 		$this->container = $container;
+		$this->config = new \phpbb\config\config(array());
+		$this->user = new \phpbb\user('\phpbb\datetime');
 	}
 }


### PR DESCRIPTION
Made is_available much more strict, in line with the checks in all_available

PHPBB3-14938

Checklist:

- [ ] Correct branch: master for new features; 3.2.x, 3.1.x for fixes
- [ ] Tests pass
- [ ] Code follows coding guidelines: [master / 3.2.x](https://area51.phpbb.com/docs/master/coding-guidelines.html), [3.1.x](https://area51.phpbb.com/docs/31x/coding-guidelines.html)
- [ ] Commit follows commit message [format](https://wiki.phpbb.com/Git#Commit_Messages)

Tracker ticket:

https://tracker.phpbb.com/browse/PHPBB3-14938
