### PR TITLE
[ticket/15097] Add PHP version to Board statistics

### DIFF
--- a/phpBB/adm/style/acp_main.html
+++ b/phpBB/adm/style/acp_main.html
@@ -169,7 +169,7 @@
 	</tr>
         <tr>
         <td>{L_PHP_VERSION}{L_COLON} </td>
-        <td><strong>{PHP_VERSION}</strong></td>
+        <td><strong>{PHP_VERSION_INFO}</strong></td>
     </tr>
 	<!-- ENDIF -->
 	</tbody>

--- a/phpBB/adm/style/acp_main.html
+++ b/phpBB/adm/style/acp_main.html
@@ -94,15 +94,45 @@
 
 	<!-- EVENT acp_main_notice_after -->
 
+	<table class="table1 no-header" style="width: auto;" data-no-responsive-header="true">
+		<caption>{L_SOFTWARE_HEADING}</caption>
+		<col class="col1" /><col class="col2" />
+	<thead>
+	<tr>
+		<th>{L_SOFTWARE_PRODUCT}</th>
+		<th>{L_SOFTWARE_VERSION}</th>
+	</tr>
+	</thead>
+	<tbody>
+	<tr>
+		<td>{L_BOARD_VERSION}</td>
+	<!-- IF S_VERSIONCHECK -->
+		<td><strong><a href="{U_VERSIONCHECK}" <!-- IF S_VERSION_UP_TO_DATE -->style="color: #228822;" <!-- ELSEIF not S_VERSIONCHECK_FAIL -->style="color: #BC2A4D;" <!-- ENDIF -->title="{L_MORE_INFORMATION}">{BOARD_VERSION}</a></strong> [&nbsp;<a href="{U_VERSIONCHECK_FORCE}">{L_VERSIONCHECK_FORCE_UPDATE}</a>&nbsp;]
+		</td>
+	<!-- ELSE -->
+		<td><strong>{BOARD_VERSION}</strong></td>
+	<!-- ENDIF -->
+	</tr>
+	<tr>
+		<td>{L_PHP_VERSION}</td>
+		<td><strong>{PHP_VERSION_INFO}</strong></td>
+	</tr>
+	<tr>
+		<td>{L_DATABASE_SERVER_INFO}</td>
+		<td><strong>{DATABASE_INFO}</strong></td>
+	</tr>
+	</tbody>
+	</table>
+
 	<table class="table1 two-columns no-header" data-no-responsive-header="true">
 		<caption>{L_FORUM_STATS}</caption>
 		<col class="col1" /><col class="col2" /><col class="col1" /><col class="col2" />
 	<thead>
 	<tr>
-		<th>{L_STATISTIC}</th>
-		<th>{L_VALUE}</th>
-		<th>{L_STATISTIC}</th>
-		<th>{L_VALUE}</th>
+		<th style="width: 25%">{L_STATISTIC}</th>
+		<th style="width: 25%">{L_VALUE}</th>
+		<th style="width: 25%">{L_STATISTIC}</th>
+		<th style="width: 25%">{L_VALUE}</th>
 	</tr>
 	</thead>
 	<tbody>
@@ -130,8 +160,6 @@
 		<td>{L_FILES_PER_DAY}{L_COLON} </td>
 		<td><strong>{FILES_PER_DAY}</strong></td>
 	</tr>
-
-
 	<tr>
 		<td>{L_BOARD_STARTED}{L_COLON} </td>
 		<td><strong>{START_DATE}</strong></td>
@@ -145,33 +173,16 @@
 		<td><strong>{UPLOAD_DIR_SIZE}</strong></td>
 	</tr>
 	<tr>
-		<td>{L_DATABASE_SERVER_INFO}{L_COLON} </td>
-		<td><strong>{DATABASE_INFO}</strong></td>
 		<td>{L_GZIP_COMPRESSION}{L_COLON} </td>
 		<td><strong>{GZIP_COMPRESSION}</strong></td>
