### PR TITLE
[ticket/15393] PR1 Fix wrong direction for text boxs contain code in rtl

### DIFF
--- a/phpBB/adm/style/acp_attachments.html
+++ b/phpBB/adm/style/acp_attachments.html
@@ -78,7 +78,7 @@
 		<p>{L_DOWNLOAD_ADD_IPS_EXPLAIN}</p>
 	<dl>
 		<dt><label for="ip_hostname">{L_IP_HOSTNAME}{L_COLON}</label></dt>
-		<dd><textarea id="ip_hostname" cols="40" rows="3" name="ips"></textarea></dd>
+		<dd><textarea class="always-ltr" id="ip_hostname" cols="40" rows="3" name="ips"></textarea></dd>
 	</dl>
 	<dl>
 		<dt><label for="exclude">{L_IP_EXCLUDE}{L_COLON}</label><br /><span>{L_EXCLUDE_ENTERED_IP}</span></dt>
@@ -272,7 +272,7 @@
 		<legend>{L_ADD_EXTENSION}</legend>
 	<dl>
 		<dt><label for="add_extension">{L_EXTENSION}</label></dt>
-		<dd><input type="text" id="add_extension" size="20" maxlength="100" name="add_extension" value="{ADD_EXTENSION}" /></dd>
+		<dd><input type="text" class="always-ltr" id="add_extension" size="20" maxlength="100" name="add_extension" value="{ADD_EXTENSION}" /></dd>
 	</dl>
 	<dl>
 		<dt><label for="extension_group">{L_EXTENSION_GROUP}</label></dt>

--- a/phpBB/adm/style/acp_attachments.html
+++ b/phpBB/adm/style/acp_attachments.html
@@ -79,7 +79,7 @@
 		<p>{L_DOWNLOAD_ADD_IPS_EXPLAIN}</p>
 	<dl>
 		<dt><label for="ip_hostname">{L_IP_HOSTNAME}{L_COLON}</label></dt>
-		<dd><textarea id="ip_hostname" cols="40" rows="3" name="ips"></textarea></dd>
+		<dd><textarea class="always-ltr" id="ip_hostname" cols="40" rows="3" name="ips"></textarea></dd>
 	</dl>
 	<dl>
 		<dt><label for="exclude">{L_IP_EXCLUDE}{L_COLON}</label><br /><span>{L_EXCLUDE_ENTERED_IP}</span></dt>
@@ -270,7 +270,7 @@
 		<legend>{L_ADD_EXTENSION}</legend>
 	<dl>
 		<dt><label for="add_extension">{L_EXTENSION}</label></dt>
-		<dd><input type="text" id="add_extension" size="20" maxlength="100" name="add_extension" value="{ADD_EXTENSION}" /></dd>
+		<dd><input type="text" class="always-ltr" id="add_extension" size="20" maxlength="100" name="add_extension" value="{ADD_EXTENSION}" /></dd>
 	</dl>
 	<dl>
 		<dt><label for="extension_group">{L_EXTENSION_GROUP}</label></dt>

--- a/phpBB/adm/style/acp_ban.html
+++ b/phpBB/adm/style/acp_ban.html
@@ -52,7 +52,7 @@
 	<legend>{L_TITLE}</legend>
 <dl>
 	<dt><label for="ban">{L_BAN_CELL}{L_COLON}</label></dt>
-	<dd><!-- EVENT acp_ban_cell_prepend --><textarea name="ban" cols="40" rows="3" id="ban"></textarea><!-- EVENT acp_ban_cell_append --></dd>
+	<dd><!-- EVENT acp_ban_cell_prepend --><textarea <!-- IF not S_USERNAME_BAN -->class="always-ltr" <!-- ENDIF -->name="ban" cols="40" rows="3" id="ban"></textarea><!-- EVENT acp_ban_cell_append --></dd>
 	<!-- IF S_USERNAME_BAN --><dd>[ <a href="{U_FIND_USERNAME}" onclick="find_username(this.href); return false;">{L_FIND_USERNAME}</a> ]</dd><!-- ENDIF -->
 </dl>
 <dl>

--- a/phpBB/adm/style/acp_bbcodes.html
+++ b/phpBB/adm/style/acp_bbcodes.html
@@ -17,7 +17,7 @@
 		<p>{L_BBCODE_USAGE_EXPLAIN}</p>
 	<dl>
 		<dt><label for="bbcode_match">{L_EXAMPLES}</label><br /><br /><span>{L_BBCODE_USAGE_EXAMPLE}</span></dt>
