### PR TITLE
[ticket/15475] Fix Travis pull request commit messages validation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,4 +53,4 @@ script:
   - sh -c "if [ '$SLOWTESTS' != '1' -a '$DB' = 'mysqli' ]; then phpBB/vendor/bin/phpunit tests/lint_test.php; fi"
   - sh -c "if [ '$NOTESTS' != '1' -a '$SLOWTESTS' != '1' ]; then phpBB/vendor/bin/phpunit --configuration travis/phpunit-$DB-travis.xml --verbose --stop-on-error; fi"
   - sh -c "if [ '$SLOWTESTS' = '1' ]; then phpBB/vendor/bin/phpunit --configuration travis/phpunit-$DB-travis.xml --group slow; fi"
-  - sh -c "set -x;if [ '$NOTESTS' = '1' -a '$TRAVIS_PULL_REQUEST' != 'false' ]; then git-tools/commit-msg-hook-range.sh origin/$TRAVIS_BRANCH..FETCH_HEAD; fi"
+  - sh -c "set -x;if [ '$NOTESTS' = '1' -a '$TRAVIS_PULL_REQUEST' != 'false' ]; then git remote set-branches --add origin $TRAVIS_BRANCH && git fetch && git-tools/commit-msg-hook-range.sh origin/$TRAVIS_BRANCH..$TRAVIS_PULL_REQUEST_SHA; fi"


### PR DESCRIPTION
It stopped working on the 3.2.x branch because of Travis's default clone depth of 50. Fixing it by setting the remote branch and fetching it. Also now comparing the commit range to `$TRAVIS_PULL_REQUEST_SHA` instead of `FETCH_HEAD` since that might be set to the newly fetched (3.2.x) branch.

Error message:
<img width="1141" alt="travis_commit_message_validation_fails" src="https://user-images.githubusercontent.com/318762/33788802-8786bc82-dc74-11e7-87d0-57bf4afb5c42.png">

Result of commit message validation in this PR:
<img width="1269" alt="travic_commit_message_validation_success" src="https://user-images.githubusercontent.com/318762/33788835-ce4b34b8-dc74-11e7-9e1c-4393396f1299.png">
Commit messages validation still worked on master. I've also tested this PR on master and it keeps working as well. Result of my test to master: (on my own fork so different commit hash)
<img width="1260" alt="travis_commit_message_validation_success_master" src="https://user-images.githubusercontent.com/318762/33788964-b90d8a32-dc75-11e7-9d42-5f302339ce49.png">
So the only difference is that it doesn't add a [new branch] because master was already available.

Checklist:

- [x] Correct branch: master for new features; 3.2.x, 3.1.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master / 3.2.x](https://area51.phpbb.com/docs/master/coding-guidelines.html), [3.1.x](https://area51.phpbb.com/docs/31x/coding-guidelines.html)
- [x] Commit follows commit message [format](https://wiki.phpbb.com/Git#Commit_Messages)

Tracker ticket:
https://tracker.phpbb.com/browse/PHPBB3-15475