-	</tr>
-	<!-- IF S_TOTAL_ORPHAN or S_VERSIONCHECK -->
-	<tr>
-	<!-- IF S_VERSIONCHECK -->
-		<td>{L_BOARD_VERSION}{L_COLON} </td>
-		<td>
-			<strong><a href="{U_VERSIONCHECK}" <!-- IF S_VERSION_UP_TO_DATE -->style="color: #228822;" <!-- ELSEIF not S_VERSIONCHECK_FAIL -->style="color: #BC2A4D;" <!-- ENDIF -->title="{L_MORE_INFORMATION}">{BOARD_VERSION}</a></strong> [&nbsp;<a href="{U_VERSIONCHECK_FORCE}">{L_VERSIONCHECK_FORCE_UPDATE}</a>&nbsp;]
-		</td>
-	<!-- ENDIF -->
 	<!-- IF S_TOTAL_ORPHAN -->
 		<td>{L_NUMBER_ORPHAN}{L_COLON} </td>
 		<td><strong>{TOTAL_ORPHAN}</strong></td>
-	<!-- ENDIF -->
-	<!-- IF not S_TOTAL_ORPHAN or not S_VERSIONCHECK -->
+	<!-- ELSE -->
 		<td>&nbsp;</td>
 		<td>&nbsp;</td>
 	<!-- ENDIF -->
 	</tr>
-        <tr>
-        <td>{L_PHP_VERSION}{L_COLON} </td>
-        <td><strong>{PHP_VERSION_INFO}</strong></td>
-    </tr>
-	<!-- ENDIF -->
 	</tbody>
 	</table>
 

--- a/phpBB/adm/style/acp_main.html
+++ b/phpBB/adm/style/acp_main.html
@@ -167,6 +167,10 @@
 		<td>&nbsp;</td>
 	<!-- ENDIF -->
 	</tr>
+        <tr>
+        <td>{L_PHP_VERSION}{L_COLON} </td>
+        <td><strong>{PHP_VERSION}</strong></td>
+    </tr>
 	<!-- ENDIF -->
 	</tbody>
 	</table>

--- a/phpBB/includes/acp/acp_main.php
+++ b/phpBB/includes/acp/acp_main.php
@@ -569,7 +569,7 @@ class acp_main
 			'S_TOTAL_ORPHAN'	=> ($total_orphan === false) ? false : true,
 			'GZIP_COMPRESSION'	=> ($config['gzip_compress'] && @extension_loaded('zlib')) ? $user->lang['ON'] : $user->lang['OFF'],
 			'DATABASE_INFO'		=> $db->sql_server_info(),
-            'PHP_VERSION'       => PHP_VERSION,
+            'PHP_VERSION_INFO'  => PHP_VERSION,
 			'BOARD_VERSION'		=> $config['version'],
 
 			'U_ACTION'			=> $this->u_action,

--- a/phpBB/includes/acp/acp_main.php
+++ b/phpBB/includes/acp/acp_main.php
@@ -569,6 +569,7 @@ class acp_main
 			'S_TOTAL_ORPHAN'	=> ($total_orphan === false) ? false : true,
 			'GZIP_COMPRESSION'	=> ($config['gzip_compress'] && @extension_loaded('zlib')) ? $user->lang['ON'] : $user->lang['OFF'],
 			'DATABASE_INFO'		=> $db->sql_server_info(),
+            'PHP_VERSION'       => PHP_VERSION,
 			'BOARD_VERSION'		=> $config['version'],
 
 			'U_ACTION'			=> $this->u_action,

--- a/phpBB/includes/acp/acp_main.php
+++ b/phpBB/includes/acp/acp_main.php
@@ -569,7 +569,7 @@ class acp_main
 			'S_TOTAL_ORPHAN'	=> ($total_orphan === false) ? false : true,
 			'GZIP_COMPRESSION'	=> ($config['gzip_compress'] && @extension_loaded('zlib')) ? $user->lang['ON'] : $user->lang['OFF'],
 			'DATABASE_INFO'		=> $db->sql_server_info(),
