### PR TITLE
[ticket/14997] Fixing topiclist_row_topic_title_after position

### DIFF
--- a/phpBB/styles/prosilver/template/search_results.html
+++ b/phpBB/styles/prosilver/template/search_results.html
@@ -76,6 +76,7 @@
 							<!-- IF searchresults.S_TOPIC_UNAPPROVED or searchresults.S_POSTS_UNAPPROVED --><a href="{searchresults.U_MCP_QUEUE}">{searchresults.UNAPPROVED_IMG}</a> <!-- ENDIF -->
 							<!-- IF searchresults.S_TOPIC_DELETED --><a href="{searchresults.U_MCP_QUEUE}">{DELETED_IMG}</a> <!-- ENDIF -->
 							<!-- IF searchresults.S_TOPIC_REPORTED --><a href="{searchresults.U_MCP_REPORT}">{REPORTED_IMG}</a><!-- ENDIF --><br />
+							<!-- EVENT topiclist_row_topic_title_after -->
 							<!-- IF .searchresults.pagination -->
 							<div class="pagination">
 								<ul>
@@ -91,7 +92,6 @@
 							</div>
 							<!-- ENDIF -->
 							<!-- IF searchresults.S_HAS_POLL -->{POLL_IMG} <!-- ENDIF -->
-							<!-- EVENT topiclist_row_topic_title_after -->
 							{L_POST_BY_AUTHOR} {searchresults.TOPIC_AUTHOR_FULL} &raquo; {searchresults.FIRST_POST_TIME} &raquo; {L_IN} <a href="{searchresults.U_VIEW_FORUM}">{searchresults.FORUM_TITLE}</a>
 							<!-- EVENT topiclist_row_append -->
 


### PR DESCRIPTION
Fixing position as it is correctly on subsilver, or else it will appear
some problems when using polls or on topics with page numbers.

PHPBB3-14997

Checklist:

- [x] Correct branch: master for new features; 3.2.x, 3.1.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master / 3.2.x](https://area51.phpbb.com/docs/master/coding-guidelines.html), [3.1.x](https://area51.phpbb.com/docs/31x/coding-guidelines.html)
- [x] Commit follows commit message [format](https://wiki.phpbb.com/Git#Commit_Messages)

Tracker ticket (set the ticket ID to **your ticket ID**):

https://tracker.phpbb.com/browse/PHPBB3-14997
