### PR TITLE
[ticket/14944] Add search for template loop indexes by key

### DIFF
--- a/phpBB/phpbb/template/base.php
+++ b/phpBB/phpbb/template/base.php
@@ -135,7 +135,7 @@ abstract class base implements template
 	/**
 	* {@inheritdoc}
 	*/
-	public function find_key_index($blockname, $key = false)
+	public function find_key_index($blockname, $key)
 	{
 		return $this->context->find_key_index($blockname, $key);
 	}

--- a/phpBB/phpbb/template/base.php
+++ b/phpBB/phpbb/template/base.php
@@ -133,6 +133,14 @@ abstract class base implements template
 	}
 
 	/**
+	* {@inheritdoc}
+	*/
+	public function find_key_index($blockname, $key = false)
+	{
+		return $this->context->find_key_index($blockname, $key);
+	}
+
+	/**
 	* Calls hook if any is defined.
 	*
 	* @param string $handle Template handle being displayed.

--- a/phpBB/phpbb/template/context.php
+++ b/phpBB/phpbb/template/context.php
@@ -305,16 +305,28 @@ class context
 				$name = $blocks[$i];
 				$index = sizeof($block[$name]) - 1;
 			}
+			if (!isset($block[$name]))
+			{
+				return false;
+			}
 			$block = $block[$name];
+			if (!isset($block[$index]))
+			{
+				return false;
+			}
 			$block = $block[$index];
 		}
 
+		if (!isset($block[$blocks[$i]]))
+		{
+			return false;
+		}
 		$block = $block[$blocks[$i]]; // Traverse the last block
 
 		// Change key to zero (change first position) if false and to last position if true
 		if ($key === false || $key === true)
 		{
-			return ($key === false) ? 0 : sizeof($block);
+			return ($key === false) ? 0 : sizeof($block) - 1;
 		}
 
 		// Get correct position if array given
@@ -331,7 +343,7 @@ class context
 			}
 		}
 
-		return is_int($key) ? $key : false;
+		return (is_int($key) && ((0 <= $key) && ($key < sizeof($block)))) ? $key : false;
 	}
 
 	/**

--- a/phpBB/phpbb/template/context.php
+++ b/phpBB/phpbb/template/context.php
@@ -284,7 +284,7 @@ class context
 		$blocks = explode('.', $blockname);
 		$blockcount = sizeof($blocks) - 1;
 
-		$block = &$this->tpldata;
+		$block = $this->tpldata;
 		for ($i = 0; $i < $blockcount; $i++)
 		{
 			if (($pos = strpos($blocks[$i], '[')) !== false)
@@ -305,11 +305,11 @@ class context
 				$name = $blocks[$i];
 				$index = sizeof($block[$name]) - 1;
 			}
-			$block = &$block[$name];
-			$block = &$block[$index];
+			$block = $block[$name];
+			$block = $block[$index];
 		}
 
-		$block = &$block[$blocks[$i]]; // Traverse the last block
+		$block = $block[$blocks[$i]]; // Traverse the last block
 
 		// Change key to zero (change first position) if false and to last position if true
 		if ($key === false || $key === true)
@@ -331,7 +331,7 @@ class context
 			}
 		}
 
-		return false;
+		return is_int($key) ? $key : false;
 	}
 
 	/**

--- a/phpBB/phpbb/template/context.php
+++ b/phpBB/phpbb/template/context.php
@@ -278,7 +278,7 @@ class context
 	*
 	* @return mixed false if not found, index position otherwise; be sure to test with ===
 	*/