-		<dd><textarea id="bbcode_match" name="bbcode_match" cols="60" rows="5">{BBCODE_MATCH}</textarea></dd>
+		<dd><textarea class="always-ltr" id="bbcode_match" name="bbcode_match" cols="60" rows="5">{BBCODE_MATCH}</textarea></dd>
 	</dl>
 	</fieldset>
 
@@ -26,7 +26,7 @@
 		<p>{L_HTML_REPLACEMENT_EXPLAIN}</p>
 	<dl>
 		<dt><label for="bbcode_tpl">{L_EXAMPLES}</label><br /><br /><span>{L_HTML_REPLACEMENT_EXAMPLE}</span></dt>
-		<dd><textarea id="bbcode_tpl" name="bbcode_tpl" cols="60" rows="8">{BBCODE_TPL}</textarea></dd>
+		<dd><textarea class="always-ltr" id="bbcode_tpl" name="bbcode_tpl" cols="60" rows="8">{BBCODE_TPL}</textarea></dd>
 	</dl>
 	</fieldset>
 
@@ -102,7 +102,7 @@
 	<tbody>
 	<!-- BEGIN bbcodes -->
 		<tr>
-			<td style="text-align: center;">{bbcodes.BBCODE_TAG}</td>
+			<td class="always-ltr" style="text-align: center;">{bbcodes.BBCODE_TAG}</td>
 			<td class="actions"><!-- EVENT acp_bbcodes_actions_prepend --> <a href="{bbcodes.U_EDIT}">{ICON_EDIT}</a> <a href="{bbcodes.U_DELETE}" data-ajax="row_delete">{ICON_DELETE}</a> <!-- EVENT acp_bbcodes_actions_append --></td>
 		</tr>
 	<!-- BEGINELSE -->

--- a/phpBB/adm/style/acp_bots.html
+++ b/phpBB/adm/style/acp_bots.html
@@ -23,7 +23,7 @@
 		<legend>{L_TITLE}</legend>
 	<dl>
 		<dt><label for="bot_name">{L_BOT_NAME}{L_COLON}</label><br /><span>{L_BOT_NAME_EXPLAIN}</span></dt>
-		<dd><input name="bot_name" type="text" id="bot_name" value="{BOT_NAME}" maxlength="255" /></dd>
+		<dd><input class="always-ltr" name="bot_name" type="text" id="bot_name" value="{BOT_NAME}" maxlength="255" /></dd>
 	</dl>
 	<dl>
 		<dt><label for="bot_style">{L_BOT_STYLE}{L_COLON}</label><br /><span>{L_BOT_STYLE_EXPLAIN}</span></dt>
@@ -39,11 +39,11 @@
 	</dl>
 	<dl>
 		<dt><label for="bot_agent">{L_BOT_AGENT}{L_COLON}</label><br /><span>{L_BOT_AGENT_EXPLAIN}</span></dt>
-		<dd><input name="bot_agent" type="text" id="bot_agent" value="{BOT_AGENT}" maxlength="255" /></dd>
+		<dd><input class="always-ltr" name="bot_agent" type="text" id="bot_agent" value="{BOT_AGENT}" maxlength="255" /></dd>
 	</dl>
 	<dl>
 		<dt><label for="bot_ip">{L_BOT_IP}{L_COLON}</label><br /><span>{L_BOT_IP_EXPLAIN}</span></dt>
-		<dd><input name="bot_ip" type="text" id="bot_ip" value="{BOT_IP}" maxlength="255" /></dd>
+		<dd><input class="always-ltr" name="bot_ip" type="text" id="bot_ip" value="{BOT_IP}" maxlength="255" /></dd>
 	</dl>
 
 	<p class="submit-buttons">

--- a/phpBB/adm/style/acp_forums.html
+++ b/phpBB/adm/style/acp_forums.html
@@ -160,7 +160,7 @@
 	</dl>
 	<dl>
 		<dt><label for="forum_image">{L_FORUM_IMAGE}{L_COLON}</label><br /><span>{L_FORUM_IMAGE_EXPLAIN}</span></dt>
-		<dd><input class="text medium" type="text" id="forum_image" name="forum_image" value="{FORUM_IMAGE}" maxlength="255" /></dd>
+		<dd><input class="text medium always-ltr" type="text" id="forum_image" name="forum_image" value="{FORUM_IMAGE}" maxlength="255" /></dd>
 		<!-- IF FORUM_IMAGE_SRC -->
 			<dd><img src="{FORUM_IMAGE_SRC}" alt="{L_FORUM_IMAGE}" /></dd>
 		<!-- ENDIF -->
