### PR TITLE
[ticket/15087] Optimize creation of metadata objects by caching

### DIFF
--- a/phpBB/includes/acp/acp_extensions.php
+++ b/phpBB/includes/acp/acp_extensions.php
@@ -25,35 +25,36 @@ if (!defined('IN_PHPBB'))
 class acp_extensions
 {
 	var $u_action;
+	var $tpl_name;
+	var $page_title;
 
-	private $db;
 	private $config;
 	private $template;
 	private $user;
-	private $cache;
 	private $log;
 	private $request;
+	private $phpbb_dispatcher;
+	private $ext_manager;
 
 	function main()
 	{
 		// Start the page
-		global $config, $user, $template, $request, $phpbb_extension_manager, $db, $phpbb_root_path, $phpbb_log, $cache, $phpbb_dispatcher;
+		global $config, $user, $template, $request, $phpbb_extension_manager, $phpbb_root_path, $phpbb_log, $phpbb_dispatcher;
 
-		$this->db = $db;
 		$this->config = $config;
 		$this->template = $template;
 		$this->user = $user;
-		$this->cache = $cache;
 		$this->request = $request;
 		$this->log = $phpbb_log;
 		$this->phpbb_dispatcher = $phpbb_dispatcher;
+		$this->ext_manager = $phpbb_extension_manager;
 
-		$user->add_lang(array('install', 'acp/extensions', 'migrator'));
+		$this->user->add_lang(array('install', 'acp/extensions', 'migrator'));
 
 		$this->page_title = 'ACP_EXTENSIONS';
 
-		$action = $request->variable('action', 'list');
-		$ext_name = $request->variable('ext_name', '');
+		$action = $this->request->variable('action', 'list');
+		$ext_name = $this->request->variable('ext_name', '');
 
 		// What is a safe limit of execution time? Half the max execution time should be safe.
 		$safe_time_limit = (ini_get('max_execution_time') / 2);
@@ -75,13 +76,13 @@ class acp_extensions
 		extract($this->phpbb_dispatcher->trigger_event('core.acp_extensions_run_action', compact($vars)));
 
 		// Cancel action
-		if ($request->is_set_post('cancel'))
+		if ($this->request->is_set_post('cancel'))
 		{
 			$action = 'list';
 			$ext_name = '';
 		}
 
-		if (in_array($action, array('enable', 'disable', 'delete_data')) && !check_link_hash($request->variable('hash', ''), $action . '.' . $ext_name))
+		if (in_array($action, array('enable', 'disable', 'delete_data')) && !check_link_hash($this->request->variable('hash', ''), $action . '.' . $ext_name))
 		{
 			trigger_error('FORM_INVALID', E_USER_WARNING);
 		}
@@ -89,7 +90,7 @@ class acp_extensions
 		// If they've specified an extension, let's load the metadata manager and validate it.
 		if ($ext_name)
 		{
-			$md_manager = new \phpbb\extension\metadata_manager($ext_name, $config, $phpbb_extension_manager, $phpbb_root_path);
+			$md_manager = $this->ext_manager->create_extension_metadata_manager($ext_name);
 
 			try
 			{
@@ -114,12 +115,12 @@ class acp_extensions
 						'force_unstable'	=> $force_unstable,
 					));
 
-					confirm_box(false, $user->lang('EXTENSION_FORCE_UNSTABLE_CONFIRM'), $s_hidden_fields);
+					confirm_box(false, $this->user->lang('EXTENSION_FORCE_UNSTABLE_CONFIRM'), $s_hidden_fields);
 				}
 				else
 				{
-					$config->set('extension_force_unstable', false);
-					trigger_error($user->lang['CONFIG_UPDATED'] . adm_back_link($this->u_action));
+					$this->config->set('extension_force_unstable', false);
+					trigger_error($this->user->lang['CONFIG_UPDATED'] . adm_back_link($this->u_action));
 				}
 				break;
 
@@ -127,17 +128,17 @@ class acp_extensions
 			default:
 				if (confirm_box(true))
 				{
-					$config->set('extension_force_unstable', true);
-					trigger_error($user->lang['CONFIG_UPDATED'] . adm_back_link($this->u_action));
+					$this->config->set('extension_force_unstable', true);
+					trigger_error($this->user->lang['CONFIG_UPDATED'] . adm_back_link($this->u_action));
 				}
 
-				$this->list_enabled_exts($phpbb_extension_manager);
-				$this->list_disabled_exts($phpbb_extension_manager);
-				$this->list_available_exts($phpbb_extension_manager);
+				$this->list_enabled_exts();
+				$this->list_disabled_exts();
+				$this->list_available_exts();
 
 				$this->template->assign_vars(array(
 					'U_VERSIONCHECK_FORCE' 	=> $this->u_action . '&amp;action=list&amp;versioncheck_force=1',
-					'FORCE_UNSTABLE'		=> $config['extension_force_unstable'],
+					'FORCE_UNSTABLE'		=> $this->config['extension_force_unstable'],
 					'U_ACTION' 				=> $this->u_action,
 				));
 
@@ -147,28 +148,28 @@ class acp_extensions
 			case 'enable_pre':
 				if (!$md_manager->validate_dir())
 				{
-					trigger_error($user->lang['EXTENSION_DIR_INVALID'] . adm_back_link($this->u_action), E_USER_WARNING);
+					trigger_error($this->user->lang['EXTENSION_DIR_INVALID'] . adm_back_link($this->u_action), E_USER_WARNING);
 				}
 
 				if (!$md_manager->validate_enable())
 				{
-					trigger_error($user->lang['EXTENSION_NOT_AVAILABLE'] . adm_back_link($this->u_action), E_USER_WARNING);
+					trigger_error($this->user->lang['EXTENSION_NOT_AVAILABLE'] . adm_back_link($this->u_action), E_USER_WARNING);
 				}
 
-				$extension = $phpbb_extension_manager->get_extension($ext_name);
+				$extension = $this->ext_manager->get_extension($ext_name);
 				if (!$extension->is_enableable())
 				{
-					trigger_error($user->lang['EXTENSION_NOT_ENABLEABLE'] . adm_back_link($this->u_action), E_USER_WARNING);
+					trigger_error($this->user->lang['EXTENSION_NOT_ENABLEABLE'] . adm_back_link($this->u_action), E_USER_WARNING);
 				}
 
-				if ($phpbb_extension_manager->is_enabled($ext_name))
+				if ($this->ext_manager->is_enabled($ext_name))
 				{
 					redirect($this->u_action);
 				}
 
 				$this->tpl_name = 'acp_ext_enable';
 
-				$template->assign_vars(array(
+				$this->template->assign_vars(array(
 					'PRE'				=> true,
 					'L_CONFIRM_MESSAGE'	=> $this->user->lang('EXTENSION_ENABLE_CONFIRM', $md_manager->get_metadata('display-name')),
 					'U_ENABLE'			=> $this->u_action . '&amp;action=enable&amp;ext_name=' . urlencode($ext_name) . '&amp;hash=' . generate_link_hash('enable.' . $ext_name),
@@ -178,55 +179,55 @@ class acp_extensions
 			case 'enable':
 				if (!$md_manager->validate_dir())
 				{
-					trigger_error($user->lang['EXTENSION_DIR_INVALID'] . adm_back_link($this->u_action), E_USER_WARNING);
+					trigger_error($this->user->lang['EXTENSION_DIR_INVALID'] . adm_back_link($this->u_action), E_USER_WARNING);
 				}
 
 				if (!$md_manager->validate_enable())
 				{
-					trigger_error($user->lang['EXTENSION_NOT_AVAILABLE'] . adm_back_link($this->u_action), E_USER_WARNING);
+					trigger_error($this->user->lang['EXTENSION_NOT_AVAILABLE'] . adm_back_link($this->u_action), E_USER_WARNING);
 				}
 
-				$extension = $phpbb_extension_manager->get_extension($ext_name);
+				$extension = $this->ext_manager->get_extension($ext_name);
 				if (!$extension->is_enableable())
 				{
-					trigger_error($user->lang['EXTENSION_NOT_ENABLEABLE'] . adm_back_link($this->u_action), E_USER_WARNING);
+					trigger_error($this->user->lang['EXTENSION_NOT_ENABLEABLE'] . adm_back_link($this->u_action), E_USER_WARNING);
 				}
 
 				try
 				{
-					while ($phpbb_extension_manager->enable_step($ext_name))
+					while ($this->ext_manager->enable_step($ext_name))
 					{
 						// Are we approaching the time limit? If so we want to pause the update and continue after refreshing
 						if ((time() - $start_time) >= $safe_time_limit)
 						{
-							$template->assign_var('S_NEXT_STEP', true);
+							$this->template->assign_var('S_NEXT_STEP', true);
 
 							meta_refresh(0, $this->u_action . '&amp;action=enable&amp;ext_name=' . urlencode($ext_name) . '&amp;hash=' . generate_link_hash('enable.' . $ext_name));
 						}
 					}
-					$this->log->add('admin', $user->data['user_id'], $user->ip, 'LOG_EXT_ENABLE', time(), array($ext_name));
+					$this->log->add('admin', $this->user->data['user_id'], $this->user->ip, 'LOG_EXT_ENABLE', time(), array($ext_name));
 				}
 				catch (\phpbb\db\migration\exception $e)
 				{
-					$template->assign_var('MIGRATOR_ERROR', $e->getLocalisedMessage($user));
+					$this->template->assign_var('MIGRATOR_ERROR', $e->getLocalisedMessage($this->user));
 				}
 
 				$this->tpl_name = 'acp_ext_enable';
 
-				$template->assign_vars(array(
+				$this->template->assign_vars(array(
 					'U_RETURN'		=> $this->u_action . '&amp;action=list',
 				));
 			break;
 
 			case 'disable_pre':
-				if (!$phpbb_extension_manager->is_enabled($ext_name))
+				if (!$this->ext_manager->is_enabled($ext_name))
 				{
 					redirect($this->u_action);
 				}
 
 				$this->tpl_name = 'acp_ext_disable';
 
-				$template->assign_vars(array(
+				$this->template->assign_vars(array(
 					'PRE'				=> true,
 					'L_CONFIRM_MESSAGE'	=> $this->user->lang('EXTENSION_DISABLE_CONFIRM', $md_manager->get_metadata('display-name')),
 					'U_DISABLE'			=> $this->u_action . '&amp;action=disable&amp;ext_name=' . urlencode($ext_name) . '&amp;hash=' . generate_link_hash('disable.' . $ext_name),
@@ -234,38 +235,38 @@ class acp_extensions
 			break;
 
 			case 'disable':
-				if (!$phpbb_extension_manager->is_enabled($ext_name))
+				if (!$this->ext_manager->is_enabled($ext_name))
 				{
 					redirect($this->u_action);
 				}
 
-				while ($phpbb_extension_manager->disable_step($ext_name))
+				while ($this->ext_manager->disable_step($ext_name))
 				{
 					// Are we approaching the time limit? If so we want to pause the update and continue after refreshing
 					if ((time() - $start_time) >= $safe_time_limit)
 					{
-						$template->assign_var('S_NEXT_STEP', true);
+						$this->template->assign_var('S_NEXT_STEP', true);
 
 						meta_refresh(0, $this->u_action . '&amp;action=disable&amp;ext_name=' . urlencode($ext_name) . '&amp;hash=' . generate_link_hash('disable.' . $ext_name));
 					}
 				}
-				$this->log->add('admin', $user->data['user_id'], $user->ip, 'LOG_EXT_DISABLE', time(), array($ext_name));
+				$this->log->add('admin', $this->user->data['user_id'], $this->user->ip, 'LOG_EXT_DISABLE', time(), array($ext_name));
 
 				$this->tpl_name = 'acp_ext_disable';
 
-				$template->assign_vars(array(
+				$this->template->assign_vars(array(
 					'U_RETURN'	=> $this->u_action . '&amp;action=list',
 				));
 			break;
 
 			case 'delete_data_pre':
-				if ($phpbb_extension_manager->is_enabled($ext_name))
+				if ($this->ext_manager->is_enabled($ext_name))
 				{
 					redirect($this->u_action);
 				}
 				$this->tpl_name = 'acp_ext_delete_data';
 
-				$template->assign_vars(array(
+				$this->template->assign_vars(array(
 					'PRE'				=> true,
 					'L_CONFIRM_MESSAGE'	=> $this->user->lang('EXTENSION_DELETE_DATA_CONFIRM', $md_manager->get_metadata('display-name')),
 					'U_PURGE'			=> $this->u_action . '&amp;action=delete_data&amp;ext_name=' . urlencode($ext_name) . '&amp;hash=' . generate_link_hash('delete_data.' . $ext_name),
@@ -273,75 +274,75 @@ class acp_extensions
 			break;
 
 			case 'delete_data':
-				if ($phpbb_extension_manager->is_enabled($ext_name))
+				if ($this->ext_manager->is_enabled($ext_name))
 				{
 					redirect($this->u_action);
 				}
 
 				try
 				{
-					while ($phpbb_extension_manager->purge_step($ext_name))
+					while ($this->ext_manager->purge_step($ext_name))
 					{
 						// Are we approaching the time limit? If so we want to pause the update and continue after refreshing
 						if ((time() - $start_time) >= $safe_time_limit)
 						{
-							$template->assign_var('S_NEXT_STEP', true);
+							$this->template->assign_var('S_NEXT_STEP', true);
 
 							meta_refresh(0, $this->u_action . '&amp;action=delete_data&amp;ext_name=' . urlencode($ext_name) . '&amp;hash=' . generate_link_hash('delete_data.' . $ext_name));
 						}
 					}
-					$this->log->add('admin', $user->data['user_id'], $user->ip, 'LOG_EXT_PURGE', time(), array($ext_name));
+					$this->log->add('admin', $this->user->data['user_id'], $this->user->ip, 'LOG_EXT_PURGE', time(), array($ext_name));
 				}
 				catch (\phpbb\db\migration\exception $e)
 				{
-					$template->assign_var('MIGRATOR_ERROR', $e->getLocalisedMessage($user));
+					$this->template->assign_var('MIGRATOR_ERROR', $e->getLocalisedMessage($this->user));
 				}
 
 				$this->tpl_name = 'acp_ext_delete_data';
 
-				$template->assign_vars(array(
+				$this->template->assign_vars(array(
 					'U_RETURN'	=> $this->u_action . '&amp;action=list',
 				));
 			break;
 
 			case 'details':
 				// Output it to the template
-				$md_manager->output_template_data($template);
+				$md_manager->output_template_data($this->template);
 
 				$meta = $md_manager->get_metadata('all');
 				if (isset($meta['extra']['version-check']))
 				{
 					try
 					{
-						$updates_available = $phpbb_extension_manager->version_check($md_manager, $request->variable('versioncheck_force', false), $this->config['extension_force_unstable'] ? 'unstable' : null);
+						$updates_available = $this->ext_manager->version_check($md_manager, $this->request->variable('versioncheck_force', false), $this->config['extension_force_unstable'] ? 'unstable' : null);
 
-						$template->assign_vars(array(
+					$this->template->assign_vars(array(
 							'S_UP_TO_DATE' => empty($updates_available),
 							'UP_TO_DATE_MSG' => $this->user->lang(empty($updates_available) ? 'UP_TO_DATE' : 'NOT_UP_TO_DATE', $md_manager->get_metadata('display-name')),
 						));
 
 						foreach ($updates_available as $branch => $version_data)
 						{
-							$template->assign_block_vars('updates_available', $version_data);
+						$this->template->assign_block_vars('updates_available', $version_data);
 						}
 					}
 					catch (exception_interface $e)
 					{
 						$message = call_user_func_array(array($this->user, 'lang'), array_merge(array($e->getMessage()), $e->get_parameters()));
 
-						$template->assign_vars(array(
+						$this->template->assign_vars(array(
 							'S_VERSIONCHECK_FAIL' => true,
 							'VERSIONCHECK_FAIL_REASON' => ($e->getMessage() !== 'VERSIONCHECK_FAIL') ? $message : '',
 						));
 					}
-					$template->assign_var('S_VERSIONCHECK', true);
+					$this->template->assign_var('S_VERSIONCHECK', true);
 				}
 				else
 				{
-					$template->assign_var('S_VERSIONCHECK', false);
+					$this->template->assign_var('S_VERSIONCHECK', false);
 				}
 
-				$template->assign_vars(array(
+				$this->template->assign_vars(array(
 					'U_BACK'				=> $this->u_action . '&amp;action=list',
 					'U_VERSIONCHECK_FORCE'	=> $this->u_action . '&amp;action=details&amp;versioncheck_force=1&amp;ext_name=' . urlencode($md_manager->get_metadata('name')),
 				));
@@ -354,16 +355,15 @@ class acp_extensions
 	/**
 	* Lists all the enabled extensions and dumps to the template
 	*
-	* @param  $phpbb_extension_manager     An instance of the extension manager
 	* @return null
 	*/
-	public function list_enabled_exts(\phpbb\extension\manager $phpbb_extension_manager)
+	public function list_enabled_exts()
 	{
 		$enabled_extension_meta_data = array();
 
-		foreach ($phpbb_extension_manager->all_enabled() as $name => $location)
+		foreach ($this->ext_manager->all_enabled() as $name => $location)
 		{
-			$md_manager = $phpbb_extension_manager->create_extension_metadata_manager($name);
+			$md_manager = $this->ext_manager->create_extension_metadata_manager($name);
 
 			try
 			{
@@ -378,7 +378,7 @@ class acp_extensions
 					try
 					{
 						$force_update = $this->request->variable('versioncheck_force', false);
-						$updates = $phpbb_extension_manager->version_check($md_manager, $force_update, !$force_update);
+						$updates = $this->ext_manager->version_check($md_manager, $force_update, !$force_update);
 
 						$enabled_extension_meta_data[$name]['S_UP_TO_DATE'] = empty($updates);
 						$enabled_extension_meta_data[$name]['S_VERSIONCHECK'] = true;
@@ -426,16 +426,15 @@ class acp_extensions
 	/**
 	* Lists all the disabled extensions and dumps to the template
 	*
-	* @param  $phpbb_extension_manager     An instance of the extension manager
 	* @return null
 	*/
-	public function list_disabled_exts(\phpbb\extension\manager $phpbb_extension_manager)
+	public function list_disabled_exts()
 	{
 		$disabled_extension_meta_data = array();
 
-		foreach ($phpbb_extension_manager->all_disabled() as $name => $location)
+		foreach ($this->ext_manager->all_disabled() as $name => $location)
 		{
-			$md_manager = $phpbb_extension_manager->create_extension_metadata_manager($name);
+			$md_manager = $this->ext_manager->create_extension_metadata_manager($name);
 
 			try
 			{
@@ -448,7 +447,7 @@ class acp_extensions
 				if (isset($meta['extra']['version-check']))
 				{
 					$force_update = $this->request->variable('versioncheck_force', false);
-					$updates = $phpbb_extension_manager->version_check($md_manager, $force_update, !$force_update);
+					$updates = $this->ext_manager->version_check($md_manager, $force_update, !$force_update);
 
 					$disabled_extension_meta_data[$name]['S_UP_TO_DATE'] = empty($updates);
 					$disabled_extension_meta_data[$name]['S_VERSIONCHECK'] = true;
@@ -496,18 +495,17 @@ class acp_extensions
 	/**
 	* Lists all the available extensions and dumps to the template
 	*
-	* @param  $phpbb_extension_manager     An instance of the extension manager
 	* @return null
 	*/
-	public function list_available_exts(\phpbb\extension\manager $phpbb_extension_manager)
+	public function list_available_exts()
 	{
-		$uninstalled = array_diff_key($phpbb_extension_manager->all_available(), $phpbb_extension_manager->all_configured());
+		$uninstalled = array_diff_key($this->ext_manager->all_available(), $this->ext_manager->all_configured());
 
 		$available_extension_meta_data = array();
 
 		foreach ($uninstalled as $name => $location)
 		{
-			$md_manager = $phpbb_extension_manager->create_extension_metadata_manager($name);
+			$md_manager = $this->ext_manager->create_extension_metadata_manager($name);
 
 			try
 			{
@@ -520,7 +518,7 @@ class acp_extensions
 				if (isset($meta['extra']['version-check']))
 				{
 					$force_update = $this->request->variable('versioncheck_force', false);
-					$updates = $phpbb_extension_manager->version_check($md_manager, $force_update, !$force_update);
+					$updates = $this->ext_manager->version_check($md_manager, $force_update, !$force_update);
 
 					$available_extension_meta_data[$name]['S_UP_TO_DATE'] = empty($updates);
 					$available_extension_meta_data[$name]['S_VERSIONCHECK'] = true;

--- a/phpBB/includes/acp/acp_extensions.php
+++ b/phpBB/includes/acp/acp_extensions.php
@@ -307,23 +307,23 @@ class acp_extensions
 
 			case 'details':
 				// Output it to the template
-				$md_manager->output_template_data($this->template);
-
 				$meta = $md_manager->get_metadata('all');
+				$this->output_metadata_to_template($meta);
+
 				if (isset($meta['extra']['version-check']))
 				{
 					try
 					{
 						$updates_available = $this->ext_manager->version_check($md_manager, $this->request->variable('versioncheck_force', false), $this->config['extension_force_unstable'] ? 'unstable' : null);
 
-					$this->template->assign_vars(array(
+						$this->template->assign_vars(array(
 							'S_UP_TO_DATE' => empty($updates_available),
 							'UP_TO_DATE_MSG' => $this->user->lang(empty($updates_available) ? 'UP_TO_DATE' : 'NOT_UP_TO_DATE', $md_manager->get_metadata('display-name')),
 						));
 
 						foreach ($updates_available as $branch => $version_data)
 						{
-						$this->template->assign_block_vars('updates_available', $version_data);
+							$this->template->assign_block_vars('updates_available', $version_data);
 						}
 					}
 					catch (exception_interface $e)
@@ -582,5 +582,42 @@ class acp_extensions
 	protected function sort_extension_meta_data_table($val1, $val2)
 	{
 		return strnatcasecmp($val1['META_DISPLAY_NAME'], $val2['META_DISPLAY_NAME']);
+	}
+
+	/**
+	* Outputs extension metadata into the template
+	*
+	* @param array $metadata Array with all metadata for the extension
+	* @return null
+	*/
+	public function output_metadata_to_template($metadata)
+	{
+		$this->template->assign_vars(array(
+			'META_NAME'			=> $metadata['name'],
+			'META_TYPE'			=> $metadata['type'],
+			'META_DESCRIPTION'	=> (isset($metadata['description'])) ? $metadata['description'] : '',
+			'META_HOMEPAGE'		=> (isset($metadata['homepage'])) ? $metadata['homepage'] : '',
+			'META_VERSION'		=> $metadata['version'],
+			'META_TIME'			=> (isset($metadata['time'])) ? $metadata['time'] : '',
+			'META_LICENSE'		=> $metadata['license'],
+
+			'META_REQUIRE_PHP'		=> (isset($metadata['require']['php'])) ? $metadata['require']['php'] : '',
+			'META_REQUIRE_PHP_FAIL'	=> (isset($metadata['require']['php'])) ? false : true,
+
+			'META_REQUIRE_PHPBB'		=> (isset($metadata['extra']['soft-require']['phpbb/phpbb'])) ? $metadata['extra']['soft-require']['phpbb/phpbb'] : '',
+			'META_REQUIRE_PHPBB_FAIL'	=> (isset($metadata['extra']['soft-require']['phpbb/phpbb'])) ? false : true,
+
+			'META_DISPLAY_NAME'	=> (isset($metadata['extra']['display-name'])) ? $metadata['extra']['display-name'] : '',
+		));
+
+		foreach ($metadata['authors'] as $author)
+		{
+			$this->template->assign_block_vars('meta_authors', array(
+				'AUTHOR_NAME'		=> $author['name'],
+				'AUTHOR_EMAIL'		=> (isset($author['email'])) ? $author['email'] : '',
+				'AUTHOR_HOMEPAGE'	=> (isset($author['homepage'])) ? $author['homepage'] : '',
+				'AUTHOR_ROLE'		=> (isset($author['role'])) ? $author['role'] : '',
+			));
+		}
 	}
 }

--- a/phpBB/phpbb/console/command/update/check.php
+++ b/phpBB/phpbb/console/command/update/check.php
@@ -134,7 +134,7 @@ class check extends \phpbb\console\command\command
 		try
 		{
 			$ext_manager = $this->phpbb_container->get('ext.manager');
-			$md_manager = $ext_manager->create_extension_metadata_manager($ext_name, null);
+			$md_manager = $ext_manager->create_extension_metadata_manager($ext_name);
 			$updates_available = $ext_manager->version_check($md_manager, $recheck, false, $stability);
 
 			$metadata = $md_manager->get_metadata('all');

--- a/phpBB/phpbb/extension/metadata_manager.php
+++ b/phpBB/phpbb/extension/metadata_manager.php
@@ -19,24 +19,6 @@ namespace phpbb\extension;
 class metadata_manager
 {
 	/**
-	* phpBB Config instance
-	* @var \phpbb\config\config
-	*/
-	protected $config;
-
-	/**
-	* phpBB Extension Manager
-	* @var \phpbb\extension\manager
-	*/
-	protected $extension_manager;
-
-	/**
-	* phpBB root path
-	* @var string
-	*/
-	protected $phpbb_root_path;
-
-	/**
 	* Name (including vendor) of the extension
 	* @var string
 	*/
@@ -58,19 +40,13 @@ class metadata_manager
 	* Creates the metadata manager
 	*
 	* @param string				$ext_name			Name (including vendor) of the extension
-	* @param \phpbb\config\config		$config				phpBB Config instance
-	* @param \phpbb\extension\manager	$extension_manager	An instance of the phpBB extension manager
-	* @param string				$phpbb_root_path	Path to the phpbb includes directory.
+	* @param string				$ext_path			Path to the extension directory including root path
 	*/
-	public function __construct($ext_name, \phpbb\config\config $config, \phpbb\extension\manager $extension_manager, $phpbb_root_path)
+	public function __construct($ext_name, $ext_path)
 	{
-		$this->config = $config;
-		$this->extension_manager = $extension_manager;
-		$this->phpbb_root_path = $phpbb_root_path;
-
 		$this->ext_name = $ext_name;
 		$this->metadata = array();
-		$this->metadata_file = '';
+		$this->metadata_file = $ext_path . 'composer.json';
 	}
 
 	/**
@@ -119,15 +95,12 @@ class metadata_manager
 	}
 
 	/**
-	* Sets the path of the metadata file, gets its contents and cleans loaded file
+	* Gets the metadata file contents and cleans loaded file
 	*
 	* @throws \phpbb\extension\exception
 	*/
 	private function fetch_metadata_from_file()
 	{
-		$ext_filepath = $this->extension_manager->get_extension_path($this->ext_name);
-		$this->metadata_file = $this->phpbb_root_path . $ext_filepath . 'composer.json';
-
 		if (!file_exists($this->metadata_file))
 		{
 			throw new \phpbb\extension\exception('FILE_NOT_FOUND', array($this->metadata_file));
@@ -182,9 +155,19 @@ class metadata_manager
 			case 'all':
 				$this->validate('display');
 
-				if (!$this->validate_enable())
+				if (!$this->validate_dir())
 				{
-					throw new \phpbb\extension\exception('META_FIELD_NOT_SET', array($name));
+					throw new \phpbb\extension\exception('EXTENSION_DIR_INVALID');
+				}
+
+				if (!$this->validate_require_phpbb())
+				{
+					throw new \phpbb\extension\exception('META_FIELD_NOT_SET', array('soft-require'));
+				}
+
+				if (!$this->validate_require_php())
+				{
+					throw new \phpbb\extension\exception('META_FIELD_NOT_SET', array('require php'));
 				}
 			break;
 
@@ -295,41 +278,5 @@ class metadata_manager
 		}
 
 		return true;
-	}
-
-	/**
-	* Outputs the metadata into the template
-	*
-	* @param \phpbb\template\template	$template	phpBB Template instance
-	*/
-	public function output_template_data(\phpbb\template\template $template)
-	{
-		$template->assign_vars(array(
-			'META_NAME'			=> $this->metadata['name'],
-			'META_TYPE'			=> $this->metadata['type'],
-			'META_DESCRIPTION'	=> (isset($this->metadata['description'])) ? $this->metadata['description'] : '',
-			'META_HOMEPAGE'		=> (isset($this->metadata['homepage'])) ? $this->metadata['homepage'] : '',
-			'META_VERSION'		=> (isset($this->metadata['version'])) ? $this->metadata['version'] : '',
-			'META_TIME'			=> (isset($this->metadata['time'])) ? $this->metadata['time'] : '',
-			'META_LICENSE'		=> $this->metadata['license'],
-
-			'META_REQUIRE_PHP'		=> (isset($this->metadata['require']['php'])) ? $this->metadata['require']['php'] : '',
-			'META_REQUIRE_PHP_FAIL'	=> !$this->validate_require_php(),
-
-			'META_REQUIRE_PHPBB'		=> (isset($this->metadata['extra']['soft-require']['phpbb/phpbb'])) ? $this->metadata['extra']['soft-require']['phpbb/phpbb'] : '',
-			'META_REQUIRE_PHPBB_FAIL'	=> !$this->validate_require_phpbb(),
-
-			'META_DISPLAY_NAME'	=> (isset($this->metadata['extra']['display-name'])) ? $this->metadata['extra']['display-name'] : '',
-		));
-
-		foreach ($this->metadata['authors'] as $author)
-		{
-			$template->assign_block_vars('meta_authors', array(
-				'AUTHOR_NAME'		=> $author['name'],
-				'AUTHOR_EMAIL'		=> (isset($author['email'])) ? $author['email'] : '',
-				'AUTHOR_HOMEPAGE'	=> (isset($author['homepage'])) ? $author['homepage'] : '',
-				'AUTHOR_ROLE'		=> (isset($author['role'])) ? $author['role'] : '',
-			));
-		}
 	}
 }

--- a/phpBB/phpbb/extension/metadata_manager.php
+++ b/phpBB/phpbb/extension/metadata_manager.php
@@ -81,13 +81,11 @@ class metadata_manager
 	*/
 	public function get_metadata($element = 'all')
 	{
-		$this->set_metadata_file();
-
-		// Fetch the metadata
-		$this->fetch_metadata();
-
-		// Clean the metadata
-		$this->clean_metadata_array();
+		// Fetch and clean the metadata if not done yet
+		if ($this->metadata === array())
+		{
+			$this->fetch_metadata_from_file();
+		}
 
 		switch ($element)
 		{
@@ -121,52 +119,32 @@ class metadata_manager
 	}
 
 	/**
-	* Sets the filepath of the metadata file
+	* Sets the path of the metadata file, gets its contents and cleans loaded file
 	*
 	* @throws \phpbb\extension\exception
 	*/
-	private function set_metadata_file()
+	private function fetch_metadata_from_file()
 	{
 		$ext_filepath = $this->extension_manager->get_extension_path($this->ext_name);
-		$metadata_filepath = $this->phpbb_root_path . $ext_filepath . 'composer.json';
-
-		$this->metadata_file = $metadata_filepath;
+		$this->metadata_file = $this->phpbb_root_path . $ext_filepath . 'composer.json';
 
 		if (!file_exists($this->metadata_file))
 		{
 			throw new \phpbb\extension\exception('FILE_NOT_FOUND', array($this->metadata_file));
 		}
-	}
 
-	/**
-	* Gets the contents of the composer.json file
-	*
-	* @return bool True if success, throws an exception on failure
-	* @throws \phpbb\extension\exception
-	*/
-	private function fetch_metadata()
-	{
-		if (!file_exists($this->metadata_file))
+		if (!($file_contents = file_get_contents($this->metadata_file)))
 		{
-			throw new \phpbb\extension\exception('FILE_NOT_FOUND', array($this->metadata_file));
+			throw new \phpbb\extension\exception('FILE_CONTENT_ERR', array($this->metadata_file));
 		}
-		else
+
+		if (($metadata = json_decode($file_contents, true)) === null)
 		{
-			if (!($file_contents = file_get_contents($this->metadata_file)))
-			{
-				throw new \phpbb\extension\exception('FILE_CONTENT_ERR', array($this->metadata_file));
-			}
-
-			if (($metadata = json_decode($file_contents, true)) === null)
-			{
-				throw new \phpbb\extension\exception('FILE_JSON_DECODE_ERR', array($this->metadata_file));
-			}
-
-			array_walk_recursive($metadata, array($this, 'sanitize_json'));
-			$this->metadata = $metadata;
-
-			return true;
+			throw new \phpbb\extension\exception('FILE_JSON_DECODE_ERR', array($this->metadata_file));
 		}
+
+		array_walk_recursive($metadata, array($this, 'sanitize_json'));
+		$this->metadata = $metadata;
 	}
 
 	/**
@@ -178,16 +156,6 @@ class metadata_manager
 	public function sanitize_json(&$value, $key)
 	{
 		$value = htmlspecialchars($value);
-	}
-
-	/**
-	* This array handles the cleaning of the array
-	*
-	* @return array Contains the cleaned metadata array
-	*/
-	private function clean_metadata_array()
-	{
-		return $this->metadata;
 	}
 
 	/**

--- a/tests/extension/metadata_manager_test.php
+++ b/tests/extension/metadata_manager_test.php
@@ -364,9 +364,7 @@ class phpbb_extension_metadata_manager_test extends phpbb_database_test_case
 	{
 		return new phpbb_mock_metadata_manager(
 			$ext_name,
-			$this->config,
-			$this->extension_manager,
-			$this->phpbb_root_path
+			$this->extension_manager->get_extension_path($ext_name, true)
 		);
 	}
 }


### PR DESCRIPTION
Caching is done in ext_manager, and metadata_manager is further simplified
by reducing the number of parameters needed.  Also, move template output
function from metadata_manager to acp_extensions, where it belongs.

Included here are 3.2 versions of the following PRs:

- https://github.com/phpbb/phpbb/pull/4581 [ticket/14919] Do not directly use globals in acp_extensions
- https://github.com/phpbb/phpbb/pull/4592 [ticket/14938] Inconsistency in ext_mgr all_available vs is_available
- https://github.com/phpbb/phpbb/pull/4689 [ticket/15080] Save unneeded file loads for extension metadata

Checklist:

- [x] Correct branch: master for new features; 3.2.x, 3.1.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master / 3.2.x](https://area51.phpbb.com/docs/master/coding-guidelines.html), [3.1.x](https://area51.phpbb.com/docs/31x/coding-guidelines.html)
- [x] Commit follows commit message [format](https://wiki.phpbb.com/Git#Commit_Messages)

Tracker ticket:

https://tracker.phpbb.com/browse/PHPBB3-15087
