### PR TITLE
[ticket/14943] Fix template loop access by index

### DIFF
--- a/phpBB/phpbb/template/context.php
+++ b/phpBB/phpbb/template/context.php
@@ -325,11 +325,13 @@ class context
 			}
 
 			$block = &$block[$blocks[$i]]; // Traverse the last block
+			$name = $blocks[$i];
 		}
 		else
 		{
 			// Top-level block.
 			$block = &$this->tpldata[$blockname];
+			$name = $blockname;
 		}
 
 		// Change key to zero (change first position) if false and to last position if true
@@ -378,7 +380,7 @@ class context
 			}
 
 			// Assign S_BLOCK_NAME
-			$vararray['S_BLOCK_NAME'] = $blockname;
+			$vararray['S_BLOCK_NAME'] = $name;
 
 			// Re-position template blocks
 			for ($i = sizeof($block); $i > $key; $i--)

--- a/phpBB/phpbb/template/context.php
+++ b/phpBB/phpbb/template/context.php
@@ -293,46 +293,48 @@ class context
 	public function alter_block_array($blockname, array $vararray, $key = false, $mode = 'insert')
 	{
 		$this->num_rows_is_set = false;
-		if (strpos($blockname, '.') !== false)
+
+		// For nested block, $blockcount > 0, for top-level block, $blockcount == 0
+		$blocks = explode('.', $blockname);
+		$blockcount = sizeof($blocks) - 1;
+
+		$block = &$this->tpldata;
+		for ($i = 0; $i < $blockcount; $i++)
 		{
-			// Nested block.
-			$blocks = explode('.', $blockname);
-			$blockcount = sizeof($blocks) - 1;
-
-			$block = &$this->tpldata;
-			for ($i = 0; $i < $blockcount; $i++)
+			if (($pos = strpos($blocks[$i], '[')) !== false)
 			{
-				if (($pos = strpos($blocks[$i], '[')) !== false)
-				{
-					$name = substr($blocks[$i], 0, $pos);
+				$name = substr($blocks[$i], 0, $pos);
 
-					if (strpos($blocks[$i], '[]') === $pos)
-					{
-						$index = sizeof($block[$name]) - 1;
-					}
-					else
-					{
-						$index = min((int) substr($blocks[$i], $pos + 1, -1), sizeof($block[$name]) - 1);
-					}
+				if (strpos($blocks[$i], '[]') === $pos)
+				{
+					$index = sizeof($block[$name]) - 1;
 				}
 				else
 				{
-					$name = $blocks[$i];
-					$index = sizeof($block[$name]) - 1;
+					$index = min((int) substr($blocks[$i], $pos + 1, -1), sizeof($block[$name]) - 1);
 				}
-				$block = &$block[$name];
-				$block = &$block[$index];
 			}
+			else
+			{
+				$name = $blocks[$i];
+				$index = sizeof($block[$name]) - 1;
+			}
+			$block = &$block[$name];
+			$block = &$block[$index];
+		}
+		$name = $blocks[$i];
 
-			$block = &$block[$blocks[$i]]; // Traverse the last block
-			$name = $blocks[$i];
-		}
-		else
+		// If last block does not exist and we are inserting, and not searching for key, we create it empty; otherwise, nothing to do
+		if (!isset($block[$name]))
 		{
-			// Top-level block.
-			$block = &$this->tpldata[$blockname];
-			$name = $blockname;
+			if ($mode != 'insert' || is_array($key))
+			{
+				return false;
+			}
+			$block[$name] = array();
 		}
+
+		$block = &$block[$name]; // Now we can traverse the last block
 
 		// Change key to zero (change first position) if false and to last position if true
 		if ($key === false || $key === true)
@@ -373,8 +375,9 @@ class context
 				unset($block[($key - 1)]['S_LAST_ROW']);
 				$vararray['S_LAST_ROW'] = true;
 			}
-			else if ($key === 0)
+			if ($key <= 0)
 			{
+				$key = 0;
 				unset($block[0]['S_FIRST_ROW']);
 				$vararray['S_FIRST_ROW'] = true;
 			}
