### PR TITLE
[ticket/15678] Fix build and cache flow for container

### DIFF
--- a/phpBB/phpbb/di/container_builder.php
+++ b/phpBB/phpbb/di/container_builder.php
@@ -143,6 +143,13 @@ class container_builder
 			{
 				if ($this->use_extensions)
 				{
+					$autoload_cache = new ConfigCache($this->get_autoload_filename(), defined('DEBUG'));
+					if (!$autoload_cache->isFresh())
+					{
+						// autoload cache should be refreshed
+						$this->load_extensions();
+					}
+
 					require($this->get_autoload_filename());
 				}
 

--- a/phpBB/phpbb/filesystem/filesystem.php
+++ b/phpBB/phpbb/filesystem/filesystem.php
@@ -367,7 +367,7 @@ class filesystem implements filesystem_interface
 				$common_php_group	= @filegroup(__FILE__);
 
 				// And the owner and the groups PHP is running under.
-				$php_uid	= (function_exists('posic_getuid')) ? @posix_getuid() : false;
+				$php_uid	= (function_exists('posix_getuid')) ? @posix_getuid() : false;
 				$php_gids	= (function_exists('posix_getgroups')) ? @posix_getgroups() : false;
 
 				// If we are unable to get owner/group, then do not try to set them by guessing


### PR DESCRIPTION
1. During procedure of building container we have to check both required files
in cache: container_* and autoload_*. This files should be "fresh" and if one 
of the does not exist then we have to build it and put into a cache one more 
time.

2. Fix typo 'posic_getuid' does not exist, so $php_uid is alwasy was false.

PHPBB3-15678

Checklist:

- [x] Correct branch: master for new features; 3.2.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master](https://area51.phpbb.com/docs/dev/master/development/coding_guidelines.html) and [3.2.x](https://area51.phpbb.com/docs/dev/3.2.x/development/coding_guidelines.html)
- [x] Commit follows commit message [format](https://area51.phpbb.com/docs/dev/3.2.x/development/git.html)

https://tracker.phpbb.com/browse/PHPBB3-15678
