### PR TITLE
[ticket/14992] Add temp index migration for removing duplicates

### DIFF
--- a/phpBB/phpbb/db/migration/data/v32x/user_notifications_table_reduce_column_sizes.php
+++ b/phpBB/phpbb/db/migration/data/v32x/user_notifications_table_reduce_column_sizes.php
@@ -18,7 +18,7 @@ class user_notifications_table_reduce_column_sizes extends \phpbb\db\migration\m
 	static public function depends_on()
 	{
 		return array(
-			'\phpbb\db\migration\data\v32x\user_notifications_table_remove_duplicates',
+			'\phpbb\db\migration\data\v32x\user_notifications_table_index_p3',
 		);
 	}
 

--- a/phpBB/phpbb/db/migration/data/v32x/user_notifications_table_remove_duplicates.php
+++ b/phpBB/phpbb/db/migration/data/v32x/user_notifications_table_remove_duplicates.php
@@ -18,7 +18,7 @@ class user_notifications_table_remove_duplicates extends \phpbb\db\migration\mig
 	static public function depends_on()
 	{
 		return array(
-			'\phpbb\db\migration\data\v32x\user_notifications_table_index_p3',
+			'\phpbb\db\migration\data\v32x\user_notifications_table_temp_index',
 		);
 	}
 

--- a/phpBB/phpbb/db/migration/data/v32x/user_notifications_table_temp_index.php
+++ b/phpBB/phpbb/db/migration/data/v32x/user_notifications_table_temp_index.php
@@ -13,24 +13,19 @@
 
 namespace phpbb\db\migration\data\v32x;
 
-class user_notifications_table_unique_index extends \phpbb\db\migration\migration
+class user_notifications_table_temp_index extends \phpbb\db\migration\migration
 {
 	static public function depends_on()
 	{
 		return array(
-			'\phpbb\db\migration\data\v32x\user_notifications_table_remove_duplicates',
+			'\phpbb\db\migration\data\v32x\user_notifications_table_reduce_column_sizes',
 		);
 	}
 
 	public function update_schema()
 	{
 		return array(
-			'drop_keys'			=> array(
-				$this->table_prefix . 'user_notifications' => array(
-					'itm_usr_mthd',
-				),
-			),
-			'add_unique_index'  => array(
+			'add_index' => array(
 				$this->table_prefix . 'user_notifications' => array(
 					'itm_usr_mthd'	=> array('item_type', 'item_id', 'user_id', 'method'),
 				),


### PR DESCRIPTION
This migration got removed when trying to resolve the build error. It is actually needed in order for the deduplication migration to complete on larger databases (i.e. phpbb.com's).

Checklist:

- [x] Correct branch: master for new features; 3.2.x, 3.1.x for fixes
- [ ] Tests pass
- [x] Code follows coding guidelines: [master / 3.2.x](https://area51.phpbb.com/docs/master/coding-guidelines.html), [3.1.x](https://area51.phpbb.com/docs/31x/coding-guidelines.html)
- [x] Commit follows commit message [format](https://wiki.phpbb.com/Git#Commit_Messages)

Tracker ticket (set the ticket ID to **your ticket ID**):

https://tracker.phpbb.com/browse/PHPBB3-14992