### PR TITLE
[ticket/15328] Disable checkbox if notification method isn't supported

### DIFF
--- a/phpBB/includes/ucp/ucp_notifications.php
+++ b/phpBB/includes/ucp/ucp_notifications.php
@@ -180,13 +180,13 @@ class ucp_notifications
 				'GROUP_NAME'	=> $user->lang($group),
 			));
 
-			foreach ($subscription_types as $type => $data)
+			foreach ($subscription_types as $type => $type_data)
 			{
 				$template->assign_block_vars($block, array(
 					'TYPE'				=> $type,
 
-					'NAME'				=> $user->lang($data['lang']),
-					'EXPLAIN'			=> (isset($user->lang[$data['lang'] . '_EXPLAIN'])) ? $user->lang($data['lang'] . '_EXPLAIN') : '',
+					'NAME'				=> $user->lang($type_data['lang']),
+					'EXPLAIN'			=> (isset($user->lang[$type_data['lang'] . '_EXPLAIN'])) ? $user->lang($type_data['lang'] . '_EXPLAIN') : '',
 				));
 
 				foreach ($notification_methods as $method => $method_data)
@@ -195,6 +195,8 @@ class ucp_notifications
 						'METHOD'			=> $method_data['id'],
 
 						'NAME'				=> $user->lang($method_data['lang']),
+
+						'AVAILABLE'			=> $method_data['method']->is_available($type_data['type']),
 
 						'SUBSCRIBED'		=> (isset($subscriptions[$type]) && in_array($method_data['id'], $subscriptions[$type])) ? true : false,
 					));

