### PR TITLE
[ticket/15385] nginx.sample.conf: www redirection, security regex

### DIFF
--- a/phpBB/docs/nginx.sample.conf
+++ b/phpBB/docs/nginx.sample.conf
@@ -18,11 +18,11 @@ http {
     gzip_vary on;
     gzip_http_version 1.1;
     gzip_min_length 700;
-    
+
     # Compression levels over 6 do not give an appreciable improvement
     # in compression ratio, but take more resources.
     gzip_comp_level 6;
-    
+
     # IE 6 and lower do not support gzip with Vary correctly.
     gzip_disable "msie6";
     # Before nginx 0.7.63:
@@ -49,9 +49,7 @@ http {
         server_name myforums.com;
 
         # A trick from http://wiki.nginx.org/Pitfalls#Taxing_Rewrites:
-        rewrite ^ http://www.myforums.com$request_uri permanent;
-        # Equivalent to:
-        #rewrite ^(.*)$ http://www.myforums.com$1 permanent;
+        return 301 http://www.myforums.com$request_uri;
     }
 
     # The actual board domain.
@@ -72,7 +70,7 @@ http {
         }
 
         # Deny access to internal phpbb files.
-        location ~ /(config\.php|common\.php|cache|files|images/avatars/upload|includes|phpbb|store|vendor) {
+        location ~ /(config\.php|common\.php|cache|files|images/avatars/upload|includes|(?<!ext/)phpbb|store|vendor) {
             deny all;
             # deny was ignored before 0.8.40 for connections over IPv6.
             # Use internal directive to prohibit access on older versions.


### PR DESCRIPTION
Checklist:

- [x] Correct branch: master for new features; 3.2.x, 3.1.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master / 3.2.x](https://area51.phpbb.com/docs/master/coding-guidelines.html), [3.1.x](https://area51.phpbb.com/docs/31x/coding-guidelines.html)
- [x] Commit follows commit message [format](https://wiki.phpbb.com/Git#Commit_Messages)

Tracker ticket: https://tracker.phpbb.com/browse/PHPBB3-15385

according to the latest wiki info:
http://wiki.nginx.org/Pitfalls#Taxing_Rewrites
`return 301` is preferred over a `rewrite`.

also, the 'security' regex breaks some official extensions because it 
will match and deny access to `/ext/phpbb`.

looking through the names of dirs and files containing `phpbb`, it 
looks like the intent of the regex was to only disallow the folder 
`phpbb` in the root dir and not other `/phpbb` matches.
a negative lookbehind was added to specifically not match `/ext/phpbb` 
but still match other occurrences of `/phpbb`.