### PR TITLE
[ticket/14754] Only one email notification per topic

### DIFF
--- a/phpBB/config/default/container/services_notification.yml
+++ b/phpBB/config/default/container/services_notification.yml
@@ -209,11 +209,7 @@ services:
             - '@dbal.conn'
             - '%core.root_path%'
             - '%core.php_ext%'
-            - '%tables.topics_watch%'
-            - '%tables.topics_track%'
-            - '%tables.posts%'
-            - '%tables.forums_watch%'
-            - '%tables.forums_track%'
+            - '%tables.email_notifications%'
         tags:
             - { name: notification.method }
 

--- a/phpBB/config/default/container/services_notification.yml
+++ b/phpBB/config/default/container/services_notification.yml
@@ -206,8 +206,14 @@ services:
             - '@user_loader'
             - '@user'
             - '@config'
+            - '@dbal.conn'
             - '%core.root_path%'
             - '%core.php_ext%'
+            - '%tables.topics_watch%'
+            - '%tables.topics_track%'
+            - '%tables.posts%'
+            - '%tables.forums_watch%'
+            - '%tables.forums_track%'
         tags:
             - { name: notification.method }
 

--- a/phpBB/config/default/container/tables.yml
+++ b/phpBB/config/default/container/tables.yml
@@ -20,6 +20,7 @@ parameters:
     tables.confirm: '%core.table_prefix%confirm'
     tables.disallow: '%core.table_prefix%disallow'
     tables.drafts: '%core.table_prefix%drafts'
+    tables.email_notifications: '%core.table_prefix%email_notifications'
     tables.ext: '%core.table_prefix%ext'
     tables.extensions: '%core.table_prefix%extensions'
     tables.extension_groups: '%core.table_prefix%extension_groups'

--- a/phpBB/phpbb/db/migration/data/v32x/add_email_notifications_table.php
+++ b/phpBB/phpbb/db/migration/data/v32x/add_email_notifications_table.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ *
+ * This file is part of the phpBB Forum Software package.
+ *
+ * @copyright (c) phpBB Limited <https://www.phpbb.com>
+ * @license GNU General Public License, version 2 (GPL-2.0)
+ *
+ * For full copyright and license information, please see
+ * the docs/CREDITS.txt file.
+ *
+ */
+
+namespace phpbb\db\migration\data\v32x;
+
+class add_email_notifications_table extends \phpbb\db\migration\migration
+{
+	static public function depends_on()
+	{
+		return array(
+			'\phpbb\db\migration\data\v32x\v323',
+		);
+	}
+
+	public function update_schema()
+	{
+		return array(
+			'add_tables'	=> array(
+				$this->table_prefix . 'email_notifications' => array(
+					'COLUMNS'	=> array(
+						'notification_type_id'	=> array('USINT', 0),
+						'item_id'				=> array('UINT', 0),
+						'item_parent_id'		=> array('UINT', 0),
+						'user_id'				=> array('UINT', 0),
+					),
+					'PRIMARY_KEY' => array('notification_type_id', 'item_id', 'item_parent_id', 'user_id'),
+				),
+			),
+		);
+	}
+
+	public function revert_schema()
+	{
+		return array(
+			'drop_tables' => array(
+				$this->table_prefix . 'email_notifications',
+			),
+		);
+	}
+}

