### PR TITLE
[ticket/14935] Correct get_valid_name to avoid system hang when migration dependency hasn't sarted with backslash

### DIFF
--- a/phpBB/phpbb/db/migrator.php
+++ b/phpBB/phpbb/db/migrator.php
@@ -215,13 +215,13 @@ class migrator
 			$prepended_name = ($name[0] == '\\' ? '' : '\\') . $name;
 			$prefixless_name = $name[0] == '\\' ? substr($name, 1) : $name;
 
-			if (isset($this->migration_state[$prepended_name]))
-			{
-				$name = $prepended_name;
-			}
-			else if (isset($this->migration_state[$prefixless_name]))
+			if (!isset($this->migration_state[$prepended_name]) && isset($this->migration_state[$prefixless_name]))
 			{
 				$name = $prefixless_name;
+			}
+			else
+			{
+				$name = $prepended_name;
 			}
 		}
 


### PR DESCRIPTION
Correct function get_valid_name to return $name started by backslash as
default unless it exist in migration db without backslash

PHPBB3-14935

Checklist:

- [ ] Correct branch: master for new features; 3.2.x, 3.1.x for fixes
- [ ] Tests pass
- [ ] Code follows coding guidelines: [master / 3.2.x](https://area51.phpbb.com/docs/master/coding-guidelines.html), [3.1.x](https://area51.phpbb.com/docs/31x/coding-guidelines.html)
- [ ] Commit follows commit message [format](https://wiki.phpbb.com/Git#Commit_Messages)

Tracker ticket (set the ticket ID to **your ticket ID**):

https://tracker.phpbb.com/browse/PHPBB3-14935
