### PR TITLE
[ticket/14950] Add possibility to delete a template block

### DIFF
--- a/phpBB/phpbb/template/context.php
+++ b/phpBB/phpbb/template/context.php
@@ -280,10 +280,11 @@ class context
 	* If key is false the position is set to 0
 	* If key is true the position is set to the last entry
 	*
-	* @param	string	$mode		Mode to execute (valid modes are 'insert' and 'change')
+	* @param	string	$mode		Mode to execute (valid modes are 'insert', 'change' and 'delete')
 	*
 	*	If insert, the vararray is inserted at the given position (position counting from zero).
 	*	If change, the current block gets merged with the vararray (resulting in new key/value pairs be added and existing keys be replaced by the new \value).
+	*	If delete, the vararray is ignored, and the block at the given position (counting from zero) is removed.
 	*
 	* Since counting begins by zero, inserting at the last position will result in this array: array(vararray, last positioned array)
 	* and inserting at position 1 will result in this array: array(first positioned array, vararray, following vars)
@@ -404,6 +405,45 @@ class context
 			}
 
 			$block[$key] = array_merge($block[$key], $vararray);
+
+			return true;
+		}
+
+		// Delete Block
+		if ($mode == 'delete')
+		{
+			// If we are exceeding last iteration, do not delete anything
+			if ($key > sizeof($block))
+			{
+				return false;
+			}
+
+			// If we are positioned at the end, we remove the last element
+			if ($key == sizeof($block))
+			{
+				$key--;
+			}
+
+			// We are deleting the last element in the block, so remove the block
+			if (sizeof($block) === 1)
+			{
+				unset($block);
+				return true;
+			}
+
+			// Re-position template blocks
+			for ($i = $key; $i < sizeof($block)-1; $i++)
+			{
+				$block[$i] = $block[$i+1];
+				$block[$i]['S_ROW_COUNT'] = $block[$i]['S_ROW_NUM'] = $i;
+			}
+
+			// Remove the last element
+			unset($block[$i]);
+
+			// Set first and last elements again, in case they were removed
+			$block[0]['S_FIRST_ROW'] = true;
+			$block[sizeof($block)-1]['S_LAST_ROW'] = true;
 
 			return true;
 		}

--- a/phpBB/phpbb/template/template.php
+++ b/phpBB/phpbb/template/template.php
@@ -160,10 +160,11 @@ interface template
 	* If key is false the position is set to 0
 	* If key is true the position is set to the last entry
 	*
-	* @param	string	$mode		Mode to execute (valid modes are 'insert' and 'change')
+	* @param	string	$mode		Mode to execute (valid modes are 'insert', 'change' and 'delete')
 	*
 	*	If insert, the vararray is inserted at the given position (position counting from zero).
 	*	If change, the current block gets merged with the vararray (resulting in new \key/value pairs be added and existing keys be replaced by the new \value).
+	*	If delete, the vararray is ignored, and the block at the given position (counting from zero) is removed.
 	*
 	* Since counting begins by zero, inserting at the last position will result in this array: array(vararray, last positioned array)
 	* and inserting at position 1 will result in this array: array(first positioned array, vararray, following vars)


### PR DESCRIPTION
Adds a new mode to alter_block_array to allow for the deletion of
a certain block of template variables.  The selection method is the
same as for the other modes for alter_block_array.  The passed in
vararray is ignored, and an out of bounds index is considered an error.

PHPBB3-14950

Checklist:

- [ ] Correct branch: master for new features; 3.2.x, 3.1.x for fixes
- [ ] Tests pass
- [ ] Code follows coding guidelines: [master / 3.2.x](https://area51.phpbb.com/docs/master/coding-guidelines.html), [3.1.x](https://area51.phpbb.com/docs/31x/coding-guidelines.html)
- [ ] Commit follows commit message [format](https://wiki.phpbb.com/Git#Commit_Messages)

Tracker ticket:

https://tracker.phpbb.com/browse/PHPBB3-14950
