### PR TITLE
[ticket/15431] Add event core.ucp_register_modify_template_data

### DIFF
--- a/phpBB/includes/ucp/ucp_register.php
+++ b/phpBB/includes/ucp/ucp_register.php
@@ -528,10 +528,7 @@ class ucp_register
 			break;
 		}
 
-		// Assign template vars for timezone select
-		phpbb_timezone_select($template, $user, $data['tz'], true);
-
-		$template->assign_vars(array(
+		$template_vars = array(
 			'ERROR'				=> (sizeof($error)) ? implode('<br />', $error) : '',
 			'USERNAME'			=> $data['username'],
 			'PASSWORD'			=> $data['new_password'],
@@ -552,7 +549,37 @@ class ucp_register
 
 			'COOKIE_NAME'		=> $config['cookie_name'],
 			'COOKIE_PATH'		=> $config['cookie_path'],
-		));
+		);
+
+		$tpl_name = 'ucp_register';
+		$page_title = 'UCP_REGISTRATION';
+
+		/**
+		* Modify template data on the registration page
+		*
+		* @event core.ucp_register_modify_template_data
+		* @var	array	template_vars		Array with template data
+		* @var	array	data				Array with user data
+		* @var	array	error				Array with errors
+		* @var	array	s_hidden_fields		Array hidden form fields
+		* @var	string	tpl_name			Template name
+		* @var	string	page_title			Page title
+		* @since 3.2.2-RC1
+		*/
+		$vars = array(
+			'template_vars',
+			'data',
+			'error',
+			's_hidden_fields',
+			'tpl_name',
+			'page_title',
+		);
+		extract($phpbb_dispatcher->trigger_event('core.ucp_register_modify_template_data', compact($vars)));
+
+		// Assign template vars for timezone select
+		phpbb_timezone_select($template, $user, $data['tz'], true);
+
+		$template->assign_vars($template_vars);
 
 		//
 		$user->profile_fields = array();
@@ -561,8 +588,8 @@ class ucp_register
 		$cp->generate_profile_fields('register', $user->get_iso_lang_id());
 
 		//
-		$this->tpl_name = 'ucp_register';
-		$this->page_title = 'UCP_REGISTRATION';
+		$this->tpl_name = $tpl_name;
+		$this->page_title = $page_title;
 	}
 
 	/**

--- a/phpBB/includes/ucp/ucp_register.php
+++ b/phpBB/includes/ucp/ucp_register.php
@@ -561,7 +561,7 @@ class ucp_register
 		* @var	array	template_vars		Array with template data
 		* @var	array	data				Array with user data
 		* @var	array	error				Array with errors
-		* @var	array	s_hidden_fields		Array hidden form fields
+		* @var	string	s_hidden_fields		HTML with hidden form field elements
 		* @var	string	tpl_name			Template name
 		* @var	string	page_title			Page title
 		* @since 3.2.2-RC1

--- a/phpBB/includes/ucp/ucp_register.php
+++ b/phpBB/includes/ucp/ucp_register.php
@@ -505,7 +505,6 @@ class ucp_register
 		{
 			$s_hidden_fields = array_merge($s_hidden_fields, $captcha->get_hidden_fields());
 		}
-		$s_hidden_fields = build_hidden_fields($s_hidden_fields);
 
 		// Visual Confirmation - Show images
 		if ($config['enable_confirm'])
@@ -529,7 +528,6 @@ class ucp_register
 		}
 
 		$template_vars = array(
-			'ERROR'				=> (sizeof($error)) ? implode('<br />', $error) : '',
 			'USERNAME'			=> $data['username'],
 			'PASSWORD'			=> $data['new_password'],
 			'PASSWORD_CONFIRM'	=> $data['password_confirm'],
@@ -544,13 +542,13 @@ class ucp_register
 			'S_CONFIRM_REFRESH'	=> ($config['enable_confirm'] && $config['confirm_refresh']) ? true : false,
 			'S_REGISTRATION'	=> true,
 			'S_COPPA'			=> $coppa,
-			'S_HIDDEN_FIELDS'	=> $s_hidden_fields,
 			'S_UCP_ACTION'		=> append_sid("{$phpbb_root_path}ucp.$phpEx", 'mode=register'),
 
 			'COOKIE_NAME'		=> $config['cookie_name'],
 			'COOKIE_PATH'		=> $config['cookie_path'],
 		);
 
+		$tz = $data['tz'];
 		$tpl_name = 'ucp_register';
 
 		/**
@@ -558,9 +556,10 @@ class ucp_register
 		*
 		* @event core.ucp_register_modify_template_data
 		* @var	array	template_vars		Array with template data
-		* @var	array	data				Array with user data
+		* @var	array	data				Array with user data, read only
 		* @var	array	error				Array with errors
-		* @var	string	s_hidden_fields		HTML with hidden form field elements
+		* @var	array	s_hidden_fields		Array with hidden field elements
+		* @var	string	tz					The selected timezone
 		* @var	string	tpl_name			Template name
 		* @since 3.2.2-RC1
 		*/
