### PR TITLE
[ticket/15139] Assigned 'topics_per_page' before template included

### DIFF
--- a/phpBB/viewforum.php
+++ b/phpBB/viewforum.php
@@ -148,6 +148,12 @@ else
 	}
 }
 
+// Is a forum specific topic count required?
+if ($forum_data['forum_topics_per_page'])
+{
+    $config['topics_per_page'] = $forum_data['forum_topics_per_page'];
+}
+
 /* @var $phpbb_content_visibility \phpbb\content_visibility */
 $phpbb_content_visibility = $phpbb_container->get('content.visibility');
 
@@ -210,12 +216,6 @@ if ($mark_read == 'topics')
 	}
 
 	trigger_error($user->lang['TOPICS_MARKED'] . '<br /><br />' . sprintf($user->lang['RETURN_FORUM'], '<a href="' . $redirect_url . '">', '</a>'));
-}
-
-// Is a forum specific topic count required?
-if ($forum_data['forum_topics_per_page'])
-{
-    $config['topics_per_page'] = $forum_data['forum_topics_per_page'];
 }
 
 // Do the forum Prune thang - cron type job ...

--- a/phpBB/viewforum.php
+++ b/phpBB/viewforum.php
@@ -148,6 +148,12 @@ else
 	}
 }
 
+// Is a forum specific topic count required?
+if ($forum_data['forum_topics_per_page'])
+{
+    $config['topics_per_page'] = $forum_data['forum_topics_per_page'];
+}
+
 /* @var $phpbb_content_visibility \phpbb\content_visibility */
 $phpbb_content_visibility = $phpbb_container->get('content.visibility');
 
@@ -210,12 +216,6 @@ if ($mark_read == 'topics')
 	}
 
 	trigger_error($user->lang['TOPICS_MARKED'] . '<br /><br />' . sprintf($user->lang['RETURN_FORUM'], '<a href="' . $redirect_url . '">', '</a>'));
-}
-
-// Is a forum specific topic count required?
-if ($forum_data['forum_topics_per_page'])
-{
-	$config['topics_per_page'] = $forum_data['forum_topics_per_page'];
 }
 
 // Do the forum Prune thang - cron type job ...

--- a/phpBB/viewforum.php
+++ b/phpBB/viewforum.php
@@ -148,12 +148,6 @@ else
 	}
 }
 
-// Is a forum specific topic count required?
-if ($forum_data['forum_topics_per_page'])
-{
-    $config['topics_per_page'] = $forum_data['forum_topics_per_page'];
-}
-
 /* @var $phpbb_content_visibility \phpbb\content_visibility */
 $phpbb_content_visibility = $phpbb_container->get('content.visibility');
 
@@ -216,6 +210,12 @@ if ($mark_read == 'topics')
 	}
 
 	trigger_error($user->lang['TOPICS_MARKED'] . '<br /><br />' . sprintf($user->lang['RETURN_FORUM'], '<a href="' . $redirect_url . '">', '</a>'));
+}
+
+// Is a forum specific topic count required?
+if ($forum_data['forum_topics_per_page'])
+{
+    $config['topics_per_page'] = $forum_data['forum_topics_per_page'];
 }
 
 // Do the forum Prune thang - cron type job ...


### PR DESCRIPTION

The element $config['topics_per_page'] was assigned a value after the
template was included, which led to incorrect page number display in the
header when pagination.
Now this var is assigned the correct value before the template is included

PHPBB3-15139

Checklist:

- [x] Correct branch: master for new features; 3.2.x, 3.1.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master / 3.2.x](https://area51.phpbb.com/docs/master/coding-guidelines.html), [3.1.x](https://area51.phpbb.com/docs/31x/coding-guidelines.html)
- [x] Commit follows commit message [format](https://wiki.phpbb.com/Git#Commit_Messages)

Tracker ticket (set the ticket ID to **your ticket ID**):

https://tracker.phpbb.com/browse/PHPBB3-15139