@@ -309,7 +309,7 @@
 		</dl>
 		<dl>
 			<dt><label for="forum_link">{L_FORUM_LINK}{L_COLON}</label><br /><span>{L_FORUM_LINK_EXPLAIN}</span></dt>
-			<dd><input class="text medium" type="text" id="forum_link" name="forum_link" value="{FORUM_DATA_LINK}" maxlength="255" /></dd>
+			<dd><input class="text medium always-ltr" type="text" id="forum_link" name="forum_link" value="{FORUM_DATA_LINK}" maxlength="255" /></dd>
 		</dl>
 		<dl>
 			<dt><label for="forum_link_track">{L_FORUM_LINK_TRACK}{L_COLON}</label><br /><span>{L_FORUM_LINK_TRACK_EXPLAIN}</span></dt>
@@ -325,7 +325,7 @@
 		<!-- EVENT acp_forums_rules_settings_prepend -->
 		<dl>
 			<dt><label for="forum_rules_link">{L_FORUM_RULES_LINK}{L_COLON}</label><br /><span>{L_FORUM_RULES_LINK_EXPLAIN}</span></dt>
-			<dd><input class="text medium" type="text" id="forum_rules_link" name="forum_rules_link" value="{FORUM_RULES_LINK}" maxlength="255" /></dd>
+			<dd><input class="text medium always-ltr" type="text" id="forum_rules_link" name="forum_rules_link" value="{FORUM_RULES_LINK}" maxlength="255" /></dd>
 		</dl>
 	<!-- IF FORUM_RULES_PREVIEW -->
 		<dl>

--- a/phpBB/adm/style/acp_forums.html
+++ b/phpBB/adm/style/acp_forums.html
@@ -160,7 +160,7 @@
 	</dl>
 	<dl>
 		<dt><label for="forum_image">{L_FORUM_IMAGE}{L_COLON}</label><br /><span>{L_FORUM_IMAGE_EXPLAIN}</span></dt>
-		<dd><input class="text medium" type="text" id="forum_image" name="forum_image" value="{FORUM_IMAGE}" maxlength="255" /></dd>
+		<dd><input class="text medium always-ltr" type="text" id="forum_image" name="forum_image" value="{FORUM_IMAGE}" maxlength="255" /></dd>
 		<!-- IF FORUM_IMAGE_SRC -->
 			<dd><img src="{FORUM_IMAGE_SRC}" alt="{L_FORUM_IMAGE}" /></dd>
 		<!-- ENDIF -->
@@ -314,7 +314,7 @@
 		</dl>
 		<dl>
 			<dt><label for="forum_link">{L_FORUM_LINK}{L_COLON}</label><br /><span>{L_FORUM_LINK_EXPLAIN}</span></dt>
-			<dd><input class="text medium" type="text" id="forum_link" name="forum_link" value="{FORUM_DATA_LINK}" maxlength="255" /></dd>
+			<dd><input class="text medium always-ltr" type="text" id="forum_link" name="forum_link" value="{FORUM_DATA_LINK}" maxlength="255" /></dd>
 		</dl>
 		<dl>
 			<dt><label for="forum_link_track">{L_FORUM_LINK_TRACK}{L_COLON}</label><br /><span>{L_FORUM_LINK_TRACK_EXPLAIN}</span></dt>
@@ -330,7 +330,7 @@
 		<!-- EVENT acp_forums_rules_settings_prepend -->
 		<dl>
 			<dt><label for="forum_rules_link">{L_FORUM_RULES_LINK}{L_COLON}</label><br /><span>{L_FORUM_RULES_LINK_EXPLAIN}</span></dt>
-			<dd><input class="text medium" type="text" id="forum_rules_link" name="forum_rules_link" value="{FORUM_RULES_LINK}" maxlength="255" /></dd>
+			<dd><input class="text medium always-ltr" type="text" id="forum_rules_link" name="forum_rules_link" value="{FORUM_RULES_LINK}" maxlength="255" /></dd>
 		</dl>
 	<!-- IF FORUM_RULES_PREVIEW -->
 		<dl>