-	public function find_key_index($blockname, $key = false)
+	public function find_key_index($blockname, $key)
 	{
 		// For nested block, $blockcount > 0, for top-level block, $blockcount == 0
 		$blocks = explode('.', $blockname);

--- a/phpBB/phpbb/template/template.php
+++ b/phpBB/phpbb/template/template.php
@@ -187,7 +187,7 @@ interface template
 	*
 	* @return mixed false if not found, index position otherwise; be sure to test with ===
 	*/
-	public function find_key_index($blockname, $key = false);
+	public function find_key_index($blockname, $key);
 
 	/**
 	* Get path to template for handle (required for BBCode parser)

--- a/phpBB/phpbb/template/template.php
+++ b/phpBB/phpbb/template/template.php
@@ -173,6 +173,23 @@ interface template
 	public function alter_block_array($blockname, array $vararray, $key = false, $mode = 'insert');
 
 	/**
+	* Find the index for a specified key in the innermost specified block
+	*
+	* @param	string	$blockname	the blockname, for example 'loop'
+	* @param	mixed	$key		Key to search for
+	*
+	* array: KEY => VALUE [the key/value pair to search for within the loop to determine the correct position]
+	*
+	* int: Position [the position to search for]
+	*
+	* If key is false the position is set to 0
+	* If key is true the position is set to the last entry
+	*
+	* @return mixed false if not found, index position otherwise; be sure to test with ===
+	*/
+	public function find_key_index($blockname, $key = false);
+
+	/**
 	* Get path to template for handle (required for BBCode parser)
 	*
 	* @param string $handle Handle to retrieve the source file

--- a/tests/template/template_test.php
+++ b/tests/template/template_test.php
@@ -637,8 +637,8 @@ EOT
 		$this->assertEquals(1, $this->template->find_key_index('outer[2].middle', array('VARIABLE' => '2B')), 'Find index by key in middle loop');
 		$this->assertEquals(2, $this->template->find_key_index('outer.middle', true), 'Find index at the end of middle loop');
 
-		$this->assertEquals(false, $this->template->find_key_index('outer.wrong'), 'Wrong middle block name');
-		$this->assertEquals(false, $this->template->find_key_index('wrong.middle'), 'Wrong outer block name');
+		$this->assertEquals(false, $this->template->find_key_index('outer.wrong', true), 'Wrong middle block name');
+		$this->assertEquals(false, $this->template->find_key_index('wrong.middle', false), 'Wrong outer block name');
 	}
 	public function assign_block_vars_array_data()
 	{

--- a/tests/template/template_test.php
+++ b/tests/template/template_test.php
@@ -603,6 +603,43 @@ EOT
 		$this->assertEquals($expect, str_replace(array("\n", "\r", "\t"), '', $this->display('test')), 'Ensuring S_NUM_ROWS is correct after modification');
 	}
 
+	public function test_find_key_index()
+	{
+		$this->template->set_filenames(array('test' => 'loop_nested.html'));
+
+		$this->template->assign_var('TEST_MORE', true);
+
+		// @todo Change this
+		$this->template->assign_block_vars('outer', array('VARIABLE' => 'zero'));
+		$this->template->assign_block_vars('outer', array('VARIABLE' => 'one'));
+		$this->template->assign_block_vars('outer.middle', array('VARIABLE' => '1A'));
+		$this->template->assign_block_vars('outer', array('VARIABLE' => 'two'));
+		$this->template->assign_block_vars('outer.middle', array('VARIABLE' => '2A'));
+		$this->template->assign_block_vars('outer.middle', array('VARIABLE' => '2B'));
+		$this->template->assign_block_vars('outer', array('VARIABLE' => 'three'));
+		$this->template->assign_block_vars('outer.middle', array('VARIABLE' => '3A'));
+		$this->template->assign_block_vars('outer.middle', array('VARIABLE' => '3B'));
+		$this->template->assign_block_vars('outer.middle', array('VARIABLE' => '3C'));
+
+		$expect = 'outer - 0 - zero[outer|4]outer - 1 - one[outer|4]middle - 0 - 1A[middle|1]outer - 2 - two[outer|4]middle - 0 - 2A[middle|2]middle - 1 - 2B[middle|2]outer - 3 - three[outer|4]middle - 0 - 3A[middle|3]middle - 1 - 3B[middle|3]middle - 2 - 3C[middle|3]';
+		$this->assertEquals($expect, str_replace(array("\n", "\r", "\t"), '', $this->display('test')), 'Ensuring template is built correctly before modification');
+
+		$this->template->find_key_index('outer', false);
+
+		$this->assertEquals(0, $this->template->find_key_index('outer', false), 'Find index at the beginning of outer loop');
+		$this->assertEquals(1, $this->template->find_key_index('outer', 1), 'Find index by index in outer loop');
+		$this->assertEquals(2, $this->template->find_key_index('outer', array('VARIABLE' => 'two')), 'Find index by key in outer loop');
+		$this->assertEquals(3, $this->template->find_key_index('outer', true), 'Find index at the end of outer loop');
+		$this->assertEquals(false, $this->template->find_key_index('outer', 7), 'Find index out of bounds of outer loop');
+
+		$this->assertEquals(false, $this->template->find_key_index('outer[0].middle', false), 'Find index at the beginning of middle loop, no middle block');
+		$this->assertEquals(false, $this->template->find_key_index('outer[1].middle', 1), 'Find index by index in inner loop, out of bounds');
+		$this->assertEquals(1, $this->template->find_key_index('outer[2].middle', array('VARIABLE' => '2B')), 'Find index by key in middle loop');
+		$this->assertEquals(2, $this->template->find_key_index('outer.middle', true), 'Find index at the end of middle loop');
+
+		$this->assertEquals(false, $this->template->find_key_index('outer.wrong'), 'Wrong middle block name');
+		$this->assertEquals(false, $this->template->find_key_index('wrong.middle'), 'Wrong outer block name');
+	}
 	public function assign_block_vars_array_data()
 	{
 		return array(


### PR DESCRIPTION
Adds a new function to the template interface, and implements it in the
context class.  The function returns the ordinal index for a specified key,
with the same structure that the key for alter_block_array.
Reuses same code.

PHPBB3-14944

Checklist:

- [x] Correct branch: master for new features; 3.2.x, 3.1.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master / 3.2.x](https://area51.phpbb.com/docs/master/coding-guidelines.html), [3.1.x](https://area51.phpbb.com/docs/31x/coding-guidelines.html)
- [x] Commit follows commit message [format](https://wiki.phpbb.com/Git#Commit_Messages)

Tracker ticket:

https://tracker.phpbb.com/browse/PHPBB3-14944
