### PR TITLE
[ticket/15795] Fix broken migration, $config is not a method

### DIFF
--- a/phpBB/phpbb/db/migration/data/v330/extensions_composer_2.php
+++ b/phpBB/phpbb/db/migration/data/v330/extensions_composer_2.php
@@ -17,7 +17,7 @@ class extensions_composer_2 extends \phpbb\db\migration\migration
 {
 	public function update_data()
 	{
-		$repositories = json_decode($this->config('exts_composer_repositories'), true);
+		$repositories = json_decode($this->config['exts_composer_repositories'], true);
 		$repositories[] = 'https://satis.phpbb.com';
 		$repositories = array_unique($repositories);
 


### PR DESCRIPTION
PHPBB3-15795

Checklist:

- [x] Correct branch: master for new features; 3.2.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master](https://area51.phpbb.com/docs/dev/master/development/coding_guidelines.html) and [3.2.x](https://area51.phpbb.com/docs/dev/3.2.x/development/coding_guidelines.html)
- [x] Commit follows commit message [format](https://area51.phpbb.com/docs/dev/3.2.x/development/git.html)

Tracker ticket (set the ticket ID to **your ticket ID**):

https://tracker.phpbb.com/browse/PHPBB3-15795

Surprised this got through since the migration causes installs (at least for me) to fail.