### PR TITLE
[ticket/15583] Update session time in AJAX request only once a minute

### DIFF
--- a/phpBB/phpbb/session.php
+++ b/phpBB/phpbb/session.php
@@ -1614,13 +1614,15 @@ class session
 			return;
 		}
 
+		// Do not update the session page for ajax requests, so the view online still works as intended
+		$page_changed = $this->update_session_page && $this->data['session_page'] != $this->page['page'] && !$request->is_ajax();
+
 		// Only update session DB a minute or so after last update or if page changes
-		if ($this->time_now - ((isset($this->data['session_time'])) ? $this->data['session_time'] : 0) > 60 || ($this->update_session_page && $this->data['session_page'] != $this->page['page']))
+		if ($this->time_now - ((isset($this->data['session_time'])) ? $this->data['session_time'] : 0) > 60 || $page_changed)
 		{
 			$sql_ary = array('session_time' => $this->time_now);
 
-			// Do not update the session page for ajax requests, so the view online still works as intended
-			if ($this->update_session_page && !$request->is_ajax())
+			if ($page_changed)
 			{
 				$sql_ary['session_page'] = substr($this->page['page'], 0, 199);
 				$sql_ary['session_forum_id'] = $this->page['forum'];

--- a/phpBB/phpbb/session.php
+++ b/phpBB/phpbb/session.php
@@ -1618,7 +1618,7 @@ class session
 		$page_changed = $this->update_session_page && $this->data['session_page'] != $this->page['page'] && !$request->is_ajax();
 
 		// Only update session DB a minute or so after last update or if page changes
-		if ($this->time_now - ((isset($this->data['session_time'])) ? $this->data['session_time'] : 0) > 60 || $page_changed)
+		if ($this->time_now - (isset($this->data['session_time']) ? $this->data['session_time'] : 0) > 60 || $page_changed)
 		{
 			$sql_ary = array('session_time' => $this->time_now);
 


### PR DESCRIPTION
PHPBB3-15583

The check if the `session_page` needs to be updated was done in two places but they didn't check for the same thing:

* line 1618: `$this->update_session_page && $this->data['session_page'] != $this->page['page'])`
* line 1623: `$this->update_session_page && !$request->is_ajax()`

On AJAX requests, the first condition always passed, so the `if` block was entered and the `session_time` was prepared to be sent to the sessions table, but the second condition never passed, resulting in the `session_page` never actually being updated and only the `session_time` mistakenly being updated.

Checklist:

- [x] Correct branch: master for new features; 3.2.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master](https://area51.phpbb.com/docs/dev/master/development/coding_guidelines.html) and [3.2.x](https://area51.phpbb.com/docs/dev/3.2.x/development/coding_guidelines.html)
- [x] Commit follows commit message [format](https://area51.phpbb.com/docs/dev/3.2.x/development/git.html)

https://tracker.phpbb.com/browse/PHPBB3-15583
