### PR TITLE
[ticket/15259] Fatal error on SQLite/Oracle database update

### DIFF
--- a/tests/dbal/db_tools_test.php
+++ b/tests/dbal/db_tools_test.php
@@ -421,4 +421,41 @@ class phpbb_dbal_db_tools_test extends phpbb_database_test_case
 		$this->assertTrue($this->tools->sql_column_add('prefix_table_name', 'c_bug_13282', array('TINT:2')));
 		$this->assertTrue($this->tools->sql_column_exists('prefix_table_name', 'c_bug_13282'));
 	}
+
+	public function test_create_index_with_long_name()
+	{
+		// This constant is being used for checking table prefix.
+		$table_prefix = substr(CONFIG_TABLE, 0, -6); // strlen(config)
+
+		if (strlen($table_prefix) > 20)
+		{
+			$this->markTestIncomplete('The table prefix length is too long for proper testing of index shortening function.');
+		}
+
+		$table_suffix = str_repeat('a', 25 - strlen($table_prefix));
+		$table_name = $table_prefix . $table_suffix;
+
+		$this->tools->sql_create_table($table_name, $this->table_data);
+
+		// Index name and table suffix and table prefix have > 30 chars in total.
+		// Index name and table suffix have <= 30 chars in total.
+		$long_index_name = str_repeat('i', 30 - strlen($table_suffix));
+		$this->assertFalse($this->tools->sql_index_exists($table_name, $long_index_name));
+		$this->assertTrue($this->tools->sql_create_index($table_name, $long_index_name, array('c_timestamp')));
+		$this->assertTrue($this->tools->sql_index_exists($table_name, $long_index_name));
+
+		// Index name and table suffix have > 30 chars in total.
+		$very_long_index_name = str_repeat('i', 30);
+		$this->assertFalse($this->tools->sql_index_exists($table_name, $very_long_index_name));
+		$this->assertTrue($this->tools->sql_create_index($table_name, $very_long_index_name, array('c_timestamp')));
+		$this->assertTrue($this->tools->sql_index_exists($table_name, $very_long_index_name));
+
+		$this->tools->sql_table_drop($table_name);
+
+		// Index name has > 30 chars - that should not be possible.
+		$too_long_index_name = str_repeat('i', 31);
+		$this->assertFalse($this->tools->sql_index_exists('prefix_table_name', $too_long_index_name));
+		$this->setExpectedTriggerError(E_USER_ERROR);
+		$this->tools->sql_create_index('prefix_table_name', $too_long_index_name, array('c_timestamp'));
+	}
 }


### PR DESCRIPTION
PHPBB3-15259

Checklist:

- [x] Correct branch: master for new features; 3.2.x, 3.1.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master / 3.2.x](https://area51.phpbb.com/docs/master/coding-guidelines.html), [3.1.x](https://area51.phpbb.com/docs/31x/coding-guidelines.html)
- [x] Commit follows commit message [format](https://wiki.phpbb.com/Git#Commit_Messages)

Tracker ticket (set the ticket ID to **your ticket ID**):

https://tracker.phpbb.com/browse/PHPBB3-15259

The tools code was changed with some remaining issues that resulted into Fatal error during the update to phpBB 3.2.1-RC1 on SQLite database.

What I've tried to fix in this commit:
- `check_index_name_length` does not take the third parameter into account when calls itself recursively.
- `check_index_name_length` reduces one more symbol from `index_name` when tries to remove `table_prefix` (it is not separated from the remaining `table_suffix` with `_` like `table_name` from `index_name`).
- `check_index_name_length` incorrectly tries to remove `table_name` after it has removed `table_prefix` (instead we need to remove the remaining part of `table_name` - `table_suffix`).
- `sql_index_exists` does not take into account that `$index_name` should be the same on the next iteration of the `while` loop.
- `sql_index_exists` does not take into account the new shortening method for other DBMS (like MySQL).

What I've not fixed (because need some help):
- `sql_unique_index_exists` still needs fixing the same way. It's too complicated for me because I do not have Oracle DBMS for testing its different cases.

Hope that my explanations are informative.