### PR TITLE
[ticket/15736] Add posting_topic_review_content_after template event

### DIFF
--- a/phpBB/docs/events.md
+++ b/phpBB/docs/events.md
@@ -1714,6 +1714,13 @@ posting_preview_poll_after
 * Since: 3.1.7-RC1
 * Purpose: Add content after the poll preview block
 
+posting_topic_review_content_after
+===
+* Locations:
+    + styles/prosilver/template/posting_topic_review.html
+* Since: 3.2.4-RC1
+* Purpose: Add content after the message content in topic review
+
 posting_topic_review_row_post_details_after
 ===
 * Locations:

--- a/phpBB/styles/prosilver/template/posting_topic_review.html
+++ b/phpBB/styles/prosilver/template/posting_topic_review.html
@@ -60,6 +60,8 @@
 
 			<div class="content">{topic_review_row.MESSAGE}</div>
 
+			<!-- EVENT posting_topic_review_content_after -->
+
 			<!-- IF topic_review_row.S_HAS_ATTACHMENTS -->
 				<dl class="attachbox">
 					<dt>{L_ATTACHMENTS}</dt>


### PR DESCRIPTION
Needed for extensions who adds information at the end of the message
(such as moderator messages).

PHPBB3-15736

Checklist:

- [x] Correct branch: master for new features; 3.2.x for fixes
- [ ] Tests pass
- [x] Code follows coding guidelines: [master](https://area51.phpbb.com/docs/dev/master/development/coding_guidelines.html) and [3.2.x](https://area51.phpbb.com/docs/dev/3.2.x/development/coding_guidelines.html)
- [x] Commit follows commit message [format](https://area51.phpbb.com/docs/dev/3.2.x/development/git.html)

Tracker ticket (set the ticket ID to **your ticket ID**):

https://tracker.phpbb.com/browse/PHPBB3-15736