### PR TITLE
[ticket/15737] Add $user_rows to core.delete_user_before

### DIFF
--- a/phpBB/includes/functions_user.php
+++ b/phpBB/includes/functions_user.php
@@ -461,9 +461,11 @@ function user_delete($mode, $user_ids, $retain_username = true)
 	* @var	array	user_ids	IDs of the deleted user
 	* @var	mixed	retain_username	True if username should be retained
 	*				or false if not
+	* @var	array	user_rows	Array containing data of the deleted users
 	* @since 3.1.0-a1
+	* @changed 3.2.4-RC1 Added user_rows
 	*/
-	$vars = array('mode', 'user_ids', 'retain_username');
+	$vars = array('mode', 'user_ids', 'retain_username', 'user_rows');
 	extract($phpbb_dispatcher->trigger_event('core.delete_user_before', compact($vars)));
 
 	// Before we begin, we will remove the reports the user issued.


### PR DESCRIPTION
It was added to `core.delete_user_after` in GH-4905.

Checklist:

- [x] Correct branch: master for new features; 3.2.x for fixes
- [ ] Tests pass
- [x] Code follows coding guidelines: [master](https://area51.phpbb.com/docs/dev/master/development/coding_guidelines.html) and [3.2.x](https://area51.phpbb.com/docs/dev/3.2.x/development/coding_guidelines.html)
- [x] Commit follows commit message [format](https://area51.phpbb.com/docs/dev/3.2.x/development/git.html)

Tracker ticket (set the ticket ID to **your ticket ID**):

https://tracker.phpbb.com/browse/PHPBB3-15737
