### PR TITLE
[ticket/15274] Allow "custom" migrations to use parameters

### DIFF
--- a/phpBB/phpbb/db/migrator.php
+++ b/phpBB/phpbb/db/migrator.php
@@ -694,7 +694,7 @@ class migrator
 				{
 					return array(
 						$parameters[0],
-						array($last_result),
+						isset($parameters[1]) ? array_merge($parameters[1], array($last_result)) : array($last_result),
 					);
 				}
 			break;

--- a/tests/dbal/migration/if.php
+++ b/tests/dbal/migration/if.php
@@ -23,11 +23,11 @@ class phpbb_dbal_migration_if extends \phpbb\db\migration\migration
 		return array(
 			array('if', array(
 				true,
-				array('custom', array(array(&$this, 'test_true'))),
+				array('custom', array(array($this, 'test_true'))),
 			)),
 			array('if', array(
 				false,
-				array('custom', array(array(&$this, 'test_false'))),
+				array('custom', array(array($this, 'test_false'))),
 			)),
 		);
 	}

--- a/tests/dbal/migration/if_params.php
+++ b/tests/dbal/migration/if_params.php
@@ -23,11 +23,11 @@ class phpbb_dbal_migration_if_params extends \phpbb\db\migration\migration
 		return array(
 			array('if', array(
 				true,
-				array('custom', array(array(&$this, 'test'), array('true'))),
+				array('custom', array(array($this, 'test'), array('true'))),
 			)),
 			array('if', array(
 				false,
-				array('custom', array(array(&$this, 'test'), array('false'))),
+				array('custom', array(array($this, 'test'), array('false'))),
 			)),
 		);
 	}

--- a/tests/dbal/migration/if_params.php
+++ b/tests/dbal/migration/if_params.php
@@ -1,0 +1,44 @@
+<?php
+/**
+*
+* This file is part of the phpBB Forum Software package.
+*
+* @copyright (c) phpBB Limited <https://www.phpbb.com>
+* @license GNU General Public License, version 2 (GPL-2.0)
+*
+* For full copyright and license information, please see
+* the docs/CREDITS.txt file.
+*
+*/
+
+class phpbb_dbal_migration_if_params extends \phpbb\db\migration\migration
+{
+	function update_schema()
+	{
+		return array();
+	}
+
+	function update_data()
+	{
+		return array(
+			array('if', array(
+				true,
+				array('custom', array(array(&$this, 'test'), array('true'))),
+			)),
+			array('if', array(
+				false,
+				array('custom', array(array(&$this, 'test'), array('false'))),
+			)),
+		);
+	}
+
+	function test($param)
+	{
+		global $migrator_test_if_true_failed, $migrator_test_if_false_failed;
+
+		$var = 'migrator_test_if_' . $param . '_failed';
+
+		${$var} = !${$var};
+	}
+
+}

--- a/tests/dbal/migration/recall.php
+++ b/tests/dbal/migration/recall.php
@@ -21,7 +21,7 @@ class phpbb_dbal_migration_recall extends \phpbb\db\migration\migration
 	function update_data()
 	{
 		return array(
-			array('custom', array(array(&$this, 'test_call'))),
+			array('custom', array(array($this, 'test_call'))),
 		);
 	}
 

--- a/tests/dbal/migration/recall_params.php
+++ b/tests/dbal/migration/recall_params.php
@@ -1,0 +1,42 @@
+<?php
+/**
+*
+* This file is part of the phpBB Forum Software package.
+*
+* @copyright (c) phpBB Limited <https://www.phpbb.com>
+* @license GNU General Public License, version 2 (GPL-2.0)
+*
+* For full copyright and license information, please see
+* the docs/CREDITS.txt file.
+*
+*/
+
+class phpbb_dbal_migration_recall_params extends \phpbb\db\migration\migration
+{
+	function update_schema()
+	{
+		return array();
+	}
+
+	function update_data()
+	{
+		return array(
+			array('custom', array(array(&$this, 'test_call'), array(5))),
+		);
+	}
+
+	// This function should be called 5 times
+	function test_call($times, $input)
+	{
+		global $migrator_test_call_input;
+
+		$migrator_test_call_input = (int) $input;
+
+		if ($migrator_test_call_input < $times)
+		{
+			return ($migrator_test_call_input + 1);
+		}
+
+		return;
+	}
+}

