### PR TITLE
3.2.x   Hiding place inline button when BBcode is disabled posting.ph…

### DIFF
--- a/phpBB/assets/javascript/core.js
+++ b/phpBB/assets/javascript/core.js
@@ -1676,3 +1676,17 @@ $(function() {
 });
 
 })(jQuery); // Avoid conflicts with other libraries
+
+$(document).ready(function(){
+var allow_bbcode = $("#inline").val();
+
+if(allow_bbcode == 0)
+{
+$("#inlineButton").css("visibility", "hidden");
+}
+else{
+	$("#inlineButton").css("visibility", "visible");
+}
+	
+
+});

--- a/phpBB/posting.php
+++ b/phpBB/posting.php
@@ -1815,7 +1815,7 @@ $page_data = array(
 	'U_VIEW_TOPIC'			=> ($mode != 'post') ? append_sid("{$phpbb_root_path}viewtopic.$phpEx", "f=$forum_id&amp;t=$topic_id") : '',
 	'U_PROGRESS_BAR'		=> append_sid("{$phpbb_root_path}posting.$phpEx", "f=$forum_id&amp;mode=popup"),
 	'UA_PROGRESS_BAR'		=> addslashes(append_sid("{$phpbb_root_path}posting.$phpEx", "f=$forum_id&amp;mode=popup")),
-
+	'ALLOWED_BBCODE' 		=> $config['allow_bbcode'],
 	'S_PRIVMSGS'				=> false,
 	'S_CLOSE_PROGRESS_WINDOW'	=> (isset($_POST['add_file'])) ? true : false,
 	'S_EDIT_POST'				=> ($mode == 'edit') ? true : false,

--- a/phpBB/styles/prosilver/template/posting_attach_body.html
+++ b/phpBB/styles/prosilver/template/posting_attach_body.html
@@ -37,8 +37,9 @@
 							<td class="attach-name">
 								<span class="file-name ellipsis-text"></span>
 								<span class="attach-controls">
-									<input type="button" value="{L_PLACE_INLINE}" class="button2 hidden file-inline-bbcode" />&nbsp;
+									<input type="button" value="{L_PLACE_INLINE}" class="button2 hidden file-inline-bbcode" id="inlineButton" />&nbsp;
 									<input type="button" value="{L_DELETE_FILE}" class="button2 file-delete" />
+									<input type="hidden" id="inline" value="{ALLOWED_BBCODE}" />
 								</span>
 								<span class="clear"></span>
 							</td>


### PR DESCRIPTION
…p core.js and posting_attach_body.html changed [ticket/15592]

3.2.x   Hiding place inline button when BBcode is disabled

 posting.php is changed to add a variable allow_bbcode core.js changed to add a function to hide/view the button and posting_attach_body.html changed to add a hidden field to pass php variable to JS

PHPBB3 15592

Checklist:

- [ ] Correct branch: master for new features; 3.2.x for fixes
- [ ] Tests pass
- [ ] Code follows coding guidelines: [master](https://area51.phpbb.com/docs/dev/master/development/coding_guidelines.html) and [3.2.x](https://area51.phpbb.com/docs/dev/3.2.x/development/coding_guidelines.html)
- [ ] Commit follows commit message [format](https://area51.phpbb.com/docs/dev/3.2.x/development/git.html)

Tracker ticket (set the ticket ID to **your ticket ID**):

https://tracker.phpbb.com/browse/PHPBB3-15592
