### PR TITLE
[ticket/15510] Link Orphan attachments in ACP General to its page

### DIFF
--- a/phpBB/adm/style/acp_main.html
+++ b/phpBB/adm/style/acp_main.html
@@ -154,7 +154,7 @@
 	<!-- IF S_TOTAL_ORPHAN -->
 		<td>{L_NUMBER_ORPHAN}{L_COLON} </td>
 		<td>
-		<!-- IF TOTAL_ORPHAN -->
+		<!-- IF TOTAL_ORPHAN > 0 -->
 			<a href="{U_ATTACH_ORPHAN}" title="{L_MORE_INFORMATION}"><strong>{TOTAL_ORPHAN}</strong></a>
 		<!-- ELSE -->
 			<strong>{TOTAL_ORPHAN}</strong>

--- a/phpBB/adm/style/acp_main.html
+++ b/phpBB/adm/style/acp_main.html
@@ -153,8 +153,14 @@
 		<td><strong>{PHP_VERSION_INFO}</strong></td>
 	<!-- IF S_TOTAL_ORPHAN -->
 		<td>{L_NUMBER_ORPHAN}{L_COLON} </td>
-		<td><strong>{TOTAL_ORPHAN}</strong></td>
-	<!-- ELSE -->
+		<td>
+		<!-- IF TOTAL_ORPHAN -->
+			<a href="{U_ATTACH_ORPHAN}" title="{L_MORE_INFORMATION}"><strong>{TOTAL_ORPHAN}</strong></a>
+		<!-- ELSE -->
+			<strong>{TOTAL_ORPHAN}</strong>
+		<!-- ENDIF -->
+		</td>
+		<!-- ELSE -->
 		<td>&nbsp;</td>
 		<td>&nbsp;</td>
 	<!-- ENDIF -->

--- a/phpBB/includes/acp/acp_main.php
+++ b/phpBB/includes/acp/acp_main.php
@@ -585,6 +585,7 @@ class acp_main
 			'U_INACTIVE_USERS'	=> append_sid("{$phpbb_admin_path}index.$phpEx", 'i=inactive&amp;mode=list'),
 			'U_VERSIONCHECK'	=> append_sid("{$phpbb_admin_path}index.$phpEx", 'i=update&amp;mode=version_check'),
 			'U_VERSIONCHECK_FORCE'	=> append_sid("{$phpbb_admin_path}index.$phpEx", 'versioncheck_force=1'),
+			'U_ATTACH_ORPHAN'	=> append_sid("{$phpbb_admin_path}index.$phpEx", 'i=acp_attachments&mode=orphan'),
 
 			'S_VERSIONCHECK'	=> ($auth->acl_get('a_board')) ? true : false,
 			'S_ACTION_OPTIONS'	=> ($auth->acl_get('a_board')) ? true : false,


### PR DESCRIPTION
Link Orphan attachments in ACP General to Orphaned attachments page
if Orphan attachments>0

PHPBB3-15510

Checklist:

- [x] Correct branch: master for new features; 3.2.x, 3.1.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master / 3.2.x](https://area51.phpbb.com/docs/master/coding-guidelines.html), [3.1.x](https://area51.phpbb.com/docs/31x/coding-guidelines.html)
- [x] Commit follows commit message [format](https://wiki.phpbb.com/Git#Commit_Messages)

Tracker ticket :

https://tracker.phpbb.com/browse/PHPBB3-15510