@@ -569,12 +568,18 @@ class ucp_register
 			'data',
 			'error',
 			's_hidden_fields',
+			'tz',
 			'tpl_name',
 		);
 		extract($phpbb_dispatcher->trigger_event('core.ucp_register_modify_template_data', compact($vars)));
 
 		// Assign template vars for timezone select
-		phpbb_timezone_select($template, $user, $data['tz'], true);
+		phpbb_timezone_select($template, $user, $tz, true);
+
+		$template_vars = array_merge($template_vars, array(
+			'ERROR'				=> (sizeof($error)) ? implode('<br />', $error) : '',
+			'S_HIDDEN_FIELDS'	=> build_hidden_fields($s_hidden_fields),
+		));
 
 		$template->assign_vars($template_vars);
 

--- a/phpBB/includes/ucp/ucp_register.php
+++ b/phpBB/includes/ucp/ucp_register.php
@@ -527,6 +527,9 @@ class ucp_register
 			break;
 		}
 
+		// Assign template vars for timezone select
+		phpbb_timezone_select($template, $user, $data['tz'], true);
+
 		$template_vars = array(
 			'USERNAME'			=> $data['username'],
 			'PASSWORD'			=> $data['new_password'],
@@ -548,7 +551,6 @@ class ucp_register
 			'COOKIE_PATH'		=> $config['cookie_path'],
 		);
 
-		$tz = $data['tz'];
 		$tpl_name = 'ucp_register';
 
 		/**
@@ -559,7 +561,6 @@ class ucp_register
 		* @var	array	data				Array with user data, read only
 		* @var	array	error				Array with errors
 		* @var	array	s_hidden_fields		Array with hidden field elements
-		* @var	string	tz					The selected timezone
 		* @var	string	tpl_name			Template name
 		* @since 3.2.2-RC1
 		*/
@@ -568,13 +569,9 @@ class ucp_register
 			'data',
 			'error',
 			's_hidden_fields',
-			'tz',
 			'tpl_name',
 		);
 		extract($phpbb_dispatcher->trigger_event('core.ucp_register_modify_template_data', compact($vars)));
-
-		// Assign template vars for timezone select
-		phpbb_timezone_select($template, $user, $tz, true);
 
 		$template_vars = array_merge($template_vars, array(
 			'ERROR'				=> (sizeof($error)) ? implode('<br />', $error) : '',

--- a/phpBB/includes/ucp/ucp_register.php
+++ b/phpBB/includes/ucp/ucp_register.php
@@ -552,7 +552,6 @@ class ucp_register
 		);
 
 		$tpl_name = 'ucp_register';
-		$page_title = 'UCP_REGISTRATION';
 
 		/**
 		* Modify template data on the registration page
@@ -563,7 +562,6 @@ class ucp_register
 		* @var	array	error				Array with errors
 		* @var	string	s_hidden_fields		HTML with hidden form field elements
 		* @var	string	tpl_name			Template name
-		* @var	string	page_title			Page title
 		* @since 3.2.2-RC1
 		*/
 		$vars = array(
@@ -572,7 +570,6 @@ class ucp_register
 			'error',
 			's_hidden_fields',
 			'tpl_name',
-			'page_title',
 		);
 		extract($phpbb_dispatcher->trigger_event('core.ucp_register_modify_template_data', compact($vars)));
 
@@ -589,7 +586,6 @@ class ucp_register
 
 		//
 		$this->tpl_name = $tpl_name;
-		$this->page_title = $page_title;
 	}
 
 	/**


### PR DESCRIPTION
I moved the `phpbb_timezone_select()` call below the event so that changes to the `$data['tz']` field in event handlers can take effect.

PHPBB3-15431

Checklist:

- [x] Correct branch: master for new features; 3.2.x, 3.1.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master / 3.2.x](https://area51.phpbb.com/docs/master/coding-guidelines.html), [3.1.x](https://area51.phpbb.com/docs/31x/coding-guidelines.html)
- [x] Commit follows commit message [format](https://wiki.phpbb.com/Git#Commit_Messages)

https://tracker.phpbb.com/browse/PHPBB3-15431
