### PR TITLE
[ticket/15586] Fixed adding module the automatic way without specifying modes

### DIFF
--- a/phpBB/phpbb/db/migration/tool/module.php
+++ b/phpBB/phpbb/db/migration/tool/module.php
@@ -514,12 +514,6 @@ class module implements \phpbb\db\migration\tool\tool_interface
 		// Allow '' to be sent as 0
 		$parent_id = $parent_id ?: 0;
 
-		// If automatic adding is in action, convert array back to string to simplify things
-		if (is_array($data) && count($data) == 1)
-		{
-			$data = $data['module_langname'];
-		}
-
 		if (!is_numeric($parent_id))
 		{
 			// Refresh the $module_categories array

--- a/tests/dbal/ext/foo/bar/acp/acp_test_info.php
+++ b/tests/dbal/ext/foo/bar/acp/acp_test_info.php
@@ -1,0 +1,37 @@
+<?php
+/**
+*
+* This file is part of the phpBB Forum Software package.
+*
+* @copyright (c) phpBB Limited <https://www.phpbb.com>
+* @license GNU General Public License, version 2 (GPL-2.0)
+*
+* For full copyright and license information, please see
+* the docs/CREDITS.txt file.
+*
+*/
+
+namespace foo\bar\acp;
+
+class acp_test_info
+{
+	public function module()
+	{
+		return array(
+			'filename'	=> '\foo\bar\acp\acp_test_module',
+			'title'		=> 'ACP_NEW_MODULE',
+			'modes'		=> array(
+				'mode_1' => array(
+					'title'	=> 'ACP_NEW_MODULE_MODE_1',
+					'auth'	=> '',
+					'cat'	=> array('ACP_NEW_MODULE'),
+				),
+				'mode_2' => array(
+					'title'	=> 'ACP_NEW_MODULE_MODE_2',
+					'auth'	=> '',
+					'cat'	=> array('ACP_NEW_MODULE'),
+				),
+			),
+		);
+	}
+}

--- a/tests/dbal/ext/foo/bar/acp/acp_test_module.php
+++ b/tests/dbal/ext/foo/bar/acp/acp_test_module.php
@@ -1,0 +1,25 @@
+<?php
+/**
+*
+* This file is part of the phpBB Forum Software package.
+*
+* @copyright (c) phpBB Limited <https://www.phpbb.com>
+* @license GNU General Public License, version 2 (GPL-2.0)
+*
+* For full copyright and license information, please see
+* the docs/CREDITS.txt file.
+*
+*/
+
+namespace foo\bar\acp;
+
+class acp_test_module
+{
+	var $u_action;
+
+	function main($id, $mode)
+	{
+		$this->tpl_name = 'foobar';
+		$this->page_title = 'Bertie';
+	}
+}

--- a/tests/dbal/ext/foo/bar/composer.json
+++ b/tests/dbal/ext/foo/bar/composer.json
@@ -1,0 +1,24 @@
+{
+	"name": "foo/bar",
+	"type": "phpbb-extension",
+	"description": "An example/sample extension to be used for testing purposes in phpBB Development.",
+	"version": "1.0.0",
+	"time": "2012-02-15 01:01:01",
+	"license": "GNU GPL v2",
+	"authors": [{
+			"name": "John Smith",
+			"username": "JohnSmith27",
+			"email": "email@phpbb.com",
+			"homepage": "http://phpbb.com",
+			"role": "N/A"
+		}],
+	"require": {
+		"php": ">=5.4.7"
+	},
+	"extra": {
+		"display-name": "phpBB BarFoo Extension",
+		"soft-require": {
+			"phpbb/phpbb": "3.2.*@dev"
+		}
+	}
+}

--- a/tests/dbal/ext/foo/bar/ucp/ucp_test_info.php
+++ b/tests/dbal/ext/foo/bar/ucp/ucp_test_info.php
@@ -1,0 +1,37 @@
+<?php
+/**
+*
+* This file is part of the phpBB Forum Software package.
+*
+* @copyright (c) phpBB Limited <https://www.phpbb.com>
+* @license GNU General Public License, version 2 (GPL-2.0)
+*
+* For full copyright and license information, please see
+* the docs/CREDITS.txt file.
+*
+*/
+
+namespace foo\bar\ucp;
+
+class ucp_test_info
+{
+	public function module()
+	{
+		return array(
+			'filename'	=> '\foo\bar\ucp\ucp_test_module',
+			'title'		=> 'UCP_NEW_MODULE',
+			'modes'		=> array(
+				'mode_1' => array(
+					'title'	=> 'UCP_NEW_MODULE_MODE_1',
+					'auth'	=> '',
+					'cat'	=> array('UCP_NEW_MODULE'),
+				),
+				'mode_2' => array(
+					'title'	=> 'UCP_NEW_MODULE_MODE_2',
+					'auth'	=> '',
+					'cat'	=> array('UCP_NEW_MODULE'),
+				),
+			),
+		);
+	}
+}

--- a/tests/dbal/ext/foo/bar/ucp/ucp_test_module.php
+++ b/tests/dbal/ext/foo/bar/ucp/ucp_test_module.php
@@ -1,0 +1,25 @@
+<?php
+/**
+*
+* This file is part of the phpBB Forum Software package.
+*
+* @copyright (c) phpBB Limited <https://www.phpbb.com>
+* @license GNU General Public License, version 2 (GPL-2.0)
+*
+* For full copyright and license information, please see
+* the docs/CREDITS.txt file.
+*
+*/
+
+namespace foo\bar\ucp;
+
+class ucp_test_module
+{
+	var $u_action;
+
+	function main($id, $mode)
+	{
+		$this->tpl_name = 'foobar';
+		$this->page_title = 'Bertie';
+	}
+}

--- a/tests/dbal/migrator_tool_module_test.php
+++ b/tests/dbal/migrator_tool_module_test.php
@@ -11,6 +11,9 @@
 *
 */
 
+require_once dirname(__FILE__) . '/ext/foo/bar/acp/acp_test_info.php';
+require_once dirname(__FILE__) . '/ext/foo/bar/ucp/ucp_test_info.php';
+
 class phpbb_dbal_migrator_tool_module_test extends phpbb_database_test_case
 {
 	public function getDataSet()
@@ -38,6 +41,9 @@ class phpbb_dbal_migrator_tool_module_test extends phpbb_database_test_case
 		$phpbb_dispatcher = new phpbb_mock_event_dispatcher();
 		$auth = $this->getMock('\phpbb\auth\auth');
 		$phpbb_log = new \phpbb\log\log($db, $user, $auth, $phpbb_dispatcher, $phpbb_root_path, 'adm/', $phpEx, LOG_TABLE);
+
+		// Correctly set the root path for this test to this directory, so the classes can be found
+		$phpbb_root_path = dirname(__FILE__) . '/';
 
 		$phpbb_extension_manager = new phpbb_mock_extension_manager($phpbb_root_path);
 		$module_manager = new \phpbb\module\module_manager($cache, $this->db, $phpbb_extension_manager, MODULES_TABLE, $phpbb_root_path, $phpEx);
@@ -250,6 +256,35 @@ class phpbb_dbal_migrator_tool_module_test extends phpbb_database_test_case
 			$this->fail($e);
 		}
 		$this->assertEquals(true, $this->tool->exists('ucp', 'UCP_NEW_SUBCAT', 'UCP_NEW_MODULE'));
+
+		// Test adding new UCP module the automatic way, single mode
+		try
+		{
+			$this->tool->add('ucp', 'UCP_NEW_CAT', array(
+				'module_basename'	=> '\foo\bar\ucp\ucp_test_module',
+				'modes'				=> array('mode_1'),
+			));
+		}
+		catch (Exception $e)
+		{
+			$this->fail($e);
+		}
+		$this->assertEquals(true, $this->tool->exists('ucp', 'UCP_NEW_CAT', 'UCP_NEW_MODULE_MODE_1'));
+		$this->assertEquals(false, $this->tool->exists('ucp', 'UCP_NEW_CAT', 'UCP_NEW_MODULE_MODE_2'));
+
+		// Test adding new ACP module the automatic way, all modes
+		try
+		{
+			$this->tool->add('acp', 'ACP_NEW_CAT', array(
+				'module_basename' => '\foo\bar\acp\acp_test_module',
+			));
+		}
+		catch (Exception $e)
+		{
+			$this->fail($e);
+		}
+		$this->assertEquals(true, $this->tool->exists('acp', 'ACP_NEW_CAT', 'ACP_NEW_MODULE_MODE_1'));
+		$this->assertEquals(true, $this->tool->exists('acp', 'ACP_NEW_CAT', 'ACP_NEW_MODULE_MODE_2'));
 	}
 
 	public function test_remove()


### PR DESCRIPTION
PHPBB3-15586

`$data` isn't used anymore in this method. The code that is deleted in this commit causes an undefined index error when adding a module the automatic way when only specifying the `module_basename` key.

Checklist:

- [x] Correct branch: master for new features; 3.2.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master](https://area51.phpbb.com/docs/dev/master/development/coding_guidelines.html) and [3.2.x](https://area51.phpbb.com/docs/dev/3.2.x/development/coding_guidelines.html)
- [x] Commit follows commit message [format](https://area51.phpbb.com/docs/dev/3.2.x/development/git.html)

https://tracker.phpbb.com/browse/PHPBB3-15586
