### PR TITLE
[ticket/15393] Fix wrong direction for text boxs contain code in RTL

### DIFF
--- a/phpBB/adm/style/acp_bbcodes.html
+++ b/phpBB/adm/style/acp_bbcodes.html
@@ -102,7 +102,7 @@
 	<tbody>
 	<!-- BEGIN bbcodes -->
 		<tr>
-			<td style="text-align: center;">{bbcodes.BBCODE_TAG}</td>
+			<td style="direction: ltr; text-align: center;">{bbcodes.BBCODE_TAG}</td>
 			<td class="actions"><!-- EVENT acp_bbcodes_actions_prepend --> <a href="{bbcodes.U_EDIT}">{ICON_EDIT}</a> <a href="{bbcodes.U_DELETE}" data-ajax="row_delete">{ICON_DELETE}</a> <!-- EVENT acp_bbcodes_actions_append --></td>
 		</tr>
 	<!-- BEGINELSE -->

--- a/phpBB/adm/style/admin.css
+++ b/phpBB/adm/style/admin.css
@@ -1126,6 +1126,24 @@ input, textarea {
 	border-bottom: 1px solid #D5D5C8;
 }
 
+.rtl input[type="email"], .rtl input[type="url"],
+.rtl #add_extension, .rtl #ban,
+.rtl #bbcode_match, .rtl #bbcode_tpl,
+.rtl #bot_name, .rtl #bot_agent, .rtl #bot_ip,
+.rtl #forum_image, .rtl #forum_link, .rtl #forum_rules_link,
+.rtl #jab_host, .rtl #jab_username,
+.rtl #email,
+.rtl #upload_path, .rtl #img_imagick,
+.rtl #allowed_schemes_links, .rtl #cookie_domain, .rtl #cookie_name, .rtl #cookie_path,
+.rtl #smilies_path, .rtl #icons_path, .rtl #upload_icons_path, .rtl #ranks_path,
+.rtl #server_protocol, .rtl #server_name, .rtl #script_path,
+.rtl #smtp_host, .rtl #smtp_username,
+.rtl #default_dateformat,
+.rtl #avatar_gallery_path, .rtl #avatar_path,
+.rtl #fulltext_sphinx_data_path, .rtl #fulltext_sphinx_host {
+	direction:ltr;
+}
+
 input:hover, textarea:hover {
 	border-left: 1px solid #AFAEAA;
 	border-top: 1px solid #AFAEAA;

--- a/phpBB/styles/prosilver/template/ucp_prefs_personal.html
+++ b/phpBB/styles/prosilver/template/ucp_prefs_personal.html
@@ -70,7 +70,7 @@
 				{S_DATEFORMAT_OPTIONS}
 			</select>
 		</dd>
-		<dd id="custom_date" style="display:none;"><input type="text" name="dateformat" id="dateformat" value="{DATE_FORMAT}" maxlength="64" class="inputbox narrow" style="margin-top: 3px;" /></dd>
+		<dd id="custom_date" style="display:none;"><input type="text" name="dateformat" id="dateformat" value="{DATE_FORMAT}" maxlength="64" class="inputbox narrow" style="margin-top: 3px; direction:ltr;" /></dd>
 	</dl>
 	<!-- EVENT ucp_prefs_personal_append -->
 	</fieldset>


### PR DESCRIPTION
 A css class 'always-ltr' was added to adm/style/admin.css 
class 'always-ltr' was added to style files in adm/style
function 'build_cfg_template()' in includes/functions_acp.php was modified to handle sent class
Another files how use 'build_cfg_template()' function was modifed by adding 'always-ltr'

UPDATED:
only changes to admin.css and 2 other template files as vinny and marc directed

Checklist:

- [ ] Correct branch: master for new features; 3.2.x, 3.1.x for fixes
- [ ] Tests pass
- [ ] Code follows coding guidelines: [master / 3.2.x](https://area51.phpbb.com/docs/master/coding-guidelines.html), [3.1.x](https://area51.phpbb.com/docs/31x/coding-guidelines.html)
- [ ] Commit follows commit message [format](https://wiki.phpbb.com/Git#Commit_Messages)

Tracker ticket 

https://tracker.phpbb.com/browse/PHPBB3-15393
