### PR TITLE
[ticket/15788] Fix return button for Privacy Policy

### DIFF
--- a/phpBB/ucp.php
+++ b/phpBB/ucp.php
@@ -138,7 +138,7 @@ switch ($mode)
 			'AGREEMENT_TITLE'		=> $user->lang[$title],
 			'AGREEMENT_TEXT'		=> sprintf($user->lang[$message], $config['sitename'], generate_board_url()),
 			'U_BACK'				=> append_sid("{$phpbb_root_path}ucp.$phpEx", 'mode=login'),
-			'L_BACK'				=> $user->lang['BACK_TO_LOGIN'],
+			'L_BACK'				=> $user->lang['BACK_TO_PREV'],
 		));
 
 		page_footer();


### PR DESCRIPTION
[ticket/15788] Fix return button for Privacy Policy

Change the text from "Return to Login Page" to "Return to Previous page" as the privacy policy can now be accessed through the footer so we could return to any random previous page instead of just the login page. 

PHPBB3-15788

Checklist:

- [x] Correct branch: master for new features; 3.2.x for fixes
- [ ] Tests pass
- [x] Code follows coding guidelines: [master](https://area51.phpbb.com/docs/dev/master/development/coding_guidelines.html) and [3.2.x](https://area51.phpbb.com/docs/dev/3.2.x/development/coding_guidelines.html)
- [x] Commit follows commit message [format](https://area51.phpbb.com/docs/dev/3.2.x/development/git.html)

Tracker ticket (set the ticket ID to **your ticket ID**):

https://tracker.phpbb.com/browse/PHPBB3-15788