### PR TITLE
[ticket/15556] Alternative Fix to translate AM/PM in time Format

### DIFF
--- a/phpBB/language/en/common.php
+++ b/phpBB/language/en/common.php
@@ -946,6 +946,11 @@ $lang = array_merge($lang, array(
 		'Oct'		=> 'Oct',
 		'Nov'		=> 'Nov',
 		'Dec'		=> 'Dec',
+
+		'AMsmall'	=> 'am',
+		'PMsmall'	=> 'pm',
+		'AM'		=> 'AM',
+		'PM'		=> 'PM',
 	),
 
 	// Timezones can be translated. We use this for the Etc/GMT timezones here,

--- a/phpBB/phpbb/datetime.php
+++ b/phpBB/phpbb/datetime.php
@@ -66,6 +66,7 @@ class datetime extends \DateTime
 			$format = preg_replace('/([^\\\])S/','$1', $format);
 		}
 
+		$format		= preg_replace('/([^\\\])a/','$1A\s\m\a\l\l', $format);
 		$format		= self::format_cache($format, $this->user);
 		$relative	= ($format['is_short'] && !$force_absolute);
 		$now		= new self($this->user, 'now', $this->user->timezone);


### PR DESCRIPTION
This a lightweight alternative fix
Taking care in case that `am` may be apart of word
PHPBB3-15556

Checklist:

- [ ] Correct branch: master for new features; 3.2.x for fixes
- [ ] Tests pass
- [ ] Code follows coding guidelines: [master](https://area51.phpbb.com/docs/dev/master/development/coding_guidelines.html) and [3.2.x](https://area51.phpbb.com/docs/dev/3.2.x/development/coding_guidelines.html)
- [ ] Commit follows commit message [format](https://area51.phpbb.com/docs/dev/3.2.x/development/git.html)

Tracker ticket:

https://tracker.phpbb.com/browse/PHPBB3-15556
