### PR TITLE
[ticket/15310] Do not recognize numbers as template names

### DIFF
--- a/phpBB/phpbb/template/twig/lexer.php
+++ b/phpBB/phpbb/template/twig/lexer.php
@@ -118,7 +118,7 @@ class lexer extends \Twig_Lexer
 
 		// Replace all of our variables, {VARNAME}, with Twig style, {{ VARNAME }}
 		// Appends any filters
-		$code = preg_replace('#{([a-zA-Z][a-zA-Z0-9_\.]*)(\|[^}]+?)?}#', '{{ $1$2 }}', $code);
+		$code = preg_replace('#{([a-zA-Z_][a-zA-Z0-9_\.]*)(\|[^}]+?)?}#', '{{ $1$2 }}', $code);
 
 		return parent::tokenize($code, $filename);
 	}

--- a/phpBB/phpbb/template/twig/lexer.php
+++ b/phpBB/phpbb/template/twig/lexer.php
@@ -118,7 +118,7 @@ class lexer extends \Twig_Lexer
 
 		// Replace all of our variables, {VARNAME}, with Twig style, {{ VARNAME }}
 		// Appends any filters
-		$code = preg_replace('#{([a-zA-Z0-9_\.]+)(\|[^}]+?)?}#', '{{ $1$2 }}', $code);
+		$code = preg_replace('#{([a-zA-Z][a-zA-Z0-9_\.]*)(\|[^}]+?)?}#', '{{ $1$2 }}', $code);
 
 		return parent::tokenize($code, $filename);
 	}


### PR DESCRIPTION
Currently, something like {923} in a template file is recognized as a potential template name, and replaced by {{ 923 }} for Twig processing.  This also happens with things like {9abc._} or {.a_b.}.
At the very least, things that do not start with a letter should be excluded, and that would rule out most of the "false positives" that it is currently identifying.

PHPBB3-15310

Checklist:

- [x] Correct branch: master for new features; 3.2.x, 3.1.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master / 3.2.x](https://area51.phpbb.com/docs/master/coding-guidelines.html), [3.1.x](https://area51.phpbb.com/docs/31x/coding-guidelines.html)
- [x] Commit follows commit message [format](https://wiki.phpbb.com/Git#Commit_Messages)

Tracker ticket:

https://tracker.phpbb.com/browse/PHPBB3-15310