--- a/phpBB/phpbb/notification/manager.php
+++ b/phpBB/phpbb/notification/manager.php
@@ -475,9 +475,10 @@ class manager
 				if ($type instanceof \phpbb\notification\type\type_interface && $type->is_available())
 				{
 					$options = array_merge(array(
-						'id' => $type->get_type(),
-						'lang' => 'NOTIFICATION_TYPE_' . strtoupper($type->get_type()),
-						'group' => 'NOTIFICATION_GROUP_MISCELLANEOUS',
+						'type'	=> $type,
+						'id'	=> $type->get_type(),
+						'lang'	=> 'NOTIFICATION_TYPE_' . strtoupper($type->get_type()),
+						'group'	=> 'NOTIFICATION_GROUP_MISCELLANEOUS',
 					), (($type::$notification_option !== false) ? $type::$notification_option : array()));
 
 					$this->subscription_types[$options['group']][$options['id']] = $options;
@@ -509,6 +510,7 @@ class manager
 		foreach ($this->get_available_subscription_methods() as $method_name => $method)
 		{
 			$subscription_methods[$method_name] = array(
+				'method'	=> $method,
 				'id'		=> $method->get_type(),
 				'lang'		=> str_replace('.', '_', strtoupper($method->get_type())),
 			);

--- a/phpBB/phpbb/notification/method/email.php
+++ b/phpBB/phpbb/notification/method/email.php
@@ -13,6 +13,8 @@
 
 namespace phpbb\notification\method;
 
+use phpbb\notification\type\type_interface;
+
 /**
 * Email notification method class
 * This class handles sending emails for notifications
@@ -57,11 +59,11 @@ class email extends \phpbb\notification\method\messenger_base
 	* Is this method available for the user?
 	* This is checked on the notifications options
 	*
-	* @param \phpbb\notification\type\type_interface $notification_type An optional instance of a notification type. If provided, this
-	*																	method additionally checks if the type provides an email template.
+	* @param type_interface $notification_type  An optional instance of a notification type. If provided, this
+	*											method additionally checks if the type provides an email template.
 	* @return bool
 	*/
-	public function is_available(\phpbb\notification\type\type_interface $notification_type = null)
+	public function is_available(type_interface $notification_type = null)
 	{
 		return parent::is_available($notification_type) && $this->config['email_enable'] && $this->user->data['user_email'];
 	}

--- a/phpBB/phpbb/notification/method/email.php
+++ b/phpBB/phpbb/notification/method/email.php
@@ -56,10 +56,14 @@ class email extends \phpbb\notification\method\messenger_base
 	/**
 	* Is this method available for the user?
 	* This is checked on the notifications options
+	*
+	* @param \phpbb\notification\type\type_interface $notification_type An optional instance of a notification type. If provided, this
+	*																	method additionally checks if the type provides an email template.
+	* @return bool
 	*/
-	public function is_available()
+	public function is_available(\phpbb\notification\type\type_interface $notification_type = null)
 	{
-		return $this->config['email_enable'] && $this->user->data['user_email'];
+		return parent::is_available($notification_type) && $this->config['email_enable'] && $this->user->data['user_email'];
 	}
 
 	/**

--- a/phpBB/phpbb/notification/method/jabber.php
+++ b/phpBB/phpbb/notification/method/jabber.php
@@ -13,6 +13,8 @@
 
 namespace phpbb\notification\method;
 
+use phpbb\notification\type\type_interface;
+
 /**
 * Jabber notification method class
 * This class handles sending Jabber messages for notifications
@@ -57,11 +59,11 @@ class jabber extends \phpbb\notification\method\messenger_base
 	* Is this method available for the user?
 	* This is checked on the notifications options
 	*
-	* @param \phpbb\notification\type\type_interface $notification_type	An optional instance of a notification type. If provided, this
-	*																	method additionally checks if the type provides an email template.
+	* @param type_interface $notification_type	An optional instance of a notification type. If provided, this
+	*											method additionally checks if the type provides an email template.
 	* @return bool
 	*/
-	public function is_available(\phpbb\notification\type\type_interface $notification_type = null)
+	public function is_available(type_interface $notification_type = null)
 	{
 		return parent::is_available($notification_type) && $this->global_available() && $this->user->data['user_jabber'];
 	}

--- a/phpBB/phpbb/notification/method/jabber.php
+++ b/phpBB/phpbb/notification/method/jabber.php
@@ -56,10 +56,14 @@ class jabber extends \phpbb\notification\method\messenger_base
 	/**
 	* Is this method available for the user?
 	* This is checked on the notifications options
+	*
+	* @param \phpbb\notification\type\type_interface $notification_type	An optional instance of a notification type. If provided, this
+	*																	method additionally checks if the type provides an email template.
+	* @return bool
 	*/
-	public function is_available()
+	public function is_available(\phpbb\notification\type\type_interface $notification_type = null)
 	{
-		return ($this->global_available() && $this->user->data['user_jabber']);
+		return parent::is_available($notification_type) && $this->global_available() && $this->user->data['user_jabber'];
 	}
 
 	/**

--- a/phpBB/phpbb/notification/method/messenger_base.php
+++ b/phpBB/phpbb/notification/method/messenger_base.php
@@ -13,6 +13,8 @@
 
 namespace phpbb\notification\method;
 
+use phpbb\notification\type\type_interface;
+
 /**
 * Abstract notification method handling email and jabber notifications
 * using the phpBB messenger.
@@ -46,11 +48,11 @@ abstract class messenger_base extends \phpbb\notification\method\base
 	* Is this method available for the user?
 	* This is checked on the notifications options
 	*
-	* @param \phpbb\notification\type\type_interface $notification_type	An optional instance of a notification type. This method returns false
-	*																	only if the type is provided and if it doesn't provide an email template.
+	* @param type_interface $notification_type	An optional instance of a notification type. This method returns false
+	*											only if the type is provided and if it doesn't provide an email template.
 	* @return bool
 	*/
-	public function is_available(\phpbb\notification\type\type_interface $notification_type = null)
+	public function is_available(type_interface $notification_type = null)
 	{
 		return $notification_type === null || $notification_type->get_email_template() !== false;
 	}

--- a/phpBB/phpbb/notification/method/messenger_base.php
+++ b/phpBB/phpbb/notification/method/messenger_base.php
@@ -43,6 +43,19 @@ abstract class messenger_base extends \phpbb\notification\method\base
 	}
 
 	/**
+	* Is this method available for the user?
+	* This is checked on the notifications options
+	*
+	* @param \phpbb\notification\type\type_interface $notification_type	An optional instance of a notification type. This method returns false
+	*																	only if the type is provided and if it doesn't provide an email template.
+	* @return bool
+	*/
+	public function is_available(\phpbb\notification\type\type_interface $notification_type = null)
+	{
+		return $notification_type === null || $notification_type->get_email_template() !== false;
+	}
+
+	/**
 	* Notify using phpBB messenger
 	*
 	* @param int $notify_method				Notify method for messenger (e.g. NOTIFY_IM)

--- a/phpBB/styles/prosilver/template/ucp_notifications.html
+++ b/phpBB/styles/prosilver/template/ucp_notifications.html
@@ -31,7 +31,7 @@
 								<!-- IF notification_types.EXPLAIN --><br />&nbsp; &nbsp;{notification_types.EXPLAIN}<!-- ENDIF -->
 							</td>
 							<!-- BEGIN notification_methods -->
-								<td class="mark"><input type="checkbox" name="{notification_types.TYPE}_{notification_methods.METHOD}"<!-- IF notification_methods.SUBSCRIBED --> checked="checked"<!-- ENDIF --> /></td>
+								<td class="mark"><input type="checkbox" name="{notification_types.TYPE}_{notification_types.notification_methods.METHOD}"<!-- IF notification_types.notification_methods.AVAILABLE and notification_types.notification_methods.SUBSCRIBED --> checked="checked"<!-- ENDIF --><!-- IF not notification_types.notification_methods.AVAILABLE --> disabled="disabled"<!-- ENDIF --> /></td>
 							<!-- END notification_methods -->
 						</tr>
 					<!-- ENDIF -->


### PR DESCRIPTION
Stuffing the instances into the `type` and `method` data arrays in `manager.php` doesn't feel like an elegant solution but it's the best I could find that is extensible.

As an alternative, it could all be done in the UCP module, probably with some `instanceof` checks, but that would make it deal with things that it shouldn't deal with, in my opinion. Other suggestions are welcome.

Checklist:

- [x] Correct branch: master for new features; 3.2.x, 3.1.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master / 3.2.x](https://area51.phpbb.com/docs/master/coding-guidelines.html), [3.1.x](https://area51.phpbb.com/docs/31x/coding-guidelines.html)
- [x] Commit follows commit message [format](https://wiki.phpbb.com/Git#Commit_Messages)

https://tracker.phpbb.com/browse/PHPBB3-15328
