### PR TITLE
[ticket/15646] Add support for Argon2i passwords

### DIFF
--- a/phpBB/config/default/container/parameters.yml
+++ b/phpBB/config/default/container/parameters.yml
@@ -14,6 +14,7 @@ parameters:
 
     # List of default password driver types
     passwords.algorithms:
+        - passwords.driver.argon2i
         - passwords.driver.bcrypt_2y
         - passwords.driver.bcrypt
         - passwords.driver.salted_md5

--- a/phpBB/config/default/container/services_password.yml
+++ b/phpBB/config/default/container/services_password.yml
@@ -1,4 +1,7 @@
 parameters:
+    passwords.driver.argon2_memory_cost: 1024
+    passwords.driver.argon2_threads: 2
+    passwords.driver.argon2_time_cost: 2
     passwords.driver.bcrypt_cost: 10
 
 services:
@@ -26,6 +29,17 @@ services:
             - '@service_container'
         tags:
             - { name: service_collection, tag: passwords.driver }
+
+    passwords.driver.argon2i:
+        class: phpbb\passwords\driver\argon2i
+        arguments:
+            - '@config'
+            - '@passwords.driver_helper'
+            - '%passwords.driver.argon2_memory_cost%'
+            - '%passwords.driver.argon2_threads%'
+            - '%passwords.driver.argon2_time_cost%'
+        tags:
+            - { name: passwords.driver }
 
     passwords.driver.bcrypt:
         class: phpbb\passwords\driver\bcrypt

--- a/phpBB/phpbb/passwords/driver/argon2i.php
+++ b/phpBB/phpbb/passwords/driver/argon2i.php
@@ -1,0 +1,101 @@
+<?php
+/**
+*
+* This file is part of the phpBB Forum Software package.
+*
+* @copyright (c) phpBB Limited <https://www.phpbb.com>
+* @license GNU General Public License, version 2 (GPL-2.0)
+*
+* For full copyright and license information, please see
+* the docs/CREDITS.txt file.
+*
+*/
+
+namespace phpbb\passwords\driver;
+
+class argon2i extends base
+{
+	const PREFIX = '$argon2i$';
+
+	/** @var int Maximum memory (in bytes) that may be used to compute the Argon2 hash */
+	protected $memory_cost;
+
+	/** @var int Number of threads to use for computing the Argon2 hash */
+	protected $threads;
+
+	/** @var int Maximum amount of time it may take to compute the Argon2 hash */
+	protected $time_cost;
+
+	/**
+	* Constructor of passwords driver object
+	*
+	* @param \phpbb\config\config $config phpBB config
+	* @param \phpbb\passwords\driver\helper $helper Password driver helper
+	* @param int $memory_cost Maximum memory (optional)
+	* @param int $threads Number of threads to use (optional)
+	* @param int $time_cost Maximum amount of time (optional)
+	*/
+	public function __construct(\phpbb\config\config $config, helper $helper, $memory_cost = 1024, $threads = 2, $time_cost = 2)
+	{
+		parent::__construct($config, $helper);
+
+		// Don't allow cost factors to be below default settings
+		$this->memory_cost = max($memory_cost, 1024);
+		$this->threads     = max($threads,     2);
+		$this->time_cost   = max($time_cost,   2);
+	}
+
+	/**
+	* {@inheritdoc}
+	*/
+	public function check($password, $hash, $user_row = [])
+	{
+		return password_verify($password, $hash);
+	}
+
+	/**
+	* Return the options set for this driver instance
+	*
+	* @return array
+	*/
+	public function get_options()
+	{
+		return [
+			'memory_cost' => $this->memory_cost,
+			'time_cost'   => $this->time_cost,
+			'threads'     => $this->threads
+		];
+	}
+
+	/**
+	* {@inheritdoc}
+	*/
+	public function get_prefix()
+	{
+		return self::PREFIX;
+	}
+
+	/**
+	* {@inheritdoc}
+	*/
+	public function hash($password)
+	{
+		return password_hash($password, PASSWORD_ARGON2I, $this->get_options());
+	}
+
+	/**
+	* {@inheritdoc}
+	*/
+	public function is_supported()
+	{
+		return defined('PASSWORD_ARGON2I') && function_exists('password_hash') && function_exists('password_needs_rehash') && function_exists('password_verify');
+	}
+
+	/**
+	* {@inheritdoc}
+	*/
+	public function needs_rehash($hash)
+	{
+		return password_needs_rehash($hash, PASSWORD_ARGON2I, $this->get_options());
+	}
+}

