### PR TITLE
[ticket/15389] Allow arrays in event dispatcher

### DIFF
--- a/phpBB/phpbb/event/dispatcher.php
+++ b/phpBB/phpbb/event/dispatcher.php
@@ -57,7 +57,12 @@ class dispatcher extends ContainerAwareEventDispatcher implements dispatcher_int
 			return $event;
 		}
 
-		return parent::dispatch($eventName, $event);
+		foreach ((array) $eventName as $name)
+		{
+			$event = parent::dispatch($name, $event);
+		}
+
+		return $event;
 	}
 
 	/**

--- a/phpBB/phpbb/event/php_exporter.php
+++ b/phpBB/phpbb/event/php_exporter.php
@@ -196,13 +196,13 @@ class php_exporter
 		$content = file_get_contents($this->path . $this->current_file);
 		$num_events_found = 0;
 
-		if (strpos($content, "dispatcher->trigger_event('") || strpos($content, "dispatcher->dispatch('"))
+		if (strpos($content, 'dispatcher->trigger_event(') || strpos($content, 'dispatcher->dispatch('))
 		{
 			$this->set_content(explode("\n", $content));
 			for ($i = 0, $num_lines = sizeof($this->file_lines); $i < $num_lines; $i++)
 			{
 				$event_line = false;
-				$found_trigger_event = strpos($this->file_lines[$i], "dispatcher->trigger_event('");
+				$found_trigger_event = strpos($this->file_lines[$i], 'dispatcher->trigger_event(');
 				$arguments = array();
 				if ($found_trigger_event !== false)
 				{
@@ -216,7 +216,7 @@ class php_exporter
 				}
 				else
 				{
-					$found_dispatch = strpos($this->file_lines[$i], "dispatcher->dispatch('");
+					$found_dispatch = strpos($this->file_lines[$i], 'dispatcher->dispatch(');
 					if ($found_dispatch !== false)
 					{
 						$event_line = $i;
@@ -316,17 +316,17 @@ class php_exporter
 
 		if ($is_dispatch)
 		{
-			$regex = '#\$([a-z](?:[a-z0-9_]|->)*)';
-			$regex .= '->dispatch\(';
-			$regex .= '\'' . $this->preg_match_event_name() . '\'';
-			$regex .= '\);#';
+			$regex = '#\$[a-z](?:[a-z0-9_]|->)*';
+			$regex .= '->dispatch\((\[)?';
+			$regex .= '\'' . $this->preg_match_event_name() . '(?(1)\', \'(?2))+\'';
+			$regex .= '(?(1)\])\);#';
 		}
 		else
 		{
-			$regex = '#extract\(\$([a-z](?:[a-z0-9_]|->)*)';
-			$regex .= '->trigger_event\(';
-			$regex .= '\'' . $this->preg_match_event_name() . '\'';
-			$regex .= ', compact\(\$vars\)\)\);#';
+			$regex = '#extract\(\$[a-z](?:[a-z0-9_]|->)*';
+			$regex .= '->trigger_event\((\[)?';
+			$regex .= '\'' . $this->preg_match_event_name() . '(?(1)\', \'(?2))+\'';
+			$regex .= '(?(1)\]), compact\(\$vars\)\)\);#';
 		}
 
 		$match = array();
@@ -359,7 +359,7 @@ class php_exporter
 	public function get_vars_from_array()
 	{
 		$line = ltrim($this->file_lines[$this->current_event_line - 1], "\t");
-		if ($line === ');')
+		if ($line === ');' || $line === '];')
 		{
 			$vars_array = $this->get_vars_from_multi_line_array();
 		}
@@ -370,7 +370,7 @@ class php_exporter
 
 		foreach ($vars_array as $var)
 		{
-			if (!preg_match('#^([a-zA-Z_][a-zA-Z0-9_]*)$#', $var))
+			if (!preg_match('#^[a-z_][a-z0-9_]*$#i', $var))
 			{
 				throw new \LogicException("Found invalid var '{$var}' in array for event '{$this->current_event}' in file '{$this->current_file}:{$this->current_event_line}'", 3);
 			}
@@ -392,11 +392,11 @@ class php_exporter
 	public function get_vars_from_single_line_array($line, $throw_multiline = true)
 	{
 		$match = array();
-		preg_match('#^\$vars = (?:\[|array\()\'([a-zA-Z0-9_\' ,]+)\'[\)\]];$#', $line, $match);
+		preg_match('#^\$vars = (?:(\[)|array\()\'([a-z0-9_\' ,]+)\'(?(1)\]|\));$#i', $line, $match);
 
-		if (isset($match[1]))
+		if (isset($match[2]))
 		{
-			$vars_array = explode("', '", $match[1]);
+			$vars_array = explode("', '", $match[2]);
 			if ($throw_multiline && sizeof($vars_array) > 6)
 			{
 				throw new \LogicException('Should use multiple lines for $vars definition '
@@ -420,7 +420,7 @@ class php_exporter
 	{
 		$current_vars_line = 2;
 		$var_lines = array();
-		while (ltrim($this->file_lines[$this->current_event_line - $current_vars_line], "\t") !== '$vars = array(')
+		while (!in_array(ltrim($this->file_lines[$this->current_event_line - $current_vars_line], "\t"), ['$vars = array(', '$vars = [']))
 		{
 			$var_lines[] = substr(trim($this->file_lines[$this->current_event_line - $current_vars_line]), 0, -1);
 
@@ -485,7 +485,7 @@ class php_exporter
 
 		foreach ($doc_vars as $var)
 		{
-			if (!preg_match('#^([a-zA-Z_][a-zA-Z0-9_]*)$#', $var))
+			if (!preg_match('#^[a-z_][a-z0-9_]*$#i', $var))
 			{
 				throw new \LogicException("Found invalid @var '{$var}' in docblock for event "
 					. "'{$this->current_event}' in file '{$this->current_file}:{$this->current_event_line}'", 4);

--- a/tests/event/dispatcher_test.php
+++ b/tests/event/dispatcher_test.php
@@ -29,5 +29,21 @@ class phpbb_event_dispatcher_test extends phpbb_test_case
         $result = $dispatcher->trigger_event('core.test_event', compact($vars));
 
         $this->assertSame(array('foo' => 'foo2', 'bar' => 'bar2'), $result);
+
+        // Test migrating events
+		$dispatcher->addListener('core.foo_br', function(\phpbb\event\data $event) {
+			$event['pi'] = '3.14159';
+		});
+		$dispatcher->addListener('core.foo_bar', function(\phpbb\event\data $event) {
+			$event['pi'] = '3.1';
+		});
+
+
+		$pi = '3';
+
+		$vars = array('pi');
+		$result = $dispatcher->trigger_event(['core.foo_bar', 'core.foo_br'], compact($vars));
+
+		$this->assertSame(array('pi' => '3.14159'), $result);
     }
 }

--- a/tests/event/fixtures/event_migration.test
+++ b/tests/event/fixtures/event_migration.test
@@ -1,0 +1,30 @@
+<?php
+
+	/**
+	* Modify pm and sender data before it is assigned to the template
+	*
+	* @event core.ucp_pm_view_message
+	* @var	mixed	id			Active module category (can be int or string)
+	* @var	string	mode		Active module
+	* @var	int		folder_id	ID of the folder the message is in
+	* @var	int		msg_id		ID of the private message
+	* @var	array	folder		Array with data of user's message folders
+	* @var	array	message_row	Array with message data
+	* @var	array	cp_row		Array with senders custom profile field data
+	* @var	array	msg_data	Template array with message data
+	* @var 	array	user_info	User data of the sender
+	* @since 3.1.0-a1
+	* @changed 3.1.6-RC1		Added user_info into event
+	*/
+	$vars = array(
+		'id',
+		'mode',
+		'folder_id',
+		'msg_id',
+		'folder',
+		'message_row',
+		'cp_row',
+		'msg_data',
+		'user_info',
+	);
+	extract($phpbb_dispatcher->trigger_event(['core.ucp_pm_view_message', 'core.ucp_pm_view_messsage'], compact($vars)));

