### PR TITLE
[ticket/15396] Fix revert_schema() steps not executed in correct order

### DIFF
--- a/phpBB/phpbb/db/migrator.php
+++ b/phpBB/phpbb/db/migrator.php
@@ -503,11 +503,14 @@ class migrator
 			return;
 		}
 
-		foreach ($this->migration_state as $name => $state)
+		foreach ($this->migrations as $name)
 		{
-			if (!empty($state['migration_depends_on']) && in_array($migration, $state['migration_depends_on']))
+			$state = $this->migration_state($name);
+
+			if ($state && in_array($migration, $state['migration_depends_on']) && ($state['migration_schema_done'] || $state['migration_data_done']))
 			{
 				$this->revert_do($name);
+				return;
 			}
 		}
 

--- a/tests/dbal/migration/revert_table.php
+++ b/tests/dbal/migration/revert_table.php
@@ -1,0 +1,39 @@
+<?php
+/**
+*
+* This file is part of the phpBB Forum Software package.
+*
+* @copyright (c) phpBB Limited <https://www.phpbb.com>
+* @license GNU General Public License, version 2 (GPL-2.0)
+*
+* For full copyright and license information, please see
+* the docs/CREDITS.txt file.
+*
+*/
+
+class phpbb_dbal_migration_revert_table extends \phpbb\db\migration\migration
+{
+	function update_schema()
+	{
+		return array(
+			'add_tables' => array(
+				'phpbb_foobar' => array(
+					'COLUMNS' => array(
+						'module_id' => array('UINT:3', NULL, 'auto_increment'),
+						'bar_column' => array('UINT', 1),
+					),
+					'PRIMARY_KEY'	=> 'module_id',
+				),
+			),
+		);
+	}
+
+	function revert_schema()
+	{
+		return array(
+			'drop_tables'	=> array(
+				'phpbb_foobar',
+			),
+		);
+	}
+}

--- a/tests/dbal/migration/revert_table_with_dependency.php
+++ b/tests/dbal/migration/revert_table_with_dependency.php
@@ -1,0 +1,52 @@
+<?php
+/**
+*
+* This file is part of the phpBB Forum Software package.
+*
+* @copyright (c) phpBB Limited <https://www.phpbb.com>
+* @license GNU General Public License, version 2 (GPL-2.0)
+*
+* For full copyright and license information, please see
+* the docs/CREDITS.txt file.
+*
+*/
+
+class phpbb_dbal_migration_revert_table_with_dependency extends \phpbb\db\migration\migration
+{
+	static public function depends_on()
+	{
+		return array('phpbb_dbal_migration_revert_table');
+	}
+
+	function update_schema()
+	{
+		return array(
+			'add_columns' => array(
+				'phpbb_foobar' => array(
+					'baz_column' => array('UINT', 1),
+				),
+			),
+			'drop_columns' => array(
+				'phpbb_foobar' => array(
+					'bar_column',
+				),
+			),
+		);
+	}
+
+	function revert_schema()
+	{
+		return array(
+			'add_columns' => array(
+				'phpbb_foobar' => array(
+					'bar_column' => array('UINT', 1),
+				),
+			),
+			'drop_columns' => array(
+				'phpbb_foobar' => array(
+					'baz_column',
+				),
+			),
+		);
+	}
+}

--- a/tests/dbal/migrator_test.php
+++ b/tests/dbal/migrator_test.php
@@ -17,15 +17,25 @@ require_once dirname(__FILE__) . '/migration/if.php';
 require_once dirname(__FILE__) . '/migration/recall.php';
 require_once dirname(__FILE__) . '/migration/revert.php';
 require_once dirname(__FILE__) . '/migration/revert_with_dependency.php';
+require_once dirname(__FILE__) . '/migration/revert_table.php';
+require_once dirname(__FILE__) . '/migration/revert_table_with_dependency.php';
 require_once dirname(__FILE__) . '/migration/fail.php';
 require_once dirname(__FILE__) . '/migration/installed.php';
 require_once dirname(__FILE__) . '/migration/schema.php';
 
 class phpbb_dbal_migrator_test extends phpbb_database_test_case
 {
+	/** @var \phpbb\db\driver\driver_interface */
 	protected $db;
+
+	/** @var \phpbb\db\tools\tools_interface */
 	protected $db_tools;
+
+	/** @var \phpbb\db\migrator */
 	protected $migrator;
+
+	/** @var \phpbb\config\config */
+	protected $config;
 
 	public function getDataSet()
 	{
@@ -239,6 +249,41 @@ class phpbb_dbal_migrator_test extends phpbb_database_test_case
 		}
 
 		$this->assertEquals(1, $migrator_test_revert_counter, 'Revert did call custom function again');
+	}
+
+	public function test_revert_table()
+	{
+		// Make sure there are no other migrations in the db, this could cause issues
+		$this->db->sql_query("DELETE FROM phpbb_migrations");
+		$this->migrator->load_migration_state();
+
+		$this->migrator->set_migrations(array('phpbb_dbal_migration_revert_table', 'phpbb_dbal_migration_revert_table_with_dependency'));
+
+		$this->assertFalse($this->migrator->migration_state('phpbb_dbal_migration_revert_table'));
+		$this->assertFalse($this->migrator->migration_state('phpbb_dbal_migration_revert_table_with_dependency'));
+
+		// Install the migration first
+		while (!$this->migrator->finished())
+		{
+			$this->migrator->update();
+		}
+
+		$this->assertTrue($this->migrator->migration_state('phpbb_dbal_migration_revert_table') !== false);
+		$this->assertTrue($this->migrator->migration_state('phpbb_dbal_migration_revert_table_with_dependency') !== false);
+
+		$this->assertTrue($this->db_tools->sql_column_exists('phpbb_foobar', 'baz_column'));
+		$this->assertFalse($this->db_tools->sql_column_exists('phpbb_foobar', 'bar_column'));
+
+		// Revert migrations
+		while ($this->migrator->migration_state('phpbb_dbal_migration_revert_table') !== false)
+		{
+			$this->migrator->revert('phpbb_dbal_migration_revert_table');
+		}
+
+		$this->assertFalse($this->migrator->migration_state('phpbb_dbal_migration_revert_table'));
+		$this->assertFalse($this->migrator->migration_state('phpbb_dbal_migration_revert_table_with_dependency'));
+
+		$this->assertFalse($this->db_tools->sql_table_exists('phpbb_foobar'));
 	}
 
 	public function test_fail()


### PR DESCRIPTION
When applying database changes, [the `try_apply` method _returns_ after applying a migration step from a dependency](https://github.com/phpbb/phpbb/blob/release-3.2.1/phpBB/phpbb/db/migrator.php#L351). When reverting database changes, there is no _return_, which causes the migrator to apply the first step of a depending migration, then the steps of the migration itself, and all remaining steps of the depending migration afterwards.

With these changes, the migrator _returns_ after each `revert_do` of depending migrations and continues at the correct next step, therefore handling all dependencies' steps in correct order.

Deleting data of the test extension from the ticket, @blitze's SiteMaker 3.0.1 and @VSEphpbb's Ad Manangement 1.0.2 works fine.

Some tests coming right up.

PHPBB3-15396

Checklist:

- [x] Correct branch: master for new features; 3.2.x, 3.1.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master / 3.2.x](https://area51.phpbb.com/docs/master/coding-guidelines.html), [3.1.x](https://area51.phpbb.com/docs/31x/coding-guidelines.html)
- [x] Commit follows commit message [format](https://wiki.phpbb.com/Git#Commit_Messages)

https://tracker.phpbb.com/browse/PHPBB3-15396