### PR TITLE
[ticket/15011] Use exception interface for 3.2

### DIFF
--- a/phpBB/includes/acp/acp_extensions.php
+++ b/phpBB/includes/acp/acp_extensions.php
@@ -106,7 +106,7 @@ class acp_extensions
 			catch (exception_interface $e)
 			{
 				$message = call_user_func_array(array($this->user, 'lang'), array_merge(array($e->getMessage()), $e->get_parameters()));
-				trigger_error($message, E_USER_WARNING);
+				trigger_error($message . adm_back_link($this->u_action), E_USER_WARNING);
 			}
 		}
 
@@ -161,7 +161,7 @@ class acp_extensions
 				{
 					$md_manager->validate_enable();
 				}
-				catch (\phpbb\extension\exception $e)
+				catch (exception_interface $e)
 				{
 					$message = call_user_func_array(array($this->user, 'lang'), array_merge(array($e->getMessage()), $e->get_parameters()));
 					trigger_error($message . adm_back_link($this->u_action), E_USER_WARNING);
@@ -192,7 +192,7 @@ class acp_extensions
 				{
 					$md_manager->validate_enable();
 				}
-				catch (\phpbb\extension\exception $e)
+				catch (exception_interface $e)
 				{
 					$message = call_user_func_array(array($this->user, 'lang'), array_merge(array($e->getMessage()), $e->get_parameters()));
 					trigger_error($message . adm_back_link($this->u_action), E_USER_WARNING);


### PR DESCRIPTION
Update the mentioned ticket to 3.2 by using exception_inteface
instead of the actual exception class.
Also, use adm_back_link consistently.

PHPBB3-15011

Checklist:

- [x] Correct branch: master for new features; 3.2.x, 3.1.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master / 3.2.x](https://area51.phpbb.com/docs/master/coding-guidelines.html), [3.1.x](https://area51.phpbb.com/docs/31x/coding-guidelines.html)
- [x] Commit follows commit message [format](https://wiki.phpbb.com/Git#Commit_Messages)

Tracker ticket:

https://tracker.phpbb.com/browse/PHPBB3-15011
