### PR TITLE
[WIP][ticket/14740] Decode HTML special chars in BBCode usage

### DIFF
--- a/phpBB/phpbb/textformatter/s9e/factory.php
+++ b/phpBB/phpbb/textformatter/s9e/factory.php
@@ -294,9 +294,12 @@ class factory implements \phpbb\textformatter\cache_interface
 				$row['bbcode_tpl']
 			);
 
+			// Note: BBCode usage is stored as HTML
+			$usage = htmlspecialchars_decode($row['bbcode_match']);
+
 			try
 			{
-				$configurator->BBCodes->addCustom($row['bbcode_match'], new UnsafeTemplate($tpl));
+				$configurator->BBCodes->addCustom($usage, new UnsafeTemplate($tpl));
 			}
 			catch (\Exception $e)
 			{

--- a/tests/text_processing/tickets_data/PHPBB3-14740.xml
+++ b/tests/text_processing/tickets_data/PHPBB3-14740.xml
@@ -17,7 +17,7 @@
 			<value>mod=</value>
 			<value></value>
 			<value>1</value>
-			<value>[mod=&quot;{TEXT1}&quot;]{TEXT2}[/mod]</value>
+			<value><![CDATA[[mod=&quot;{TEXT1}&quot;]{TEXT2}[/mod]]]></value>
 			<value><![CDATA[<div id="modremark">
 	<div id="modremarkexclamation">!</div>
 	<div>
@@ -25,9 +25,9 @@
 		<div id="moderemarktext">{TEXT2}</div>
 	</div>
 </div>]]></value>
-			<value>!\[mod\=&quot;(.*?)&quot;\](.*?)\[/mod\]!ies</value>
-			<value>'[mod=&quot;'.str_replace(array("\r\n", '\"', '\'', '(', ')'), array("\n", '"', '&#39;', '&#40;', '&#41;'), trim('${1}')).'&quot;:$uid]'.str_replace(array("\r\n", '\"', '\'', '(', ')'), array("\n", '"', '&#39;', '&#40;', '&#41;'), trim('${2}')).'[/mod:$uid]'</value>
-			<value>!\[mod\=&quot;(.*?)&quot;:$uid\](.*?)\[/mod:$uid\]!s</value>
+			<value><![CDATA[[!\[mod\=&quot;(.*?)&quot;\](.*?)\[/mod\]!ies]]></value>
+			<value><![CDATA[['[mod=&quot;'.str_replace(array("\r\n", '\"', '\'', '(', ')'), array("\n", '"', '&#39;', '&#40;', '&#41;'), trim('${1}')).'&quot;:$uid]'.str_replace(array("\r\n", '\"', '\'', '(', ')'), array("\n", '"', '&#39;', '&#40;', '&#41;'), trim('${2}')).'[/mod:$uid]']]></value>
+			<value><![CDATA[[!\[mod\=&quot;(.*?)&quot;:$uid\](.*?)\[/mod:$uid\]!s]]></value>
 			<value><![CDATA[<div id="modremark">
 	<div id="modremarkexclamation">!</div>
 	<div>


### PR DESCRIPTION
BBCode usage is stored as HTML and needs to be decoded before use. I assume that it is meant to be stored in this format and this is not a bug. The test fixture has been updated accordingly.

PHPBB3-14740

Checklist:

- [x] Correct branch: master for new features; 3.2.x, 3.1.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master / 3.2.x](https://area51.phpbb.com/docs/master/coding-guidelines.html), [3.1.x](https://area51.phpbb.com/docs/31x/coding-guidelines.html)
- [x] Commit follows commit message [format](https://wiki.phpbb.com/Git#Commit_Messages)

Tracker ticket (set the ticket ID to **your ticket ID**):

https://tracker.phpbb.com/browse/PHPBB3-14740
