### PR TITLE
[ticket/15257] Provide extension not enableable messages

### DIFF
--- a/phpBB/includes/acp/acp_extensions.php
+++ b/phpBB/includes/acp/acp_extensions.php
@@ -167,7 +167,7 @@ class acp_extensions
 				$extension = $this->ext_manager->get_extension($ext_name);
 				if (!$extension->is_enableable())
 				{
-					$message = $extension->get_not_enableable_msg() ?: $this->user->lang['EXTENSION_NOT_ENABLEABLE'];
+					$message = $extension->not_enableable_msg() ?: $this->user->lang['EXTENSION_NOT_ENABLEABLE'];
 					$message = is_array($message) ? implode('<br/>', $message) : $message;
 					trigger_error($message . adm_back_link($this->u_action), E_USER_WARNING);
 				}
@@ -199,7 +199,7 @@ class acp_extensions
 				$extension = $this->ext_manager->get_extension($ext_name);
 				if (!$extension->is_enableable())
 				{
-					$message = $extension->get_not_enableable_msg() ?: $this->user->lang['EXTENSION_NOT_ENABLEABLE'];
+					$message = $extension->not_enableable_msg() ?: $this->user->lang['EXTENSION_NOT_ENABLEABLE'];
 					$message = is_array($message) ? implode('<br/>', $message) : $message;
 					trigger_error($message . adm_back_link($this->u_action), E_USER_WARNING);
 				}

--- a/phpBB/includes/acp/acp_extensions.php
+++ b/phpBB/includes/acp/acp_extensions.php
@@ -129,7 +129,7 @@ class acp_extensions
 				else
 				{
 					$this->config->set('extension_force_unstable', false);
-					trigger_error($this->user->lang['CONFIG_UPDATED'] . adm_back_link($this->u_action));
+					trigger_error($this->user->lang('CONFIG_UPDATED') . adm_back_link($this->u_action));
 				}
 				break;
 
@@ -138,7 +138,7 @@ class acp_extensions
 				if (confirm_box(true))
 				{
 					$this->config->set('extension_force_unstable', true);
-					trigger_error($this->user->lang['CONFIG_UPDATED'] . adm_back_link($this->u_action));
+					trigger_error($this->user->lang('CONFIG_UPDATED') . adm_back_link($this->u_action));
 				}
 
 				$this->list_enabled_exts();
@@ -167,7 +167,7 @@ class acp_extensions
 				$extension = $this->ext_manager->get_extension($ext_name);
 				if (!$extension->is_enableable())
 				{
-					$message = $extension->not_enableable_reason() ?: $this->user->lang['EXTENSION_NOT_ENABLEABLE'];
+					$message = $extension->not_enableable_reason() ?: $this->user->lang('EXTENSION_NOT_ENABLEABLE');
 					$message = is_array($message) ? implode('<br/>', $message) : $message;
 					trigger_error($message . adm_back_link($this->u_action), E_USER_WARNING);
 				}
@@ -199,7 +199,7 @@ class acp_extensions
 				$extension = $this->ext_manager->get_extension($ext_name);
 				if (!$extension->is_enableable())
 				{
-					$message = $extension->not_enableable_reason() ?: $this->user->lang['EXTENSION_NOT_ENABLEABLE'];
+					$message = $extension->not_enableable_reason() ?: $this->user->lang('EXTENSION_NOT_ENABLEABLE');
 					$message = is_array($message) ? implode('<br/>', $message) : $message;
 					trigger_error($message . adm_back_link($this->u_action), E_USER_WARNING);
 				}

--- a/phpBB/includes/acp/acp_extensions.php
+++ b/phpBB/includes/acp/acp_extensions.php
@@ -167,7 +167,7 @@ class acp_extensions
 				$extension = $this->ext_manager->get_extension($ext_name);
 				if (!$extension->is_enableable())
 				{
-					$message = $extension->not_enableable_msg() ?: $this->user->lang['EXTENSION_NOT_ENABLEABLE'];
+					$message = $extension->not_enableable_reason() ?: $this->user->lang['EXTENSION_NOT_ENABLEABLE'];
 					$message = is_array($message) ? implode('<br/>', $message) : $message;
 					trigger_error($message . adm_back_link($this->u_action), E_USER_WARNING);
 				}
