### PR TITLE
[ticket/15600] Escaped ban reasons in JavaScript code of mcp_warn.html

### DIFF
--- a/phpBB/styles/prosilver/template/mcp_ban.html
+++ b/phpBB/styles/prosilver/template/mcp_ban.html
@@ -13,10 +13,10 @@
 	<!-- BEGIN bans -->
 		ban_length['{bans.BAN_ID}'] = '{bans.A_LENGTH}';
 		<!-- IF bans.A_REASON -->
-			ban_reason['{bans.BAN_ID}'] = '{bans.A_REASON}';
+			ban_reason['{bans.BAN_ID}'] = '{{ bans.A_REASON | e('js') }}';
 		<!-- ENDIF -->
 		<!-- IF bans.A_GIVE_REASON -->
-			ban_give_reason['{bans.BAN_ID}'] = '{bans.A_GIVE_REASON}';
+			ban_give_reason['{bans.BAN_ID}'] = '{{ bans.A_GIVE_REASON | e('js') }}';
 		<!-- ENDIF -->
 	<!-- END bans -->
 


### PR DESCRIPTION
Technically it is possible to store multiline ban reasons in database, however this breaks unescaped JavaScript code stored in template.

I suggest to use TWIG e('js') function to fix this issue.

PHPBB3-15600

Checklist:

- [x] Correct branch: master for new features; 3.2.x for fixes
- [ ] Tests pass
- [x] Code follows coding guidelines: [master](https://area51.phpbb.com/docs/dev/master/development/coding_guidelines.html) and [3.2.x](https://area51.phpbb.com/docs/dev/3.2.x/development/coding_guidelines.html)
- [x] Commit follows commit message [format](https://area51.phpbb.com/docs/dev/3.2.x/development/git.html)

Tracker ticket (set the ticket ID to **your ticket ID**):

https://tracker.phpbb.com/browse/PHPBB3-15600
