### PR TITLE
[ticket/15390] Fix vertical bar permission tooltip

### DIFF
--- a/phpBB/adm/style/admin.css
+++ b/phpBB/adm/style/admin.css
@@ -525,7 +525,6 @@ li {
 	padding: 0;
 	border-right: 1px solid #CCCFD3;
 	position: relative;
-	z-index: 1;
 }
 
 .rtl #menu {
@@ -1891,7 +1890,6 @@ li.pagination ul {
 	color: #000;
 	text-align: center;
 	border: 1px solid #AAA;
-	opacity: .95;
 }
 
 .tooltip span.top {

--- a/phpBB/adm/style/permission_mask.html
+++ b/phpBB/adm/style/permission_mask.html
@@ -41,7 +41,7 @@
 			<dt style="width: 20%"><label for="role{p_mask.S_ROW_COUNT}{p_mask.f_mask.S_ROW_COUNT}">{L_ROLE}{L_COLON}</label></dt>
 			{% if p_mask.f_mask.role_options %}
 				<dd style="margin-{S_CONTENT_FLOW_BEGIN}{L_COLON} 20%">
-					<div class="dropdown-container dropdown-button-control roles-options" data-alt-text="{LA_ROLE_DESCRIPTION}">
+					<div class="dropdown-container dropdown-right dropdown-button-control roles-options" data-alt-text="{LA_ROLE_DESCRIPTION}">
 						<select id="role{p_mask.S_ROW_COUNT}{p_mask.f_mask.S_ROW_COUNT}" name="role[{p_mask.f_mask.UG_ID}][{p_mask.f_mask.FORUM_ID}]">{p_mask.f_mask.S_ROLE_OPTIONS}</select>
 						<span title="Roles" class="button icon-button tools-icon dropdown-trigger dropdown-select">{L_NO_ROLE_ASSIGNED}</span>
 						<div class="dropdown hidden">


### PR DESCRIPTION
Fix a vertical bar and menu text running through the Admin Permission Role Tooltip pop-up caused by z-index on menu div (and opacity of the popup of .95 rather than 1).

Checklist:

- [x] Correct branch: master for new features; 3.2.x, 3.1.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master / 3.2.x](https://area51.phpbb.com/docs/master/coding-guidelines.html), [3.1.x](https://area51.phpbb.com/docs/31x/coding-guidelines.html)
- [x] Commit follows commit message [format](https://wiki.phpbb.com/Git#Commit_Messages)

Tracker ticket:

https://tracker.phpbb.com/browse/PHPBB3-15390
