### PR TITLE
[ticket/15124] Hide navbar icon titles in repsonsive view

### DIFF
--- a/phpBB/styles/prosilver/theme/common.css
+++ b/phpBB/styles/prosilver/theme/common.css
@@ -1242,7 +1242,7 @@ ul.linklist:after,
 	margin: 0 7px 0 0;
 }
 
-.linklist.compact .rightside > a > span span {
+.linklist.compact .rightside > a > span {
 	display: none;
 }
 


### PR DESCRIPTION
3.2.x/master only.

Checklist:

- [x] Correct branch: master for new features; 3.2.x, 3.1.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master / 3.2.x](https://area51.phpbb.com/docs/master/coding-guidelines.html), [3.1.x](https://area51.phpbb.com/docs/31x/coding-guidelines.html)
- [x] Commit follows commit message [format](https://wiki.phpbb.com/Git#Commit_Messages)

<a href="https://tracker.phpbb.com/browse/PHPBB3-15124">PHPBB3-15124</a>.

Before the fix:
![responsive](https://cloud.githubusercontent.com/assets/212322/23834211/2d80492a-0785-11e7-93b3-1cebeccbda99.png)

After the fix:
![responsive1](https://cloud.githubusercontent.com/assets/212322/23834193/dd8a04ba-0784-11e7-901f-954bf931615b.png) ![responsive2](https://cloud.githubusercontent.com/assets/212322/23834192/d8bdca2a-0784-11e7-9083-da41ceae2fd3.png)
