### PR TITLE
[ticket/15803] Add events on ucp_pm_compose for additional message list actions

### DIFF
--- a/phpBB/includes/ucp/ucp_pm_compose.php
+++ b/phpBB/includes/ucp/ucp_pm_compose.php
@@ -1260,7 +1260,7 @@ function compose_pm($id, $mode, $action, $user_folders = array())
 function handle_message_list_actions(&$address_list, &$error, $remove_u, $remove_g, $add_to, $add_bcc)
 {
 	global $auth, $db, $user;
-	global $request;
+	global $request, $phpbb_dispatcher;
 
 	// Delete User [TO/BCC]
 	if ($remove_u && $request->variable('remove_u', array(0 => '')))

--- a/phpBB/includes/ucp/ucp_pm_compose.php
+++ b/phpBB/includes/ucp/ucp_pm_compose.php
@@ -1448,7 +1448,7 @@ function handle_message_list_actions(&$address_list, &$error, $remove_u, $remove
 	* @var	object	remove_g			The variable for removing a group
 	* @var	object	add_to				The variable for adding a user to the [TO] field
 	* @var	object	add_bcc				The variable for adding a user to the [BCC] field
-	* @since 3.1.7-RC1
+	* @since 3.2.4-RC1
 	*/
 	$vars = array('address_list', 'error', 'remove_u', 'remove_g', 'add_to', 'add_bcc');
 	extract($phpbb_dispatcher->trigger_event('core.message_list_actions', compact($vars)));

--- a/phpBB/includes/ucp/ucp_pm_compose.php
+++ b/phpBB/includes/ucp/ucp_pm_compose.php
@@ -1437,6 +1437,21 @@ function handle_message_list_actions(&$address_list, &$error, $remove_u, $remove
 			$error[] = $user->lang['PM_USERS_REMOVED_NO_PERMISSION'];
 		}
 	}
+
+	/**
+	* Event for additional message list actions
+	*
+	* @event core.message_list_actions
+	* @var	array	address_list		The assoc array with the recipient user/group ids
+	* @var	array	error				The array containing error data
+	* @var	object	remove_u			The variable for removing a user
+	* @var	object	remove_g			The variable for removing a group
+	* @var	object	add_to				The variable for adding a user to the [TO] field
+	* @var	object	add_bcc				The variable for adding a user to the [BCC] field
+	* @since 3.1.7-RC1
+	*/
+	$vars = array('address_list', 'error', 'remove_u', 'remove_g', 'add_to', 'add_bcc');
+	extract($phpbb_dispatcher->trigger_event('core.message_list_actions', compact($vars)));
 }
 
 /**

--- a/phpBB/includes/ucp/ucp_pm_compose.php
+++ b/phpBB/includes/ucp/ucp_pm_compose.php
@@ -1444,10 +1444,10 @@ function handle_message_list_actions(&$address_list, &$error, $remove_u, $remove
 	* @event core.message_list_actions
 	* @var	array	address_list		The assoc array with the recipient user/group ids
 	* @var	array	error				The array containing error data
-	* @var	object	remove_u			The variable for removing a user
-	* @var	object	remove_g			The variable for removing a group
-	* @var	object	add_to				The variable for adding a user to the [TO] field
-	* @var	object	add_bcc				The variable for adding a user to the [BCC] field
+	* @var	bool	remove_u			The variable for removing a user
+	* @var	bool	remove_g			The variable for removing a group
+	* @var	bool	add_to				The variable for adding a user to the [TO] field
+	* @var	bool	add_bcc				The variable for adding a user to the [BCC] field
 	* @since 3.2.4-RC1
 	*/
 	$vars = array('address_list', 'error', 'remove_u', 'remove_g', 'add_to', 'add_bcc');


### PR DESCRIPTION
Event added for the handle_message_list_actions() function in ucp_pm_compose
so that extensions can perform additional actions.

PHPBB3-15803

Checklist:

- [x] Correct branch: master for new features; 3.2.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master](https://area51.phpbb.com/docs/dev/master/development/coding_guidelines.html) and [3.2.x](https://area51.phpbb.com/docs/dev/3.2.x/development/coding_guidelines.html)
- [x] Commit follows commit message [format](https://area51.phpbb.com/docs/dev/3.2.x/development/git.html)

Tracker ticket (set the ticket ID to **your ticket ID**):

https://tracker.phpbb.com/browse/PHPBB3-15803
