### PR TITLE
[ticket/15266] Fix events in content_visibility

### DIFF
--- a/phpBB/download/file.php
+++ b/phpBB/download/file.php
@@ -149,6 +149,8 @@ $user->session_begin(false);
 $auth->acl($user->data);
 $user->setup('viewtopic');
 
+$phpbb_content_visibility = $phpbb_container->get('content.visibility');
+
 if (!$config['allow_attachments'] && !$config['allow_pm_attach'])
 {
 	send_status_line(404, 'Not Found');
@@ -215,7 +217,7 @@ else
 			$post_row = $db->sql_fetchrow($result);
 			$db->sql_freeresult($result);
 
-			if (!$post_row || ($post_row['post_visibility'] != ITEM_APPROVED && !$auth->acl_get('m_approve', $post_row['forum_id'])))
+			if (!$post_row || !$phpbb_content_visibility->is_visible('post', $post_row['forum_id'], $post_row))
 			{
 				// Attachment of a soft deleted post and the user is not allowed to see the post
 				send_status_line(404, 'Not Found');

--- a/phpBB/includes/functions_download.php
+++ b/phpBB/includes/functions_download.php
@@ -650,6 +650,8 @@ function phpbb_increment_downloads($db, $ids)
 */
 function phpbb_download_handle_forum_auth($db, $auth, $topic_id)
 {
+	global $phpbb_container;
+
 	$sql_array = array(
 		'SELECT'	=> 't.topic_visibility, t.forum_id, f.forum_name, f.forum_password, f.parent_id',
 		'FROM'		=> array(
@@ -665,7 +667,9 @@ function phpbb_download_handle_forum_auth($db, $auth, $topic_id)
 	$row = $db->sql_fetchrow($result);
 	$db->sql_freeresult($result);
 
-	if ($row && $row['topic_visibility'] != ITEM_APPROVED && !$auth->acl_get('m_approve', $row['forum_id']))
+	$phpbb_content_visibility = $phpbb_container->get('content.visibility');
+
+	if ($row && !$phpbb_content_visibility->is_visible('topic', $row['forum_id'], $row))
 	{
 		send_status_line(404, 'Not Found');
 		trigger_error('ERROR_NO_ATTACHMENT');

--- a/phpBB/includes/functions_mcp.php
+++ b/phpBB/includes/functions_mcp.php
@@ -197,7 +197,7 @@ function phpbb_get_topic_data($topic_ids, $acl_list = false, $read_tracking = fa
 */
 function phpbb_get_post_data($post_ids, $acl_list = false, $read_tracking = false)
 {
-	global $db, $auth, $config, $user;
+	global $db, $auth, $config, $user, $phpbb_container;
 
 	$rowset = array();
 
@@ -246,6 +246,8 @@ function phpbb_get_post_data($post_ids, $acl_list = false, $read_tracking = fals
 	$result = $db->sql_query($sql);
 	unset($sql_array);
 
+	$phpbb_content_visibility = $phpbb_container->get('content.visibility');
+
 	while ($row = $db->sql_fetchrow($result))
 	{
 		if ($acl_list && !$auth->acl_gets($acl_list, $row['forum_id']))
@@ -253,7 +255,7 @@ function phpbb_get_post_data($post_ids, $acl_list = false, $read_tracking = fals
 			continue;
 		}
 
-		if ($row['post_visibility'] != ITEM_APPROVED && !$auth->acl_get('m_approve', $row['forum_id']))
+		if (!$phpbb_content_visibility->is_visible('post', $row['forum_id'], $row))
 		{
 			// Moderators without the permission to approve post should at least not see them. ;)
 			continue;

--- a/phpBB/phpbb/content_visibility.php
+++ b/phpBB/phpbb/content_visibility.php
@@ -419,7 +419,7 @@ class content_visibility
 		 * @var			int			topic_id		Topic of the post IDs to be modified.
 		 * @var			int			forum_id		Forum ID that the topic_id resides in.
 		 * @var			int			user_id			User ID doing this action.
-		 * @var			int			timestamp		Timestamp of this action.
+		 * @var			int			time			Timestamp of this action.
 		 * @var			string		reason			Reason specified by the user for this change.
 		 * @var			bool		is_starter		Are we changing the topic's starter?
 		 * @var			bool		is_latest		Are we changing the topic's latest post?
@@ -432,7 +432,7 @@ class content_visibility
 			'topic_id',
 			'forum_id',
 			'user_id',
-			'timestamp',
+			'time',
 			'reason',
 			'is_starter',
 			'is_latest',
@@ -604,7 +604,7 @@ class content_visibility
 		 * @var			int			topic_id		Topic of the post IDs to be modified.
 		 * @var			int			forum_id		Forum ID that the topic_id resides in.
 		 * @var			int			user_id			User ID doing this action.
-		 * @var			int			timestamp		Timestamp of this action.
+		 * @var			int			time			Timestamp of this action.
 		 * @var			string		reason			Reason specified by the user for this change.
 		 * @var			bool		is_starter		Are we changing the topic's starter?
 		 * @var			bool		is_latest		Are we changing the topic's latest post?
@@ -617,7 +617,7 @@ class content_visibility
 			'topic_id',
 			'forum_id',
 			'user_id',
-			'timestamp',
+			'time',
 			'reason',
 			'is_starter',
 			'is_latest',
@@ -691,7 +691,7 @@ class content_visibility
 		 * @var			int			topic_id			Topic of the post IDs to be modified.
 		 * @var			int			forum_id			Forum ID that the topic_id resides in.
 		 * @var			int			user_id				User ID doing this action.
-		 * @var			int			timestamp			Timestamp of this action.
+		 * @var			int			time				Timestamp of this action.
 		 * @var			string		reason				Reason specified by the user for this change.
 		 * @var			bool		force_update_all	Force an update on all posts within the topic, regardless of their current approval state.
 		 * @var			array		data				The data array for this action.
@@ -702,7 +702,7 @@ class content_visibility
 			'topic_id',
 			'forum_id',
 			'user_id',
-			'timestamp',
+			'time',
 			'reason',
 			'force_update_all',
 			'data',
@@ -740,7 +740,7 @@ class content_visibility
 		 * @var			int			topic_id			Topic of the post IDs to be modified.
 		 * @var			int			forum_id			Forum ID that the topic_id resides in.
 		 * @var			int			user_id				User ID doing this action.
-		 * @var			int			timestamp			Timestamp of this action.
+		 * @var			int			time				Timestamp of this action.
 		 * @var			string		reason				Reason specified by the user for this change.
 		 * @var			bool		force_update_all	Force an update on all posts within the topic, regardless of their current approval state.
 		 * @var			array		data				The data array for this action.
@@ -751,7 +751,7 @@ class content_visibility
 			'topic_id',
 			'forum_id',
 			'user_id',
-			'timestamp',
+			'time',
 			'reason',
 			'force_update_all',
 			'data',

--- a/phpBB/phpbb/content_visibility.php
+++ b/phpBB/phpbb/content_visibility.php
@@ -131,6 +131,42 @@ class content_visibility
 		return (int) $data[$mode . '_approved'] + (int) $data[$mode . '_unapproved'] + (int) $data[$mode . '_softdeleted'];
 	}
 
+
+	/**
+	* Check topic/post visibility for a given forum ID
+	*
+	* Note: Read permissions are not checked.
+	*
+	* @param $mode		string	Either "topic" or "post"
+	* @param $forum_id	int		The forum id is used for permission checks
+	* @param $data		array	Array with item information to check visibility
+	* @return bool		True if the item is visible, false if not
+	*/
+	public function is_visible($mode, $forum_id, $data)
+	{
+		$is_visible = $this->auth->acl_get('m_approve', $forum_id) || $data[$mode . '_visibility'] == ITEM_APPROVED;
+
+		/**
+		* Allow changing the result of calling is_visible
+		*
+		* @event core.phpbb_content_visibility_is_visible
+		* @var	bool		is_visible			Default visibility condition, to be modified by extensions if needed.
+		* @var	string		mode				Either "topic" or "post"
+		* @var	int			forum_id			Forum id of the current item
+		* @var	array		data				Array of item information
+		* @since 3.1.12-RC1
+		*/
+		$vars = array(
+			'is_visible',
+			'mode',
+			'forum_id',
+			'data',
+		);
+		extract($this->phpbb_dispatcher->trigger_event('core.phpbb_content_visibility_is_visible', compact($vars)));
+
+		return $is_visible;
+	}
+
 	/**
 	* Create topic/post visibility SQL for a given forum ID
 	*

--- a/phpBB/phpbb/content_visibility.php
+++ b/phpBB/phpbb/content_visibility.php
@@ -154,7 +154,7 @@ class content_visibility
 		* @var	string		mode				Either "topic" or "post"
 		* @var	int			forum_id			Forum id of the current item
 		* @var	array		data				Array of item information
-		* @since 3.1.12-RC1
+		* @since 3.2.2-RC1
 		*/
 		$vars = array(
 			'is_visible',
@@ -238,7 +238,7 @@ class content_visibility
 		$where_sql = '';
 
 		$approve_forums = array_keys($this->auth->acl_getf('m_approve', true));
-		if ($forum_ids && $approve_forums)
+		if (!empty($forum_ids) && !empty($approve_forums))
 		{
 			$approve_forums = array_intersect($forum_ids, $approve_forums);
 			$forum_ids = array_diff($forum_ids, $approve_forums);
@@ -311,7 +311,7 @@ class content_visibility
 		* @var	array		exclude_forum_ids					Array of forum ids the current user doesn't have access to
 		* @var	string		table_alias							Table alias to prefix in SQL queries
 		* @var	array		approve_forums						Array of forums where the user has m_approve permissions
-		* @var	string		visibility_sql_overwrite	If a string, forces the function to return visibility_sql_overwrite after executing the event
+		* @var	string		visibility_sql_overwrite			If not empty, forces the function to return visibility_sql_overwrite after executing the event
 		* @since 3.1.3-RC1
 		*/
 		$vars = array(
@@ -461,6 +461,7 @@ class content_visibility
 		 * @var			bool		is_latest		Are we changing the topic's latest post?
 		 * @var			array		data			The data array for this action.
 		 * @since 3.1.10-RC1
+		 * @changed 3.2.2-RC1 Use time instead of non-existent timestamp
 		 */
 		$vars = array(
 			'visibility',
@@ -646,6 +647,7 @@ class content_visibility
 		 * @var			bool		is_latest		Are we changing the topic's latest post?
 		 * @var			array		data			The data array for this action.
 		 * @since 3.1.10-RC1
+		 * @changed 3.2.2-RC1 Use time instead of non-existent timestamp
 		 */
 		$vars = array(
 			'visibility',
@@ -732,6 +734,7 @@ class content_visibility
 		 * @var			bool		force_update_all	Force an update on all posts within the topic, regardless of their current approval state.
 		 * @var			array		data				The data array for this action.
 		 * @since 3.1.10-RC1
+		 * @changed 3.2.2-RC1 Use time instead of non-existent timestamp
 		 */
 		$vars = array(
 			'visibility',
@@ -781,6 +784,7 @@ class content_visibility
 		 * @var			bool		force_update_all	Force an update on all posts within the topic, regardless of their current approval state.
 		 * @var			array		data				The data array for this action.
 		 * @since 3.1.10-RC1
+		 * @changed 3.2.2-RC1 Use time instead of non-existent timestamp
 		 */
 		$vars = array(
 			'visibility',

--- a/phpBB/viewforum.php
+++ b/phpBB/viewforum.php
@@ -520,7 +520,7 @@ if ($forum_data['forum_type'] == FORUM_POST)
 
 	while ($row = $db->sql_fetchrow($result))
 	{
-		if ($row['topic_visibility'] != ITEM_APPROVED && !$auth->acl_get('m_approve', $row['forum_id']))
+		if (!$phpbb_content_visibility->is_visible('topic', $row['forum_id'], $row))
 		{
 			// Do not display announcements that are waiting for approval or soft deleted.
 			continue;

--- a/phpBB/viewtopic.php
+++ b/phpBB/viewtopic.php
@@ -262,7 +262,7 @@ if (!$topic_data)
 $forum_id = (int) $topic_data['forum_id'];
 
 // Now we know the forum_id and can check the permissions
-if ($topic_data['topic_visibility'] != ITEM_APPROVED && !$auth->acl_get('m_approve', $forum_id))
+if (!$phpbb_content_visibility->is_visible('topic', $forum_id, $topic_data))
 {
 	trigger_error('NO_TOPIC');
 }


### PR DESCRIPTION
Fixes core.phpbb_content_visibility_get_visibility_sql_before,
core.phpbb_content_visibility_get_forums_visibility_before,
core.phpbb_content_visibility_get_global_visibility_before

Does not modify the events, but fixes some comments, and changes
the rest of the function to allow (at least) the documented
event functionality.

PHPBB3-15266

Checklist:

- [x] Correct branch: master for new features; 3.2.x, 3.1.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master / 3.2.x](https://area51.phpbb.com/docs/master/coding-guidelines.html), [3.1.x](https://area51.phpbb.com/docs/31x/coding-guidelines.html)
- [x] Commit follows commit message [format](https://wiki.phpbb.com/Git#Commit_Messages)

Tracker ticket PHPBB3-15266:

https://tracker.phpbb.com/browse/PHPBB3-15266
