### PR TITLE
[ticket/15506] Assign attachrow_template_vars before foreach

### DIFF
--- a/phpBB/includes/functions_posting.php
+++ b/phpBB/includes/functions_posting.php
@@ -727,10 +727,11 @@ function posting_gen_attachment_entry($attachment_data, &$filename_data, $show_a
 		// We display the posted attachments within the desired order.
 		($config['display_order']) ? krsort($attachment_data) : ksort($attachment_data);
 
+		$attachrow_template_vars = [];
+
 		foreach ($attachment_data as $count => $attach_row)
 		{
 			$hidden = '';
-			$attachrow_template_vars = array();
 			$attach_row['real_filename'] = utf8_basename($attach_row['real_filename']);
 
 			foreach ($attach_row as $key => $value)


### PR DESCRIPTION
The attachrow_template_vars array needs to be defined once in front of the
foreach instead of resetting the array on every iteration of the foreach.

PHPBB3-15506

Checklist:

- [x] Correct branch: master for new features; 3.2.x, 3.1.x for fixes
- [ ] Tests pass
- [x] Code follows coding guidelines: [master / 3.2.x](https://area51.phpbb.com/docs/master/coding-guidelines.html), [3.1.x](https://area51.phpbb.com/docs/31x/coding-guidelines.html)
- [x] Commit follows commit message [format](https://wiki.phpbb.com/Git#Commit_Messages)

Tracker ticket (set the ticket ID to **your ticket ID**):

https://tracker.phpbb.com/browse/PHPBB3-15506
