### PR TITLE
[ticket/15649] Allow to define a custom cache directory

### DIFF
--- a/phpBB/bin/phpbbcli.php
+++ b/phpBB/bin/phpbbcli.php
@@ -47,6 +47,11 @@ require($phpbb_root_path . 'includes/functions_compatibility.' . $phpEx);
 $phpbb_container_builder = new \phpbb\di\container_builder($phpbb_root_path, $phpEx);
 $phpbb_container = $phpbb_container_builder->with_config($phpbb_config_php_file);
 
+if (defined('PHPBB_CACHE_PATH'))
+{
+	$phpbb_container_builder->with_cache_dir(PHPBB_CACHE_PATH);
+}
+
 $input = new ArgvInput();
 
 if ($input->hasParameterOption(array('--env')))

--- a/phpBB/common.php
+++ b/phpBB/common.php
@@ -112,6 +112,12 @@ $phpbb_class_loader_ext->register();
 try
 {
 	$phpbb_container_builder = new \phpbb\di\container_builder($phpbb_root_path, $phpEx);
+
+	if (defined('PHPBB_CACHE_PATH'))
+	{
+		$phpbb_container_builder->with_cache_dir(PHPBB_CACHE_PATH);
+	}
+
 	$phpbb_container = $phpbb_container_builder->with_config($phpbb_config_php_file)->get_container();
 }
 catch (InvalidArgumentException $e)

--- a/phpBB/download/file.php
+++ b/phpBB/download/file.php
@@ -63,6 +63,12 @@ if (isset($_GET['avatar']))
 
 	// Set up container
 	$phpbb_container_builder = new \phpbb\di\container_builder($phpbb_root_path, $phpEx);
+
+	if (defined('PHPBB_CACHE_PATH'))
+	{
+		$phpbb_container_builder->with_cache_dir(PHPBB_CACHE_PATH);
+	}
+
 	$phpbb_container = $phpbb_container_builder->with_config($phpbb_config_php_file)->get_container();
 
 	$phpbb_class_loader->set_cache($phpbb_container->get('cache.driver'));


### PR DESCRIPTION
(Experimented) users should be allowed to easily change the location of the cache directory.

Some examples of use:
* Move the cache directory to a ramdisk filesystem, allowing to reduce writes on drives
* On development boards using different config.php files (to easily switch from a "profile" to another one), it allows to use a different cache directory for each profile

This commit allows to define a constant `PHPBB_CACHE_PATH` (ideally, in `config.php`) which will be used to define the path of the cache directory.

Checklist:

- [x] Correct branch: master for new features; 3.2.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master](https://area51.phpbb.com/docs/dev/master/development/coding_guidelines.html) and [3.2.x](https://area51.phpbb.com/docs/dev/3.2.x/development/coding_guidelines.html)
- [x] Commit follows commit message [format](https://area51.phpbb.com/docs/dev/3.2.x/development/git.html)

https://tracker.phpbb.com/browse/PHPBB3-15649