### PR TITLE
Update functions.php

### DIFF
--- a/phpBB/includes/functions.php
+++ b/phpBB/includes/functions.php
@@ -554,6 +554,7 @@ function markread($mode, $forum_id = false, $topic_id = false, $post_time = 0, $
 	global $request, $phpbb_container, $phpbb_dispatcher;
 
 	$post_time = ($post_time === 0 || $post_time > time()) ? time() : (int) $post_time;
+	$user_id = ($user_id === 0) ? $user->data['user_id']  : (int) $user_id;
 
 	$should_markread = true;
 


### PR DESCRIPTION
The 'user_id' field used to fire the event  core.markread_before was always 0, while all calls to mark notifications as read below use $user->data['user_id']
I added a line fetching $user_id from $user if necessary.

Checklist:

- [ ] Correct branch: master for new features; 3.2.x, 3.1.x for fixes
- [ ] Tests pass
- [ ] Code follows coding guidelines: [master / 3.2.x](https://area51.phpbb.com/docs/master/coding-guidelines.html), [3.1.x](https://area51.phpbb.com/docs/31x/coding-guidelines.html)
- [ ] Commit follows commit message [format](https://wiki.phpbb.com/Git#Commit_Messages)

Tracker ticket (set the ticket ID to **your ticket ID**):

https://tracker.phpbb.com/browse/PHPBB3-12345
