### PR TITLE
[ticket/15683] Better error message when commit message has CRLF

### DIFF
--- a/git-tools/hooks/commit-msg
+++ b/git-tools/hooks/commit-msg
@@ -147,6 +147,15 @@ then
 	quit $ERR_LENGTH;
 fi
 
+# Check for CR/LF line breaks
+if grep -q $'\r$' "$1"
+then
+	complain "The commit message uses CR/LF line breaks, which are not permitted." >&2
+	complain >&2
+
+	quit $ERR_EOF;
+fi
+
 lines=$(wc -l "$1" | awk '{ print $1; }');
 expecting=header;
 in_description=0;


### PR DESCRIPTION
When someone tries to do a pull request with incorrect line breaks in the commit message, the error message as given by Travis is "Unexpected EOF encountered". The error message should be clearer that CR/LF was the problem. This change adds a separate check for CRLF line endings.

PHPBB3-15683