### PR TITLE
[ticket/11076] State current and minimum required versions in old PHP notice

### DIFF
--- a/phpBB/common.php
+++ b/phpBB/common.php
@@ -12,12 +12,17 @@
 */
 
 /**
-* Minimum Requirement: PHP 5.3.9
+* Minimum Requirement: PHP 5.4.0
 */
 
 if (!defined('IN_PHPBB'))
 {
 	exit;
+}
+
+if (version_compare(PHP_VERSION, '5.4') < 0)
+{
+	die('You are running an unsupported PHP version. Please upgrade to PHP 5.4.0 or higher before trying to install or update to phpBB 3.2');
 }
 
 require($phpbb_root_path . 'includes/startup.' . $phpEx);

--- a/phpBB/install/app.php
+++ b/phpBB/install/app.php
@@ -20,6 +20,11 @@ define('PHPBB_ENVIRONMENT', 'production');
 $phpbb_root_path = '../';
 $phpEx = substr(strrchr(__FILE__, '.'), 1);
 
+if (version_compare(PHP_VERSION, '5.4') < 0)
+{
+	die('You are running an unsupported PHP version. Please upgrade to PHP 5.4.0 or higher before trying to install or update to phpBB 3.2');
+}
+
 $startup_new_path = $phpbb_root_path . 'install/update/update/new/install/startup.' . $phpEx;
 $startup_path = (file_exists($startup_new_path)) ? $startup_new_path : $phpbb_root_path . 'install/startup.' . $phpEx;
 require($startup_path);


### PR DESCRIPTION
Rhea version of #4649 which also adds a simple `die()` for when people try to upgrade to 3.2 with an old PHP version.

Checklist:

- [x] Correct branch: master for new features; 3.2.x, 3.1.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master / 3.2.x](https://area51.phpbb.com/docs/master/coding-guidelines.html), [3.1.x](https://area51.phpbb.com/docs/31x/coding-guidelines.html)
- [x] Commit follows commit message [format](https://wiki.phpbb.com/Git#Commit_Messages)

Tracker ticket (set the ticket ID to **your ticket ID**):

https://tracker.phpbb.com/browse/PHPBB3-11076
