### PR TITLE
[ticket/15050] Use new file when new file already exists

### DIFF
--- a/phpBB/phpbb/install/module/update_filesystem/task/diff_files.php
+++ b/phpBB/phpbb/install/module/update_filesystem/task/diff_files.php
@@ -132,41 +132,62 @@ class diff_files extends task_base
 			$file_contents = array();
 
 			// Handle the special case when user created a file with the filename that is now new in the core
-			$file_contents[0] = (file_exists($old_path . $filename)) ? file_get_contents($old_path . $filename) : '';
-
-			$filenames = array(
-				$this->phpbb_root_path . $filename,
-				$new_path . $filename
-			);
-
-			foreach ($filenames as $file_to_diff)
+			if (file_exists($old_path . $filename))
 			{
-				$file_contents[] = file_get_contents($file_to_diff);
+				$file_contents[0] = file_get_contents($old_path . $filename);
 
-				if ($file_contents[sizeof($file_contents) - 1] === false)
+				$filenames = array(
+					$this->phpbb_root_path . $filename,
+					$new_path . $filename
+				);
+
+				foreach ($filenames as $file_to_diff)
+				{
+					$file_contents[] = file_get_contents($file_to_diff);
+
+					if ($file_contents[sizeof($file_contents) - 1] === false)
+					{
+						$this->iohandler->add_error_message(array('FILE_DIFFER_ERROR_FILE_CANNOT_BE_READ', $files_to_diff));
+						unset($file_contents);
+						throw new user_interaction_required_exception();
+					}
+				}
+
+				$diff = new \diff3($file_contents[0], $file_contents[1], $file_contents[2]);
+				unset($file_contents);
+
+				// Handle conflicts
+				if ($diff->get_num_conflicts() !== 0)
+				{
+					$merge_conflicts[] = $filename;
+				}
+
+				// Save merged output
+				$this->cache->put(
+					'_file_' . md5($filename),
+					base64_encode(implode("\n", $diff->merged_output()))
+				);
+
+				unset($diff);
+			}
+			else
+			{
+				$new_file_content  = file_get_contents($new_path . $filename);
+
+				if ($new_file_content  === false)
 				{
 					$this->iohandler->add_error_message(array('FILE_DIFFER_ERROR_FILE_CANNOT_BE_READ', $files_to_diff));
-					unset($file_contents);
+					unset($new_file_content );
 					throw new user_interaction_required_exception();
 				}
+
+				// Save new file content to cache
+				$this->cache->put(
+					'_file_' . md5($filename),
+					base64_encode($new_file_content)
+				);
+				unset($new_file_content);
 			}
-
-			$diff = new \diff3($file_contents[0], $file_contents[1], $file_contents[2]);
-			unset($file_contents);
-
-			// Handle conflicts
-			if ($diff->get_num_conflicts() !== 0)
-			{
-				$merge_conflicts[] = $filename;
-			}
-
-			// Save merged output
-			$this->cache->put(
-				'_file_' . md5($filename),
-				base64_encode(implode("\n", $diff->merged_output()))
-			);
-
-			unset($diff);
 
 			$progress_count++;
 			$this->iohandler->set_progress('UPDATE_FILE_DIFF', $progress_count);

--- a/phpBB/phpbb/install/module/update_filesystem/task/diff_files.php
+++ b/phpBB/phpbb/install/module/update_filesystem/task/diff_files.php
@@ -172,9 +172,9 @@ class diff_files extends task_base
 			}
 			else
 			{
-				$new_file_content  = file_get_contents($new_path . $filename);
+				$new_file_content = file_get_contents($new_path . $filename);
 
-				if ($new_file_content  === false)
+				if ($new_file_content === false)
 				{
 					$this->iohandler->add_error_message(array('FILE_DIFFER_ERROR_FILE_CANNOT_BE_READ', $files_to_diff));
 					unset($new_file_content );


### PR DESCRIPTION
Instead of trying to diff the new file against a pre-existing file,
we're just going to use the new file. It's impossible to know whether
the pre-existing file is newer or older than the new file. As the
system will rely on the files being in the "new" state it's better
to simply use the file in "new" state.

PHPBB3-15050

Checklist:

- [x] Correct branch: master for new features; 3.2.x, 3.1.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master / 3.2.x](https://area51.phpbb.com/docs/master/coding-guidelines.html), [3.1.x](https://area51.phpbb.com/docs/31x/coding-guidelines.html)
- [x] Commit follows commit message [format](https://wiki.phpbb.com/Git#Commit_Messages)

Tracker ticket (set the ticket ID to **your ticket ID**):

https://tracker.phpbb.com/browse/PHPBB3-15050
