### PR TITLE
[ticket/15667] Fix first char keys in MemberList

### DIFF
--- a/phpBB/includes/functions_user.php
+++ b/phpBB/includes/functions_user.php
@@ -298,7 +298,7 @@ function user_add($user_row, $cp_data = false, $notifications_data = null)
 	$user_id = $db->sql_nextid();
 
 	//	Check users_first_characters
-	$cache = $phpbb_container->get('cache');
+	$cache = $phpbb_container->get('cache.driver');
 	$users_first_characters = $cache->get('users_first_characters');
 	if (($users_first_characters !== false) && (! array_key_exists(mb_substr($username_clean, 0, 1), $users_first_characters)))
 	{

--- a/phpBB/includes/functions_user.php
+++ b/phpBB/includes/functions_user.php
@@ -185,7 +185,7 @@ function user_update_name($old_name, $new_name)
 */
 function user_add($user_row, $cp_data = false, $notifications_data = null)
 {
-	global $db, $config, $cache;
+	global $db, $config;
 	global $phpbb_dispatcher, $phpbb_container;
 
 	if (empty($user_row['username']) || !isset($user_row['group_id']) || !isset($user_row['user_email']) || !isset($user_row['user_type']))
@@ -298,11 +298,13 @@ function user_add($user_row, $cp_data = false, $notifications_data = null)
 	$user_id = $db->sql_nextid();
 
 	//	Check users_first_characters
+	$cache = $phpbb_container->get('cache');
 	$users_first_characters = $cache->get('users_first_characters');
 	if (($users_first_characters !== false) && (! array_key_exists(mb_substr($username_clean, 0, 1), $users_first_characters)))
 	{
 		$cache->destroy('users_first_characters');
 	}
+
 	// Insert Custom Profile Fields
 	if ($cp_data !== false && count($cp_data))
 	{
@@ -715,6 +717,7 @@ function user_delete($mode, $user_ids, $retain_username = true)
 	$db->sql_return_on_error();
 
 	$cache->destroy('sql', MODERATOR_CACHE_TABLE);
+	$cache->destroy('users_first_characters');
 
 	// Change user_id to anonymous for posts edited by this user
 	$sql = 'UPDATE ' . POSTS_TABLE . '

--- a/phpBB/includes/functions_user.php
+++ b/phpBB/includes/functions_user.php
@@ -172,6 +172,7 @@ function user_update_name($old_name, $new_name)
 
 	// Because some tables/caches use username-specific data we need to purge this here.
 	$cache->destroy('sql', MODERATOR_CACHE_TABLE);
+	$cache->destroy('users_first_characters');
 }
 
 /**
@@ -184,7 +185,7 @@ function user_update_name($old_name, $new_name)
 */
 function user_add($user_row, $cp_data = false, $notifications_data = null)
 {
-	global $db, $config;
+	global $db, $config, $cache;
 	global $phpbb_dispatcher, $phpbb_container;
 
 	if (empty($user_row['username']) || !isset($user_row['group_id']) || !isset($user_row['user_email']) || !isset($user_row['user_type']))
@@ -296,6 +297,12 @@ function user_add($user_row, $cp_data = false, $notifications_data = null)
 
 	$user_id = $db->sql_nextid();
 
+	//	Check users_first_characters
+	$users_first_characters = $cache->get('users_first_characters');
+	if (($users_first_characters !== false) && (! array_key_exists(mb_substr($username_clean, 0, 1), $users_first_characters)))
+	{
+		$cache->destroy('users_first_characters');
+	}
 	// Insert Custom Profile Fields
 	if ($cp_data !== false && count($cp_data))
 	{

--- a/phpBB/memberlist.php
+++ b/phpBB/memberlist.php
@@ -1183,7 +1183,9 @@ switch ($mode)
 				{
 					$users_first_characters[chr($i)] = chr($i - 32);
 				}
-			} else {
+			}
+			else
+			{
 				$sql = 'SELECT ' . $substring_function . '(username_clean,1,1) first_char, count(*) count_users
 					FROM ' . USERS_TABLE . '
 					WHERE ' . $db->sql_in_set('user_type', $user_types) . '

--- a/phpBB/memberlist.php
+++ b/phpBB/memberlist.php
@@ -1407,6 +1407,8 @@ switch ($mode)
 		{
 			$first_characters[$row['first_char']] = mb_strtoupper($row['first_char']);
 		}
+		$db->sql_freeresult($result);		
+
 		foreach ($first_characters as $char => $desc)
 		{
 			$first_char_block_vars[] = [

--- a/phpBB/memberlist.php
+++ b/phpBB/memberlist.php
@@ -1407,7 +1407,7 @@ switch ($mode)
 		{
 			$first_characters[$row['first_char']] = mb_strtoupper($row['first_char']);
 		}
-		$db->sql_freeresult($result);		
+		$db->sql_freeresult($result);
 
 		foreach ($first_characters as $char => $desc)
 		{

--- a/phpBB/memberlist.php
+++ b/phpBB/memberlist.php
@@ -1180,7 +1180,7 @@ switch ($mode)
 				$substring_function = 'substr';
 			}
 
-			$sql = 'SELECT ' . $substring_function . '(username_clean,1,1) first_char, count(*) count_users
+			$sql = 'SELECT ' . $substring_function . '(username_clean,1,1) AS first_char, count(*) AS count_users
 				FROM ' . USERS_TABLE . '
 				WHERE ' . $db->sql_in_set('user_type', $user_types) . '
 				GROUP BY first_char


### PR DESCRIPTION
Fixing memberlist to get first_char keys from `Users` table. So it will support any language, and it will show only used characters.
Edit in last commit:
- Adding first characters to cache to avoid reduce performance.
- Change `includes/functions_user.php` to destroy the cache if new user is added or current user name  is changed.
- Limit first characters to 50 characters for the most 50 characters used in users table.
- When `users first characters` reaches the limit word `other` will be added.
- Change `other` query for more performance and shorter SQL statement.

Checklist:

- [ ] Correct branch: master for new features; 3.2.x for fixes
- [ ] Tests pass
- [ ] Code follows coding guidelines: [master](https://area51.phpbb.com/docs/dev/master/development/coding_guidelines.html) and [3.2.x](https://area51.phpbb.com/docs/dev/3.2.x/development/coding_guidelines.html)
- [ ] Commit follows commit message [format](https://area51.phpbb.com/docs/dev/3.2.x/development/git.html)

Tracker ticket (set the ticket ID to **your ticket ID**):

https://tracker.phpbb.com/browse/PHPBB3-15667
