### PR TITLE
[ticket/15735] Add *_content_after template event

### DIFF
--- a/phpBB/docs/events.md
+++ b/phpBB/docs/events.md
@@ -2674,6 +2674,13 @@ viewtopic_body_postrow_back2top_prepend
 * Since: 3.1.8-RC1
 * Purpose: Add content to the post's bottom directly before the back to top link 
 
+viewtopic_body_postrow_content_after
+===
+* Locations:
+    + styles/prosilver/template/viewtopic_body.html
+* Since: 3.2.4-RC1
+* Purpose: Add content after the message content in topics views
+
 viewtopic_body_postrow_custom_fields_after
 ===
 * Locations:

--- a/phpBB/docs/events.md
+++ b/phpBB/docs/events.md
@@ -1889,6 +1889,13 @@ search_body_search_query_prepend
 * Since: 3.1.7-RC1
 * Purpose: Put content at the top of the search query fields set
 
+search_results_content_after
+===
+* Locations:
+    + styles/prosilver/template/search_results.html
+* Since: 3.2.4-RC1
+* Purpose: Add content after the message content in search results
+
 search_results_header_after
 ===
 * Locations:

--- a/phpBB/docs/events.md
+++ b/phpBB/docs/events.md
@@ -1707,6 +1707,13 @@ posting_poll_body_options_after
 * Since: 3.1.4-RC1
 * Purpose: Add content after the poll options on creating a poll
 
+posting_preview_content_after
+===
+* Locations:
+    + styles/prosilver/template/posting_preview.html
+* Since: 3.2.4-RC1
+* Purpose: Add content after the message content preview
+
 posting_preview_poll_after
 ===
 * Locations:

--- a/phpBB/docs/events.md
+++ b/phpBB/docs/events.md
@@ -1721,6 +1721,13 @@ posting_preview_poll_after
 * Since: 3.1.7-RC1
 * Purpose: Add content after the poll preview block
 
+posting_topic_review_row_content_after
+===
+* Locations:
+    + styles/prosilver/template/posting_topic_review.html
+* Since: 3.2.4-RC1
+* Purpose: Add content after the message content in topic review
+
 posting_topic_review_row_post_details_after
 ===
 * Locations:

--- a/phpBB/styles/prosilver/template/posting_preview.html
+++ b/phpBB/styles/prosilver/template/posting_preview.html
@@ -31,6 +31,8 @@
 
 		<div class="content">{PREVIEW_MESSAGE}</div>
 
+		<!-- EVENT posting_preview_content_after -->
+
 		<!-- IF .attachment -->
 		<dl class="attachbox">
 			<dt>{L_ATTACHMENTS}</dt>

--- a/phpBB/styles/prosilver/template/posting_topic_review.html
+++ b/phpBB/styles/prosilver/template/posting_topic_review.html
@@ -60,6 +60,8 @@
 
 			<div class="content">{topic_review_row.MESSAGE}</div>
 
+			<!-- EVENT posting_topic_review_row_content_after -->
+
 			<!-- IF topic_review_row.S_HAS_ATTACHMENTS -->
 				<dl class="attachbox">
 					<dt>{L_ATTACHMENTS}</dt>

--- a/phpBB/styles/prosilver/template/search_results.html
+++ b/phpBB/styles/prosilver/template/search_results.html
@@ -194,6 +194,7 @@
 		<div class="postbody">
 			<h3><a href="{searchresults.U_VIEW_POST}">{searchresults.POST_SUBJECT}</a></h3>
 			<div class="content">{searchresults.MESSAGE}</div>
+			<!-- EVENT search_results_content_after -->
 		</div>
 	<!-- ENDIF -->
 

--- a/phpBB/styles/prosilver/template/viewtopic_body.html
+++ b/phpBB/styles/prosilver/template/viewtopic_body.html
@@ -326,6 +326,8 @@
 
 			<div class="content">{postrow.MESSAGE}</div>
 
+			<!-- EVENT viewtopic_body_postrow_content_after -->
+
 			<!-- IF postrow.S_HAS_ATTACHMENTS -->
 				<dl class="attachbox">
 					<dt>


### PR DESCRIPTION
Needed for extensions who adds information at the end of the message (such as moderator messages).

Checklist:

- [x] Correct branch: master for new features; 3.2.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master](https://area51.phpbb.com/docs/dev/master/development/coding_guidelines.html) and [3.2.x](https://area51.phpbb.com/docs/dev/3.2.x/development/coding_guidelines.html)
- [x] Commit follows commit message [format](https://area51.phpbb.com/docs/dev/3.2.x/development/git.html)

Tracker ticket (set the ticket ID to **your ticket ID**):

https://tracker.phpbb.com/browse/PHPBB3-15735
