### PR TITLE
[ticket/14943] Fix template loop access by index

### DIFF
--- a/phpBB/phpbb/template/context.php
+++ b/phpBB/phpbb/template/context.php
@@ -365,15 +365,15 @@ class context
 		if ($mode == 'insert')
 		{
 			// Make sure we are not exceeding the last iteration
-			if ($key >= sizeof($this->tpldata[$blockname]))
+			if ($key >= sizeof($block))
 			{
-				$key = sizeof($this->tpldata[$blockname]);
-				unset($this->tpldata[$blockname][($key - 1)]['S_LAST_ROW']);
+				$key = sizeof($block);
+				unset($block[($key - 1)]['S_LAST_ROW']);
 				$vararray['S_LAST_ROW'] = true;
 			}
 			else if ($key === 0)
 			{
-				unset($this->tpldata[$blockname][0]['S_FIRST_ROW']);
+				unset($block[0]['S_FIRST_ROW']);
 				$vararray['S_FIRST_ROW'] = true;
 			}
 


### PR DESCRIPTION
Allows inserting elements in a loop specified as 'outer[3].inner'.
This was coded, but malfunctioning.

PHPBB3-14943

Checklist:

- [ ] Correct branch: master for new features; 3.2.x, 3.1.x for fixes
- [ ] Tests pass
- [ ] Code follows coding guidelines: [master / 3.2.x](https://area51.phpbb.com/docs/master/coding-guidelines.html), [3.1.x](https://area51.phpbb.com/docs/31x/coding-guidelines.html)
- [ ] Commit follows commit message [format](https://wiki.phpbb.com/Git#Commit_Messages)

Tracker ticket:

https://tracker.phpbb.com/browse/PHPBB3-14943