--- a/tests/dbal/migration/recall_params.php
+++ b/tests/dbal/migration/recall_params.php
@@ -21,7 +21,7 @@ class phpbb_dbal_migration_recall_params extends \phpbb\db\migration\migration
 	function update_data()
 	{
 		return array(
-			array('custom', array(array(&$this, 'test_call'), array(5))),
+			array('custom', array(array($this, 'test_call'), array(5))),
 		);
 	}
 

--- a/tests/dbal/migrator_test.php
+++ b/tests/dbal/migrator_test.php
@@ -16,6 +16,8 @@ require_once dirname(__FILE__) . '/migration/dummy.php';
 require_once dirname(__FILE__) . '/migration/unfulfillable.php';
 require_once dirname(__FILE__) . '/migration/if.php';
 require_once dirname(__FILE__) . '/migration/recall.php';
+require_once dirname(__FILE__) . '/migration/if_params.php';
+require_once dirname(__FILE__) . '/migration/recall_params.php';
 require_once dirname(__FILE__) . '/migration/revert.php';
 require_once dirname(__FILE__) . '/migration/revert_with_dependency.php';
 require_once dirname(__FILE__) . '/migration/fail.php';
@@ -186,6 +188,54 @@ class phpbb_dbal_migrator_test extends phpbb_database_test_case
 		}
 
 		$this->assertSame(10, $migrator_test_call_input);
+	}
+
+	public function test_if_params()
+	{
+		$this->migrator->set_migrations(array('phpbb_dbal_migration_if_params'));
+
+		// Don't like this, but I'm not sure there is any other way to do this
+		global $migrator_test_if_true_failed, $migrator_test_if_false_failed;
+		$migrator_test_if_true_failed = true;
+		$migrator_test_if_false_failed = false;
+
+		while (!$this->migrator->finished())
+		{
+			$this->migrator->update();
+		}
+
+		$this->assertFalse($migrator_test_if_true_failed, 'True test failed');
+		$this->assertFalse($migrator_test_if_false_failed, 'False test failed');
+
+		while ($this->migrator->migration_state('phpbb_dbal_migration_if_params') !== false)
+		{
+			$this->migrator->revert('phpbb_dbal_migration_if_params');
+		}
+
+		$this->assertFalse($migrator_test_if_true_failed, 'True test after revert failed');
+		$this->assertFalse($migrator_test_if_false_failed, 'False test after revert failed');
+	}
+
+	public function test_recall_params()
+	{
+		$this->migrator->set_migrations(array('phpbb_dbal_migration_recall_params'));
+
+		global $migrator_test_call_input;
+
+		// Run the schema first
+		$this->migrator->update();
+
+		$i = 0;
+		while (!$this->migrator->finished())
+		{
+			$this->migrator->update();
+
+			$this->assertSame($i, $migrator_test_call_input);
+
+			$i++;
+		}
+
+		$this->assertSame(5, $migrator_test_call_input);
 	}
 
 	public function test_revert()


### PR DESCRIPTION
Add the possibility to have custom migrations with parameters,
allowing the use of a single function for several uses.

PHPBB3-15274

Checklist:

- [x] Correct branch: master for new features; 3.2.x, 3.1.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master / 3.2.x](https://area51.phpbb.com/docs/master/coding-guidelines.html), [3.1.x](https://area51.phpbb.com/docs/31x/coding-guidelines.html)
- [x] Commit follows commit message [format](https://wiki.phpbb.com/Git#Commit_Messages)

Tracker ticket:

https://tracker.phpbb.com/browse/PHPBB3-15274
