### PR TITLE
[ticket/13735] Fix input type number for Firefox in prosilver

### DIFF
--- a/phpBB/styles/prosilver/theme/forms.css
+++ b/phpBB/styles/prosilver/theme/forms.css
@@ -288,7 +288,7 @@ textarea.inputbox {
 }
 
 input[type="number"] {
-	-moz-padding-end: inherit;
+	-moz-padding-end: 0;
 }
 
 input[type="search"] {


### PR DESCRIPTION
Use the same CSS already used in the ACP: 
https://github.com/phpbb/phpbb/blob/3.1.x/phpBB/adm/style/admin.css#L1143

This way, input type number show correctly on Firefox.

Checklist:

- [x] Correct branch: master for new features; 3.2.x, 3.1.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master / 3.2.x](https://area51.phpbb.com/docs/master/coding-guidelines.html), [3.1.x](https://area51.phpbb.com/docs/31x/coding-guidelines.html)
- [x] Commit follows commit message [format](https://wiki.phpbb.com/Git#Commit_Messages)

Tracker ticket:

https://tracker.phpbb.com/browse/PHPBB3-13735
