### PR TITLE
[ticket/14857] Throw `S` from dateformat for non English languages

### DIFF
--- a/phpBB/phpbb/datetime.php
+++ b/phpBB/phpbb/datetime.php
@@ -60,6 +60,12 @@ class datetime extends \DateTime
 	public function format($format = '', $force_absolute = false)
 	{
 		$format		= $format ? $format : $this->user->date_format;
+
+		if (substr($this->user->lang_name, 0,2) != 'en')
+		{
+			$format = preg_replace('/([^\\\])S/','$1', $format);
+		}
+
 		$format		= self::format_cache($format, $this->user);
 		$relative	= ($format['is_short'] && !$force_absolute);
 		$now		= new self($this->user, 'now', $this->user->timezone);


### PR DESCRIPTION
Throw `S` (ordinal suffix) from dateformat for non English languages

PHPBB3-14857

Checklist:

- [x] Correct branch: master for new features; 3.2.x, 3.1.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master / 3.2.x](https://area51.phpbb.com/docs/master/coding-guidelines.html), [3.1.x](https://area51.phpbb.com/docs/31x/coding-guidelines.html)
- [x] Commit follows commit message [format](https://wiki.phpbb.com/Git#Commit_Messages)

Tracker ticket (set the ticket ID to **your ticket ID**):

https://tracker.phpbb.com/browse/PHPBB3-14857
