### PR TITLE
ticket/15345 Add links to icons for forums, topics with no unread posts

### DIFF
--- a/phpBB/styles/prosilver/template/forumlist_body.html
+++ b/phpBB/styles/prosilver/template/forumlist_body.html
@@ -33,7 +33,7 @@
 			<!-- EVENT forumlist_body_forum_row_prepend -->
 			<dl class="row-item {forumrow.FORUM_IMG_STYLE}">
 				<dt title="{forumrow.FORUM_FOLDER_IMG_ALT}">
-					<!-- IF forumrow.S_UNREAD_FORUM --><a href="{forumrow.U_VIEWFORUM}" class="row-item-link"></a><!-- ENDIF -->
+					<a href="{forumrow.U_VIEWFORUM}" class="row-item-link"></a>
 					<div class="list-inner">
 						<!-- IF S_ENABLE_FEEDS and forumrow.S_FEED_ENABLED -->
 							<!--

--- a/phpBB/styles/prosilver/template/search_results.html
+++ b/phpBB/styles/prosilver/template/search_results.html
@@ -80,6 +80,7 @@
 				<dl class="row-item {searchresults.TOPIC_IMG_STYLE}">
 					<dt<!-- IF searchresults.TOPIC_ICON_IMG --> style="background-image: url({T_ICONS_PATH}{searchresults.TOPIC_ICON_IMG}); background-repeat: no-repeat;"<!-- ENDIF --> title="{searchresults.TOPIC_FOLDER_IMG_ALT}">
 						<!-- IF searchresults.S_UNREAD_TOPIC and not S_IS_BOT --><a href="{searchresults.U_NEWEST_POST}" class="row-item-link"></a><!-- ENDIF -->
+						<!-- IF not searchresults.S_UNREAD_TOPIC and not S_IS_BOT --><a href="{searchresults.U_LAST_POST}" class="row-item-link"></a><!-- ENDIF -->
 						<div class="list-inner">
 							<!-- EVENT topiclist_row_prepend -->
 							<!-- IF searchresults.S_UNREAD_TOPIC and not S_IS_BOT -->

--- a/phpBB/styles/prosilver/template/viewforum_body.html
+++ b/phpBB/styles/prosilver/template/viewforum_body.html
@@ -158,6 +158,7 @@
 			<dl class="row-item {topicrow.TOPIC_IMG_STYLE}">
 				<dt<!-- IF topicrow.TOPIC_ICON_IMG and S_TOPIC_ICONS --> style="background-image: url({T_ICONS_PATH}{topicrow.TOPIC_ICON_IMG}); background-repeat: no-repeat;"<!-- ENDIF --> title="{topicrow.TOPIC_FOLDER_IMG_ALT}">
 					<!-- IF topicrow.S_UNREAD_TOPIC and not S_IS_BOT --><a href="{topicrow.U_NEWEST_POST}" class="row-item-link"></a><!-- ENDIF -->
+					<!-- IF not topicrow.S_UNREAD_TOPIC and not S_IS_BOT --><a href="{topicrow.U_LAST_POST}" class="row-item-link"></a><!-- ENDIF -->
 					<div class="list-inner">
 						<!-- EVENT topiclist_row_prepend -->
 						<!-- IF topicrow.S_UNREAD_TOPIC and not S_IS_BOT -->


### PR DESCRIPTION

A patch that gives icons for forums with no unread posts a link to the forum
(same as existing for forums with unread posts),
and gives icons for topics with unread posts a link to the last post in the topic,
which seems to be the natural thing to do as an extension of the existing behaviour 
for topics with unread posts.

PHPBB3-15345

Checklist:

- [*] Correct branch: master for new features; 3.2.x, 3.1.x for fixes
- [*] Tests pass
- [*] Code follows coding guidelines: [master / 3.2.x](https://area51.phpbb.com/docs/master/coding-guidelines.html), [3.1.x](https://area51.phpbb.com/docs/31x/coding-guidelines.html)
- [*] Commit follows commit message [format](https://wiki.phpbb.com/Git#Commit_Messages)

Tracker ticket (set the ticket ID to **your ticket ID**):

https://tracker.phpbb.com/browse/PHPBB3-15345
