### PR TITLE
[ticket/15035] Add phpinfo.php to 3.2.x install directory

### DIFF
--- a/phpBB/install/phpinfo.php
+++ b/phpBB/install/phpinfo.php
@@ -1,0 +1,14 @@
+<?php
+/**
+ *
+ * This file is part of the phpBB Forum Software package.
+ *
+ * @copyright (c) phpBB Limited <https://www.phpbb.com>
+ * @license GNU General Public License, version 2 (GPL-2.0)
+ *
+ * For full copyright and license information, please see
+ * the docs/CREDITS.txt file.
+ *
+ */
+
+phpinfo();


### PR DESCRIPTION
In 3.1.x there's a phpinfo.php in the /install folder which seems to be removed in 3.2.x, perhaps by accident?
https://github.com/phpbb/phpbb/commits/3.2.x/phpBB/install/phpinfo.php
Let's add it back for easier troubleshooting potential issues during installation.

PHPBB3-15035

Checklist:

- [x] Correct branch: master for new features; 3.2.x, 3.1.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master / 3.2.x](https://area51.phpbb.com/docs/master/coding-guidelines.html), [3.1.x](https://area51.phpbb.com/docs/31x/coding-guidelines.html)
- [x] Commit follows commit message [format](https://wiki.phpbb.com/Git#Commit_Messages)

Tracker ticket (set the ticket ID to **your ticket ID**):

https://tracker.phpbb.com/browse/PHPBB3-15035
