### PR TITLE
[ticket/15791] fix php 7.2 count() bug in memory cache driver

### DIFF
--- a/phpBB/phpbb/cache/driver/memory.php
+++ b/phpBB/phpbb/cache/driver/memory.php
@@ -51,10 +51,11 @@ abstract class memory extends \phpbb\cache\driver\base
 	function load()
 	{
 		// grab the global cache
-		$this->vars = $this->_read('global');
+		$data = $this->_read('global');
 
-		if ($this->vars !== false)
+		if ($data !== false)
 		{
+			$this->vars = $data;
 			return true;
 		}
 


### PR DESCRIPTION
function `_read` in classes inherited from `memory`
may returns `false` but `$vars` must be an array

PHPBB3-15791

Checklist:

- [x] Correct branch: master for new features; 3.2.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master](https://area51.phpbb.com/docs/dev/master/development/coding_guidelines.html) and [3.2.x](https://area51.phpbb.com/docs/dev/3.2.x/development/coding_guidelines.html)
- [x] Commit follows commit message [format](https://area51.phpbb.com/docs/dev/3.2.x/development/git.html)

Tracker ticket:
https://tracker.phpbb.com/browse/PHPBB3-15791
