### PR TITLE
[ticket/15187] Add paths of newly enabled extensions to template

### DIFF
--- a/phpBB/includes/acp/acp_extensions.php
+++ b/phpBB/includes/acp/acp_extensions.php
@@ -214,7 +214,7 @@ class acp_extensions
 					}
 
 					// Update custom style for admin area
-					$template->set_custom_style(array(
+					$this->template->set_custom_style(array(
 						array(
 							'name' 		=> 'adm',
 							'ext_path' 	=> 'adm/style/',

--- a/phpBB/includes/acp/acp_extensions.php
+++ b/phpBB/includes/acp/acp_extensions.php
@@ -212,6 +212,15 @@ class acp_extensions
 							meta_refresh(0, $this->u_action . '&amp;action=enable&amp;ext_name=' . urlencode($ext_name) . '&amp;hash=' . generate_link_hash('enable.' . $ext_name));
 						}
 					}
+
+					// Update custom style for admin area
+					$template->set_custom_style(array(
+						array(
+							'name' 		=> 'adm',
+							'ext_path' 	=> 'adm/style/',
+						),
+					), array($phpbb_root_path . 'adm/style'));
+
 					$this->log->add('admin', $this->user->data['user_id'], $this->user->ip, 'LOG_EXT_ENABLE', time(), array($ext_name));
 				}
 				catch (\phpbb\db\migration\exception $e)

--- a/phpBB/phpbb/extension/manager.php
+++ b/phpBB/phpbb/extension/manager.php
@@ -227,8 +227,6 @@ class manager
 		if ($active)
 		{
 			$this->config->increment('assets_version', 1);
-
-			$this->update_template_paths($name);
 		}
 
 		return !$active;
@@ -590,40 +588,5 @@ class manager
 			$finder->set_extensions(array_keys($this->all_enabled()));
 		}
 		return $finder;
-	}
-
-	/**
-	* Make the template aware of ACP template events of a newly enabled extension
-	*
-	* @param string $name The extension's name
-	* @return null
-	*/
-	protected function update_template_paths($name)
-	{
-		if (!$this->container->has('template'))
-		{
-			return;
-		}
-
-		$possible_paths = array(
-			$this->phpbb_root_path . 'ext/' . $name . '/adm/style',
-			$this->phpbb_root_path . 'ext/' . $name . '/styles',
-		);
-
-		$paths = array_filter($possible_paths, 'is_dir');
-
-		if ($paths)
-		{
-			$names = array(
-				array(
-					'name' 		=> 'adm',
-					'ext_path' 	=> 'adm/style/',
-				),
-			);
-
-			$paths[] = $this->phpbb_root_path . 'adm/style';
-
-			$this->container->get('template')->set_custom_style($names, $paths);
-		}
 	}
 }

--- a/phpBB/phpbb/extension/manager.php
+++ b/phpBB/phpbb/extension/manager.php
@@ -227,6 +227,8 @@ class manager
 		if ($active)
 		{
 			$this->config->increment('assets_version', 1);
+
+			$this->update_template_paths($name, $this->container->get('template'));
 		}
 
 		return !$active;
@@ -588,5 +590,39 @@ class manager
 			$finder->set_extensions(array_keys($this->all_enabled()));
 		}
 		return $finder;
+	}
+
+	/**
+	* Make the template aware of ACP template events of a newly enabled extension
+	*
+	* @param string						$name		The extension's name
+	* @param \phpbb\template\base|null	$template	The template service
+	* @return null
+	*/
+	protected function update_template_paths($name, \phpbb\template\base $template = null)
+	{
+		if ($template instanceof \phpbb\template\base)
+		{
+			$possible_paths = array(
+				$this->phpbb_root_path . 'ext/' . $name . '/adm/style',
+				$this->phpbb_root_path . 'ext/' . $name . '/styles',
+			);
+
+			$paths = array_filter($possible_paths, 'is_dir');
+
+			if ($paths)
+			{
+				$names = array(
+					array(
+						'name' 		=> 'adm',
+						'ext_path' 	=> 'adm/style/',
+					),
+				);
+
+				$paths[] = $this->phpbb_root_path . 'adm/style';
+
+				$template->set_custom_style($names, $paths);
+			}
+		}
 	}
 }

--- a/phpBB/phpbb/extension/manager.php
+++ b/phpBB/phpbb/extension/manager.php
@@ -228,7 +228,7 @@ class manager
 		{
 			$this->config->increment('assets_version', 1);
 
-			$this->update_template_paths($name, $this->container->get('template'));
+			$this->update_template_paths($name);
 		}
 
 		return !$active;
@@ -595,34 +595,35 @@ class manager
 	/**
 	* Make the template aware of ACP template events of a newly enabled extension
 	*
-	* @param string						$name		The extension's name
-	* @param \phpbb\template\base|null	$template	The template service
+	* @param string $name The extension's name
 	* @return null
 	*/
-	protected function update_template_paths($name, \phpbb\template\base $template = null)
+	protected function update_template_paths($name)
 	{
-		if ($template instanceof \phpbb\template\base)
+		if (!$this->container->has('template'))
 		{
-			$possible_paths = array(
-				$this->phpbb_root_path . 'ext/' . $name . '/adm/style',
-				$this->phpbb_root_path . 'ext/' . $name . '/styles',
+			return;
+		}
+
+		$possible_paths = array(
+			$this->phpbb_root_path . 'ext/' . $name . '/adm/style',
+			$this->phpbb_root_path . 'ext/' . $name . '/styles',
+		);
+
+		$paths = array_filter($possible_paths, 'is_dir');
+
+		if ($paths)
+		{
+			$names = array(
+				array(
+					'name' 		=> 'adm',
+					'ext_path' 	=> 'adm/style/',
+				),
 			);
 
-			$paths = array_filter($possible_paths, 'is_dir');
+			$paths[] = $this->phpbb_root_path . 'adm/style';
 
-			if ($paths)
-			{
-				$names = array(
-					array(
-						'name' 		=> 'adm',
-						'ext_path' 	=> 'adm/style/',
-					),
-				);
-
-				$paths[] = $this->phpbb_root_path . 'adm/style';
-
-				$template->set_custom_style($names, $paths);
-			}
+			$this->container->get('template')->set_custom_style($names, $paths);
 		}
 	}
 }


### PR DESCRIPTION
When enabling an extension its paths aren't added immediately to
the template which results in ACP template events not being registered in
the compiled template files.

PHPBB3-15187

Checklist:

- [x] Correct branch: master for new features; 3.2.x, 3.1.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master / 3.2.x](https://area51.phpbb.com/docs/master/coding-guidelines.html), [3.1.x](https://area51.phpbb.com/docs/31x/coding-guidelines.html)
- [x] Commit follows commit message [format](https://wiki.phpbb.com/Git#Commit_Messages)

https://tracker.phpbb.com/browse/PHPBB3-15187