--- a/tests/event/php_exporter_test.php
+++ b/tests/event/php_exporter_test.php
@@ -38,6 +38,18 @@ class phpbb_event_php_exporter_test extends phpbb_test_case
 				),
 			),
 			array(
+				'event_migration.test',
+				array(
+					'core.ucp_pm_view_message'	=> array(
+						'event'			=> 'core.ucp_pm_view_message',
+						'file'			=> 'event_migration.test',
+						'arguments'		=> array('cp_row', 'folder', 'folder_id', 'id', 'message_row', 'mode', 'msg_data', 'msg_id', 'user_info'),
+						'since'			=> '3.1.0-a1',
+						'description'	=> 'Modify pm and sender data before it is assigned to the template',
+					),
+				),
+			),
+			array(
 				'extra_description.test',
 				array(
 					'extra_description.dispatch'	=> array(
@@ -240,6 +252,8 @@ class phpbb_event_php_exporter_test extends phpbb_test_case
 			array("\t\$phpbb_dispatcher->dispatch('dispatch.one2.thr_ee4');", 'dispatch.one2.thr_ee4'),
 			array("\$this->dispatcher->dispatch('dispatch.one2');", 'dispatch.one2'),
 			array("\$phpbb_dispatcher->dispatch('dis_patch.one');", 'dis_patch.one'),
+			array("\$phpbb_dispatcher->dispatch(['dis_patch.one', 'dis_patch.one2']);", 'dis_patch.one'),
+			array("\$phpbb_dispatcher->dispatch(['dis_patch.one', 'dis_patch.one2', 'dis_patch.two3']);", 'dis_patch.one'),
 		);
 	}
 
@@ -259,6 +273,8 @@ class phpbb_event_php_exporter_test extends phpbb_test_case
 			array("\$phpbb_dispatcher->dispatch('');"),
 			array("\$phpbb_dispatcher->dispatch('dispatch.2one');"),
 			array("\$phpbb_dispatcher->dispatch('dispatch');"),
+			array("\$phpbb_dispatcher->dispatch(['dispatch.one']);"),
+			array("\$phpbb_dispatcher->dispatch(array('dispatch.one', 'dispatch.one2'));"),
 		);
 	}
 
