### PR TITLE
[ticket/15080] Save unneeded file loads for extension metadata

### DIFF
--- a/phpBB/phpbb/extension/metadata_manager.php
+++ b/phpBB/phpbb/extension/metadata_manager.php
@@ -97,13 +97,11 @@ class metadata_manager
 	*/
 	public function get_metadata($element = 'all')
 	{
-		$this->set_metadata_file();
-
-		// Fetch the metadata
-		$this->fetch_metadata();
-
-		// Clean the metadata
-		$this->clean_metadata_array();
+		// Fetch and clean the metadata if not done yet
+		if ($this->metadata_file === '')
+		{
+			$this->fetch_metadata_from_file();
+		}
 
 		switch ($element)
 		{
@@ -136,11 +134,11 @@ class metadata_manager
 	}
 
 	/**
-	* Sets the filepath of the metadata file
+	* Sets the path of the metadata file, gets its contents and cleans loaded file
 	*
 	* @throws \phpbb\extension\exception
 	*/
-	private function set_metadata_file()
+	private function fetch_metadata_from_file()
 	{
 		$ext_filepath = $this->extension_manager->get_extension_path($this->ext_name);
 		$metadata_filepath = $this->phpbb_root_path . $ext_filepath . 'composer.json';
@@ -151,37 +149,19 @@ class metadata_manager
 		{
 			throw new \phpbb\extension\exception($this->user->lang('FILE_NOT_FOUND', $this->metadata_file));
 		}
-	}
 
-	/**
-	* Gets the contents of the composer.json file
-	*
-	* @return bool True if success, throws an exception on failure
-	* @throws \phpbb\extension\exception
-	*/
-	private function fetch_metadata()
-	{
-		if (!file_exists($this->metadata_file))
+		if (!($file_contents = file_get_contents($this->metadata_file)))
 		{
-			throw new \phpbb\extension\exception($this->user->lang('FILE_NOT_FOUND', $this->metadata_file));
+			throw new \phpbb\extension\exception($this->user->lang('FILE_CONTENT_ERR', $this->metadata_file));
 		}
-		else
+
+		if (($metadata = json_decode($file_contents, true)) === null)
 		{
-			if (!($file_contents = file_get_contents($this->metadata_file)))
-			{
-				throw new \phpbb\extension\exception($this->user->lang('FILE_CONTENT_ERR', $this->metadata_file));
-			}
-
-			if (($metadata = json_decode($file_contents, true)) === null)
-			{
-				throw new \phpbb\extension\exception($this->user->lang('FILE_JSON_DECODE_ERR', $this->metadata_file));
-			}
-
-			array_walk_recursive($metadata, array($this, 'sanitize_json'));
-			$this->metadata = $metadata;
-
-			return true;
+			throw new \phpbb\extension\exception($this->user->lang('FILE_JSON_DECODE_ERR', $this->metadata_file));
 		}
+
+		array_walk_recursive($metadata, array($this, 'sanitize_json'));
+		$this->metadata = $metadata;
 	}
 
 	/**
@@ -193,16 +173,6 @@ class metadata_manager
 	public function sanitize_json(&$value, $key)
 	{
 		$value = htmlspecialchars($value);
-	}
-
-	/**
-	* This array handles the cleaning of the array
-	*
-	* @return array Contains the cleaned metadata array
-	*/
-	private function clean_metadata_array()
-	{
-		return $this->metadata;
 	}
 
 	/**


### PR DESCRIPTION
PHPBB3-15080

Save unneeded file loads for extension metadata.  Currently, each time get_metadata() is called, the metadata file gets reloaded from disk.  This is happening multiple times per instance of metadata_manager created, so saving these calls and replacing by one, on first time call, would improve execution time.

Checklist:

- [x] Correct branch: master for new features; 3.2.x, 3.1.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master / 3.2.x](https://area51.phpbb.com/docs/master/coding-guidelines.html), [3.1.x](https://area51.phpbb.com/docs/31x/coding-guidelines.html)
- [x] Commit follows commit message [format](https://wiki.phpbb.com/Git#Commit_Messages)

Tracker ticket:

https://tracker.phpbb.com/browse/PHPBB3-15080
