### PR TITLE
[ticket/14950] Add possibility to delete a template block

### DIFF
--- a/phpBB/phpbb/template/context.php
+++ b/phpBB/phpbb/template/context.php
@@ -280,10 +280,11 @@ class context
 	* If key is false the position is set to 0
 	* If key is true the position is set to the last entry
 	*
-	* @param	string	$mode		Mode to execute (valid modes are 'insert' and 'change')
+	* @param	string	$mode		Mode to execute (valid modes are 'insert', 'change' and 'delete')
 	*
 	*	If insert, the vararray is inserted at the given position (position counting from zero).
 	*	If change, the current block gets merged with the vararray (resulting in new key/value pairs be added and existing keys be replaced by the new \value).
+	*	If delete, the vararray is ignored, and the block at the given position (counting from zero) is removed.
 	*
 	* Since counting begins by zero, inserting at the last position will result in this array: array(vararray, last positioned array)
 	* and inserting at position 1 will result in this array: array(first positioned array, vararray, following vars)
@@ -404,6 +405,45 @@ class context
 			}
 
 			$block[$key] = array_merge($block[$key], $vararray);
+
+			return true;
+		}
+
+		// Delete Block
+		if ($mode == 'delete')
+		{
+			// If we are exceeding last iteration, do not delete anything
+			if ($key > sizeof($block))
+			{
+				return false;
+			}
+
+			// If we are positioned at the end, we remove the last element
+			if ($key == sizeof($block))
+			{
+				$key--;
+			}
+
+			// We are deleting the last element in the block, so remove the block
+			if (sizeof($block) === 1)
+			{
+				$block = null; // unset($block); does not work on references
+				return true;
+			}
+
+			// Re-position template blocks
+			for ($i = $key; $i < sizeof($block)-1; $i++)
+			{
+				$block[$i] = $block[$i+1];
+				$block[$i]['S_ROW_COUNT'] = $block[$i]['S_ROW_NUM'] = $i;
+			}
+
+			// Remove the last element
+			unset($block[$i]);
+
+			// Set first and last elements again, in case they were removed
+			$block[0]['S_FIRST_ROW'] = true;
+			$block[sizeof($block)-1]['S_LAST_ROW'] = true;
 
 			return true;
 		}

--- a/phpBB/phpbb/template/context.php
+++ b/phpBB/phpbb/template/context.php
@@ -413,7 +413,7 @@ class context
 		if ($mode == 'delete')
 		{
 			// If we are exceeding last iteration, do not delete anything
-			if ($key > sizeof($block))
+			if ($key > sizeof($block) || $key < 0)
 			{
 				return false;
 			}

--- a/phpBB/phpbb/template/template.php
+++ b/phpBB/phpbb/template/template.php
@@ -160,10 +160,11 @@ interface template
 	* If key is false the position is set to 0
 	* If key is true the position is set to the last entry
 	*
-	* @param	string	$mode		Mode to execute (valid modes are 'insert' and 'change')
+	* @param	string	$mode		Mode to execute (valid modes are 'insert', 'change' and 'delete')
 	*
 	*	If insert, the vararray is inserted at the given position (position counting from zero).
 	*	If change, the current block gets merged with the vararray (resulting in new \key/value pairs be added and existing keys be replaced by the new \value).
+	*	If delete, the vararray is ignored, and the block at the given position (counting from zero) is removed.
 	*
 	* Since counting begins by zero, inserting at the last position will result in this array: array(vararray, last positioned array)
 	* and inserting at position 1 will result in this array: array(first positioned array, vararray, following vars)

--- a/tests/template/template_test.php
+++ b/tests/template/template_test.php
@@ -636,7 +636,7 @@ EOT
 
 		$this->template->alter_block_array('outer', array(), 1, 'delete');
 
-		$expect = 'outer - 0 - one[outer|2]outer - 1 - three[outer|3]middle - 0 - 3A[middle|3]middle - 1 - 3B[middle|3]middle - 2 - 3C[middle|3]';
+		$expect = 'outer - 0 - one[outer|2]outer - 1 - three[outer|2]middle - 0 - 3A[middle|3]middle - 1 - 3B[middle|3]middle - 2 - 3C[middle|3]';
 		$this->assertEquals($expect, str_replace(array("\n", "\r", "\t"), '', $this->display('test')), 'Deleting by index at top level');
 
 		$this->template->alter_block_array('outer.middle', array(), 1, 'delete');

--- a/tests/template/template_test.php
+++ b/tests/template/template_test.php
@@ -636,8 +636,13 @@ EOT
 
 		$this->template->alter_block_array('outer', array(), 1, 'delete');
 
-		$expect = 'outer - 0 - one[outer|2]outer - 1 - three[outer|2]middle - 0 - 3A[middle|2]middle - 1 - 3C[middle|2]';
+		$expect = 'outer - 0 - one[outer|2]outer - 1 - three[outer|3]middle - 0 - 3A[middle|3]middle - 1 - 3B[middle|3]middle - 2 - 3C[middle|3]';
 		$this->assertEquals($expect, str_replace(array("\n", "\r", "\t"), '', $this->display('test')), 'Deleting by index at top level');
+
+		$this->template->alter_block_array('outer.middle', array(), 1, 'delete');
+
+		$expect = 'outer - 0 - one[outer|2]outer - 1 - three[outer|2]middle - 0 - 3A[middle|2]middle - 1 - 3C[middle|2]';
+		$this->assertEquals($expect, str_replace(array("\n", "\r", "\t"), '', $this->display('test')), 'Deleting by index at middle level');
 
 		$this->template->alter_block_array('outer', array(), 4, 'delete');
 

--- a/tests/template/template_test.php
+++ b/tests/template/template_test.php
@@ -603,6 +603,48 @@ EOT
 		$this->assertEquals($expect, str_replace(array("\n", "\r", "\t"), '', $this->display('test')), 'Ensuring S_NUM_ROWS is correct after modification');
 	}
 