@@ -400,6 +403,12 @@ class context
 		// Which block to change?
 		if ($mode == 'change')
 		{
+			// If key is out of bounds, do not change anything
+			if ($key > sizeof($block) || $key < 0)
+			{
+				return false;
+			}
+
 			if ($key == sizeof($block))
 			{
 				$key--;

--- a/tests/template/template_test.php
+++ b/tests/template/template_test.php
@@ -718,6 +718,16 @@ EOT
 
 		$expect = 'outer - 0[outer|4]outer - 1[outer|4]middle - 0[middle|1]outer - 2 - test[outer|4]middle - 0[middle|2]middle - 1[middle|2]outer - 3[outer|4]middle - 0[middle|3]middle - 1[middle|3]middle - 2[middle|3]';
 		$this->assertEquals($expect, str_replace(array("\n", "\r", "\t"), '', $this->display('test')), 'Ensuring S_NUM_ROWS is correct after modification');
+
+		$this->template->alter_block_array('outer.middle', array());
+
+		$expect = 'outer - 0[outer|4]outer - 1[outer|4]middle - 0[middle|1]outer - 2 - test[outer|4]middle - 0[middle|2]middle - 1[middle|2]outer - 3[outer|4]middle - 0[middle|4]middle - 1[middle|4]middle - 2[middle|4]middle - 3[middle|4]';
+		$this->assertEquals($expect, str_replace(array("\n", "\r", "\t"), '', $this->display('test')), 'Ensuring S_NUM_ROWS is correct after insertion at middle level');
+
+		$this->template->alter_block_array('outer.middle', array('VARIABLE' => 'test'), 2, 'change');
+
+		$expect = 'outer - 0[outer|4]outer - 1[outer|4]middle - 0[middle|1]outer - 2 - test[outer|4]middle - 0[middle|2]middle - 1[middle|2]outer - 3[outer|4]middle - 0[middle|4]middle - 1[middle|4]middle - 2 - test[middle|4]middle - 3[middle|4]';
+		$this->assertEquals($expect, str_replace(array("\n", "\r", "\t"), '', $this->display('test')), 'Ensuring S_NUM_ROWS is correct after modification at middle level');
 	}
 
 	public function assign_block_vars_array_data()

--- a/tests/template/template_test.php
+++ b/tests/template/template_test.php
@@ -528,11 +528,11 @@ EOT
 			),
 			array(
 				'outer',
-				array('VARIABLE' => 'pos #1'),
+				array('VARIABLE' => 'changed'),
 				0,
 				'change',
 				<<<EOT
-outer - 0 - pos #1
+outer - 0 - changed
 middle - 0
 middle - 1
 outer - 1
@@ -543,7 +543,124 @@ middle - 0
 middle - 1
 EOT
 ,
-				'Test inserting at 1 on top level block',
+				'Test changing at 0 on top level block',
+			),
+			array(
+				'outer',
+				array('VARIABLE' => 'changed'),
+				array('S_ROW_NUM' => 2),
+				'change',
+				<<<EOT
+outer - 0
+middle - 0
+middle - 1
+outer - 1
+middle - 0
+middle - 1
+outer - 2 - changed
+middle - 0
+middle - 1
+EOT
+,
+				'Test changing at KEY on top level block',
+			),
+			array(
+				'outer.middle',
+				array('VARIABLE' => 'before'),
+				false,
+				'insert',
+				<<<EOT
+outer - 0
+middle - 0
+middle - 1
+outer - 1
+middle - 0
+middle - 1
+outer - 2
+middle - 0 - before
+middle - 1
+middle - 2
+EOT
+,
+				'Test inserting before on middle level block',
+			),
+			array(
+				'outer.middle',
+				array('VARIABLE' => 'after'),
+				true,
+				'insert',
+				<<<EOT
+outer - 0
+middle - 0
+middle - 1
+outer - 1
+middle - 0
+middle - 1
+outer - 2
+middle - 0
+middle - 1
+middle - 2 - after
+EOT
+,
+				'Test inserting after on middle level block',
+			),
+			array(
+				'outer[1].middle',
+				array('VARIABLE' => 'pos #1'),
+				1,
+				'insert',
+				<<<EOT
+outer - 0
+middle - 0
+middle - 1
+outer - 1
+middle - 0
+middle - 1 - pos #1
+middle - 2
+outer - 2
+middle - 0
+middle - 1
+EOT
+,
+				'Test inserting at 1 on middle level block',
+			),
+			array(
+				'outer[].middle',
+				array('VARIABLE' => 'changed'),
+				0,
+				'change',
+				<<<EOT
+outer - 0
+middle - 0
+middle - 1
+outer - 1
+middle - 0
+middle - 1
+outer - 2
+middle - 0 - changed
+middle - 1
+EOT
+,
+				'Test changing at beginning of last top level block',
+			),
+			array(
+				'outer.middle',
+				array('VARIABLE' => 'changed'),
+				array('S_ROW_NUM' => 1),
+				'change',
+				<<<EOT
+outer - 0
+middle - 0
+middle - 1
+outer - 1
+middle - 0
+middle - 1
+outer - 2
+middle - 0
+middle - 1 - changed
+EOT
+,
+				'Test changing at beginning of last top level block',
 			),
 		);
 	}


### PR DESCRIPTION
Allows inserting elements in a loop specified as 'outer[3].inner'.
This was coded, but malfunctioning.  
Name incorrectly set on insert.

PHPBB3-14943

Checklist:

- [x] Correct branch: master for new features; 3.2.x, 3.1.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master / 3.2.x](https://area51.phpbb.com/docs/master/coding-guidelines.html), [3.1.x](https://area51.phpbb.com/docs/31x/coding-guidelines.html)
- [x] Commit follows commit message [format](https://wiki.phpbb.com/Git#Commit_Messages)

Tracker ticket:

https://tracker.phpbb.com/browse/PHPBB3-14943