@@ -199,7 +199,7 @@ class acp_extensions
 				$extension = $this->ext_manager->get_extension($ext_name);
 				if (!$extension->is_enableable())
 				{
-					$message = $extension->not_enableable_msg() ?: $this->user->lang['EXTENSION_NOT_ENABLEABLE'];
+					$message = $extension->not_enableable_reason() ?: $this->user->lang['EXTENSION_NOT_ENABLEABLE'];
 					$message = is_array($message) ? implode('<br/>', $message) : $message;
 					trigger_error($message . adm_back_link($this->u_action), E_USER_WARNING);
 				}

--- a/phpBB/includes/acp/acp_extensions.php
+++ b/phpBB/includes/acp/acp_extensions.php
@@ -167,7 +167,9 @@ class acp_extensions
 				$extension = $this->ext_manager->get_extension($ext_name);
 				if (!$extension->is_enableable())
 				{
-					trigger_error($this->user->lang['EXTENSION_NOT_ENABLEABLE'] . adm_back_link($this->u_action), E_USER_WARNING);
+					$message = $extension->get_not_enableable_msg() ?: $this->user->lang['EXTENSION_NOT_ENABLEABLE'];
+					$message = is_array($message) ? implode('<br/>', $message) : $message;
+					trigger_error($message . adm_back_link($this->u_action), E_USER_WARNING);
 				}
 
 				if ($this->ext_manager->is_enabled($ext_name))
@@ -197,7 +199,9 @@ class acp_extensions
 				$extension = $this->ext_manager->get_extension($ext_name);
 				if (!$extension->is_enableable())
 				{
-					trigger_error($this->user->lang['EXTENSION_NOT_ENABLEABLE'] . adm_back_link($this->u_action), E_USER_WARNING);
+					$message = $extension->get_not_enableable_msg() ?: $this->user->lang['EXTENSION_NOT_ENABLEABLE'];
+					$message = is_array($message) ? implode('<br/>', $message) : $message;
+					trigger_error($message . adm_back_link($this->u_action), E_USER_WARNING);
 				}
 
 				try

--- a/phpBB/phpbb/console/command/extension/enable.php
+++ b/phpBB/phpbb/console/command/extension/enable.php
@@ -45,7 +45,7 @@ class enable extends command
 		}
 		else
 		{
-			$message = $this->manager->get_extension($name)->not_enableable_msg() ?: $this->user->lang('CLI_EXTENSION_ENABLE_FAILURE', $name);
+			$message = $this->manager->get_extension($name)->not_enableable_reason() ?: $this->user->lang('CLI_EXTENSION_ENABLE_FAILURE', $name);
 			$message = is_array($message) ? implode(PHP_EOL, $message) : $message;
 			$output->writeln('<error>' . $message . '</error>');
 			return 1;

--- a/phpBB/phpbb/console/command/extension/enable.php
+++ b/phpBB/phpbb/console/command/extension/enable.php
@@ -45,7 +45,9 @@ class enable extends command
 		}
 		else
 		{
-			$output->writeln('<error>' . $this->user->lang('CLI_EXTENSION_ENABLE_FAILURE', $name) . '</error>');
+			$message = $this->manager->get_extension($name)->not_enableable_msg() ?: $this->user->lang('CLI_EXTENSION_ENABLE_FAILURE', $name);
+			$message = is_array($message) ? implode('\n', $message) : $message;
+			$output->writeln('<error>' . $message . '</error>');
 			return 1;
 		}
 	}

--- a/phpBB/phpbb/console/command/extension/enable.php
+++ b/phpBB/phpbb/console/command/extension/enable.php
@@ -46,7 +46,7 @@ class enable extends command
 		else
 		{
 			$message = $this->manager->get_extension($name)->not_enableable_msg() ?: $this->user->lang('CLI_EXTENSION_ENABLE_FAILURE', $name);
-			$message = is_array($message) ? implode('\n', $message) : $message;
+			$message = is_array($message) ? implode(PHP_EOL, $message) : $message;
 			$output->writeln('<error>' . $message . '</error>');
 			return 1;
 		}

