### PR TITLE
[ticket/15190] Consolidate validation methods in metadata manager

### DIFF
--- a/phpBB/includes/acp/acp_extensions.php
+++ b/phpBB/includes/acp/acp_extensions.php
@@ -101,7 +101,7 @@ class acp_extensions
 
 			try
 			{
-				$md_manager->get_metadata('all');
+				$md_manager->validate();
 			}
 			catch (exception_interface $e)
 			{

--- a/phpBB/includes/acp/acp_extensions.php
+++ b/phpBB/includes/acp/acp_extensions.php
@@ -321,33 +321,32 @@ class acp_extensions
 				$meta = $md_manager->get_metadata('all');
 				$this->output_metadata_to_template($meta);
 
-				if (isset($meta['extra']['version-check']))
+				try
 				{
-					try
+					$updates_available = $this->ext_manager->version_check($md_manager, $this->request->variable('versioncheck_force', false), false, $this->config['extension_force_unstable'] ? 'unstable' : null);
+
+					$this->template->assign_vars(array(
+						'S_VERSIONCHECK' => true,
+						'S_UP_TO_DATE' => empty($updates_available),
+						'UP_TO_DATE_MSG' => $this->user->lang(empty($updates_available) ? 'UP_TO_DATE' : 'NOT_UP_TO_DATE', $md_manager->get_metadata('display-name')),
+					));
+
+					$this->template->assign_block_vars('updates_available', $updates_available);
+				}
+				catch (exception_interface $e)
+				{
+					if ($e->getMessage() === 'NO_VERSIONCHECK')
 					{
-						$updates_available = $this->ext_manager->version_check($md_manager, $this->request->variable('versioncheck_force', false), false, $this->config['extension_force_unstable'] ? 'unstable' : null);
-
-						$this->template->assign_vars(array(
-							'S_UP_TO_DATE' => empty($updates_available),
-							'UP_TO_DATE_MSG' => $this->user->lang(empty($updates_available) ? 'UP_TO_DATE' : 'NOT_UP_TO_DATE', $md_manager->get_metadata('display-name')),
-						));
-
-						$this->template->assign_block_vars('updates_available', $updates_available);
+						$this->template->assign_var('S_VERSIONCHECK', false);
 					}
-					catch (exception_interface $e)
+					else
 					{
 						$message = call_user_func_array(array($this->user, 'lang'), array_merge(array($e->getMessage()), $e->get_parameters()));
-
 						$this->template->assign_vars(array(
 							'S_VERSIONCHECK_FAIL' => true,
 							'VERSIONCHECK_FAIL_REASON' => ($e->getMessage() !== 'VERSIONCHECK_FAIL') ? $message : '',
 						));
 					}
-					$this->template->assign_var('S_VERSIONCHECK', true);
-				}
-				else
-				{
-					$this->template->assign_var('S_VERSIONCHECK', false);
 				}
 
 				$this->template->assign_vars(array(
@@ -396,40 +395,36 @@ class acp_extensions
 
 			try
 			{
-				$meta = $md_manager->get_metadata('all');
 				$enabled_extension_meta_data[$name] = array(
 					'META_DISPLAY_NAME' => $md_manager->get_metadata('display-name'),
-					'META_VERSION' => $meta['version'],
+					'META_VERSION' => $md_manager->get_metadata('version'),
 				);
 
-				if (isset($meta['extra']['version-check']))
-				{
-					try
-					{
-						$force_update = $this->request->variable('versioncheck_force', false);
-						$updates = $this->ext_manager->version_check($md_manager, $force_update, !$force_update);
+				$force_update = $this->request->variable('versioncheck_force', false);
+				$updates = $this->ext_manager->version_check($md_manager, $force_update, !$force_update);
 
-						$enabled_extension_meta_data[$name]['S_UP_TO_DATE'] = empty($updates);
-						$enabled_extension_meta_data[$name]['S_VERSIONCHECK'] = true;
-						$enabled_extension_meta_data[$name]['U_VERSIONCHECK_FORCE'] = $this->u_action . '&amp;action=details&amp;versioncheck_force=1&amp;ext_name=' . urlencode($md_manager->get_metadata('name'));
-					}
-					catch (exception_interface $e)
-					{
-						// Ignore exceptions due to the version check
-					}
-				}
-				else
-				{
-					$enabled_extension_meta_data[$name]['S_VERSIONCHECK'] = false;
-				}
+				$enabled_extension_meta_data[$name]['S_UP_TO_DATE'] = empty($updates);
+				$enabled_extension_meta_data[$name]['S_VERSIONCHECK'] = true;
+				$enabled_extension_meta_data[$name]['U_VERSIONCHECK_FORCE'] = $this->u_action . '&amp;action=details&amp;versioncheck_force=1&amp;ext_name=' . urlencode($md_manager->get_metadata('name'));
+			}
+			catch (version_check_exception $e)
+			{
+				$enabled_extension_meta_data[$name]['S_VERSIONCHECK'] = false;
 			}
 			catch (exception_interface $e)
 			{
-				$message = call_user_func_array(array($this->user, 'lang'), array_merge(array($e->getMessage()), $e->get_parameters()));
-				$this->template->assign_block_vars('disabled', array(
-					'META_DISPLAY_NAME'		=> $this->user->lang('EXTENSION_INVALID_LIST', $name, $message),
-					'S_VERSIONCHECK'		=> false,
-				));
+				if ($e->getMessage() === 'NO_VERSIONCHECK')
+				{
+					$enabled_extension_meta_data[$name]['S_VERSIONCHECK'] = false;
+				}
+				else
+				{
+					$message = call_user_func_array(array($this->user, 'lang'), array_merge(array($e->getMessage()), $e->get_parameters()));
+					$this->template->assign_block_vars('disabled', array(
+						'META_DISPLAY_NAME'		=> $this->user->lang('EXTENSION_INVALID_LIST', $name, $message),
+						'S_VERSIONCHECK'		=> false,
+					));
+				}
 			}
 			catch (\RuntimeException $e)
 			{
@@ -467,25 +462,17 @@ class acp_extensions
 
 			try
 			{
-				$meta = $md_manager->get_metadata('all');
 				$disabled_extension_meta_data[$name] = array(
 					'META_DISPLAY_NAME' => $md_manager->get_metadata('display-name'),
-					'META_VERSION' => $meta['version'],
+					'META_VERSION' => $md_manager->get_metadata('version'),
 				);
 
-				if (isset($meta['extra']['version-check']))
-				{
-					$force_update = $this->request->variable('versioncheck_force', false);
-					$updates = $this->ext_manager->version_check($md_manager, $force_update, !$force_update);
+				$force_update = $this->request->variable('versioncheck_force', false);
+				$updates = $this->ext_manager->version_check($md_manager, $force_update, !$force_update);
 
-					$disabled_extension_meta_data[$name]['S_UP_TO_DATE'] = empty($updates);
-					$disabled_extension_meta_data[$name]['S_VERSIONCHECK'] = true;
-					$disabled_extension_meta_data[$name]['U_VERSIONCHECK_FORCE'] = $this->u_action . '&amp;action=details&amp;versioncheck_force=1&amp;ext_name=' . urlencode($md_manager->get_metadata('name'));
-				}
-				else
-				{
-					$disabled_extension_meta_data[$name]['S_VERSIONCHECK'] = false;
-				}
+				$disabled_extension_meta_data[$name]['S_UP_TO_DATE'] = empty($updates);
+				$disabled_extension_meta_data[$name]['S_VERSIONCHECK'] = true;
+				$disabled_extension_meta_data[$name]['U_VERSIONCHECK_FORCE'] = $this->u_action . '&amp;action=details&amp;versioncheck_force=1&amp;ext_name=' . urlencode($md_manager->get_metadata('name'));
 			}
 			catch (version_check_exception $e)
 			{
@@ -493,11 +480,18 @@ class acp_extensions
 			}
 			catch (exception_interface $e)
 			{
-				$message = call_user_func_array(array($this->user, 'lang'), array_merge(array($e->getMessage()), $e->get_parameters()));
-				$this->template->assign_block_vars('disabled', array(
-					'META_DISPLAY_NAME'		=> $this->user->lang('EXTENSION_INVALID_LIST', $name, $message),
-					'S_VERSIONCHECK'		=> false,
-				));
+				if ($e->getMessage() === 'NO_VERSIONCHECK')
+				{
+					$disabled_extension_meta_data[$name]['S_VERSIONCHECK'] = false;
+				}
+				else
+				{
+					$message = call_user_func_array(array($this->user, 'lang'), array_merge(array($e->getMessage()), $e->get_parameters()));
+					$this->template->assign_block_vars('disabled', array(
+						'META_DISPLAY_NAME'		=> $this->user->lang('EXTENSION_INVALID_LIST', $name, $message),
+						'S_VERSIONCHECK'		=> false,
+					));
+				}
 			}
 			catch (\RuntimeException $e)
 			{
@@ -538,25 +532,17 @@ class acp_extensions
 
 			try
 			{
-				$meta = $md_manager->get_metadata('all');
 				$available_extension_meta_data[$name] = array(
 					'META_DISPLAY_NAME' => $md_manager->get_metadata('display-name'),
-					'META_VERSION' => $meta['version'],
+					'META_VERSION' => $md_manager->get_metadata('version'),
 				);
 
-				if (isset($meta['extra']['version-check']))
-				{
-					$force_update = $this->request->variable('versioncheck_force', false);
-					$updates = $this->ext_manager->version_check($md_manager, $force_update, !$force_update);
+				$force_update = $this->request->variable('versioncheck_force', false);
+				$updates = $this->ext_manager->version_check($md_manager, $force_update, !$force_update);
 
-					$available_extension_meta_data[$name]['S_UP_TO_DATE'] = empty($updates);
-					$available_extension_meta_data[$name]['S_VERSIONCHECK'] = true;
-					$available_extension_meta_data[$name]['U_VERSIONCHECK_FORCE'] = $this->u_action . '&amp;action=details&amp;versioncheck_force=1&amp;ext_name=' . urlencode($md_manager->get_metadata('name'));
-				}
-				else
-				{
-					$available_extension_meta_data[$name]['S_VERSIONCHECK'] = false;
-				}
+				$available_extension_meta_data[$name]['S_UP_TO_DATE'] = empty($updates);
+				$available_extension_meta_data[$name]['S_VERSIONCHECK'] = true;
+				$available_extension_meta_data[$name]['U_VERSIONCHECK_FORCE'] = $this->u_action . '&amp;action=details&amp;versioncheck_force=1&amp;ext_name=' . urlencode($md_manager->get_metadata('name'));
 			}
 			catch (version_check_exception $e)
 			{
@@ -564,11 +550,22 @@ class acp_extensions
 			}
 			catch (exception_interface $e)
 			{
-				$message = call_user_func_array(array($this->user, 'lang'), array_merge(array($e->getMessage()), $e->get_parameters()));
-				$this->template->assign_block_vars('disabled', array(
-					'META_DISPLAY_NAME'		=> $this->user->lang('EXTENSION_INVALID_LIST', $name, $message),
-					'S_VERSIONCHECK'		=> false,
-				));
+				if ($e->getMessage() === 'NO_VERSIONCHECK')
+				{
+					$available_extension_meta_data[$name]['S_VERSIONCHECK'] = false;
+				}
+				else
+				{
+					$message = call_user_func_array(array($this->user, 'lang'), array_merge(array($e->getMessage()), $e->get_parameters()));
+					$this->template->assign_block_vars('disabled', array(
+						'META_DISPLAY_NAME'		=> $this->user->lang('EXTENSION_INVALID_LIST', $name, $message),
+						'S_VERSIONCHECK'		=> false,
+					));
+				}
+			}
+			catch (\RuntimeException $e)
+			{
+				$available_extension_meta_data[$name]['S_VERSIONCHECK'] = false;
 			}
 		}
 

--- a/phpBB/phpbb/extension/manager.php
+++ b/phpBB/phpbb/extension/manager.php
@@ -580,17 +580,17 @@ class manager
 	*/
 	public function version_check(\phpbb\extension\metadata_manager $md_manager, $force_update = false, $force_cache = false, $stability = null)
 	{
-		$meta = $md_manager->get_metadata('all');
-
-		if (!isset($meta['extra']['version-check']))
+		try
+		{
+			$version_check = $md_manager->get_metadata('version-check');
+		}
+		catch (\phpbb\extension\exception $e)
 		{
 			throw new runtime_exception('NO_VERSIONCHECK');
 		}
 
-		$version_check = $meta['extra']['version-check'];
-
 		$version_helper = new \phpbb\version_helper($this->cache, $this->config, new file_downloader());
-		$version_helper->set_current_version($meta['version']);
+		$version_helper->set_current_version($version_check['current_version']);
 		$version_helper->set_file_location($version_check['host'], $version_check['directory'], $version_check['filename'], isset($version_check['ssl']) ? $version_check['ssl'] : false);
 		$version_helper->force_stability($stability);
 

--- a/phpBB/phpbb/extension/manager.php
+++ b/phpBB/phpbb/extension/manager.php
@@ -522,10 +522,9 @@ class manager
 	*/
 	public function is_available($name)
 	{
-		$md_manager = $this->create_extension_metadata_manager($name);
 		try
 		{
-			return $md_manager->get_metadata('all') && $md_manager->validate_enable();
+			return $this->create_extension_metadata_manager($name)->validate('all');
 		}
 		catch (\phpbb\extension\exception $e)
 		{

--- a/phpBB/phpbb/extension/metadata_manager.php
+++ b/phpBB/phpbb/extension/metadata_manager.php
@@ -203,6 +203,7 @@ class metadata_manager
 	*
 	* @return boolean True when passes validation, throws exception if invalid
 	* @throws \phpbb\extension\exception
+	* @internal		Should not be used directly. As of phpBB 4.0, the method will become protected.
 	*/
 	public function validate_authors()
 	{
@@ -227,6 +228,7 @@ class metadata_manager
 	*
 	* @return bool True if validation succeeded, throws an exception if invalid
 	* @throws \phpbb\extension\exception
+	* @internal		Should not be used directly. As of phpBB 4.0, the method will become protected.
 	*/
 	public function validate_enable()
 	{
@@ -239,6 +241,7 @@ class metadata_manager
 	*
 	* @return boolean True when passes validation, throws an exception if invalid
 	* @throws \phpbb\extension\exception
+	* @internal		Should not be used directly. As of phpBB 4.0, the method will become protected.
 	*/
 	public function validate_dir()
 	{
@@ -256,6 +259,7 @@ class metadata_manager
 	*
 	* @return boolean True when passes validation, throws an exception if invalid
 	* @throws \phpbb\extension\exception
+	* @internal		Should not be used directly. As of phpBB 4.0, the method will become protected.
 	*/
 	public function validate_require_phpbb()
 	{
@@ -272,6 +276,7 @@ class metadata_manager
 	*
 	* @return boolean True when passes validation, throws an exception if invalid
 	* @throws \phpbb\extension\exception
+	* @internal		Should not be used directly. As of phpBB 4.0, the method will become protected.
 	*/
 	public function validate_require_php()
 	{

--- a/phpBB/phpbb/extension/metadata_manager.php
+++ b/phpBB/phpbb/extension/metadata_manager.php
@@ -61,11 +61,13 @@ class metadata_manager
 			'enable'		=> ['dir', 'require_php', 'require_phpbb'],
 			'display'		=> ['fields', 'authors'],
 			'fields'		=> ['name', 'type', 'license', 'version'],
+			'version-check'	=> ['version', 'version_check'],
 			// Methods
 			'authors'		=> null,
 			'dir'			=> null,
 			'require_php'	=> null,
 			'require_phpbb'	=> null,
+			'version_check'	=> null,
 			// Fields
 			'name'			=> '#^[a-zA-Z0-9_\x7f-\xff]{2,}/[a-zA-Z0-9_\x7f-\xff]{2,}$#',
 			'type'			=> '#^phpbb-extension$#',
@@ -105,6 +107,11 @@ class metadata_manager
 
 			case 'display-name':
 				return (isset($this->metadata['extra']['display-name'])) ? $this->metadata['extra']['display-name'] : $this->get_metadata('name');
+			break;
+
+			case 'version-check':
+				$this->validate($element);
+				return array_merge(array('current_version' => $this->metadata['version']), $this->metadata['extra']['version-check']);
 			break;
 		}
 	}
@@ -283,6 +290,25 @@ class metadata_manager
 		if (!isset($this->metadata['require']['php']))
 		{
 			throw new \phpbb\extension\exception('META_FIELD_NOT_SET', array('require php'));
+		}
+
+		return true;
+	}
+
+	/**
+	* Validates the version check information
+	*
+	* @return boolean True when passes validation, throws an exception if invalid
+	* @throws \phpbb\extension\exception
+	*/
+	protected function validate_version_check()
+	{
+		if (!isset($this->metadata['extra']['version-check']) ||
+			!isset($this->metadata['extra']['version-check']['host']) ||
+			!isset($this->metadata['extra']['version-check']['directory']) ||
+			!isset($this->metadata['extra']['version-check']['filename']))
+		{
+			throw new \phpbb\extension\exception('NO_VERSIONCHECK');
 		}
 
 		return true;

--- a/phpBB/phpbb/extension/metadata_manager.php
+++ b/phpBB/phpbb/extension/metadata_manager.php
@@ -53,7 +53,8 @@ class metadata_manager
 	* Processes and gets the metadata requested
 	*
 	* @param  string $element			All for all metadata that it has and is valid, otherwise specify which section you want by its shorthand term.
-	* @return array					Contains all of the requested metadata, throws an exception on failure
+	* @return mixed						Array containing all of the requested metadata or string for specific metadata elements, throws an exception on failure
+	* @throws \phpbb\extension\exception
 	*/
 	public function get_metadata($element = 'all')
 	{
@@ -124,8 +125,9 @@ class metadata_manager
 	* Validate fields
 	*
 	* @param string $name  ("all" for display and enable validation
-	* 						"display" for name, type, and authors
-	* 						"name", "type")
+	* 						"display" for name, type, license, version and authors
+	* 						"name", "type", "license", "version" according to format
+	*						"authors", "enable", "dir", "require_php", "require_phpbb" as proxy)
 	* @return Bool True if valid, throws an exception if invalid
 	* @throws \phpbb\extension\exception
 	*/
@@ -139,6 +141,12 @@ class metadata_manager
 			'version'	=> '#.+#',
 		);
 
+		// Fetch and clean the metadata if not done yet
+		if ($this->metadata === array())
+		{
+			$this->fetch_metadata_from_file();
+		}
+
 		switch ($name)
 		{
 			case 'all':
@@ -150,8 +158,18 @@ class metadata_manager
 				{
 					$this->validate($field);
 				}
+			// no break
 
+			case 'authors':
 				$this->validate_authors();
+			break;
+
+			// Proxy for other validation methods
+			case 'enable':
+			case 'dir':
+			case 'require_php':
+			case 'require_phpbb':
+				return $this->{'validate_' . $name}();
 			break;
 
 			default:

--- a/phpBB/phpbb/extension/metadata_manager.php
+++ b/phpBB/phpbb/extension/metadata_manager.php
@@ -40,22 +40,7 @@ class metadata_manager
 	* List of validations
 	* @var array
 	*/
-	protected $validations;
-
-	/**
-	* Creates the metadata manager
-	*
-	* @param string				$ext_name			Name (including vendor) of the extension
-	* @param string				$ext_path			Path to the extension directory including root path
-	*/
-	public function __construct($ext_name, $ext_path)
-	{
-		$this->ext_name = $ext_name;
-		$this->metadata = array();
-		$this->metadata_file = $ext_path . 'composer.json';
-
-		// Initialize validations
-		$this->validations = array(
+	static protected $validations = array(
 			// Combined
 			'all'			=> ['enable', 'display'],
 			'enable'		=> ['dir', 'require_php', 'require_phpbb'],
@@ -74,6 +59,18 @@ class metadata_manager
 			'license'		=> '#.+#',
 			'version'		=> '#.+#',
 		);
+
+	/**
+	* Creates the metadata manager
+	*
+	* @param string				$ext_name			Name (including vendor) of the extension
+	* @param string				$ext_path			Path to the extension directory including root path
+	*/
+	public function __construct($ext_name, $ext_path)
+	{
+		$this->ext_name = $ext_name;
+		$this->metadata = array();
+		$this->metadata_file = $ext_path . 'composer.json';
 	}
 
 	/**
@@ -172,9 +169,9 @@ class metadata_manager
 		}
 
 		// If there is a validation set, validate
-		if (isset($this->validations[$name]))
+		if (array_key_exists($name, self::$validations))
 		{
-			$validation = $this->validations[$name];
+			$validation = self::$validations[$name];
 			// Validate via a specific validation method
 			if ($validation === null)
 			{


### PR DESCRIPTION
Use a single method to access all validation options in metadata manager. Before, some validations had their own function, while others shared a single validate method. Now, the validate method acts as a proxy for all others.
Also, with the existing implementation, you should not call validate without calling get_metadata first, as get_metadata was the only way to do the file loading (any call to validate without calling get_metadata first would result in an exception being raised even if the metadata is correct); with this change, the order is irrelevant, and the file is only loaded once.  Some uses of get_metadata that were not using the returned data have been replaced with the corresponding validate call.

Checklist:

- [x] Correct branch: master for new features; 3.2.x, 3.1.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master / 3.2.x](https://area51.phpbb.com/docs/master/coding-guidelines.html), [3.1.x](https://area51.phpbb.com/docs/31x/coding-guidelines.html)
- [x] Commit follows commit message [format](https://wiki.phpbb.com/Git#Commit_Messages)

Tracker ticket:

https://tracker.phpbb.com/browse/PHPBB3-15190