-            'PHP_VERSION_INFO'  => PHP_VERSION,
+			'PHP_VERSION_INFO'	=> PHP_VERSION,
 			'BOARD_VERSION'		=> $config['version'],
 
 			'U_ACTION'			=> $this->u_action,

--- a/phpBB/language/en/acp/common.php
+++ b/phpBB/language/en/acp/common.php
@@ -373,7 +373,7 @@ $lang = array_merge($lang, array(
 	'NUMBER_USERS'		=> 'Number of users',
 	'NUMBER_ORPHAN'		=> 'Orphan attachments',
 
-    'PHP_VERSION'       => 'PHP version',
+	'PHP_VERSION'		=> 'PHP version',
 	'PHP_VERSION_OLD'	=> 'The version of PHP on this server (%1$s) will no longer be supported by future versions of phpBB. The minimum required version will be PHP %2$s. %3$sDetails%4$s',
 
 	'POSTS_PER_DAY'		=> 'Posts per day',

--- a/phpBB/language/en/acp/common.php
+++ b/phpBB/language/en/acp/common.php
@@ -373,6 +373,7 @@ $lang = array_merge($lang, array(
 	'NUMBER_USERS'		=> 'Number of users',
 	'NUMBER_ORPHAN'		=> 'Orphan attachments',
 
+    'PHP_VERSION'       => 'PHP version',
 	'PHP_VERSION_OLD'	=> 'The version of PHP on this server (%1$s) will no longer be supported by future versions of phpBB. The minimum required version will be PHP %2$s. %3$sDetails%4$s',
 
 	'POSTS_PER_DAY'		=> 'Posts per day',

--- a/phpBB/language/en/acp/common.php
+++ b/phpBB/language/en/acp/common.php
@@ -345,7 +345,7 @@ $lang = array_merge($lang, array(
 	'AVATAR_DIR_SIZE'			=> 'Avatar directory size',
 
 	'BOARD_STARTED'		=> 'Board started',
-	'BOARD_VERSION'		=> 'Board version',
+	'BOARD_VERSION'		=> 'phpBB',
 
 	'DATABASE_SERVER_INFO'	=> 'Database server',
 	'DATABASE_SIZE'			=> 'Database size',
@@ -373,7 +373,7 @@ $lang = array_merge($lang, array(
 	'NUMBER_USERS'		=> 'Number of users',
 	'NUMBER_ORPHAN'		=> 'Orphan attachments',
 
-	'PHP_VERSION'		=> 'PHP version',
+	'PHP_VERSION'		=> 'PHP',
 	'PHP_VERSION_OLD'	=> 'The version of PHP on this server (%1$s) will no longer be supported by future versions of phpBB. The minimum required version will be PHP %2$s. %3$sDetails%4$s',
 
 	'POSTS_PER_DAY'		=> 'Posts per day',
@@ -407,6 +407,10 @@ $lang = array_merge($lang, array(
 	'RESYNC_STATS_EXPLAIN'			=> 'Recalculates the total number of posts, topics, users and files.',
 	'RESYNC_STATS_SUCCESS'			=> 'Resynchronised statistics',
 	'RUN'							=> 'Run now',
+
+	'SOFTWARE_HEADING'			=> 'Installed software',
+	'SOFTWARE_PRODUCT'			=> 'Product',
+	'SOFTWARE_VERSION'			=> 'Version',
 
 	'STATISTIC'					=> 'Statistic',
 	'STATISTIC_RESYNC_OPTIONS'	=> 'Resynchronise or reset statistics',


### PR DESCRIPTION
The ACP main page shows the phpBB version and the database version, but didn't show the PHP version. With this change the PHP version is displayed as part of the Board statistics.

Checklist:

- [x] Correct branch: master for new features; 3.2.x, 3.1.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master / 3.2.x](https://area51.phpbb.com/docs/master/coding-guidelines.html), [3.1.x](https://area51.phpbb.com/docs/31x/coding-guidelines.html)
- [x] Commit follows commit message [format](https://wiki.phpbb.com/Git#Commit_Messages)

Tracker ticket (set the ticket ID to **your ticket ID**):

https://tracker.phpbb.com/browse/PHPBB3-15097
