### PR TITLE
[ticket/15507] Fix PHP 7.2 warning in functions_messenger.php

### DIFF
--- a/phpBB/includes/functions_messenger.php
+++ b/phpBB/includes/functions_messenger.php
@@ -24,8 +24,9 @@ if (!defined('IN_PHPBB'))
 */
 class messenger
 {
-	var $msg, $extra_headers, $replyto, $from, $subject;
+	var $msg, $replyto, $from, $subject;
 	var $addresses = array();
+	var $extra_headers = array();
 
 	var $mail_priority = MAIL_NORMAL_PRIORITY;
 	var $use_queue = true;


### PR DESCRIPTION
By pre assign `$extra_headers` to array.

PHPBB3-15507

Checklist:

- [x] Correct branch: master for new features; 3.2.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master](https://area51.phpbb.com/docs/dev/master/development/coding_guidelines.html) and [3.2.x](https://area51.phpbb.com/docs/dev/3.2.x/development/coding_guidelines.html)
- [x] Commit follows commit message [format](https://area51.phpbb.com/docs/dev/3.2.x/development/git.html)

Tracker ticket (set the ticket ID to **your ticket ID**):

https://tracker.phpbb.com/browse/PHPBB3-15507
