### PR TITLE
[ticket/15612] Fix PHP7.2 count() bug in MSSQL driver

### DIFF
--- a/phpBB/phpbb/db/driver/mssqlnative.php
+++ b/phpBB/phpbb/db/driver/mssqlnative.php
@@ -268,7 +268,7 @@ class mssqlnative extends \phpbb\db\driver\mssql_base
 				unset($row['line2'], $row['line3']);
 			}
 		}
-		return (count($row)) ? $row : false;
+		return ($row !== null) ? $row : false;
 	}
 
 	/**


### PR DESCRIPTION
sqlsrv_fetch_array() function returns an array when data found,
null when no data or false on error. So we need to change null to false only.

PHPBB3-15612

Checklist:

- [x] Correct branch: master for new features; 3.2.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master](https://area51.phpbb.com/docs/dev/master/development/coding_guidelines.html) and [3.2.x](https://area51.phpbb.com/docs/dev/3.2.x/development/coding_guidelines.html)
- [x] Commit follows commit message [format](https://area51.phpbb.com/docs/dev/3.2.x/development/git.html)

Tracker ticket (set the ticket ID to **your ticket ID**):

https://tracker.phpbb.com/browse/PHPBB3-15612