--- a/phpBB/adm/style/acp_jabber.html
+++ b/phpBB/adm/style/acp_jabber.html
@@ -27,7 +27,7 @@
 </dl>
 <dl>
 	<dt><label for="jab_host">{L_JAB_SERVER}{L_COLON}</label><br /><span>{L_JAB_SERVER_EXPLAIN}</span></dt>
-	<dd><input type="text" id="jab_host" name="jab_host" value="{JAB_HOST}" /></dd>
+	<dd><input class="always-ltr" type="text" id="jab_host" name="jab_host" value="{JAB_HOST}" /></dd>
 </dl>
 <dl>
 	<dt><label for="jab_port">{L_JAB_PORT}{L_COLON}</label><br /><span>{L_JAB_PORT_EXPLAIN}</span></dt>
@@ -35,7 +35,7 @@
 </dl>
 <dl>
 	<dt><label for="jab_username">{L_JAB_USERNAME}{L_COLON}</label><br /><span>{L_JAB_USERNAME_EXPLAIN}</span></dt>
-	<dd><input type="text" id="jab_username" name="jab_username" value="{JAB_USERNAME}" /></dd>
+	<dd><input class="always-ltr" type="text" id="jab_username" name="jab_username" value="{JAB_USERNAME}" /></dd>
 </dl>
 <dl>
 	<dt><label for="jab_password">{L_JAB_PASSWORD}{L_COLON}</label><br /><span>{L_JAB_PASSWORD_EXPLAIN}</span></dt>

--- a/phpBB/adm/style/acp_prune_users.html
+++ b/phpBB/adm/style/acp_prune_users.html
@@ -16,7 +16,7 @@
 </dl>
 <dl>
 	<dt><label for="email">{L_EMAIL}{L_COLON}</label></dt>
-	<dd><input type="text" id="email" name="email" /></dd>
+	<dd><input type="email" id="email" name="email" /></dd>
 </dl>
 <dl>
 	<dt><label for="joined_after">{L_JOINED}{L_COLON}</label><br /><span>{L_JOINED_EXPLAIN}</span></dt>

--- a/phpBB/adm/style/admin.css
+++ b/phpBB/adm/style/admin.css
@@ -1125,6 +1125,11 @@ input, textarea {
 	border-bottom: 1px solid #D5D5C8;
 }
 
