### PR TITLE
[ticket/15622] Fix quoting in PMs when BBCodes are disabled

### DIFF
--- a/phpBB/includes/functions_content.php
+++ b/phpBB/includes/functions_content.php
@@ -1778,14 +1778,7 @@ function format_quote($bbcode_status, $quote_attributes, $text_formatter_utils, 
 			$quote_attributes
 		);
 
-		if ($message_link)
-		{
-			$message_parser->message = $message_link . $quote_text . "\n\n";
-		}
-		else
-		{
-			$message_parser->message = $quote_text . "\n\n";
-		}
+		$message_parser->message = $quote_text . "\n\n";
 	}
 	else
 	{
@@ -1803,10 +1796,10 @@ function format_quote($bbcode_status, $quote_attributes, $text_formatter_utils, 
 		$message = str_replace("\n", "\n" . $quote_string, $message);
 
 		$message_parser->message = $quote_attributes['author'] . " " . $user->lang['WROTE'] . ":\n" . $message . "\n";
+	}
 
-		if ($message_link)
-		{
-			$message_parser->message =  $message_link . $message_parser->message;
-		}
+	if ($message_link)
+	{
+		$message_parser->message = $message_link . $message_parser->message;
 	}
 }

--- a/phpBB/includes/functions_content.php
+++ b/phpBB/includes/functions_content.php
@@ -1778,7 +1778,7 @@ function format_quote($bbcode_status, $quote_attributes, $text_formatter_utils, 
 			$quote_attributes
 		);
 
-		if($message_link)
+		if ($message_link)
 		{
 			$message_parser->message = $message_link . $quote_text . "\n\n";
 		}
@@ -1804,7 +1804,7 @@ function format_quote($bbcode_status, $quote_attributes, $text_formatter_utils, 
 
 		$message_parser->message = $quote_attributes['author'] . " " . $user->lang['WROTE'] . ":\n" . $message . "\n";
 
-		if($message_link)
+		if ($message_link)
 		{
 			$message_parser->message =  $message_link . $message_parser->message;
 		}

--- a/phpBB/includes/functions_content.php
+++ b/phpBB/includes/functions_content.php
@@ -1758,3 +1758,55 @@ class bitfield
 		$this->data = $this->data | $bitfield->get_blob();
 	}
 }
+
+/**
+ * Formats the quote according to the given BBCode status setting
+ *
+ * @param bool 						$bbcode_status The status of the BBCode setting
+ * @param array 					$quote_attributes The attributes of the quoted post
+ * @param phpbb\textformatter\utils $text_formatter_utils Text formatter utilities
+ * @param parse_message 			$message_parser Message parser class
+ * @param string 					$message_link Link of the original quoted post
+ * @since 3.2.4-RC1
+ */
+function format_quote($bbcode_status, $quote_attributes, $text_formatter_utils, $message_parser, $message_link = '')
+{
+	if ($bbcode_status)
+	{
+		$quote_text = $text_formatter_utils->generate_quote(
+			censor_text($message_parser->message),
+			$quote_attributes
+		);
+
+		if($message_link)
+		{
+			$message_parser->message = $message_link . $quote_text . "\n\n";
+		}
+		else
+		{
+			$message_parser->message = $quote_text . "\n\n";
+		}
+	}
+	else
+	{
+		$offset = 0;
+		$quote_string = "&gt; ";
+		$message = censor_text(trim($message_parser->message));
+		// see if we are nesting. It's easily tricked but should work for one level of nesting
+		if (strpos($message, "&gt;") !== false)
+		{
+			$offset = 10;
+		}
+		$message = utf8_wordwrap($message, 75 + $offset, "\n");
+
+		$message = $quote_string . $message;
+		$message = str_replace("\n", "\n" . $quote_string, $message);
+
+		$message_parser->message = $quote_attributes['author'] . " " . $user->lang['WROTE'] . ":\n" . $message . "\n";
+
+		if($message_link)
+		{
+			$message_parser->message =  $message_link . $message_parser->message;
+		}
+	}
+}

--- a/phpBB/includes/functions_content.php
+++ b/phpBB/includes/functions_content.php
@@ -1768,7 +1768,7 @@ class bitfield
  * @param parse_message 			$message_parser Message parser class
  * @param string 					$message_link Link of the original quoted post
  */
