### PR TITLE
[ticket/14549] fix mcp page redirect back after topic merge and rised warning

### DIFF
--- a/phpBB/includes/mcp/mcp_forum.php
+++ b/phpBB/includes/mcp/mcp_forum.php
@@ -458,7 +458,7 @@ function merge_topics($forum_id, $topic_ids, $to_topic_id)
 		return;
 	}
 
-	$redirect = request_var('redirect', build_url(array('quickmod')));
+	$redirect = request_var('redirect', "{$phpbb_root_path}mcp.$phpEx?f=$forum_id&amp;i=main&amp;mode=forum_view");
 
 	$s_hidden_fields = build_hidden_fields(array(
 		'i'				=> 'main',


### PR DESCRIPTION
by this correct $redirect will go to clean mcp page after merge

PHPBB3-14549

Checklist:

- [x] Correct branch: master for new features; 3.2.x, 3.1.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master / 3.2.x](https://area51.phpbb.com/docs/master/coding-guidelines.html), [3.1.x](https://area51.phpbb.com/docs/31x/coding-guidelines.html)
- [x] Commit follows commit message [format](https://wiki.phpbb.com/Git#Commit_Messages)

https://tracker.phpbb.com/browse/PHPBB3-14549
