### PR TITLE
[ticket/15320] 	Redis cache does not save keys withouth expiration

### DIFF
--- a/phpBB/phpbb/cache/driver/redis.php
+++ b/phpBB/phpbb/cache/driver/redis.php
@@ -137,7 +137,7 @@ class redis extends \phpbb\cache\driver\memory
 	*/
 	function _write($var, $data, $ttl = 2592000)
 	{
-		if($ttl == 0)
+		if ($ttl == 0)
 		{
 			return $this->redis->set($var, $data);
 		}

--- a/phpBB/phpbb/cache/driver/redis.php
+++ b/phpBB/phpbb/cache/driver/redis.php
@@ -137,6 +137,10 @@ class redis extends \phpbb\cache\driver\memory
 	*/
 	function _write($var, $data, $ttl = 2592000)
 	{
+		if($ttl == 0)
+		{
+			return $this->redis->set($var, $data);
+		}
 		return $this->redis->setex($var, $ttl, $data);
 	}
 


### PR DESCRIPTION
In some functions like sql_save in cache/memory.php, code try to save a key/value in cache with ttl = 0 so key should never expire. In current redis.php cache driver, it fails so key never get cached. 
This cause for example that when you create a subforum, it not appear imediatly in the forum box in the admincp.
To solve, if ttl is 0, we use redis->set instead of setex

Checklist:

- [x] Correct branch: master for new features; 3.2.x, 3.1.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master / 3.2.x](https://area51.phpbb.com/docs/master/coding-guidelines.html), [3.1.x](https://area51.phpbb.com/docs/31x/coding-guidelines.html)
- [x] Commit follows commit message [format](https://wiki.phpbb.com/Git#Commit_Messages)

Tracker ticket (set the ticket ID to **your ticket ID**):

https://tracker.phpbb.com/browse/PHPBB3-15320
