### PR TITLE
[ticket/15495] Use transaction in ACP move_forum

### DIFF
--- a/phpBB/includes/acp/acp_forums.php
+++ b/phpBB/includes/acp/acp_forums.php
@@ -1431,6 +1431,8 @@ class acp_forums
 			return $errors;
 		}
 
+		$db->sql_transaction('begin');
+
 		$moved_forums = get_forum_branch($from_id, 'children', 'descending');
 		$from_data = $moved_forums[0];
 		$diff = sizeof($moved_forums) * 2;
@@ -1501,6 +1503,8 @@ class acp_forums
 			SET left_id = left_id $diff, right_id = right_id $diff, forum_parents = ''
 			WHERE " . $db->sql_in_set('forum_id', $moved_ids);
 		$db->sql_query($sql);
+
+		$db->sql_transaction('commit');
 
 		return $errors;
 	}


### PR DESCRIPTION
For 3.2.3 or later.

Should prevent the forums table from getting messed up if an error or
concurrent execution happens.

PHPBB3-15495

Checklist:

- [x] Correct branch: master for new features; 3.2.x, 3.1.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master / 3.2.x](https://area51.phpbb.com/docs/master/coding-guidelines.html), [3.1.x](https://area51.phpbb.com/docs/31x/coding-guidelines.html)
- [x] Commit follows commit message [format](https://wiki.phpbb.com/Git#Commit_Messages)

Tracker ticket:

https://tracker.phpbb.com/browse/PHPBB3-15495
