### PR TITLE
[ticket/15433] Fix phpbbcli can enable non-existent extension

### DIFF
--- a/phpBB/language/en/cli.php
+++ b/phpBB/language/en/cli.php
@@ -117,6 +117,7 @@ $lang = array_merge($lang, array(
 	'CLI_EXTENSION_ENABLE_FAILURE'		=> 'Could not enable extension %s',
 	'CLI_EXTENSION_ENABLE_SUCCESS'		=> 'Successfully enabled extension %s',
 	'CLI_EXTENSION_ENABLED'				=> 'Extension %s is already enabled',
+	'CLI_EXTENSION_NOT_EXIST'			=> 'Extension %s does not exist',
 	'CLI_EXTENSION_NAME'				=> 'Name of the extension',
 	'CLI_EXTENSION_PURGE_FAILURE'		=> 'Could not purge extension %s',
 	'CLI_EXTENSION_PURGE_SUCCESS'		=> 'Successfully purged extension %s',

--- a/phpBB/phpbb/console/command/extension/enable.php
+++ b/phpBB/phpbb/console/command/extension/enable.php
@@ -37,6 +37,13 @@ class enable extends command
 		$io = new SymfonyStyle($input, $output);
 
 		$name = $input->getArgument('extension-name');
+
+		if (!$this->manager->is_available($name))
+		{
+			$io->error($this->user->lang('CLI_EXTENSION_NOT_EXIST', $name));
+			return 1;
+		}
+
 		$extension = $this->manager->get_extension($name);
 
 		if (!$extension->is_enableable())


### PR DESCRIPTION
Fix phpbbcli can enable non-existent extension

PHPBB3-15433

Checklist:

- [x] Correct branch: master for new features; 3.2.x, 3.1.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master / 3.2.x](https://area51.phpbb.com/docs/master/coding-guidelines.html), [3.1.x](https://area51.phpbb.com/docs/31x/coding-guidelines.html)
- [ ] Commit follows commit message [format](https://wiki.phpbb.com/Git#Commit_Messages)

Tracker ticket :

https://tracker.phpbb.com/browse/PHPBB3-15433
