### PR TITLE
[ticket/15227] Check PHP version and remove old unused code

### DIFF
--- a/phpBB/common.php
+++ b/phpBB/common.php
@@ -20,11 +20,6 @@ if (!defined('IN_PHPBB'))
 	exit;
 }
 
-if (version_compare(PHP_VERSION, '5.4') < 0)
-{
-	die('You are running an unsupported PHP version. Please upgrade to PHP 5.4.0 or higher before trying to install or update to phpBB 3.2');
-}
-
 require($phpbb_root_path . 'includes/startup.' . $phpEx);
 require($phpbb_root_path . 'phpbb/class_loader.' . $phpEx);
 

--- a/phpBB/includes/startup.php
+++ b/phpBB/includes/startup.php
@@ -87,12 +87,8 @@ if (version_compare(PHP_VERSION, '5.4') < 0)
 {
 	die('You are running an unsupported PHP version. Please upgrade to PHP 5.4.0 or higher before trying to install or update to phpBB 3.2');
 }
-
 // Register globals and magic quotes have been dropped in PHP 5.4 so no need for extra checks
-/**
-* @ignore
-*/
-define('STRIP', false);
+
 
 // In PHP 5.3.0 the error level has been raised to E_WARNING which causes problems
 // because we show E_WARNING errors and do not set a default timezone.

--- a/phpBB/includes/startup.php
+++ b/phpBB/includes/startup.php
@@ -80,30 +80,19 @@ function deregister_globals()
 	unset($input);
 }
 
-// Register globals and magic quotes have been dropped in PHP 5.4
-if (version_compare(PHP_VERSION, '5.4.0-dev', '>='))
+/**
+* Minimum Requirement: PHP 5.4.0
+*/
+if (version_compare(PHP_VERSION, '5.4') < 0)
 {
-	/**
-	* @ignore
-	*/
-	define('STRIP', false);
+	die('You are running an unsupported PHP version. Please upgrade to PHP 5.4.0 or higher before trying to install or update to phpBB 3.2');
 }
-else
-{
-	if (get_magic_quotes_runtime())
-	{
-		// Deactivate
-		@set_magic_quotes_runtime(0);
-	}
 
-	// Be paranoid with passed vars
-	if (@ini_get('register_globals') == '1' || strtolower(@ini_get('register_globals')) == 'on' || !function_exists('ini_get'))
-	{
-		deregister_globals();
-	}
-
-	define('STRIP', (get_magic_quotes_gpc()) ? true : false);
-}
+// Register globals and magic quotes have been dropped in PHP 5.4 so no need for extra checks
+/**
+* @ignore
+*/
+define('STRIP', false);
 
 // In PHP 5.3.0 the error level has been raised to E_WARNING which causes problems
 // because we show E_WARNING errors and do not set a default timezone.

--- a/phpBB/includes/startup.php
+++ b/phpBB/includes/startup.php
@@ -22,64 +22,6 @@ if (!defined('IN_PHPBB'))
 $level = E_ALL & ~E_NOTICE & ~E_DEPRECATED;
 error_reporting($level);
 
-/*
-* Remove variables created by register_globals from the global scope
-* Thanks to Matt Kavanagh
-*/
-function deregister_globals()
-{
-	$not_unset = array(
-		'GLOBALS'	=> true,
-		'_GET'		=> true,
-		'_POST'		=> true,
-		'_COOKIE'	=> true,
-		'_REQUEST'	=> true,
-		'_SERVER'	=> true,
-		'_SESSION'	=> true,
-		'_ENV'		=> true,
-		'_FILES'	=> true,
-		'phpEx'		=> true,
-		'phpbb_root_path'	=> true
-	);
-
-	// Not only will array_merge and array_keys give a warning if
-	// a parameter is not an array, array_merge will actually fail.
-	// So we check if _SESSION has been initialised.
-	if (!isset($_SESSION) || !is_array($_SESSION))
-	{
-		$_SESSION = array();
-	}
-
-	// Merge all into one extremely huge array; unset this later
-	$input = array_merge(
-		array_keys($_GET),
-		array_keys($_POST),
-		array_keys($_COOKIE),
-		array_keys($_SERVER),
-		array_keys($_SESSION),
-		array_keys($_ENV),
-		array_keys($_FILES)
-	);
-
-	foreach ($input as $varname)
-	{
-		if (isset($not_unset[$varname]))
-		{
-			// Hacking attempt. No point in continuing.
-			if (isset($_COOKIE[$varname]))
-			{
-				echo "Clear your cookies. ";
-			}
-			echo "Malicious variable name detected. Contact the administrator and ask them to disable register_globals.";
-			exit;
-		}
-
-		unset($GLOBALS[$varname]);
-	}
-
-	unset($input);
-}
-
 /**
 * Minimum Requirement: PHP 5.4.0
 */

--- a/phpBB/phpbb/files/filespec.php
+++ b/phpBB/phpbb/files/filespec.php
@@ -129,7 +129,7 @@ class filespec
 		$this->class_initialized = true;
 		$this->filename = $upload_ary['tmp_name'];
 		$this->filesize = $upload_ary['size'];
-		$name = (STRIP) ? stripslashes($upload_ary['name']) : $upload_ary['name'];
+		$name = $upload_ary['name'];
 		$name = trim(utf8_basename($name));
 		$this->realname = $this->uploadname = $name;
 		$this->mimetype = $upload_ary['type'];

--- a/phpBB/phpbb/passwords/driver/md5_phpbb2.php
+++ b/phpBB/phpbb/passwords/driver/md5_phpbb2.php
@@ -95,7 +95,7 @@ class md5_phpbb2 extends base
 
 		// in phpBB2 passwords were used exactly as they were sent, with addslashes applied
 		$password_old_format = isset($_REQUEST['password']) ? (string) $_REQUEST['password'] : '';
-		$password_old_format = (!STRIP) ? addslashes($password_old_format) : $password_old_format;
+		$password_old_format = addslashes($password_old_format);
 		$password_new_format = $this->request->variable('password', '', true);
 
 		if ($super_globals_disabled)


### PR DESCRIPTION
- Move PHP version check from `common.php` to `startup.php` to be effective in more cases.
- Remove redundant code in `startup.php`, only applicable to versions < 5.4

PHPBB3-15227

Checklist:

- [x] Correct branch: master for new features; 3.2.x, 3.1.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master / 3.2.x](https://area51.phpbb.com/docs/master/coding-guidelines.html), [3.1.x](https://area51.phpbb.com/docs/31x/coding-guidelines.html)
- [x] Commit follows commit message [format](https://wiki.phpbb.com/Git#Commit_Messages)

Tracker ticket:

https://tracker.phpbb.com/browse/PHPBB3-15227