--- a/phpBB/phpbb/extension/base.php
+++ b/phpBB/phpbb/extension/base.php
@@ -66,6 +66,14 @@ class base implements \phpbb\extension\extension_interface
 	}
 
 	/**
+	* {@inheritdoc}
+	*/
+	public function get_not_enableable_msg()
+	{
+		return array();
+	}
+
+	/**
 	* Single enable step that installs any included migrations
 	*
 	* @param mixed $old_state State returned by previous call of this method

--- a/phpBB/phpbb/extension/base.php
+++ b/phpBB/phpbb/extension/base.php
@@ -68,7 +68,7 @@ class base implements \phpbb\extension\extension_interface
 	/**
 	* {@inheritdoc}
 	*/
-	public function get_not_enableable_msg()
+	public function not_enableable_msg()
 	{
 		return array();
 	}

--- a/phpBB/phpbb/extension/base.php
+++ b/phpBB/phpbb/extension/base.php
@@ -68,7 +68,7 @@ class base implements \phpbb\extension\extension_interface
 	/**
 	* {@inheritdoc}
 	*/
-	public function not_enableable_msg()
+	public function not_enableable_reason()
 	{
 		return array();
 	}

--- a/phpBB/phpbb/extension/extension_interface.php
+++ b/phpBB/phpbb/extension/extension_interface.php
@@ -31,7 +31,7 @@ interface extension_interface
 	*
 	* @return string|array with actual processed language string(s) (not language keys), or empty
 	*/
-	public function get_not_enableable_msg();
+	public function not_enableable_msg();
 
 	/**
 	* enable_step is executed on enabling an extension until it returns false.

--- a/phpBB/phpbb/extension/extension_interface.php
+++ b/phpBB/phpbb/extension/extension_interface.php
@@ -27,6 +27,13 @@ interface extension_interface
 	public function is_enableable();
 
 	/**
+	* Indicate why the extension can not be enabled.
+	*
+	* @return string|array with actual processed language string(s) (not language keys), or empty
+	*/
+	public function get_not_enableable_msg();
+
+	/**
 	* enable_step is executed on enabling an extension until it returns false.
 	*
 	* Calls to this function can be made in subsequent requests, when the

--- a/phpBB/phpbb/extension/extension_interface.php
+++ b/phpBB/phpbb/extension/extension_interface.php
@@ -31,7 +31,7 @@ interface extension_interface
 	*
 	* @return string|array with actual processed language string(s) (not language keys), or empty
 	*/
