### PR TITLE
[ticket/13214] Contact us page textarea looks narrow in responsive mode

### DIFF
--- a/phpBB/styles/prosilver/template/memberlist_email.html
+++ b/phpBB/styles/prosilver/template/memberlist_email.html
@@ -77,7 +77,7 @@
 		<dl>
 			<dt><label for="message">{L_MESSAGE_BODY}{L_COLON}</label><br />
 			<span>{L_EMAIL_BODY_EXPLAIN}</span></dt>
-			<dd><textarea class="inputbox" name="message" id="message" rows="15" cols="76" tabindex="4">{MESSAGE}</textarea></dd>
+			<dd><textarea name="message" id="message" rows="15" cols="76" tabindex="4">{MESSAGE}</textarea></dd>
 		</dl>
 		<!-- IF S_REGISTERED_USER -->
 		<dl>

--- a/phpBB/styles/prosilver/theme/responsive.css
+++ b/phpBB/styles/prosilver/theme/responsive.css
@@ -344,7 +344,7 @@
 	}
 
 	fieldset dd, fieldset.fields1 dd, fieldset.fields2 dd {
-		margin-left: 20px;
+		margin-left: 0px;
 	}
 
 	textarea, dd textarea, .message-box textarea {


### PR DESCRIPTION
Checklist:

- [x] Correct branch: master for new features; 3.2.x, 3.1.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master / 3.2.x](https://area51.phpbb.com/docs/master/coding-guidelines.html), [3.1.x](https://area51.phpbb.com/docs/31x/coding-guidelines.html)
- [x] Commit follows commit message [format](https://wiki.phpbb.com/Git#Commit_Messages)

PHPBB3-13214

https://tracker.phpbb.com/browse/PHPBB3-13214

<img width="400" alt="screenshot 2017-09-11 11 36 27" src="https://user-images.githubusercontent.com/73081/30287057-aef0c308-96f1-11e7-8028-932bd78c9397.png">
