### PR TITLE
[ticket/15527] Skip malformed BBCodes during merge_duplicate_bbcodes migration

### DIFF
--- a/phpBB/phpbb/db/migration/data/v32x/merge_duplicate_bbcodes.php
+++ b/phpBB/phpbb/db/migration/data/v32x/merge_duplicate_bbcodes.php
@@ -13,8 +13,6 @@
 
 namespace phpbb\db\migration\data\v32x;
 
-use Exception;
-
 class merge_duplicate_bbcodes extends \phpbb\db\migration\container_aware_migration
 {
 	public function update_data()
@@ -61,7 +59,7 @@ class merge_duplicate_bbcodes extends \phpbb\db\migration\container_aware_migrat
 				]
 			);
 		}
-		catch (Exception $e)
+		catch (\Exception $e)
 		{
 			// Ignore the pair and move on. The BBCodes would have to be fixed manually
 			return;

--- a/phpBB/phpbb/db/migration/data/v32x/merge_duplicate_bbcodes.php
+++ b/phpBB/phpbb/db/migration/data/v32x/merge_duplicate_bbcodes.php
@@ -13,6 +13,8 @@
 
 namespace phpbb\db\migration\data\v32x;
 
+use Exception;
+
 class merge_duplicate_bbcodes extends \phpbb\db\migration\container_aware_migration
 {
 	public function update_data()
@@ -46,16 +48,25 @@ class merge_duplicate_bbcodes extends \phpbb\db\migration\container_aware_migrat
 
 	protected function merge_bbcodes(array $without, array $with)
 	{
-		$merged = $this->container->get('text_formatter.s9e.bbcode_merger')->merge_bbcodes(
-			[
-				'usage'    => $without['bbcode_match'],
-				'template' => $without['bbcode_tpl']
-			],
-			[
-				'usage'    => $with['bbcode_match'],
-				'template' => $with['bbcode_tpl']
-			]
-		);
+		try
+		{
+			$merged = $this->container->get('text_formatter.s9e.bbcode_merger')->merge_bbcodes(
+				[
+					'usage'    => $without['bbcode_match'],
+					'template' => $without['bbcode_tpl']
+				],
+				[
+					'usage'    => $with['bbcode_match'],
+					'template' => $with['bbcode_tpl']
+				]
+			);
+		}
+		catch (Exception $e)
+		{
+			// Ignore the pair and move on. The BBCodes would have to be fixed manually
+			return;
+		}
+
 		$bbcode_data = [
 			'bbcode_tag'      => $without['bbcode_tag'],
 			'bbcode_helpline' => $without['bbcode_helpline'] . ' | ' . $with['bbcode_helpline'],

--- a/phpBB/phpbb/textformatter/s9e/bbcode_merger.php
+++ b/phpBB/phpbb/textformatter/s9e/bbcode_merger.php
@@ -37,6 +37,9 @@ class bbcode_merger
 	*
 	* All of the arrays contain a "usage" element and a "template" element
 	*
+	* @throws InvalidArgumentException if a definition cannot be interpreted
+	* @throws RuntimeException if something unexpected occurs
+	*
 	* @param  array $without BBCode definition without an attribute
 	* @param  array $with    BBCode definition with an attribute
 	* @return array          Merged definition


### PR DESCRIPTION
Checklist:

- [x] Correct branch: master for new features; 3.2.x, 3.1.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master / 3.2.x](https://area51.phpbb.com/docs/master/coding-guidelines.html), [3.1.x](https://area51.phpbb.com/docs/31x/coding-guidelines.html)
- [x] Commit follows commit message [format](https://wiki.phpbb.com/Git#Commit_Messages)

Tracker ticket (set the ticket ID to **your ticket ID**):

https://tracker.phpbb.com/browse/PHPBB3-15527
