### PR TITLE
[ticket/15561] Add events for adding columns to search index

### DIFF
--- a/phpBB/phpbb/search/fulltext_native.php
+++ b/phpBB/phpbb/search/fulltext_native.php
@@ -1664,19 +1664,42 @@ class fulltext_native extends \phpbb\search\base
 	*/
 	public function delete_index($acp_module, $u_action)
 	{
+		$sql_queries = [];
+
 		switch ($this->db->get_sql_layer())
 		{
 			case 'sqlite3':
-				$this->db->sql_query('DELETE FROM ' . SEARCH_WORDLIST_TABLE);
-				$this->db->sql_query('DELETE FROM ' . SEARCH_WORDMATCH_TABLE);
-				$this->db->sql_query('DELETE FROM ' . SEARCH_RESULTS_TABLE);
+				$sql_queries[] = 'DELETE FROM ' . SEARCH_WORDLIST_TABLE;
+				$sql_queries[] = 'DELETE FROM ' . SEARCH_WORDMATCH_TABLE;
+				$sql_queries[] = 'DELETE FROM ' . SEARCH_RESULTS_TABLE;
 			break;
 
 			default:
-				$this->db->sql_query('TRUNCATE TABLE ' . SEARCH_WORDLIST_TABLE);
-				$this->db->sql_query('TRUNCATE TABLE ' . SEARCH_WORDMATCH_TABLE);
-				$this->db->sql_query('TRUNCATE TABLE ' . SEARCH_RESULTS_TABLE);
+				$sql_queries[] = 'TRUNCATE TABLE ' . SEARCH_WORDLIST_TABLE;
+				$sql_queries[] = 'TRUNCATE TABLE ' . SEARCH_WORDMATCH_TABLE;
+				$sql_queries[] = 'TRUNCATE TABLE ' . SEARCH_RESULTS_TABLE;
 			break;
+		}
+
+		$stats = $this->stats;
+
+		/**
+		* Event to modify SQL queries before the native search index is deleted
+		*
+		* @event core.search_native_delete_index_before
+		* @var array	sql_queries			Array with queries for deleting the search index
+		* @var array	stats				Array with statistics of the current index (read only)
+		* @since 3.2.3-RC1
+		*/
+		$vars = array(
+			'sql_queries',
+			'stats',
+		);
+		extract($this->phpbb_dispatcher->trigger_event('core.search_native_delete_index_before', compact($vars)));
+
+		foreach ($sql_queries as $sql_query)
+		{
+			$this->db->sql_query($sql_query);
 		}
 	}
 

--- a/phpBB/phpbb/search/fulltext_postgres.php
+++ b/phpBB/phpbb/search/fulltext_postgres.php
@@ -935,14 +935,37 @@ class fulltext_postgres extends \phpbb\search\base
 			$this->get_stats();
 		}
 
+		$sql_queries = [];
+
 		if (!isset($this->stats['post_subject']))
 		{
-			$this->db->sql_query("CREATE INDEX " . POSTS_TABLE . "_" . $this->config['fulltext_postgres_ts_name'] . "_post_subject ON " . POSTS_TABLE . " USING gin (to_tsvector ('" . $this->db->sql_escape($this->config['fulltext_postgres_ts_name']) . "', post_subject))");
+			$sql_queries[] = "CREATE INDEX " . POSTS_TABLE . "_" . $this->config['fulltext_postgres_ts_name'] . "_post_subject ON " . POSTS_TABLE . " USING gin (to_tsvector ('" . $this->db->sql_escape($this->config['fulltext_postgres_ts_name']) . "', post_subject))";
 		}
 
 		if (!isset($this->stats['post_content']))
 		{
-			$this->db->sql_query("CREATE INDEX " . POSTS_TABLE . "_" . $this->config['fulltext_postgres_ts_name'] . "_post_content ON " . POSTS_TABLE . " USING gin (to_tsvector ('" . $this->db->sql_escape($this->config['fulltext_postgres_ts_name']) . "', post_text || ' ' || post_subject))");
+			$sql_queries[] = "CREATE INDEX " . POSTS_TABLE . "_" . $this->config['fulltext_postgres_ts_name'] . "_post_content ON " . POSTS_TABLE . " USING gin (to_tsvector ('" . $this->db->sql_escape($this->config['fulltext_postgres_ts_name']) . "', post_text || ' ' || post_subject))";
+		}
+
+		$stats = $this->stats;
+
+		/**
+		* Event to modify SQL queries before the Postgres search index is created
+		*
+		* @event core.search_postgres_create_index_before
+		* @var array	sql_queries			Array with queries for creating the search index
+		* @var array	stats				Array with statistics of the current index (read only)
+		* @since 3.2.3-RC1
+		*/
+		$vars = array(
+			'sql_queries',
+			'stats',
+		);
+		extract($this->phpbb_dispatcher->trigger_event('core.search_postgres_create_index_before', compact($vars)));
+
+		foreach ($sql_queries as $sql_query)
+		{
+			$this->db->sql_query($sql_query);
 		}
 
 		$this->db->sql_query('TRUNCATE TABLE ' . SEARCH_RESULTS_TABLE);
@@ -968,14 +991,37 @@ class fulltext_postgres extends \phpbb\search\base
 			$this->get_stats();
 		}
 
+		$sql_queries = [];
+
 		if (isset($this->stats['post_subject']))
 		{
-			$this->db->sql_query('DROP INDEX ' . $this->stats['post_subject']['relname']);
+			$sql_queries[] = 'DROP INDEX ' . $this->stats['post_subject']['relname'];
 		}
 
 		if (isset($this->stats['post_content']))
 		{
-			$this->db->sql_query('DROP INDEX ' . $this->stats['post_content']['relname']);
+			$sql_queries[] = 'DROP INDEX ' . $this->stats['post_content']['relname'];
+		}
+
+		$stats = $this->stats;
+
+		/**
+		* Event to modify SQL queries before the Postgres search index is created
+		*
+		* @event core.search_postgres_delete_index_before
+		* @var array	sql_queries			Array with queries for deleting the search index
+		* @var array	stats				Array with statistics of the current index (read only)
+		* @since 3.2.3-RC1
+		*/
+		$vars = array(
+			'sql_queries',
+			'stats',
+		);
+		extract($this->phpbb_dispatcher->trigger_event('core.search_postgres_delete_index_before', compact($vars)));
+
+		foreach ($sql_queries as $sql_query)
+		{
+			$this->db->sql_query($sql_query);
 		}
 
 		$this->db->sql_query('TRUNCATE TABLE ' . SEARCH_RESULTS_TABLE);


### PR DESCRIPTION
The PR adds 5 events:

- `core.search_native_delete_index_before`
- `core.search_mysql_create_index_before`
- `core.search_mysql_delete_index_before`
- `core.search_postgres_create_index_before`
- `core.search_postgres_delete_index_before`

There is no `core.search_native_create_index_before` because the `native` backend doesn't have a `create_index()` method and there is no need for an event to add columns. The `core.search_native_delete_index_before` event isn't needed for adding columns either, I just added it for completeness sake.

Checklist:

- [x] Correct branch: master for new features; 3.2.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master](https://area51.phpbb.com/docs/dev/master/development/coding_guidelines.html) and [3.2.x](https://area51.phpbb.com/docs/dev/3.2.x/development/coding_guidelines.html)
- [x] Commit follows commit message [format](https://area51.phpbb.com/docs/dev/3.2.x/development/git.html)

https://tracker.phpbb.com/browse/PHPBB3-15561
