### PR TITLE
use pathinfo instead of strchr for $phpEx for better usability

### DIFF
--- a/phpBB/app.php
+++ b/phpBB/app.php
@@ -19,7 +19,7 @@
 */
 define('IN_PHPBB', true);
 $phpbb_root_path = (defined('PHPBB_ROOT_PATH')) ? PHPBB_ROOT_PATH : './';
-$phpEx = substr(strrchr(__FILE__, '.'), 1);
+$phpEx = pathinfo(__FILE__, PATHINFO_EXTENSION);
 include($phpbb_root_path . 'common.' . $phpEx);
 
 // Start session management

--- a/phpBB/config.php
+++ b/phpBB/config.php
@@ -1,0 +1,17 @@
+<?php
+// phpBB 3.2.x auto-generated configuration file
+// Do not change anything in this file!
+$dbms = 'phpbb\\db\\driver\\mysqli';
+$dbhost = 'localhost';
+$dbport = '';
+$dbname = 'forum';
+$dbuser = 'root';
+$dbpasswd = 'naveen17';
+$table_prefix = 'phpbb_';
+$phpbb_adm_relative_path = 'adm/';
+$acm_type = 'phpbb\\cache\\driver\\file';
+
+@define('PHPBB_INSTALLED', true);
+// @define('PHPBB_DISPLAY_LOAD_TIME', true);
+@define('PHPBB_ENVIRONMENT', 'production');
+// @define('DEBUG_CONTAINER', true);

--- a/phpBB/cron.php
+++ b/phpBB/cron.php
@@ -17,7 +17,7 @@ use Symfony\Component\HttpFoundation\RedirectResponse;
 */
 define('IN_PHPBB', true);
 $phpbb_root_path = (defined('PHPBB_ROOT_PATH')) ? PHPBB_ROOT_PATH : './';
-$phpEx = substr(strrchr(__FILE__, '.'), 1);
+$phpEx = pathinfo(__FILE__, PATHINFO_EXTENSION);
 include($phpbb_root_path . 'common.' . $phpEx);
 
 // Do not update users last page entry

--- a/phpBB/faq.php
+++ b/phpBB/faq.php
@@ -16,7 +16,7 @@
 */
 define('IN_PHPBB', true);
 $phpbb_root_path = (defined('PHPBB_ROOT_PATH')) ? PHPBB_ROOT_PATH : './';
-$phpEx = substr(strrchr(__FILE__, '.'), 1);
+$phpEx = pathinfo(__FILE__, PATHINFO_EXTENSION);
 include($phpbb_root_path . 'common.' . $phpEx);
 
 // Start session management

--- a/phpBB/feed.php
+++ b/phpBB/feed.php
@@ -24,7 +24,7 @@ use Symfony\Component\Routing\Exception\InvalidParameterException;
 **/
 define('IN_PHPBB', true);
 $phpbb_root_path = (defined('PHPBB_ROOT_PATH')) ? PHPBB_ROOT_PATH : './';
-$phpEx = substr(strrchr(__FILE__, '.'), 1);
+$phpEx = pathinfo(__FILE__, PATHINFO_EXTENSION);
 include($phpbb_root_path . 'common.' . $phpEx);
 
 /** @var \phpbb\controller\helper $controller_helper */

--- a/phpBB/index.php
+++ b/phpBB/index.php
@@ -19,7 +19,7 @@
 */
 define('IN_PHPBB', true);
 $phpbb_root_path = (defined('PHPBB_ROOT_PATH')) ? PHPBB_ROOT_PATH : './';
-$phpEx = substr(strrchr(__FILE__, '.'), 1);
+$phpEx = pathinfo(__FILE__, PATHINFO_EXTENSION);
 include($phpbb_root_path . 'common.' . $phpEx);
 include($phpbb_root_path . 'includes/functions_display.' . $phpEx);
 

--- a/phpBB/mcp.php
+++ b/phpBB/mcp.php
@@ -16,7 +16,7 @@
 */
 define('IN_PHPBB', true);
 $phpbb_root_path = (defined('PHPBB_ROOT_PATH')) ? PHPBB_ROOT_PATH : './';
-$phpEx = substr(strrchr(__FILE__, '.'), 1);
+$phpEx = pathinfo(__FILE__, PATHINFO_EXTENSION);
 include($phpbb_root_path . 'common.' . $phpEx);
 include($phpbb_root_path . 'includes/functions_admin.' . $phpEx);
 include($phpbb_root_path . 'includes/functions_mcp.' . $phpEx);

--- a/phpBB/memberlist.php
+++ b/phpBB/memberlist.php
@@ -16,7 +16,7 @@
 */
 define('IN_PHPBB', true);
 $phpbb_root_path = (defined('PHPBB_ROOT_PATH')) ? PHPBB_ROOT_PATH : './';
-$phpEx = substr(strrchr(__FILE__, '.'), 1);
+$phpEx = pathinfo(__FILE__, PATHINFO_EXTENSION);
 include($phpbb_root_path . 'common.' . $phpEx);
 include($phpbb_root_path . 'includes/functions_display.' . $phpEx);
 

