### PR TITLE
[ticket/15489] Remove NO_FORUMS message for categories with subforums

### DIFF
--- a/phpBB/language/en/viewforum.php
+++ b/phpBB/language/en/viewforum.php
@@ -54,6 +54,7 @@ $lang = array_merge($lang, array(
 	'NO_NEW_POSTS_HOT'		=> 'No new posts [ Popular ]',	// Not used anymore
 	'NO_NEW_POSTS_LOCKED'	=> 'No new posts [ Locked ]',	// Not used anymore
 	'NO_READ_ACCESS'		=> 'You do not have the required permissions to view or read topics within this forum.',
+	'NO_FORUMS_IN_CATEGORY'	=> 'This category has no forums.',
 	'NO_UNREAD_POSTS_HOT'		=> 'No unread posts [ Popular ]',
 	'NO_UNREAD_POSTS_LOCKED'	=> 'No unread posts [ Locked ]',
 

--- a/phpBB/styles/prosilver/template/viewforum_body.html
+++ b/phpBB/styles/prosilver/template/viewforum_body.html
@@ -250,7 +250,7 @@
 		<strong>{L_NO_TOPICS}</strong>
 		</div>
 	</div>
-	<!-- ELSE IF not S_USER_CAN_POST -->
+	<!-- ELSE IF not S_HAS_SUBFORUM -->
 	<div class="panel">
 		<div class="inner">
 			<strong>{L_NO_FORUMS}</strong>

--- a/phpBB/styles/prosilver/template/viewforum_body.html
+++ b/phpBB/styles/prosilver/template/viewforum_body.html
@@ -253,7 +253,7 @@
 	<!-- ELSE IF not S_HAS_SUBFORUM -->
 	<div class="panel">
 		<div class="inner">
-			<strong>{L_NO_FORUMS}</strong>
+			<strong>{L_NO_FORUMS_IN_CATEGORY}</strong>
 		</div>
 	</div>
 	<!-- ENDIF -->


### PR DESCRIPTION
The message will now only be displaced for categories without subforums. (including if you don't have permissions to view subforums). Regression from https://github.com/phpbb/phpbb/pull/4934

Checklist:
- [x] Correct branch: master for new features; 3.2.x, 3.1.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master / 3.2.x](https://area51.phpbb.com/docs/master/coding-guidelines.html), [3.1.x](https://area51.phpbb.com/docs/31x/coding-guidelines.html)
- [x] Commit follows commit message [format](https://wiki.phpbb.com/Git#Commit_Messages)

Tracker ticket:
https://tracker.phpbb.com/browse/PHPBB3-15489
