### PR TITLE
[ticket/15318] Make user option to disable word censoring effective again

### DIFF
--- a/phpBB/includes/functions_content.php
+++ b/phpBB/includes/functions_content.php
@@ -557,6 +557,7 @@ function strip_bbcode(&$text, $uid = '')
 function generate_text_for_display($text, $uid, $bitfield, $flags, $censor_text = true)
 {
 	static $bbcode;
+	global $auth, $config, $user;
 	global $phpbb_dispatcher, $phpbb_container;
 
 	if ($text === '')
@@ -584,6 +585,13 @@ function generate_text_for_display($text, $uid, $bitfield, $flags, $censor_text 
 
 		// Temporarily switch off viewcensors if applicable
 		$old_censor = $renderer->get_viewcensors();
+
+		// Check here if the user is having viewing censors disabled (and also allowed to do so).
+		if (!$user->optionget('viewcensors') && $config['allow_nocensors'] && $auth->acl_get('u_chgcensors'))
+		{
+			$censor_text = false;
+		}
+
 		if ($old_censor !== $censor_text)
 		{
 			$renderer->set_viewcensors($censor_text);

--- a/tests/text_processing/generate_text_for_display_test.php
+++ b/tests/text_processing/generate_text_for_display_test.php
@@ -29,7 +29,7 @@ class phpbb_text_processing_generate_text_for_display_test extends phpbb_test_ca
 	*/
 	public function test_legacy($original, $expected, $uid = '', $bitfield = '', $flags = 0, $censor_text = true)
 	{
-		global $cache, $user;
+		global $auth, $cache, $config, $user;
 
 		global $phpbb_root_path, $phpEx;
 
@@ -63,7 +63,7 @@ class phpbb_text_processing_generate_text_for_display_test extends phpbb_test_ca
 
 	public function test_censor_is_restored()
 	{
-		global $phpbb_container;
+		global $auth, $user, $config, $phpbb_container;
 
 		$phpbb_container = new phpbb_mock_container_builder;
 
@@ -109,7 +109,7 @@ class phpbb_text_processing_generate_text_for_display_test extends phpbb_test_ca
 	*/
 	public function test_text_formatter($original, $expected, $censor_text = true, $setup = null)
 	{
-		global $phpbb_container;
+		global $auth, $user, $config, $phpbb_container;
 
 		$phpbb_container = new phpbb_mock_container_builder;
 

--- a/tests/text_processing/generate_text_for_display_test.php
+++ b/tests/text_processing/generate_text_for_display_test.php
@@ -72,7 +72,8 @@ class phpbb_text_processing_generate_text_for_display_test extends phpbb_test_ca
 		$lang_loader = new \phpbb\language\language_file_loader($phpbb_root_path, $phpEx);
 		$lang = new \phpbb\language\language($lang_loader);
 		$user = new \phpbb\user($lang, '\phpbb\datetime');
-		$user->optionset('viewcensors', false);
+		// Do not ignore word censoring by user (switch censoring on in UCP)
+		$user->optionset('viewcensors', true);
 
 		$config = new \phpbb\config\config(array('allow_nocensors' => true));
 
@@ -102,6 +103,14 @@ class phpbb_text_processing_generate_text_for_display_test extends phpbb_test_ca
 		$this->assertSame('apple', $renderer->render($original));
 		$this->assertSame('banana', generate_text_for_display($original, '', '', 0, true));
 		$this->assertSame('apple', $renderer->render($original), 'The original setting was not restored');
+
+		// Test user option switch to ignore censoring
+		$renderer->set_viewcensors(true);
+		// 1st: censoring is still on in UCP
+		$this->assertSame('banana', generate_text_for_display($original, '', '', 0, true));
+		// 2nd: switch censoring off in UCP
+		$user->optionset('viewcensors', false);
+		$this->assertSame('apple', generate_text_for_display($original, '', '', 0, true));
 	}
 
 	/**


### PR DESCRIPTION
For 3.2.x/master only.

Checklist:

- [x] Correct branch: master for new features; 3.2.x, 3.1.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master / 3.2.x](https://area51.phpbb.com/docs/master/coding-guidelines.html), [3.1.x](https://area51.phpbb.com/docs/31x/coding-guidelines.html)
- [x] Commit follows commit message [format](https://wiki.phpbb.com/Git#Commit_Messages)

Tracker ticket (set the ticket ID to **your ticket ID**):

<a href="https://tracker.phpbb.com/browse/PHPBB3-15318">PHPBB3-15318</a>.
