### PR TITLE
[ticket/15331] Allow gravatars to be overridden by existing event - A

### DIFF
--- a/phpBB/phpbb/avatar/driver/gravatar.php
+++ b/phpBB/phpbb/avatar/driver/gravatar.php
@@ -29,21 +29,10 @@ class gravatar extends \phpbb\avatar\driver\driver
 	public function get_data($row)
 	{
 		return array(
-			'src' => $row['avatar'],
+			'src' => $this->get_gravatar_url($row),
 			'width' => $row['avatar_width'],
 			'height' => $row['avatar_height'],
 		);
-	}
-
-	/**
-	* {@inheritdoc}
-	*/
-	public function get_custom_html($user, $row, $alt = '')
-	{
-		return '<img src="' . $this->get_gravatar_url($row) . '" ' .
-			($row['avatar_width'] ? ('width="' . $row['avatar_width'] . '" ') : '') .
-			($row['avatar_height'] ? ('height="' . $row['avatar_height'] . '" ') : '') .
-			'alt="' . ((!empty($user->lang[$alt])) ? $user->lang[$alt] : $alt) . '" />';
 	}
 
 	/**


### PR DESCRIPTION
Option A:
- change the gravatar driver to not use the custom HTML function

PHPBB3-15331

Checklist:

- [x] Correct branch: master for new features; 3.2.x, 3.1.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master / 3.2.x](https://area51.phpbb.com/docs/master/coding-guidelines.html), [3.1.x](https://area51.phpbb.com/docs/31x/coding-guidelines.html)
- [x] Commit follows commit message [format](https://wiki.phpbb.com/Git#Commit_Messages)

Tracker ticket:

https://tracker.phpbb.com/browse/PHPBB3-15331