-function format_quote($bbcode_status, $quote_attributes, $text_formatter_utils, $message_parser, $message_link = '')
+function phpbb_format_quote($bbcode_status, $quote_attributes, $text_formatter_utils, $message_parser, $message_link = '')
 {
 	if ($bbcode_status)
 	{

--- a/phpBB/includes/functions_content.php
+++ b/phpBB/includes/functions_content.php
@@ -1767,7 +1767,6 @@ class bitfield
  * @param phpbb\textformatter\utils $text_formatter_utils Text formatter utilities
  * @param parse_message 			$message_parser Message parser class
  * @param string 					$message_link Link of the original quoted post
- * @since 3.2.4-RC1
  */
 function format_quote($bbcode_status, $quote_attributes, $text_formatter_utils, $message_parser, $message_link = '')
 {

--- a/phpBB/includes/ucp/ucp_pm_compose.php
+++ b/phpBB/includes/ucp/ucp_pm_compose.php
@@ -974,30 +974,8 @@ function compose_pm($id, $mode, $action, $user_folders = array())
 		{
 			$quote_attributes['post_id'] = $post['msg_id'];
 		}
-		$quote_text = $phpbb_container->get('text_formatter.utils')->generate_quote(
-			censor_text($message_parser->message),
-			$quote_attributes
-		);
-		if ($bbcode_status)
-		{
-			$message_parser->message = $message_link . $quote_text . "\n\n";
-		}
-		else
-		{
-			$offset = 0;
-			$quote_string = "&gt; ";
-			$message = censor_text(trim($message_parser->message));
-			// see if we are nesting. It's easily tricked but should work for one level of nesting
-			if (strpos($message, "&gt;") !== false)
-			{
-				$offset = 10;
-			}
-			$message = utf8_wordwrap($message, 75 + $offset, "\n");
 
-			$message = $quote_string . $message;
-			$message = str_replace("\n", "\n" . $quote_string, $message);
-			$message_parser->message =  $quote_username . " " . $user->lang['WROTE'] . ":\n" . $message . "\n";
-		}
+		format_quote($bbcode_status, $quote_attributes, $phpbb_container->get('text_formatter.utils'), $message_parser, $message_link);
 	}
 
 	if (($action == 'reply' || $action == 'quote' || $action == 'quotepost') && !$preview && !$refresh)

--- a/phpBB/includes/ucp/ucp_pm_compose.php
+++ b/phpBB/includes/ucp/ucp_pm_compose.php
@@ -978,7 +978,26 @@ function compose_pm($id, $mode, $action, $user_folders = array())
 			censor_text($message_parser->message),
 			$quote_attributes
 		);
-		$message_parser->message = $message_link . $quote_text . "\n\n";
+		if ($bbcode_status)
+		{
+			$message_parser->message = $message_link . $quote_text . "\n\n";
+		}
+		else
+		{
+			$offset = 0;
+			$quote_string = "&gt; ";
+			$message = censor_text(trim($message_parser->message));
+			// see if we are nesting. It's easily tricked but should work for one level of nesting
+			if (strpos($message, "&gt;") !== false)
+			{
+				$offset = 10;
+			}
+			$message = utf8_wordwrap($message, 75 + $offset, "\n");
+
+			$message = $quote_string . $message;
+			$message = str_replace("\n", "\n" . $quote_string, $message);
+			$message_parser->message =  $quote_username . " " . $user->lang['WROTE'] . ":\n" . $message . "\n";
+		}
 	}
 
 	if (($action == 'reply' || $action == 'quote' || $action == 'quotepost') && !$preview && !$refresh)

--- a/phpBB/includes/ucp/ucp_pm_compose.php
+++ b/phpBB/includes/ucp/ucp_pm_compose.php
@@ -954,7 +954,16 @@ function compose_pm($id, $mode, $action, $user_folders = array())
 			$post_id = $request->variable('p', 0);
 			if ($config['allow_post_links'])
 			{
-				$message_link = "[url=" . generate_board_url() . "/viewtopic.$phpEx?p={$post_id}#p{$post_id}]{$user->lang['SUBJECT']}{$user->lang['COLON']} {$message_subject}[/url]\n\n";
+				$message_link = generate_board_url() . "/viewtopic.$phpEx?p={$post_id}#p{$post_id}";
+				$message_link_subject = "{$user->lang['SUBJECT']}{$user->lang['COLON']} {$message_subject}";
+				if ($bbcode_status)
+				{
+					$message_link = "[url=" . $message_link . "]" . $message_link_subject . "[/url]\n\n";
+				}
+				else
+				{
+					$message_link = $message_link . " - " . $message_link_subject . "\n\n";
+				}
 			}
 			else
 			{

--- a/phpBB/includes/ucp/ucp_pm_compose.php
+++ b/phpBB/includes/ucp/ucp_pm_compose.php
@@ -984,7 +984,7 @@ function compose_pm($id, $mode, $action, $user_folders = array())
 			$quote_attributes['post_id'] = $post['msg_id'];
 		}
 