@@ -279,6 +295,8 @@ class phpbb_event_php_exporter_test extends phpbb_test_case
 			array("\textract(\$phpbb_dispatcher->trigger_event('dispatch.one2.thr_ee4', compact(\$vars)));", 'dispatch.one2.thr_ee4'),
 			array("extract(\$this->dispatcher->trigger_event('dispatch.one2', compact(\$vars)));", 'dispatch.one2'),
 			array("extract(\$phpbb_dispatcher->trigger_event('dis_patch.one', compact(\$vars)));", 'dis_patch.one'),
+			array("extract(\$phpbb_dispatcher->trigger_event(['dis_patch.one', 'dis_patch.one2'], compact(\$vars)));", 'dis_patch.one'),
+			array("extract(\$phpbb_dispatcher->trigger_event(['dis_patch.one', 'dis_patch.one2', 'dis_patch.two3'], compact(\$vars)));", 'dis_patch.one'),
 		);
 	}
 
@@ -301,6 +319,7 @@ class phpbb_event_php_exporter_test extends phpbb_test_case
 			array("extract(\$phpbb_dispatcher->trigger_event('dispatch.one', \$vars));"),
 			array("extract(\$phpbb_dispatcher->trigger_event('dispatch.one', compact(\$var)));"),
 			array("extract(\$phpbb_dispatcher->trigger_event('dispatch.one', compact(\$array)));"),
+			array("extract(\$phpbb_dispatcher->trigger_event(['dispatch.one'], compact(\$vars)));"),
 			array("\$phpbb_dispatcher->trigger_event('dis_patch.one', compact(\$vars));", 'dis_patch.one'),
 		);
 	}


### PR DESCRIPTION
Reasoning is in the tracker.
This change is fully backwards compatible, of course. Nothing in the existing core events or in any extension must be changed.
This change will only allow the short array syntax for the event names and will allow both array syntaxes for multi line event vars instead of just the old syntax.

Checklist:

- [x] Correct branch: master for new features; 3.2.x, 3.1.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master / 3.2.x](https://area51.phpbb.com/docs/master/coding-guidelines.html), [3.1.x](https://area51.phpbb.com/docs/31x/coding-guidelines.html)
- [x] Commit follows commit message [format](https://wiki.phpbb.com/Git#Commit_Messages)

Tracker ticket:
https://tracker.phpbb.com/browse/PHPBB3-15389