### PR TITLE
[ticket/15719] Add core events to viewtopic to edit the post_list sql query

### DIFF
--- a/phpBB/viewtopic.php
+++ b/phpBB/viewtopic.php
@@ -1148,6 +1148,29 @@ $sql = 'SELECT p.post_id
 		" . (($join_user_sql[$sort_key]) ? 'AND u.user_id = p.poster_id': '') . "
 		$limit_posts_time
 	ORDER BY $sql_sort_order";
+	
+/**
+* Event to modify the SQL query before the post and poster data is retrieved
+*
+* @event core.viewtopic_modify_post_list_sql
+* @var	int		sql			The SQL query to generate the post_list
+* @var	int		sql_limit	The number of posts that the query fetches
+* @var	int		sql_start	The index the query starts to fetch from
+* @var	int		sort_key	Key the posts are sorted by
+* @var	int		sort_days	Display posts of previous x days
+* @var	int		forum_id	Forum ID
+* @since 3.2.2
+*/
+$vars = array(
+	'sql',
+	'sql_limit',
+	'sql_start',
+	'sort_key',
+	'sort_days',
+	'forum_id',
+);
+extract($phpbb_dispatcher->trigger_event('core.viewtopic_modify_post_list_sql', compact($vars)));
+	
 $result = $db->sql_query_limit($sql, $sql_limit, $sql_start);
 
 $i = ($store_reverse) ? $sql_limit - 1 : 0;

--- a/phpBB/viewtopic.php
+++ b/phpBB/viewtopic.php
@@ -1150,7 +1150,7 @@ $sql = 'SELECT p.post_id
 	ORDER BY $sql_sort_order";
 	
 /**
-* Event to modify the SQL query before the post and poster data is retrieved
+* Event to modify the SQL query that retreives the post_list
 *
 * @event core.viewtopic_modify_post_list_sql
 * @var	int		sql			The SQL query to generate the post_list


### PR DESCRIPTION
Events added in viewtopic.php so that you can modify post_list sql.

The query, sql limit, sql start, sort keys and days are editable.

PHPBB3-15719

Checklist:

- [ ] Correct branch: master for new features; 3.2.x for fixes
- [ ] Tests pass
- [x] Code follows coding guidelines: [master](https://area51.phpbb.com/docs/dev/master/development/coding_guidelines.html) and [3.2.x](https://area51.phpbb.com/docs/dev/3.2.x/development/coding_guidelines.html)
- [x] Commit follows commit message [format](https://area51.phpbb.com/docs/dev/3.2.x/development/git.html)

Tracker ticket (set the ticket ID to **your ticket ID**):

https://tracker.phpbb.com/browse/PHPBB3-15719