+.rtl input[type="email"], .rtl input[type="url"],
+.rtl .always-ltr {
+	direction: ltr;
+}
+
 input:hover, textarea:hover {
 	border-left: 1px solid #AFAEAA;
 	border-top: 1px solid #AFAEAA;

--- a/phpBB/adm/style/admin.css
+++ b/phpBB/adm/style/admin.css
@@ -1240,6 +1240,12 @@ textarea {
 	border-left: 1px solid #d5d5c8;
 }
 
+.rtl input[type="email"],
+.rtl input[type="url"],
+.rtl .always-ltr {
+	direction: ltr;
+}
+
 input:hover,
 textarea:hover {
 	background-color: #e9e9e2;

--- a/phpBB/phpbb/search/fulltext_sphinx.php
+++ b/phpBB/phpbb/search/fulltext_sphinx.php
@@ -945,11 +945,11 @@ class fulltext_sphinx
 		<span class="error">' . $this->user->lang['FULLTEXT_SPHINX_CONFIGURE']. '</span>
 		<dl>
 			<dt><label for="fulltext_sphinx_data_path">' . $this->user->lang['FULLTEXT_SPHINX_DATA_PATH'] . $this->user->lang['COLON'] . '</label><br /><span>' . $this->user->lang['FULLTEXT_SPHINX_DATA_PATH_EXPLAIN'] . '</span></dt>
-			<dd><input id="fulltext_sphinx_data_path" type="text" size="40" maxlength="255" name="config[fulltext_sphinx_data_path]" value="' . $this->config['fulltext_sphinx_data_path'] . '" /></dd>
+			<dd><input class="always-ltr" id="fulltext_sphinx_data_path" type="text" size="40" maxlength="255" name="config[fulltext_sphinx_data_path]" value="' . $this->config['fulltext_sphinx_data_path'] . '" /></dd>
 		</dl>
 		<dl>
 			<dt><label for="fulltext_sphinx_host">' . $this->user->lang['FULLTEXT_SPHINX_HOST'] . $this->user->lang['COLON'] . '</label><br /><span>' . $this->user->lang['FULLTEXT_SPHINX_HOST_EXPLAIN'] . '</span></dt>
-			<dd><input id="fulltext_sphinx_host" type="text" size="40" maxlength="255" name="config[fulltext_sphinx_host]" value="' . $this->config['fulltext_sphinx_host'] . '" /></dd>
+			<dd><input class="always-ltr" id="fulltext_sphinx_host" type="text" size="40" maxlength="255" name="config[fulltext_sphinx_host]" value="' . $this->config['fulltext_sphinx_host'] . '" /></dd>
 		</dl>
 		<dl>
 			<dt><label for="fulltext_sphinx_port">' . $this->user->lang['FULLTEXT_SPHINX_PORT'] . $this->user->lang['COLON'] . '</label><br /><span>' . $this->user->lang['FULLTEXT_SPHINX_PORT_EXPLAIN'] . '</span></dt>

--- a/phpBB/phpbb/search/fulltext_sphinx.php
+++ b/phpBB/phpbb/search/fulltext_sphinx.php
@@ -1029,11 +1029,11 @@ class fulltext_sphinx
 		<span class="error">' . $this->user->lang['FULLTEXT_SPHINX_CONFIGURE']. '</span>
 		<dl>
 			<dt><label for="fulltext_sphinx_data_path">' . $this->user->lang['FULLTEXT_SPHINX_DATA_PATH'] . $this->user->lang['COLON'] . '</label><br /><span>' . $this->user->lang['FULLTEXT_SPHINX_DATA_PATH_EXPLAIN'] . '</span></dt>
-			<dd><input id="fulltext_sphinx_data_path" type="text" size="40" maxlength="255" name="config[fulltext_sphinx_data_path]" value="' . $this->config['fulltext_sphinx_data_path'] . '" /></dd>
+			<dd><input class="always-ltr" id="fulltext_sphinx_data_path" type="text" size="40" maxlength="255" name="config[fulltext_sphinx_data_path]" value="' . $this->config['fulltext_sphinx_data_path'] . '" /></dd>
 		</dl>
 		<dl>
 			<dt><label for="fulltext_sphinx_host">' . $this->user->lang['FULLTEXT_SPHINX_HOST'] . $this->user->lang['COLON'] . '</label><br /><span>' . $this->user->lang['FULLTEXT_SPHINX_HOST_EXPLAIN'] . '</span></dt>
-			<dd><input id="fulltext_sphinx_host" type="text" size="40" maxlength="255" name="config[fulltext_sphinx_host]" value="' . $this->config['fulltext_sphinx_host'] . '" /></dd>
+			<dd><input class="always-ltr" id="fulltext_sphinx_host" type="text" size="40" maxlength="255" name="config[fulltext_sphinx_host]" value="' . $this->config['fulltext_sphinx_host'] . '" /></dd>
 		</dl>
 		<dl>
 			<dt><label for="fulltext_sphinx_port">' . $this->user->lang['FULLTEXT_SPHINX_PORT'] . $this->user->lang['COLON'] . '</label><br /><span>' . $this->user->lang['FULLTEXT_SPHINX_PORT_EXPLAIN'] . '</span></dt>

--- a/phpBB/styles/prosilver/template/ucp_prefs_personal.html
+++ b/phpBB/styles/prosilver/template/ucp_prefs_personal.html
@@ -70,7 +70,7 @@
 				{S_DATEFORMAT_OPTIONS}
 			</select>
 		</dd>
-		<dd id="custom_date" style="display:none;"><input type="text" name="dateformat" id="dateformat" value="{DATE_FORMAT}" maxlength="64" class="inputbox narrow" style="margin-top: 3px;" /></dd>
+		<dd id="custom_date" style="display:none;"><input type="text" name="dateformat" id="dateformat" value="{DATE_FORMAT}" maxlength="64" class="inputbox narrow always-ltr" style="margin-top: 3px;" /></dd>
 	</dl>
 	<!-- EVENT ucp_prefs_personal_append -->
 	</fieldset>

--- a/phpBB/styles/prosilver/theme/bidi.css
+++ b/phpBB/styles/prosilver/theme/bidi.css
@@ -815,6 +815,7 @@ li.breadcrumbs span:first-child > a {
 	padding-left: 5px;
 }
 
+.rtl input[type="email"], .rtl input[type="url"],
 .rtl .always-ltr {
 	direction: ltr;
 }

--- a/phpBB/styles/prosilver/theme/bidi.css
+++ b/phpBB/styles/prosilver/theme/bidi.css
@@ -831,6 +831,7 @@
 	padding-left: 5px;
 }
 
+.rtl input[type="email"], .rtl input[type="url"],
 .rtl .always-ltr {
 	direction: ltr;
 }

--- a/phpBB/styles/prosilver/theme/bidi.css
+++ b/phpBB/styles/prosilver/theme/bidi.css
@@ -815,6 +815,10 @@ li.breadcrumbs span:first-child > a {
 	padding-left: 5px;
 }
 
+.rtl .always-ltr {
+	direction: ltr;
+}
+
 /* Definition list layout for forms
 ---------------------------------------- */
 .rtl fieldset dt {

--- a/phpBB/styles/prosilver/theme/bidi.css
+++ b/phpBB/styles/prosilver/theme/bidi.css
@@ -831,7 +831,8 @@
 	padding-left: 5px;
 }
 
-.rtl input[type="email"], .rtl input[type="url"],
+.rtl input[type="email"],
+.rtl input[type="url"],
 .rtl .always-ltr {
 	direction: ltr;
 }

--- a/phpBB/styles/prosilver/theme/bidi.css
+++ b/phpBB/styles/prosilver/theme/bidi.css
@@ -831,6 +831,10 @@
 	padding-left: 5px;
 }
 