--- a/tests/passwords/drivers_test.php
+++ b/tests/passwords/drivers_test.php
@@ -23,6 +23,7 @@ class phpbb_passwords_helper_test extends \phpbb_test_case
 		$php_ext = 'php';
 
 		$this->passwords_drivers = array(
+			'passwords.driver.argon2i'	=> new \phpbb\passwords\driver\argon2i($config, $this->driver_helper),
 			'passwords.driver.bcrypt_2y'	=> new \phpbb\passwords\driver\bcrypt_2y($config, $this->driver_helper, 10),
 			'passwords.driver.bcrypt'	=> new \phpbb\passwords\driver\bcrypt($config, $this->driver_helper, 10),
 			'passwords.driver.salted_md5'	=> new \phpbb\passwords\driver\salted_md5($config, $this->driver_helper),
@@ -422,6 +423,10 @@ class phpbb_passwords_helper_test extends \phpbb_test_case
 			array('passwords.driver.salted_md5', 'foobar', false),
 			array('passwords.driver.bcrypt_2y', '$2y$9$somerandomhash', true),
 			array('passwords.driver.bcrypt', '$2a$04$somerandomhash', true),
+			array('passwords.driver.argon2i', '$argon2i$v=19$m=1024,t=2,p=2$NEF0S1JSN04yNGQ1UVRKdA$KYGNI9CbjoKh1UEu1PpdlqbuLbveGwkMcwcT2Un9pPM', false),
+			array('passwords.driver.argon2i', '$argon2i$v=19$m=128,t=2,p=2$M29GUi51QjdKLjIzbC9scQ$6h1gZDqn7JTmVdQ0lJh1x5nyvgO/DaJWUKOFJ0itCJ0', true),
+			array('passwords.driver.argon2i', '$argon2i$v=19$m=1024,t=1,p=2$UnFHb2F4NER3M0xWWmxMUQ$u3javvoAZJeIyR1P3eg0tb8VjEeXvQPagqwetonq1NA', true),
+			array('passwords.driver.argon2i', '$argon2i$v=19$m=1024,t=2,p=1$bm5SeGJ3R3ZRY1A0YXJPNg$v1A9m4sJW+ge0RBtpJ4w9861+J9xkguKBAsZHrG8LQU', true),
 		);
 	}
 
@@ -430,6 +435,10 @@ class phpbb_passwords_helper_test extends \phpbb_test_case
 	 */
 	public function test_needs_rehash($driver, $hash, $expected)
 	{
-		$this->assertSame($this->passwords_drivers[$driver]->needs_rehash($hash), $expected);
+		if (!$this->passwords_drivers[$driver]->is_supported())
+		{
+			$this->markTestSkipped($driver . ' is not supported');
+		}
+		$this->assertSame($expected, $this->passwords_drivers[$driver]->needs_rehash($hash));
 	}
 }


### PR DESCRIPTION
This PR implements Argon2i as the preferred password driver where available. It uses the [default cost factors](https://wiki.php.net/rfc/argon2_password_hash#resolved_cost_factors).

Checklist:

- [x] Correct branch: master for new features; 3.2.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master](https://area51.phpbb.com/docs/dev/master/development/coding_guidelines.html) and [3.2.x](https://area51.phpbb.com/docs/dev/3.2.x/development/coding_guidelines.html)
- [x] Commit follows commit message [format](https://area51.phpbb.com/docs/dev/3.2.x/development/git.html)

Tracker ticket (set the ticket ID to **your ticket ID**):

https://tracker.phpbb.com/browse/PHPBB3-15646
