### PR TITLE
[ticket/15508] Support Twig 2.x

### DIFF
--- a/phpBB/composer.json
+++ b/phpBB/composer.json
@@ -49,7 +49,7 @@
 		"symfony/routing": "~3.1",
 		"symfony/twig-bridge": "~3.1",
 		"symfony/yaml": "~3.1",
-		"twig/twig": "^1.0"
+		"twig/twig": "^1.0 || ^2.0"
 	},
 	"require-dev": {
 		"fabpot/goutte": "~3.1",

--- a/phpBB/composer.lock
+++ b/phpBB/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "8e1c75ec0aaf938fb328165209dbb9e2",
-    "content-hash": "aa8d6a47717887456a0066a1320811e0",
+    "hash": "415e7ade9807efa2a857ad919e4ccf2a",
+    "content-hash": "919ca0781fd2e325288e60a4f0e144cd",
     "packages": [
         {
             "name": "bantu/ini-get-wrapper",

--- a/phpBB/config/default/container/services_twig.yml
+++ b/phpBB/config/default/container/services_twig.yml
@@ -37,6 +37,7 @@ services:
         class: phpbb\template\twig\extension
         arguments:
             - '@template_context'
+            - '@template.twig.environment'
             - '@language'
         tags:
             - { name: twig.extension }

--- a/phpBB/phpbb/template/twig/extension.php
+++ b/phpBB/phpbb/template/twig/extension.php
@@ -18,6 +18,9 @@ class extension extends \Twig_Extension
 	/** @var \phpbb\template\context */
 	protected $context;
 
+	/** @var \phpbb\template\twig\environment */
+	protected $environment;
+
 	/** @var \phpbb\language\language */
 	protected $language;
 
@@ -25,12 +28,14 @@ class extension extends \Twig_Extension
 	* Constructor
 	*
 	* @param \phpbb\template\context $context
+	* @param \phpbb\template\twig\environment $environment
 	* @param \phpbb\language\language $language
 	* @return \phpbb\template\twig\extension
 	*/
-	public function __construct(\phpbb\template\context $context, $language)
+	public function __construct(\phpbb\template\context $context, \phpbb\template\twig\environment $environment, $language)
 	{
 		$this->context = $context;
+		$this->environment = $environment;
 		$this->language = $language;
 	}
 
@@ -56,9 +61,9 @@ class extension extends \Twig_Extension
 			new \phpbb\template\twig\tokenparser\includeparser,
 			new \phpbb\template\twig\tokenparser\includejs,
 			new \phpbb\template\twig\tokenparser\includecss,
-			new \phpbb\template\twig\tokenparser\event,
-			new \phpbb\template\twig\tokenparser\includephp,
-			new \phpbb\template\twig\tokenparser\php,
+			new \phpbb\template\twig\tokenparser\event($this->environment),
+			new \phpbb\template\twig\tokenparser\includephp($this->environment),
+			new \phpbb\template\twig\tokenparser\php($this->environment),
 		);
 	}
 

--- a/phpBB/phpbb/template/twig/loader.php
+++ b/phpBB/phpbb/template/twig/loader.php
@@ -110,7 +110,7 @@ class loader extends \Twig_Loader_Filesystem
 	* Override for Twig_Loader_Filesystem::findTemplate to add support
 	*	for loading from safe directories.
 	*/
-	protected function findTemplate($name)
+	protected function findTemplate($name, $throw = true)
 	{
 		$name = (string) $name;
 
@@ -126,12 +126,12 @@ class loader extends \Twig_Loader_Filesystem
 
 		// First, find the template name. The override above of validateName
 		//	causes the validateName process to be skipped for this call
-		$file = parent::findTemplate($name);
+		$file = parent::findTemplate($name, $throw);
 
 		try
 		{
 			// Try validating the name (which may throw an exception)
-			parent::validateName($name);
+			$this->validateName($name);
 		}
 		catch (\Twig_Error_Loader $e)
 		{

--- a/phpBB/phpbb/template/twig/node/definenode.php
+++ b/phpBB/phpbb/template/twig/node/definenode.php
@@ -16,7 +16,7 @@ namespace phpbb\template\twig\node;
 
 class definenode extends \Twig_Node
 {
-	public function __construct($capture, \Twig_NodeInterface $name, \Twig_NodeInterface $value, $lineno, $tag = null)
+	public function __construct($capture, \Twig_Node $name, \Twig_Node $value, $lineno, $tag = null)
 	{
 		parent::__construct(array('name' => $name, 'value' => $value), array('capture' => $capture, 'safe' => false), $lineno, $tag);
 	}

--- a/phpBB/phpbb/template/twig/node/includeasset.php
+++ b/phpBB/phpbb/template/twig/node/includeasset.php
@@ -15,15 +15,11 @@ namespace phpbb\template\twig\node;
 
 abstract class includeasset extends \Twig_Node
 {
-	/** @var \Twig_Environment */
-	protected $environment;
-
-	public function __construct(\Twig_Node_Expression $expr, \phpbb\template\twig\environment $environment, $lineno, $tag = null)
+	public function __construct(\Twig_Node_Expression $expr, $lineno, $tag = null)
 	{
-		$this->environment = $environment;
-
 		parent::__construct(array('expr' => $expr), array(), $lineno, $tag);
 	}
+
 	/**
 	* Compiles the node to PHP.
 	*
@@ -33,27 +29,25 @@ abstract class includeasset extends \Twig_Node
 	{
 		$compiler->addDebugInfo($this);
 
-		$config = $this->environment->get_phpbb_config();
-
 		$compiler
 			->write("\$asset_file = ")
 			->subcompile($this->getNode('expr'))
 			->raw(";\n")
-			->write("\$asset = new \phpbb\\template\\asset(\$asset_file, \$this->getEnvironment()->get_path_helper(), \$this->getEnvironment()->get_filesystem());\n")
+			->write("\$asset = new \phpbb\\template\\asset(\$asset_file, \$this->env->get_path_helper(), \$this->env->get_filesystem());\n")
 			->write("if (substr(\$asset_file, 0, 2) !== './' && \$asset->is_relative()) {\n")
 			->indent()
 				->write("\$asset_path = \$asset->get_path();")
-				->write("\$local_file = \$this->getEnvironment()->get_phpbb_root_path() . \$asset_path;\n")
+				->write("\$local_file = \$this->env->get_phpbb_root_path() . \$asset_path;\n")
 				->write("if (!file_exists(\$local_file)) {\n")
 				->indent()
-					->write("\$local_file = \$this->getEnvironment()->findTemplate(\$asset_path);\n")
+					->write("\$local_file = \$this->env->findTemplate(\$asset_path);\n")
 					->write("\$asset->set_path(\$local_file, true);\n")
 				->outdent()
 				->write("}\n")
-				->write("\$asset->add_assets_version('{$config['assets_version']}');\n")
+				->write("\$asset->add_assets_version(\$this->env->get_phpbb_config()['assets_version']);\n")
 			->outdent()
 			->write("}\n")
-			->write("\$this->getEnvironment()->get_assets_bag()->add_{$this->get_setters_name()}(\$asset);")
+			->write("\$this->env->get_assets_bag()->add_{$this->get_setters_name()}(\$asset);")
 		;
 	}
 

--- a/phpBB/phpbb/template/twig/node/includephp.php
+++ b/phpBB/phpbb/template/twig/node/includephp.php
@@ -63,15 +63,15 @@ class includephp extends \Twig_Node
 				// Absolute path specified
 				->write("require(\$location);\n")
 			->outdent()
-			->write("} else if (file_exists(\$this->getEnvironment()->get_phpbb_root_path() . \$location)) {\n")
+			->write("} else if (file_exists(\$this->env->get_phpbb_root_path() . \$location)) {\n")
 			->indent()
 				// PHP file relative to phpbb_root_path
-				->write("require(\$this->getEnvironment()->get_phpbb_root_path() . \$location);\n")
+				->write("require(\$this->env->get_phpbb_root_path() . \$location);\n")
 			->outdent()
 			->write("} else {\n")
 			->indent()
 				// Local path (behaves like INCLUDE)
-				->write("require(\$this->getEnvironment()->getLoader()->getCacheKey(\$location));\n")
+				->write("require(\$this->env->getLoader()->getCacheKey(\$location));\n")
 			->outdent()
 			->write("}\n")
 		;

--- a/phpBB/phpbb/template/twig/tokenparser/defineparser.php
+++ b/phpBB/phpbb/template/twig/tokenparser/defineparser.php
@@ -21,7 +21,7 @@ class defineparser extends \Twig_TokenParser
 	*
 	* @param \Twig_Token $token A Twig_Token instance
 	*
-	* @return \Twig_NodeInterface A Twig_NodeInterface instance
+	* @return \Twig_Node A Twig_Node instance
 	* @throws \Twig_Error_Syntax
 	* @throws \phpbb\template\twig\node\definenode
 	*/

--- a/phpBB/phpbb/template/twig/tokenparser/event.php
+++ b/phpBB/phpbb/template/twig/tokenparser/event.php
@@ -15,6 +15,19 @@ namespace phpbb\template\twig\tokenparser;
 
 class event extends \Twig_TokenParser
 {
+	/** @var \phpbb\template\twig\environment */
+	protected $environment;
+
+	/**
+	* Constructor
+	*
+	* @param \phpbb\template\twig\environment $environment
+	*/
+	public function __construct(\phpbb\template\twig\environment $environment)
+	{
+		$this->environment = $environment;
+	}
+
 	/**
 	* Parses a token and returns a node.
 	*
@@ -29,7 +42,7 @@ class event extends \Twig_TokenParser
 		$stream = $this->parser->getStream();
 		$stream->expect(\Twig_Token::BLOCK_END_TYPE);
 
-		return new \phpbb\template\twig\node\event($expr, $this->parser->getEnvironment(), $token->getLine(), $this->getTag());
+		return new \phpbb\template\twig\node\event($expr, $this->environment, $token->getLine(), $this->getTag());
 	}
 
 	/**

--- a/phpBB/phpbb/template/twig/tokenparser/event.php
+++ b/phpBB/phpbb/template/twig/tokenparser/event.php
@@ -20,7 +20,7 @@ class event extends \Twig_TokenParser
 	*
 	* @param \Twig_Token $token A Twig_Token instance
 	*
-	* @return \Twig_NodeInterface A Twig_NodeInterface instance
+	* @return \Twig_Node A Twig_Node instance
 	*/
 	public function parse(\Twig_Token $token)
 	{

--- a/phpBB/phpbb/template/twig/tokenparser/includecss.php
+++ b/phpBB/phpbb/template/twig/tokenparser/includecss.php
@@ -20,7 +20,7 @@ class includecss extends \Twig_TokenParser
 	*
 	* @param \Twig_Token $token A Twig_Token instance
 	*
-	* @return \Twig_NodeInterface A Twig_NodeInterface instance
+	* @return \Twig_Node A Twig_Node instance
 	*/
 	public function parse(\Twig_Token $token)
 	{

--- a/phpBB/phpbb/template/twig/tokenparser/includecss.php
+++ b/phpBB/phpbb/template/twig/tokenparser/includecss.php
@@ -29,7 +29,7 @@ class includecss extends \Twig_TokenParser
 		$stream = $this->parser->getStream();
 		$stream->expect(\Twig_Token::BLOCK_END_TYPE);
 
-		return new \phpbb\template\twig\node\includecss($expr, $this->parser->getEnvironment(), $token->getLine(), $this->getTag());
+		return new \phpbb\template\twig\node\includecss($expr, $token->getLine(), $this->getTag());
 	}
 
 	/**

--- a/phpBB/phpbb/template/twig/tokenparser/includejs.php
+++ b/phpBB/phpbb/template/twig/tokenparser/includejs.php
@@ -20,7 +20,7 @@ class includejs extends \Twig_TokenParser
 	*
 	* @param \Twig_Token $token A Twig_Token instance
 	*
-	* @return \Twig_NodeInterface A Twig_NodeInterface instance
+	* @return \Twig_Node A Twig_Node instance
 	*/
 	public function parse(\Twig_Token $token)
 	{

--- a/phpBB/phpbb/template/twig/tokenparser/includejs.php
+++ b/phpBB/phpbb/template/twig/tokenparser/includejs.php
@@ -29,7 +29,7 @@ class includejs extends \Twig_TokenParser
 		$stream = $this->parser->getStream();
 		$stream->expect(\Twig_Token::BLOCK_END_TYPE);
 
-		return new \phpbb\template\twig\node\includejs($expr, $this->parser->getEnvironment(), $token->getLine(), $this->getTag());
+		return new \phpbb\template\twig\node\includejs($expr, $token->getLine(), $this->getTag());
 	}
 
 	/**

--- a/phpBB/phpbb/template/twig/tokenparser/includeparser.php
+++ b/phpBB/phpbb/template/twig/tokenparser/includeparser.php
@@ -21,7 +21,7 @@ class includeparser extends \Twig_TokenParser_Include
 	*
 	* @param \Twig_Token $token A Twig_Token instance
 	*
-	* @return \Twig_NodeInterface A Twig_NodeInterface instance
+	* @return \Twig_Node A Twig_Node instance
 	*/
 	public function parse(\Twig_Token $token)
 	{

--- a/phpBB/phpbb/template/twig/tokenparser/includephp.php
+++ b/phpBB/phpbb/template/twig/tokenparser/includephp.php
@@ -16,6 +16,19 @@ namespace phpbb\template\twig\tokenparser;
 
 class includephp extends \Twig_TokenParser
 {
+	/** @var \phpbb\template\twig\environment */
+	protected $environment;
+
+	/**
+	* Constructor
+	*
+	* @param \phpbb\template\twig\environment $environment
+	*/
+	public function __construct(\phpbb\template\twig\environment $environment)
+	{
+		$this->environment = $environment;
+	}
+
 	/**
 	* Parses a token and returns a node.
 	*
@@ -40,7 +53,7 @@ class includephp extends \Twig_TokenParser
 
 		$stream->expect(\Twig_Token::BLOCK_END_TYPE);
 
-		return new \phpbb\template\twig\node\includephp($expr, $this->parser->getEnvironment(), $token->getLine(), $ignoreMissing, $this->getTag());
+		return new \phpbb\template\twig\node\includephp($expr, $this->environment, $token->getLine(), $ignoreMissing, $this->getTag());
 	}
 
 	/**

--- a/phpBB/phpbb/template/twig/tokenparser/includephp.php
+++ b/phpBB/phpbb/template/twig/tokenparser/includephp.php
@@ -21,7 +21,7 @@ class includephp extends \Twig_TokenParser
 	*
 	* @param \Twig_Token $token A Twig_Token instance
 	*
-	* @return \Twig_NodeInterface A Twig_NodeInterface instance
+	* @return \Twig_Node A Twig_Node instance
 	*/
 	public function parse(\Twig_Token $token)
 	{

--- a/phpBB/phpbb/template/twig/tokenparser/php.php
+++ b/phpBB/phpbb/template/twig/tokenparser/php.php
@@ -15,6 +15,19 @@ namespace phpbb\template\twig\tokenparser;
 
 class php extends \Twig_TokenParser
 {
+	/** @var \phpbb\template\twig\environment */
+	protected $environment;
+
+	/**
+	* Constructor
+	*
+	* @param \phpbb\template\twig\environment $environment
+	*/
+	public function __construct(\phpbb\template\twig\environment $environment)
+	{
+		$this->environment = $environment;
+	}
+
 	/**
 	* Parses a token and returns a node.
 	*
@@ -32,7 +45,7 @@ class php extends \Twig_TokenParser
 
 		$stream->expect(\Twig_Token::BLOCK_END_TYPE);
 
-		return new \phpbb\template\twig\node\php($body, $this->parser->getEnvironment(), $token->getLine(), $this->getTag());
+		return new \phpbb\template\twig\node\php($body, $this->environment, $token->getLine(), $this->getTag());
 	}
 
 	public function decideEnd(\Twig_Token $token)

--- a/phpBB/phpbb/template/twig/tokenparser/php.php
+++ b/phpBB/phpbb/template/twig/tokenparser/php.php
@@ -20,7 +20,7 @@ class php extends \Twig_TokenParser
 	*
 	* @param \Twig_Token $token A Twig_Token instance
 	*
-	* @return \Twig_NodeInterface A Twig_NodeInterface instance
+	* @return \Twig_Node A Twig_Node instance
 	*/
 	public function parse(\Twig_Token $token)
 	{

--- a/tests/controller/common_helper_route.php
+++ b/tests/controller/common_helper_route.php
@@ -121,7 +121,7 @@ abstract class phpbb_controller_common_helper_route extends phpbb_test_case
 				'autoescape'	=> false,
 			)
 		);
-		$this->template = new phpbb\template\twig\twig($this->phpbb_path_helper, $this->config, $context, $twig, $cache_path, $this->user, array(new \phpbb\template\twig\extension($context, $this->user)));
+		$this->template = new phpbb\template\twig\twig($this->phpbb_path_helper, $this->config, $context, $twig, $cache_path, $this->user, array(new \phpbb\template\twig\extension($context, $twig, $this->user)));
 		$twig->setLexer(new \phpbb\template\twig\lexer($twig));
 
 		$this->extension_manager = new phpbb_mock_extension_manager(

--- a/tests/email/email_parsing_test.php
+++ b/tests/email/email_parsing_test.php
@@ -66,13 +66,6 @@ class phpbb_email_parsing_test extends phpbb_test_case
 		$phpbb_container->set('ext.manager', $extension_manager);
 
 		$context = new \phpbb\template\context();
-		$twig_extension = new \phpbb\template\twig\extension($context, $lang);
-		$phpbb_container->set('template.twig.extensions.phpbb', $twig_extension);
-
-		$twig_extensions_collection = new \phpbb\di\service_collection($phpbb_container);
-		$twig_extensions_collection->add('template.twig.extensions.phpbb');
-		$phpbb_container->set('template.twig.extensions.collection', $twig_extensions_collection);
-
 		$twig = new \phpbb\template\twig\environment(
 			$config,
 			$filesystem,
@@ -88,6 +81,13 @@ class phpbb_email_parsing_test extends phpbb_test_case
 				'autoescape'	=> false,
 			)
 		);
+		$twig_extension = new \phpbb\template\twig\extension($context, $twig, $lang);
+		$phpbb_container->set('template.twig.extensions.phpbb', $twig_extension);
+
+		$twig_extensions_collection = new \phpbb\di\service_collection($phpbb_container);
+		$twig_extensions_collection->add('template.twig.extensions.phpbb');
+		$phpbb_container->set('template.twig.extensions.collection', $twig_extensions_collection);
+
 		$twig->addExtension($twig_extension);
 		$phpbb_container->set('template.twig.lexer', new \phpbb\template\twig\lexer($twig));
 

--- a/tests/extension/metadata_manager_test.php
+++ b/tests/extension/metadata_manager_test.php
@@ -109,7 +109,7 @@ class phpbb_extension_metadata_manager_test extends phpbb_database_test_case
 		$lang = new \phpbb\language\language($lang_loader);
 		$this->user = new \phpbb\user($lang, '\phpbb\datetime');
 
-		$this->template = new phpbb\template\twig\twig($phpbb_path_helper, $this->config, $context, $twig, $cache_path, $this->user, array(new \phpbb\template\twig\extension($context, $this->user)));
+		$this->template = new phpbb\template\twig\twig($phpbb_path_helper, $this->config, $context, $twig, $cache_path, $this->user, array(new \phpbb\template\twig\extension($context, $twig, $this->user)));
 		$twig->setLexer(new \phpbb\template\twig\lexer($twig));
 	}
 

--- a/tests/template/template_allfolder_test.php
+++ b/tests/template/template_allfolder_test.php
@@ -74,7 +74,7 @@ class phpbb_template_allfolder_test extends phpbb_template_template_test_case
 				'autoescape'	=> false,
 			)
 		);
-		$this->template = new \phpbb\template\twig\twig($path_helper, $config, $context, $twig, $cache_path, $this->user, array(new \phpbb\template\twig\extension($context, $this->user)), $this->extension_manager);
+		$this->template = new \phpbb\template\twig\twig($path_helper, $config, $context, $twig, $cache_path, $this->user, array(new \phpbb\template\twig\extension($context, $twig, $this->user)), $this->extension_manager);
 		$twig->setLexer(new \phpbb\template\twig\lexer($twig));
 
 		$this->template_path = $this->test_path . '/templates';

--- a/tests/template/template_events_test.php
+++ b/tests/template/template_events_test.php
@@ -168,7 +168,7 @@ Zeta test event in all',
 				'autoescape'	=> false,
 			)
 		);
-		$this->template = new \phpbb\template\twig\twig($path_helper, $config, $context, $twig, $cache_path, $this->user, array(new \phpbb\template\twig\extension($context, $this->user)), $this->extension_manager);
+		$this->template = new \phpbb\template\twig\twig($path_helper, $config, $context, $twig, $cache_path, $this->user, array(new \phpbb\template\twig\extension($context, $twig, $this->user)), $this->extension_manager);
 		$twig->setLexer(new \phpbb\template\twig\lexer($twig));
 
 		$this->template->set_custom_style(((!empty($style_names)) ? $style_names : 'silver'), array($this->template_path));

--- a/tests/template/template_includecss_test.php
+++ b/tests/template/template_includecss_test.php
@@ -67,7 +67,7 @@ class phpbb_template_template_includecss_test extends phpbb_template_template_te
 			$twig,
 			$cache_path,
 			$this->user,
-			array(new \phpbb\template\twig\extension($context, $this->user)),
+			array(new \phpbb\template\twig\extension($context, $twig, $this->user)),
 			new phpbb_mock_extension_manager(
 				dirname(__FILE__) . '/',
 				array(

--- a/tests/template/template_test_case.php
+++ b/tests/template/template_test_case.php
@@ -112,7 +112,7 @@ class phpbb_template_template_test_case extends phpbb_test_case
 				'autoescape'	=> false,
 			)
 		);
-		$this->template = new phpbb\template\twig\twig($path_helper, $config, $context, $twig, $cache_path, $this->user, array(new \phpbb\template\twig\extension($context, $this->user)));
+		$this->template = new phpbb\template\twig\twig($path_helper, $config, $context, $twig, $cache_path, $this->user, array(new \phpbb\template\twig\extension($context, $twig, $this->user)));
 		$twig->setLexer(new \phpbb\template\twig\lexer($twig));
 		$this->template->set_custom_style('tests', $this->template_path);
 	}

--- a/tests/template/template_test_case_with_tree.php
+++ b/tests/template/template_test_case_with_tree.php
@@ -55,7 +55,7 @@ class phpbb_template_template_test_case_with_tree extends phpbb_template_templat
 				'autoescape'	=> false,
 			)
 		);
-		$this->template = new phpbb\template\twig\twig($this->phpbb_path_helper, $config, $context, $twig, $cache_path, $this->user, array(new \phpbb\template\twig\extension($context, $this->user)));
+		$this->template = new phpbb\template\twig\twig($this->phpbb_path_helper, $config, $context, $twig, $cache_path, $this->user, array(new \phpbb\template\twig\extension($context, $twig, $this->user)));
 		$twig->setLexer(new \phpbb\template\twig\lexer($twig));
 		$this->template->set_custom_style('tests', array($this->template_path, $this->parent_template_path));
 	}


### PR DESCRIPTION
Checklist:

- [x] Branch: master
- [x] Tests pass
- [x] Code follows coding guidelines: [master](https://area51.phpbb.com/docs/master/coding-guidelines.html), [3.1.x](https://area51.phpbb.com/docs/31x/coding-guidelines.html)
- [x] Commit follows commit message [format](https://wiki.phpbb.com/Git#Commit_Messages)

Tracker ticket: [PHPBB3-15508](https://tracker.phpbb.com/browse/PHPBB3-15508)

Changes introduced by Twig 2.x:
- `Twig_NodeInterface` was removed, `Twig_Node` should be used instead.
- `Twig_Parser::getEnvironment()` was removed
- `Twig_Loader_Filesystem::findTemplate()` has a new argument `$throw = true`
- `Twig_Loader_Filesystem::validateName()` visibility changed from protected to private.

To install Twig 2.x here's the composer command I launched (in order to ignore platform requirements as Twig 2 require php >= 7.0): `php composer.phar update twig/twig --with-dependencies --ignore-platform-reqs`