### PR TITLE
[ticket/15331] Allow gravatars to be overridden by existing event - B

### DIFF
--- a/phpBB/includes/functions.php
+++ b/phpBB/includes/functions.php
@@ -4902,11 +4902,6 @@ function phpbb_get_avatar($row, $alt, $ignore_config = false, $lazy = false)
 	if ($driver)
 	{
 		$html = $driver->get_custom_html($user, $row, $alt);
-		if (!empty($html))
-		{
-			return $html;
-		}
-
 		$avatar_data = $driver->get_data($row);
 	}
 	else
@@ -4914,7 +4909,7 @@ function phpbb_get_avatar($row, $alt, $ignore_config = false, $lazy = false)
 		$avatar_data['src'] = '';
 	}
 
-	if (!empty($avatar_data['src']))
+	if (empty($html) && !empty($avatar_data['src']))
 	{
 		if ($lazy)
 		{


### PR DESCRIPTION
Option B:
- change the get_avatar function to always trigger the event

PHPBB3-15331

Checklist:

- [x] Correct branch: master for new features; 3.2.x, 3.1.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master / 3.2.x](https://area51.phpbb.com/docs/master/coding-guidelines.html), [3.1.x](https://area51.phpbb.com/docs/31x/coding-guidelines.html)
- [x] Commit follows commit message [format](https://wiki.phpbb.com/Git#Commit_Messages)

Tracker ticket:

https://tracker.phpbb.com/browse/PHPBB3-15331
