### PR TITLE
[ticket/14987] Board closed error message can contain valid HTML

### DIFF
--- a/phpBB/phpbb/user.php
+++ b/phpBB/phpbb/user.php
@@ -354,7 +354,7 @@ class user extends \phpbb\session
 			{
 				$message = (!empty($config['board_disable_msg'])) ? $config['board_disable_msg'] : 'BOARD_DISABLE';
 			}
-			trigger_error($message);
+			trigger_error(html_entity_decode($message));
 		}
 
 		// Is board disabled and user not an admin or moderator?
@@ -366,7 +366,7 @@ class user extends \phpbb\session
 			}
 
 			$message = (!empty($config['board_disable_msg'])) ? $config['board_disable_msg'] : 'BOARD_DISABLE';
-			trigger_error($message);
+			trigger_error(html_entity_decode($message));
 		}
 
 		// Is load exceeded?


### PR DESCRIPTION
Adds ability to add HTML formatting to board closed error messages by
adding html_entities_decode function
before displaying the board error message.

PHPBB3-14987

Checklist:

- [ ] Correct branch: master for new features; 3.2.x, 3.1.x for fixes
- [ ] Tests pass
- [ ] Code follows coding guidelines: [master / 3.2.x](https://area51.phpbb.com/docs/master/coding-guidelines.html), [3.1.x](https://area51.phpbb.com/docs/31x/coding-guidelines.html)
- [ ] Commit follows commit message [format](https://wiki.phpbb.com/Git#Commit_Messages)

Tracker ticket (set the ticket ID to **14987**):

https://tracker.phpbb.com/browse/PHPBB3-14987
