### PR TITLE
[ticket/15088] Avoid code repetitions in extension manager

### DIFF
--- a/phpBB/phpbb/extension/manager.php
+++ b/phpBB/phpbb/extension/manager.php
@@ -236,14 +236,7 @@ class manager
 			'ext_state'		=> serialize($state),
 		);
 
-		$sql = 'SELECT COUNT(ext_name) as row_count
-			FROM ' . $this->extension_table . "
-			WHERE ext_name = '" . $this->db->sql_escape($name) . "'";
-		$result = $this->db->sql_query($sql);
-		$count = $this->db->sql_fetchfield('row_count');
-		$this->db->sql_freeresult($result);
-
-		$this->update_state($name, $extension_data, ($count) ? 'update' : 'insert');
+		$this->update_state($name, $extension_data, ($this->is_configured($name)) ? 'update' : 'insert');
 
 		if ($active)
 		{

--- a/phpBB/phpbb/extension/manager.php
+++ b/phpBB/phpbb/extension/manager.php
@@ -158,6 +158,48 @@ class manager
 	}
 
 	/**
+	* Update the database entry for an extension
+	*
+	* @param string $name Extension name to update
+	* @param array	$data Data to update in the database
+	* @param string	$action Action to perform, by default 'update', may be also 'insert' or 'delete'
+	*/
+	protected function update_state($name, $data, $action = 'update')
+	{
+		switch ($action)
+		{
+			case 'insert':
+				$this->extensions[$name] = $data;
+				$this->extensions[$name]['ext_path'] = $this->get_extension_path($name);
+				ksort($this->extensions);
+				$sql = 'INSERT INTO ' . $this->extension_table . '
+					' . $this->db->sql_build_array('INSERT', $data);
+				$this->db->sql_query($sql);
+			break;
+
+			case 'update':
+				$this->extensions[$name] = array_merge($this->extensions[$name], $data);
+				$sql = 'UPDATE ' . $this->extension_table . '
+					SET ' . $this->db->sql_build_array('UPDATE', $data) . "
+					WHERE ext_name = '" . $this->db->sql_escape($name) . "'";
+				$this->db->sql_query($sql);
+			break;
+
+			case 'delete':
+				unset($this->extensions[$name]);
+				$sql = 'DELETE FROM ' . $this->extension_table . "
+					WHERE ext_name = '" . $this->db->sql_escape($name) . "'";
+				$this->db->sql_query($sql);
+			break;
+		}
+
+		if ($this->cache)
+		{
+			$this->cache->purge();
+		}
+	}
+
+	/**
 	* Runs a step of the extension enabling process.
 	*
 	* Allows the exentension to enable in a long running script that works
@@ -194,10 +236,6 @@ class manager
 			'ext_state'		=> serialize($state),
 		);
 
-		$this->extensions[$name] = $extension_data;
-		$this->extensions[$name]['ext_path'] = $this->get_extension_path($extension_data['ext_name']);
-		ksort($this->extensions);
-
 		$sql = 'SELECT COUNT(ext_name) as row_count
 			FROM ' . $this->extension_table . "
 			WHERE ext_name = '" . $this->db->sql_escape($name) . "'";
@@ -205,24 +243,7 @@ class manager
 		$count = $this->db->sql_fetchfield('row_count');
 		$this->db->sql_freeresult($result);
 
-		if ($count)
-		{
-			$sql = 'UPDATE ' . $this->extension_table . '
-				SET ' . $this->db->sql_build_array('UPDATE', $extension_data) . "
-				WHERE ext_name = '" . $this->db->sql_escape($name) . "'";
-			$this->db->sql_query($sql);
-		}
-		else
-		{
-			$sql = 'INSERT INTO ' . $this->extension_table . '
-				' . $this->db->sql_build_array('INSERT', $extension_data);
-			$this->db->sql_query($sql);
-		}
-
-		if ($this->cache)
-		{
-			$this->cache->purge();
-		}
+		$this->update_state($name, $extension_data, ($count) ? 'update' : 'insert');
 
 		if ($active)
 		{
@@ -270,45 +291,17 @@ class manager
 		$extension = $this->get_extension($name);
 		$state = $extension->disable_step($old_state);
 
-		// continue until the state is false
-		if ($state !== false)
-		{
-			$extension_data = array(
-				'ext_state'		=> serialize($state),
-			);
-			$this->extensions[$name]['ext_state'] = serialize($state);
-
-			$sql = 'UPDATE ' . $this->extension_table . '
-				SET ' . $this->db->sql_build_array('UPDATE', $extension_data) . "
-				WHERE ext_name = '" . $this->db->sql_escape($name) . "'";
-			$this->db->sql_query($sql);
-
-			if ($this->cache)
-			{
-				$this->cache->purge();
-			}
-
-			return true;
-		}
+		$active = ($state !== false);
 
 		$extension_data = array(
-			'ext_active'	=> false,
-			'ext_state'		=> serialize(false),
+			'ext_active'	=> $active,
+			'ext_state'		=> serialize($state),
 		);
-		$this->extensions[$name]['ext_active'] = false;
-		$this->extensions[$name]['ext_state'] = serialize(false);
 
-		$sql = 'UPDATE ' . $this->extension_table . '
-			SET ' . $this->db->sql_build_array('UPDATE', $extension_data) . "
-			WHERE ext_name = '" . $this->db->sql_escape($name) . "'";
-		$this->db->sql_query($sql);
+		$this->update_state($name, $extension_data);
 
-		if ($this->cache)
-		{
-			$this->cache->purge();
-		}
-
-		return false;
+		// continue until the state is false
+		return $active;
 	}
 
 	/**
@@ -355,39 +348,16 @@ class manager
 		$extension = $this->get_extension($name);
 		$state = $extension->purge_step($old_state);
 
+		$purged = ($state === false);
+
+		$extension_data = array(
+			'ext_state'		=> serialize($state),
+		);
+
+		$this->update_state($name, $extension_data, ($purged) ? 'delete' : 'update');
+
 		// continue until the state is false
-		if ($state !== false)
-		{
-			$extension_data = array(
-				'ext_state'		=> serialize($state),
-			);
-			$this->extensions[$name]['ext_state'] = serialize($state);
-
-			$sql = 'UPDATE ' . $this->extension_table . '
-				SET ' . $this->db->sql_build_array('UPDATE', $extension_data) . "
-				WHERE ext_name = '" . $this->db->sql_escape($name) . "'";
-			$this->db->sql_query($sql);
-
-			if ($this->cache)
-			{
-				$this->cache->purge();
-			}
-
-			return true;
-		}
-
-		unset($this->extensions[$name]);
-
-		$sql = 'DELETE FROM ' . $this->extension_table . "
-			WHERE ext_name = '" . $this->db->sql_escape($name) . "'";
-		$this->db->sql_query($sql);
-
-		if ($this->cache)
-		{
-			$this->cache->purge();
-		}
-
-		return false;
+		return !$purged;
 	}
 
 	/**

--- a/tests/test_framework/phpbb_functional_test_case.php
+++ b/tests/test_framework/phpbb_functional_test_case.php
@@ -224,7 +224,7 @@ class phpbb_functional_test_case extends phpbb_test_case
 	{
 		global $phpbb_root_path, $phpEx;
 
-		$config = new \phpbb\config\config(array());
+		$config = new \phpbb\config\config(array('version' => '3.1.0'));
 		$db = $this->get_db();
 		$db_tools = new \phpbb\db\tools($db);
 


### PR DESCRIPTION
There are multiple identical queries in the extension manager, that can 
be made into a separate function, reused everywhere it is needed. 
Smaller code, and easier to maintain (single change to fix all uses).

Checklist:

- [x] Correct branch: master for new features; 3.2.x, 3.1.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master / 3.2.x](https://area51.phpbb.com/docs/master/coding-guidelines.html), [3.1.x](https://area51.phpbb.com/docs/31x/coding-guidelines.html)
- [x] Commit follows commit message [format](https://wiki.phpbb.com/Git#Commit_Messages)

Tracker ticket:

https://tracker.phpbb.com/browse/PHPBB3-15088
