### PR TITLE
Fix memcached driver

### DIFF
--- a/phpBB/phpbb/cache/driver/memcached.php
+++ b/phpBB/phpbb/cache/driver/memcached.php
@@ -68,7 +68,7 @@ class memcached extends \phpbb\cache\driver\memory
 		foreach (explode(',', PHPBB_ACM_MEMCACHE) as $u)
 		{
 			preg_match('#(.*)/(\d+)#', $u, $parts);
-			$this->memcache->addServer(trim($parts[1]), (int) trim($parts[2]));
+			$this->memcached->addServer(trim($parts[1]), (int) trim($parts[2]));
 		}
 	}
 


### PR DESCRIPTION
copy/paste bug in memcached driver:
PHP Fatal error:  Uncaught Error: Call to a member function addServer() on null in /phpbb/cache/driver/memcached.php:71

memcache should be memcached


Could not automatically create an issue. Please create one on https://tracker.phpbb.com/ and replace this text with a link to it.