+.rtl .always-ltr {
+	direction: ltr;
+}
+
 /* Definition list layout for forms
 ---------------------------------------- */
 .rtl fieldset dt {

--- a/phpBB/styles/prosilver/theme/utilities.css
+++ b/phpBB/styles/prosilver/theme/utilities.css
@@ -64,3 +64,8 @@
 }
 
 .affix { position: fixed }
+
+.rtl input[type="email"], .rtl input[type="url"],
+.rtl .always-ltr {
+	direction: ltr;
+}

--- a/phpBB/styles/prosilver/theme/utilities.css
+++ b/phpBB/styles/prosilver/theme/utilities.css
@@ -64,7 +64,3 @@
 }
 
 .affix { position: fixed }
-
-.rtl input[type="email"], .rtl input[type="url"] {
-	direction: ltr;
-}

--- a/phpBB/styles/prosilver/theme/utilities.css
+++ b/phpBB/styles/prosilver/theme/utilities.css
@@ -83,7 +83,3 @@
 .affix {
 	position: fixed;
 }
-
-.rtl input[type="email"], .rtl input[type="url"] {
-	direction: ltr;
-}

--- a/phpBB/styles/prosilver/theme/utilities.css
+++ b/phpBB/styles/prosilver/theme/utilities.css
@@ -83,3 +83,9 @@
 .affix {
 	position: fixed;
 }
+
+.rtl input[type="email"],
+.rtl input[type="url"],
+.rtl .always-ltr {
+	direction: ltr;
+}

--- a/phpBB/styles/prosilver/theme/utilities.css
+++ b/phpBB/styles/prosilver/theme/utilities.css
@@ -65,7 +65,6 @@
 
 .affix { position: fixed }
 
-.rtl input[type="email"], .rtl input[type="url"],
-.rtl .always-ltr {
+.rtl input[type="email"], .rtl input[type="url"] {
 	direction: ltr;
 }

--- a/phpBB/styles/prosilver/theme/utilities.css
+++ b/phpBB/styles/prosilver/theme/utilities.css
@@ -84,8 +84,6 @@
 	position: fixed;
 }
 
-.rtl input[type="email"],
-.rtl input[type="url"],
-.rtl .always-ltr {
+.rtl input[type="email"], .rtl input[type="url"] {
 	direction: ltr;
 }


### PR DESCRIPTION
This PR1 for fixing this bug contains only HTML and CSS edits.
Not all elements will be fixed with this PR, So I submit PR2 to fix remain elements that needs core files edits.
 specify class `always-ltr` to `input` that have a value contains:
code, path, url, server name, ip, email and other values
that are typed in latin charecters in usual.

PHPBB3-15393

Checklist:

- [x] Correct branch: master for new features; 3.2.x, 3.1.x for fixes
- [ ] Tests pass
- [x] Code follows coding guidelines: [master / 3.2.x](https://area51.phpbb.com/docs/master/coding-guidelines.html), [3.1.x](https://area51.phpbb.com/docs/31x/coding-guidelines.html)
- [x] Commit follows commit message [format](https://wiki.phpbb.com/Git#Commit_Messages)

Tracker ticket:

https://tracker.phpbb.com/browse/PHPBB3-15393
