### PR TITLE
[ticket/15656] Add "View post" link in the mod logs on the ACP

### DIFF
--- a/phpBB/includes/acp/acp_logs.php
+++ b/phpBB/includes/acp/acp_logs.php
@@ -151,7 +151,7 @@ class acp_logs
 		{
 			$data = array();
 
-			$checks = array('viewtopic', 'viewlogs', 'viewforum');
+			$checks = array('viewpost', 'viewtopic', 'viewlogs', 'viewforum');
 			foreach ($checks as $check)
 			{
 				if (isset($row[$check]) && $row[$check])


### PR DESCRIPTION
This link was added to the MCP view in GH-3870 ([PHPBB3-9485](https://tracker.phpbb.com/browse/PHPBB3-9485)) but I completely forgot the ACP…

Consistency is back!

[PHPBB3-15656](https://tracker.phpbb.com/browse/PHPBB3-15656)

Checklist:

- [x] Correct branch: master for new features; 3.2.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master](https://area51.phpbb.com/docs/dev/master/development/coding_guidelines.html) and [3.2.x](https://area51.phpbb.com/docs/dev/3.2.x/development/coding_guidelines.html)
- [x] Commit follows commit message [format](https://area51.phpbb.com/docs/dev/3.2.x/development/git.html)