+	public function test_delete_alter_block_array()
+	{
+		$this->template->set_filenames(array('test' => 'loop_nested.html'));
+
+		$this->template->assign_var('TEST_MORE', true);
+
+		// @todo Change this
+		$this->template->assign_block_vars('outer', array('VARIABLE' => 'zero'));
+		$this->template->assign_block_vars('outer', array('VARIABLE' => 'one'));
+		$this->template->assign_block_vars('outer.middle', array('VARIABLE' => '1A'));
+		$this->template->assign_block_vars('outer', array('VARIABLE' => 'two'));
+		$this->template->assign_block_vars('outer.middle', array('VARIABLE' => '2A'));
+		$this->template->assign_block_vars('outer.middle', array('VARIABLE' => '2B'));
+		$this->template->assign_block_vars('outer', array('VARIABLE' => 'three'));
+		$this->template->assign_block_vars('outer.middle', array('VARIABLE' => '3A'));
+		$this->template->assign_block_vars('outer.middle', array('VARIABLE' => '3B'));
+		$this->template->assign_block_vars('outer.middle', array('VARIABLE' => '3C'));
+
+		$expect = 'outer - 0 - zero[outer|4]outer - 1 - one[outer|4]middle - 0 - 1A[middle|1]outer - 2 - two[outer|4]middle - 0 - 2A[middle|2]middle - 1 - 2B[middle|2]outer - 3 - three[outer|4]middle - 0 - 3A[middle|3]middle - 1 - 3B[middle|3]middle - 2 - 3C[middle|3]';
+		$this->assertEquals($expect, str_replace(array("\n", "\r", "\t"), '', $this->display('test')), 'Ensuring template is built correctly before modification');
+
+		$this->template->alter_block_array('outer', array(), true, 'delete');
+
+		$expect = 'outer - 0 - one[outer|3]middle - 0 - 1A[middle|1]outer - 1 - two[outer|3]middle - 0 - 2A[middle|2]middle - 1 - 2B[middle|2]outer - 2 - three[outer|3]middle - 0 - 3A[middle|3]middle - 1 - 3B[middle|3]middle - 2 - 3C[middle|3]';
+		$this->assertEquals($expect, str_replace(array("\n", "\r", "\t"), '', $this->display('test')), 'Deleting at the beginning of outer loop');
+
+		$this->template->alter_block_array('outer[0].middle', array(), false, 'delete');
+
+		$expect = 'outer - 0 - one[outer|3]outer - 1 - two[outer|3]middle - 0 - 2A[middle|2]middle - 1 - 2B[middle|2]outer - 2 - three[outer|3]middle - 0 - 3A[middle|3]middle - 1 - 3B[middle|3]middle - 2 - 3C[middle|3]';
+		$this->assertEquals($expect, str_replace(array("\n", "\r", "\t"), '', $this->display('test')), 'Deleting at the end of first middle loop, delete complete loop');
+
+		$this->template->alter_block_array('outer', array(), 1, 'delete');
+
+		$expect = 'outer - 0 - one[outer|2]outer - 1 - three[outer|2]middle - 0 - 3A[middle|2]middle - 1 - 3C[middle|2]';
+		$this->assertEquals($expect, str_replace(array("\n", "\r", "\t"), '', $this->display('test')), 'Deleting by index at top level');
+
+		$this->template->alter_block_array('outer', array(), 4, 'delete');
+
+		$expect = 'outer - 0 - one[outer|2]outer - 1 - three[outer|2]middle - 0 - 3A[middle|2]middle - 1 - 3C[middle|2]';
+		$this->assertEquals($expect, str_replace(array("\n", "\r", "\t"), '', $this->display('test')), 'Deleting by index out of bounds, ignored');
+	}
+
 	public function assign_block_vars_array_data()
 	{
 		return array(

--- a/tests/template/template_test.php
+++ b/tests/template/template_test.php
@@ -624,12 +624,12 @@ EOT
 		$expect = 'outer - 0 - zero[outer|4]outer - 1 - one[outer|4]middle - 0 - 1A[middle|1]outer - 2 - two[outer|4]middle - 0 - 2A[middle|2]middle - 1 - 2B[middle|2]outer - 3 - three[outer|4]middle - 0 - 3A[middle|3]middle - 1 - 3B[middle|3]middle - 2 - 3C[middle|3]';
 		$this->assertEquals($expect, str_replace(array("\n", "\r", "\t"), '', $this->display('test')), 'Ensuring template is built correctly before modification');
 
-		$this->template->alter_block_array('outer', array(), true, 'delete');
+		$this->template->alter_block_array('outer', array(), false, 'delete');
 
 		$expect = 'outer - 0 - one[outer|3]middle - 0 - 1A[middle|1]outer - 1 - two[outer|3]middle - 0 - 2A[middle|2]middle - 1 - 2B[middle|2]outer - 2 - three[outer|3]middle - 0 - 3A[middle|3]middle - 1 - 3B[middle|3]middle - 2 - 3C[middle|3]';
 		$this->assertEquals($expect, str_replace(array("\n", "\r", "\t"), '', $this->display('test')), 'Deleting at the beginning of outer loop');
 
-		$this->template->alter_block_array('outer[0].middle', array(), false, 'delete');
+		$this->template->alter_block_array('outer[0].middle', array(), true, 'delete');
 
 		$expect = 'outer - 0 - one[outer|3]outer - 1 - two[outer|3]middle - 0 - 2A[middle|2]middle - 1 - 2B[middle|2]outer - 2 - three[outer|3]middle - 0 - 3A[middle|3]middle - 1 - 3B[middle|3]middle - 2 - 3C[middle|3]';
 		$this->assertEquals($expect, str_replace(array("\n", "\r", "\t"), '', $this->display('test')), 'Deleting at the end of first middle loop, delete complete loop');


### PR DESCRIPTION
Adds a new mode to alter_block_array to allow for the deletion of
a certain block of template variables.  The selection method is the
same as for the other modes for alter_block_array.  The passed in
vararray is ignored, and an out of bounds index is considered an error.

PHPBB3-14950

Checklist:

- [ ] Correct branch: master for new features; 3.2.x, 3.1.x for fixes
- [ ] Tests pass
- [ ] Code follows coding guidelines: [master / 3.2.x](https://area51.phpbb.com/docs/master/coding-guidelines.html), [3.1.x](https://area51.phpbb.com/docs/31x/coding-guidelines.html)
- [ ] Commit follows commit message [format](https://wiki.phpbb.com/Git#Commit_Messages)

Tracker ticket:

https://tracker.phpbb.com/browse/PHPBB3-14950