-		format_quote($bbcode_status, $quote_attributes, $phpbb_container->get('text_formatter.utils'), $message_parser, $message_link);
+		phpbb_format_quote($bbcode_status, $quote_attributes, $phpbb_container->get('text_formatter.utils'), $message_parser, $message_link);
 	}
 
 	if (($action == 'reply' || $action == 'quote' || $action == 'quotepost') && !$preview && !$refresh)

--- a/phpBB/posting.php
+++ b/phpBB/posting.php
@@ -1630,35 +1630,14 @@ if ($generate_quote)
 	// Remove attachment bbcode tags from the quoted message to avoid mixing with the new post attachments if any
 	$message_parser->message = preg_replace('#\[attachment=([0-9]+)\](.*?)\[\/attachment\]#uis', '\\2', $message_parser->message);
 
-	if ($config['allow_bbcode'])
-	{
-		$message_parser->message = $bbcode_utils->generate_quote(
-			censor_text($message_parser->message),
-			array(
-				'author'  => $post_data['quote_username'],
-				'post_id' => $post_data['post_id'],
-				'time'    => $post_data['post_time'],
-				'user_id' => $post_data['poster_id'],
-			)
-		);
-		$message_parser->message .= "\n\n";
-	}
-	else
-	{
-		$offset = 0;
-		$quote_string = "&gt; ";
-		$message = censor_text(trim($message_parser->message));
-		// see if we are nesting. It's easily tricked but should work for one level of nesting
-		if (strpos($message, "&gt;") !== false)
-		{
-			$offset = 10;
-		}
-		$message = utf8_wordwrap($message, 75 + $offset, "\n");
+	$quote_attributes = array(
+						'author'  => $post_data['quote_username'],
+						'post_id' => $post_data['post_id'],
+						'time'    => $post_data['post_time'],
+						'user_id' => $post_data['poster_id'],
+	);
 
-		$message = $quote_string . $message;
-		$message = str_replace("\n", "\n" . $quote_string, $message);
-		$message_parser->message =  $post_data['quote_username'] . " " . $user->lang['WROTE'] . ":\n" . $message . "\n";
-	}
+	format_quote($config['allow_bbcode'], $quote_attributes, $bbcode_utils, $message_parser);
 }
 
 if (($mode == 'reply' || $mode == 'quote') && !$submit && !$preview && !$refresh)

--- a/phpBB/posting.php
+++ b/phpBB/posting.php
@@ -1637,7 +1637,7 @@ if ($generate_quote)
 						'user_id' => $post_data['poster_id'],
 	);
 
-	format_quote($config['allow_bbcode'], $quote_attributes, $bbcode_utils, $message_parser);
+	phpbb_format_quote($config['allow_bbcode'], $quote_attributes, $bbcode_utils, $message_parser);
 }
 
 if (($mode == 'reply' || $mode == 'quote') && !$submit && !$preview && !$refresh)


### PR DESCRIPTION
Before parsing the private message to be loaded a simple BBCode status
check is done to verify that BBCodes are enabled. Depending on that
option the quote will be formated as BBCode or as plain text, similarly
to what is done in posting.php.

PHPBB3-15622

Checklist:

- [X] Correct branch: master for new features; 3.2.x for fixes
- [X] Tests pass
- [X] Code follows coding guidelines: [master](https://area51.phpbb.com/docs/dev/master/development/coding_guidelines.html) and [3.2.x](https://area51.phpbb.com/docs/dev/3.2.x/development/coding_guidelines.html)
- [X] Commit follows commit message [format](https://area51.phpbb.com/docs/dev/3.2.x/development/git.html)

Tracker ticket (set the ticket ID to **your ticket ID**):

https://tracker.phpbb.com/browse/PHPBB3-15622
