### PR TITLE
[ticket/15008] Disable emoji when smilies are disabled

### DIFF
--- a/phpBB/phpbb/textformatter/s9e/parser.php
+++ b/phpBB/phpbb/textformatter/s9e/parser.php
@@ -142,6 +142,7 @@ class parser implements \phpbb\textformatter\parser_interface
 	public function disable_smilies()
 	{
 		$this->parser->disablePlugin('Emoticons');
+		$this->parser->disablePlugin('Emoji');
 	}
 
 	/**
@@ -183,6 +184,7 @@ class parser implements \phpbb\textformatter\parser_interface
 	public function enable_smilies()
 	{
 		$this->parser->enablePlugin('Emoticons');
+		$this->parser->enablePlugin('Emoji');
 	}
 
 	/**

--- a/tests/text_processing/tickets_data/PHPBB3-15008.before.php
+++ b/tests/text_processing/tickets_data/PHPBB3-15008.before.php
@@ -1,0 +1,18 @@
+<?php
+/**
+*
+* This file is part of the phpBB Forum Software package.
+*
+* @copyright (c) phpBB Limited <https://www.phpbb.com>
+* @license GNU General Public License, version 2 (GPL-2.0)
+*
+* For full copyright and license information, please see
+* the docs/CREDITS.txt file.
+*
+*/
+
+function before_assert_phpbb3_15008($vars)
+{
+	extract($vars);
+	$parser->disable_smilies();
+}

--- a/tests/text_processing/tickets_data/PHPBB3-15008.html
+++ b/tests/text_processing/tickets_data/PHPBB3-15008.html
@@ -1,0 +1,1 @@
+No smilies :) or shortnames :strawberry:

--- a/tests/text_processing/tickets_data/PHPBB3-15008.txt
+++ b/tests/text_processing/tickets_data/PHPBB3-15008.txt
@@ -1,0 +1,1 @@
+No smilies :) or shortnames :strawberry:


### PR DESCRIPTION
Will effectively disable emoji shortname and won't replace emoji
with images but will not prevent a browser or OS from displaying
emoji as images.

PHPBB3-15008

Checklist:

- [x] Correct branch: master for new features; 3.2.x, 3.1.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master / 3.2.x](https://area51.phpbb.com/docs/master/coding-guidelines.html), [3.1.x](https://area51.phpbb.com/docs/31x/coding-guidelines.html)
- [x] Commit follows commit message [format](https://wiki.phpbb.com/Git#Commit_Messages)

Tracker ticket (set the ticket ID to **your ticket ID**):

https://tracker.phpbb.com/browse/PHPBB3-15008
