### PR TITLE
[ticket/15126] Disable HTML entities in quote helper

### DIFF
--- a/phpBB/phpbb/textformatter/s9e/quote_helper.php
+++ b/phpBB/phpbb/textformatter/s9e/quote_helper.php
@@ -39,8 +39,8 @@ class quote_helper
 	*/
 	public function __construct(\phpbb\user $user, $root_path, $php_ext)
 	{
-		$this->post_url = append_sid($root_path . 'viewtopic.' . $php_ext, 'p={POST_ID}#p{POST_ID}');
-		$this->profile_url = append_sid($root_path . 'memberlist.' . $php_ext, 'mode=viewprofile&u={USER_ID}');
+		$this->post_url = append_sid($root_path . 'viewtopic.' . $php_ext, 'p={POST_ID}#p{POST_ID}', false);
+		$this->profile_url = append_sid($root_path . 'memberlist.' . $php_ext, 'mode=viewprofile&u={USER_ID}', false);
 		$this->user = $user;
 	}
 


### PR DESCRIPTION
I can't reproduce the issue, that's why there's no test case attached. Regardless, `append_sid()`'s third argument should be set to `false` since we don't want an HTML-encoded URL.

PHPBB3-15126

Checklist:

- [x] Correct branch: master for new features; 3.2.x, 3.1.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master / 3.2.x](https://area51.phpbb.com/docs/master/coding-guidelines.html), [3.1.x](https://area51.phpbb.com/docs/31x/coding-guidelines.html)
- [x] Commit follows commit message [format](https://wiki.phpbb.com/Git#Commit_Messages)

Tracker ticket (set the ticket ID to **your ticket ID**):

https://tracker.phpbb.com/browse/PHPBB3-15126