-	public function not_enableable_msg();
+	public function not_enableable_reason();
 
 	/**
 	* enable_step is executed on enabling an extension until it returns false.

--- a/tests/extension/ext/vendor4/foo/composer.json
+++ b/tests/extension/ext/vendor4/foo/composer.json
@@ -1,0 +1,23 @@
+{
+	"name": "vendor4/foo",
+	"type": "phpbb-extension",
+	"description": "An example/sample extension to be used for testing purposes in phpBB Development.",
+	"version": "1.0.0",
+	"time": "2012-02-15 01:01:01",
+	"license": "GPL-2.0",
+	"authors": [{
+			"name": "John Smith",
+			"email": "email@phpbb.com",
+			"homepage": "http://phpbb.com",
+			"role": "N/A"
+		}],
+	"require": {
+		"php": ">=5.3"
+	},
+	"extra": {
+		"display-name": "phpBB Bar Extension",
+		"soft-require": {
+			"phpbb/phpbb": "3.1.*@dev"
+		}
+	}
+}

--- a/tests/extension/ext/vendor4/foo/ext.php
+++ b/tests/extension/ext/vendor4/foo/ext.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace vendor4\foo;
+
+class ext extends \phpbb\extension\base
+{
+	static public $enabled;
+
+	public function enable_step($old_state)
+	{
+		self::$enabled = true;
+
+		return self::$enabled;
+	}
+
+	public function is_enableable()
+	{
+		return false;
+	}
+
+	public function not_enableable_reason()
+	{
+		return array('Reason 1', 'Reason 2');
+	}
+}

--- a/tests/extension/manager_test.php
+++ b/tests/extension/manager_test.php
@@ -36,7 +36,7 @@ class phpbb_extension_manager_test extends phpbb_database_test_case
 	public function test_all_available()
 	{
 		// barfoo and vendor3/bar should not listed due to missing composer.json. barfoo also has incorrect dir structure.
-		$this->assertEquals(array('vendor/moo', 'vendor2/bar', 'vendor2/foo', 'vendor3/foo', 'vendor4/bar'), array_keys($this->extension_manager->all_available()));
+		$this->assertEquals(array('vendor/moo', 'vendor2/bar', 'vendor2/foo', 'vendor3/foo', 'vendor4/bar', 'vendor4/foo'), array_keys($this->extension_manager->all_available()));
 	}
 
 	public function test_all_enabled()

--- a/tests/functional/extension_acp_test.php
+++ b/tests/functional/extension_acp_test.php
@@ -86,7 +86,7 @@ class phpbb_functional_extension_acp_test extends phpbb_functional_test_case
 		$crawler = self::request('GET', 'adm/index.php?i=acp_extensions&mode=main&sid=' . $this->sid);
 
 		$this->assertCount(1, $crawler->filter('.ext_enabled'));
-		$this->assertCount(6, $crawler->filter('.ext_disabled'));
+		$this->assertCount(7, $crawler->filter('.ext_disabled'));
 
 		$this->assertContains('phpBB Foo Extension', $crawler->filter('.ext_enabled')->eq(0)->text());
 		$this->assertContainsLang('EXTENSION_DISABLE', $crawler->filter('.ext_enabled')->eq(0)->text());
@@ -168,6 +168,10 @@ class phpbb_functional_extension_acp_test extends phpbb_functional_test_case
 		// Correctly submit the enable form
 		$crawler = self::request('GET', 'adm/index.php?i=acp_extensions&mode=main&action=enable_pre&ext_name=vendor3%2Ffoo&sid=' . $this->sid);
 		$this->assertContainsLang('EXTENSION_NOT_ENABLEABLE', $crawler->filter('.errorbox')->text());
+
+		// Custom error messages returned by not enableable extension
+		$crawler = self::request('GET', 'adm/index.php?i=acp_extensions&mode=main&action=enable_pre&ext_name=vendor4%2Ffoo&sid=' . $this->sid);
+		$this->assertContains('Reason 2', $crawler->filter('.errorbox')->text());
 	}
 
 	public function test_disable_pre()

--- a/tests/functional/extension_acp_test.php
+++ b/tests/functional/extension_acp_test.php
@@ -165,12 +165,13 @@ class phpbb_functional_extension_acp_test extends phpbb_functional_test_case
 		$crawler = self::request('GET', 'adm/index.php?i=acp_extensions&mode=main&action=enable_pre&ext_name=vendor%2Fmoo&sid=' . $this->sid);
 		$this->assertContains($this->lang('EXTENSION_ENABLE_CONFIRM', 'phpBB Moo Extension'), $crawler->filter('#main')->text());
 
-		// Correctly submit the enable form
+		// Correctly submit the enable form, default not enableable message
 		$crawler = self::request('GET', 'adm/index.php?i=acp_extensions&mode=main&action=enable_pre&ext_name=vendor3%2Ffoo&sid=' . $this->sid);
 		$this->assertContainsLang('EXTENSION_NOT_ENABLEABLE', $crawler->filter('.errorbox')->text());
 
 		// Custom error messages returned by not enableable extension
 		$crawler = self::request('GET', 'adm/index.php?i=acp_extensions&mode=main&action=enable_pre&ext_name=vendor4%2Ffoo&sid=' . $this->sid);
+		$this->assertContains('Reason 1', $crawler->filter('.errorbox')->text());
 		$this->assertContains('Reason 2', $crawler->filter('.errorbox')->text());
 	}
 


### PR DESCRIPTION
Extensions may define the reasons why they cannot be enabled,
so that users are better informed and ready to fix this.
Multiple messages are possible at the same time.
Keeps 100% BC, even with the current "workarounds".

PHPBB3-15257

Checklist:

- [x] Correct branch: master for new features; 3.2.x, 3.1.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master / 3.2.x](https://area51.phpbb.com/docs/master/coding-guidelines.html), [3.1.x](https://area51.phpbb.com/docs/31x/coding-guidelines.html)
- [x] Commit follows commit message [format](https://wiki.phpbb.com/Git#Commit_Messages)

Tracker ticket:

https://tracker.phpbb.com/browse/PHPBB3-15257
