### PR TITLE
[ticket/12627] Add missing function definition for set_debug_sql_explain

### DIFF
--- a/phpBB/phpbb/db/driver/driver.php
+++ b/phpBB/phpbb/db/driver/driver.php
@@ -108,7 +108,9 @@ abstract class driver implements driver_interface
 	/**
 	* {@inheritdoc}
 	*/
+	public function set_debug_sql_explain($value)
 	{
+		$this->debug_sql_explain = $value;
 	}
 
 	/**


### PR DESCRIPTION
PHPBB3-12627

Should fix build issues caused by incorrect resolution of merge conflict when merging 3.2.x into master (https://github.com/phpbb/phpbb/pull/5267).

Checklist:

- [x] Correct branch: master for new features; 3.2.x for fixes
- [ ] Tests pass
- [x] Code follows coding guidelines: [master](https://area51.phpbb.com/docs/dev/master/development/coding_guidelines.html) and [3.2.x](https://area51.phpbb.com/docs/dev/3.2.x/development/coding_guidelines.html)
- [x] Commit follows commit message [format](https://area51.phpbb.com/docs/dev/3.2.x/development/git.html)

Tracker ticket (set the ticket ID to **your ticket ID**):

https://tracker.phpbb.com/browse/PHPBB3-12627