--- a/phpBB/posting.php
+++ b/phpBB/posting.php
@@ -16,7 +16,7 @@
 */
 define('IN_PHPBB', true);
 $phpbb_root_path = (defined('PHPBB_ROOT_PATH')) ? PHPBB_ROOT_PATH : './';
-$phpEx = substr(strrchr(__FILE__, '.'), 1);
+$phpEx = pathinfo(__FILE__, PATHINFO_EXTENSION);
 include($phpbb_root_path . 'common.' . $phpEx);
 include($phpbb_root_path . 'includes/functions_posting.' . $phpEx);
 include($phpbb_root_path . 'includes/functions_display.' . $phpEx);

--- a/phpBB/report.php
+++ b/phpBB/report.php
@@ -18,7 +18,7 @@ use Symfony\Component\HttpFoundation\RedirectResponse;
 */
 define('IN_PHPBB', true);
 $phpbb_root_path = (defined('PHPBB_ROOT_PATH')) ? PHPBB_ROOT_PATH : './';
-$phpEx = substr(strrchr(__FILE__, '.'), 1);
+$phpEx = pathinfo(__FILE__, PATHINFO_EXTENSION);
 include($phpbb_root_path . 'common.' . $phpEx);
 
 // Start session management

--- a/phpBB/search.php
+++ b/phpBB/search.php
@@ -16,7 +16,7 @@
 */
 define('IN_PHPBB', true);
 $phpbb_root_path = (defined('PHPBB_ROOT_PATH')) ? PHPBB_ROOT_PATH : './';
-$phpEx = substr(strrchr(__FILE__, '.'), 1);
+$phpEx = pathinfo(__FILE__, PATHINFO_EXTENSION);
 include($phpbb_root_path . 'common.' . $phpEx);
 
 // Start session management

--- a/phpBB/ucp.php
+++ b/phpBB/ucp.php
@@ -16,7 +16,7 @@
 */
 define('IN_PHPBB', true);
 $phpbb_root_path = (defined('PHPBB_ROOT_PATH')) ? PHPBB_ROOT_PATH : './';
-$phpEx = substr(strrchr(__FILE__, '.'), 1);
+$phpEx = pathinfo(__FILE__, PATHINFO_EXTENSION);
 require($phpbb_root_path . 'common.' . $phpEx);
 require($phpbb_root_path . 'includes/functions_user.' . $phpEx);
 require($phpbb_root_path . 'includes/functions_module.' . $phpEx);

--- a/phpBB/viewforum.php
+++ b/phpBB/viewforum.php
@@ -16,7 +16,7 @@
 */
 define('IN_PHPBB', true);
 $phpbb_root_path = (defined('PHPBB_ROOT_PATH')) ? PHPBB_ROOT_PATH : './';
-$phpEx = substr(strrchr(__FILE__, '.'), 1);
+$phpEx = pathinfo(__FILE__, PATHINFO_EXTENSION);
 include($phpbb_root_path . 'common.' . $phpEx);
 include($phpbb_root_path . 'includes/functions_display.' . $phpEx);
 

--- a/phpBB/viewonline.php
+++ b/phpBB/viewonline.php
@@ -16,7 +16,7 @@
 */
 define('IN_PHPBB', true);
 $phpbb_root_path = (defined('PHPBB_ROOT_PATH')) ? PHPBB_ROOT_PATH : './';
-$phpEx = substr(strrchr(__FILE__, '.'), 1);
+$phpEx = pathinfo(__FILE__, PATHINFO_EXTENSION);
 include($phpbb_root_path . 'common.' . $phpEx);
 
 // Start session management

--- a/phpBB/viewtopic.php
+++ b/phpBB/viewtopic.php
@@ -16,7 +16,8 @@
 */
 define('IN_PHPBB', true);
 $phpbb_root_path = (defined('PHPBB_ROOT_PATH')) ? PHPBB_ROOT_PATH : './';
-$phpEx = substr(strrchr(__FILE__, '.'), 1);
+
+$phpEx = pathinfo(__FILE__, PATHINFO_EXTENSION);
 include($phpbb_root_path . 'common.' . $phpEx);
 include($phpbb_root_path . 'includes/functions_display.' . $phpEx);
 include($phpbb_root_path . 'includes/bbcode.' . $phpEx);


### PR DESCRIPTION
$phpEx hereafter uses PATHINFO_EXTENSION
strchr may fail if there is two extension like file.php.jpg
so pathinfo is used

Checklist:

- [x] Correct branch: master for new features; 3.2.x, 3.1.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master / 3.2.x](https://area51.phpbb.com/docs/master/coding-guidelines.html), [3.1.x](https://area51.phpbb.com/docs/31x/coding-guidelines.html)
- [x] Commit follows commit message [format](https://wiki.phpbb.com/Git#Commit_Messages)

Tracker ticket (set the ticket ID to **your ticket ID**):

https://tracker.phpbb.com/browse/PHPBB3-12345