--- a/phpBB/phpbb/notification/method/email.php
+++ b/phpBB/phpbb/notification/method/email.php
@@ -126,7 +126,7 @@ class email extends \phpbb\notification\method\messenger_base
 	public function mark_notifications($notification_type_id, $item_id, $user_id, $time = false, $mark_read = true)
 	{
 		$sql = 'DELETE FROM ' . $this->email_notifications_table . '
-			WHERE ' . (($notification_type_id !== false) ? (is_array($notification_type_id) ? $this->db->sql_in_set('notification_type_id', $notification_type_id) : 'notification_type_id = ' . $notification_type_id) : '') .
+			WHERE ' . (($notification_type_id !== false) ? (is_array($notification_type_id) ? $this->db->sql_in_set('notification_type_id', $notification_type_id) : 'notification_type_id = ' . $notification_type_id) : '1=1') .
 			(($user_id !== false) ? ' AND ' . (is_array($user_id) ? $this->db->sql_in_set('user_id', $user_id) : 'user_id = ' . (int) $user_id) : '') .
 			(($item_id !== false) ? ' AND ' . (is_array($item_id) ? $this->db->sql_in_set('item_id', $item_id) : 'item_id = ' . (int) $item_id) : '');
 		$this->db->sql_query($sql);
@@ -138,7 +138,7 @@ class email extends \phpbb\notification\method\messenger_base
 	public function mark_notifications_by_parent($notification_type_id, $item_parent_id, $user_id, $time = false, $mark_read = true)
 	{
 		$sql = 'DELETE FROM ' . $this->email_notifications_table . '
-			WHERE ' . (($notification_type_id !== false) ? (is_array($notification_type_id) ? $this->db->sql_in_set('notification_type_id', $notification_type_id) : 'notification_type_id = ' . $notification_type_id) : '') .
+			WHERE ' . (($notification_type_id !== false) ? (is_array($notification_type_id) ? $this->db->sql_in_set('notification_type_id', $notification_type_id) : 'notification_type_id = ' . $notification_type_id) : '1=1') .
 			(($user_id !== false) ? ' AND ' . (is_array($user_id) ? $this->db->sql_in_set('user_id', $user_id) : 'user_id = ' . (int) $user_id) : '') .
 			(($item_parent_id !== false) ? ' AND ' . (is_array($item_parent_id) ? $this->db->sql_in_set('item_parent_id', $item_parent_id, false, true) : 'item_parent_id = ' . (int) $item_parent_id) : '');
 		$this->db->sql_query($sql);

--- a/phpBB/phpbb/notification/method/email.php
+++ b/phpBB/phpbb/notification/method/email.php
@@ -28,21 +28,51 @@ class email extends \phpbb\notification\method\messenger_base
 	/** @var \phpbb\config\config */
 	protected $config;
 
+	/** @var \phpbb\db\driver\driver_interface */
+	protected $db;
+
+	/** @var string */
+	protected $topics_watch_table;
+
+	/** @var string */
+	protected $topics_track_table;
+
+	/** @var string */
+	protected $posts_table;
+
+	/** @var string */
+	protected $forums_watch_table;
+
+	/** @var string */
+	protected $forums_track_table;
+
 	/**
 	 * Notification Method email Constructor
 	 *
 	 * @param \phpbb\user_loader $user_loader
 	 * @param \phpbb\user $user
 	 * @param \phpbb\config\config $config
+	 * @param \phpbb\db\driver\driver_interface $db
 	 * @param string $phpbb_root_path
 	 * @param string $php_ext
+	 * @param string $topics_watch_table
+	 * @param string $topics_track_table
+	 * @param string $posts_table
+	 * @param string $forums_watch_table
+	 * @param string $forums_track_table
 	 */
-	public function __construct(\phpbb\user_loader $user_loader, \phpbb\user $user, \phpbb\config\config $config, $phpbb_root_path, $php_ext)
+	public function __construct(\phpbb\user_loader $user_loader, \phpbb\user $user, \phpbb\config\config $config, \phpbb\db\driver\driver_interface $db, $phpbb_root_path, $php_ext, $topics_watch_table, $topics_track_table, $posts_table, $forums_watch_table, $forums_track_table)
 	{
 		parent::__construct($user_loader, $phpbb_root_path, $php_ext);
 
 		$this->user = $user;
 		$this->config = $config;
+		$this->db = $db;
+		$this->topics_watch_table = $topics_watch_table;
+		$this->topics_track_table = $topics_track_table;
+		$this->posts_table = $posts_table;
+		$this->forums_watch_table = $forums_watch_table;
+		$this->forums_track_table = $forums_track_table;
 	}
 
 	/**
@@ -66,6 +96,53 @@ class email extends \phpbb\notification\method\messenger_base
 	public function is_available(type_interface $notification_type = null)
 	{
 		return parent::is_available($notification_type) && $this->config['email_enable'] && $this->user->data['user_email'];
+	}
+
+	/**
+	* {@inheritdoc}
+	*/
+	public function get_notified_users($notification_type_id, array $options)
+	{
+		$notified_users = array();
+
+		if ($notification_type_id == 'notification.type.post' && !empty($options['item_parent_id']))
+		{
+			// Topics watch
+			$sql = 'SELECT tw.user_id
+					FROM ' . $this->topics_watch_table . ' tw
+					LEFT JOIN ' . $this->topics_track_table . ' tt
+						ON (tt.user_id = tw.user_id AND tt.topic_id = tw.topic_id)
+					LEFT JOIN ' . $this->posts_table . ' p
+						ON (p.topic_id = tw.topic_id)
+					WHERE tw.topic_id = ' . (int) $options['item_parent_id'] . '
+						AND p.post_time > tt.mark_time
+					HAVING COUNT(p.post_id) > 1';
+			$result = $this->db->sql_query($sql);
+			while ($row = $this->db->sql_fetchrow($result))
+			{
+				$notified_users[$row['user_id']] = $row;
+			}
+			$this->db->sql_freeresult($result);
+
+			// Forums watch
+			$sql = 'SELECT fw.user_id
+					FROM ' . $this->forums_watch_table . ' fw
+					LEFT JOIN ' . $this->forums_track_table . ' ft
+						ON (ft.user_id = fw.user_id AND ft.forum_id = fw.forum_id)
+					LEFT JOIN ' . $this->posts_table . ' p
+						ON (p.forum_id = fw.forum_id)
+					WHERE p.topic_id = ' . (int) $options['item_parent_id'] . '
+						AND p.post_time > ft.mark_time
+					HAVING COUNT(p.post_id) > 1';
+			$result = $this->db->sql_query($sql);
+			while ($row = $this->db->sql_fetchrow($result))
+			{
+				$notified_users[$row['user_id']] = $row;
+			}
+			$this->db->sql_freeresult($result);
+		}
+
+		return $notified_users;
 	}
 
 	/**

--- a/phpBB/phpbb/notification/method/method_interface.php
+++ b/phpBB/phpbb/notification/method/method_interface.php
@@ -41,7 +41,7 @@ interface method_interface
 	/**
 	* Return the list of the users already notified
 	*
-	* @param int $notification_type_id Type of the notification
+	* @param int $notification_type_id ID of the notification type
 	* @param array $options
 	* @return array User
 	*/

--- a/phpBB/phpbb/notification/type/post.php
+++ b/phpBB/phpbb/notification/type/post.php
@@ -457,6 +457,12 @@ class post extends \phpbb\notification\type\base
 		}
 
 		$data_array = array_merge(array(
+			'poster_id'		=> $post['poster_id'],
+			'topic_title'	=> $post['topic_title'],
+			'post_subject'	=> $post['post_subject'],
+			'post_username'	=> $post['post_username'],
+			'forum_id'		=> $post['forum_id'],
+			'forum_name'	=> $post['forum_name'],
 			'post_time'		=> $post['post_time'],
 			'post_id'		=> $post['post_id'],
 			'topic_id'		=> $post['topic_id']

--- a/tests/notification/base.php
+++ b/tests/notification/base.php
@@ -103,11 +103,7 @@ abstract class phpbb_tests_notification_base extends phpbb_database_test_case
 		$phpbb_container->setParameter('tables.notifications', 'phpbb_notifications');
 		$phpbb_container->setParameter('tables.user_notifications', 'phpbb_user_notifications');
 		$phpbb_container->setParameter('tables.notification_types', 'phpbb_notification_types');
-		$phpbb_container->setParameter('tables.topics_watch', 'phpbb_topics_watch');
-		$phpbb_container->setParameter('tables.topics_track', 'phpbb_topics_track');
-		$phpbb_container->setParameter('tables.posts', 'phpbb_posts');
-		$phpbb_container->setParameter('tables.forums_watch', 'phpbb_forums_watch');
-		$phpbb_container->setParameter('tables.forums_track', 'phpbb_forums_track');
+		$phpbb_container->setParameter('tables.email_notifications', 'phpbb_email_notifications');
 
 		$this->notifications = new phpbb_notification_manager_helper(
 			array(),

--- a/tests/notification/base.php
+++ b/tests/notification/base.php
@@ -103,6 +103,11 @@ abstract class phpbb_tests_notification_base extends phpbb_database_test_case
 		$phpbb_container->setParameter('tables.notifications', 'phpbb_notifications');
 		$phpbb_container->setParameter('tables.user_notifications', 'phpbb_user_notifications');
 		$phpbb_container->setParameter('tables.notification_types', 'phpbb_notification_types');
+		$phpbb_container->setParameter('tables.topics_watch', 'phpbb_topics_watch');
+		$phpbb_container->setParameter('tables.topics_track', 'phpbb_topics_track');
+		$phpbb_container->setParameter('tables.posts', 'phpbb_posts');
+		$phpbb_container->setParameter('tables.forums_watch', 'phpbb_forums_watch');
+		$phpbb_container->setParameter('tables.forums_track', 'phpbb_forums_track');
 
 		$this->notifications = new phpbb_notification_manager_helper(
 			array(),

--- a/tests/notification/submit_post_base.php
+++ b/tests/notification/submit_post_base.php
@@ -130,6 +130,11 @@ abstract class phpbb_notification_submit_post_base extends phpbb_database_test_c
 		$phpbb_container->setParameter('tables.notifications', 'phpbb_notifications');
 		$phpbb_container->setParameter('tables.user_notifications', 'phpbb_user_notifications');
 		$phpbb_container->setParameter('tables.notification_types', 'phpbb_notification_types');
+		$phpbb_container->setParameter('tables.topics_watch', 'phpbb_topics_watch');
+		$phpbb_container->setParameter('tables.topics_track', 'phpbb_topics_track');
+		$phpbb_container->setParameter('tables.posts', 'phpbb_posts');
+		$phpbb_container->setParameter('tables.forums_watch', 'phpbb_forums_watch');
+		$phpbb_container->setParameter('tables.forums_track', 'phpbb_forums_track');
 		$phpbb_container->set('content.visibility', new \phpbb\content_visibility($auth, $config, $phpbb_dispatcher, $db, $user, $phpbb_root_path, $phpEx, FORUMS_TABLE, POSTS_TABLE, TOPICS_TABLE, USERS_TABLE));
 		$phpbb_container->compile();
 

--- a/tests/notification/submit_post_base.php
+++ b/tests/notification/submit_post_base.php
@@ -130,11 +130,7 @@ abstract class phpbb_notification_submit_post_base extends phpbb_database_test_c
 		$phpbb_container->setParameter('tables.notifications', 'phpbb_notifications');
 		$phpbb_container->setParameter('tables.user_notifications', 'phpbb_user_notifications');
 		$phpbb_container->setParameter('tables.notification_types', 'phpbb_notification_types');
-		$phpbb_container->setParameter('tables.topics_watch', 'phpbb_topics_watch');
-		$phpbb_container->setParameter('tables.topics_track', 'phpbb_topics_track');
-		$phpbb_container->setParameter('tables.posts', 'phpbb_posts');
-		$phpbb_container->setParameter('tables.forums_watch', 'phpbb_forums_watch');
-		$phpbb_container->setParameter('tables.forums_track', 'phpbb_forums_track');
+		$phpbb_container->setParameter('tables.email_notifications', 'phpbb_email_notifications');
 		$phpbb_container->set('content.visibility', new \phpbb\content_visibility($auth, $config, $phpbb_dispatcher, $db, $user, $phpbb_root_path, $phpEx, FORUMS_TABLE, POSTS_TABLE, TOPICS_TABLE, USERS_TABLE));
 		$phpbb_container->compile();
 


### PR DESCRIPTION
I created a new table to track email notifications. Row is deleted when user reads the notification (e.g. visits a topic).
_______________________

PHPBB3-14754

Checklist:

- [ ] Correct branch: master for new features; 3.2.x for fixes
- [ ] Tests pass
- [ ] Code follows coding guidelines: [master](https://area51.phpbb.com/docs/dev/master/development/coding_guidelines.html) and [3.2.x](https://area51.phpbb.com/docs/dev/3.2.x/development/coding_guidelines.html)
- [ ] Commit follows commit message [format](https://area51.phpbb.com/docs/dev/3.2.x/development/git.html)

Tracker ticket (set the ticket ID to **your ticket ID**):

https://tracker.phpbb.com/browse/PHPBB3-14754
