### PR TITLE
[ticket/15544] Delete cache through module manager

### DIFF
--- a/phpBB/phpbb/db/migration/tool/module.php
+++ b/phpBB/phpbb/db/migration/tool/module.php
@@ -341,7 +341,7 @@ class module implements \phpbb\db\migration\tool\tool_interface
 		}
 
 		// Clear the Modules Cache
-		$this->cache->destroy("_modules_$class");
+		$this->module_manager->remove_cache_file($class);
 	}
 
 	/**
@@ -425,7 +425,7 @@ class module implements \phpbb\db\migration\tool\tool_interface
 				$this->module_manager->delete_module($module_id, $class);
 			}
 
-			$this->cache->destroy("_modules_$class");
+			$this->module_manager->remove_cache_file($class);
 		}
 	}
 


### PR DESCRIPTION
I've looked into this and it's possible that some migration issues are cache-related. (Everything bad comes from cache...)
In the module manager-class there's another call to purge the sql table-cache as well, so I guess calling the method is not only good for deduplication but might fix this issue as well.

Checklist:

- [x] Correct branch: master for new features; 3.2.x for fixes
- [ ] Tests pass
- [x] Code follows coding guidelines: [master](https://area51.phpbb.com/docs/dev/master/development/coding_guidelines.html) and [3.2.x](https://area51.phpbb.com/docs/dev/3.2.x/development/coding_guidelines.html)
- [ ] Commit follows commit message [format](https://area51.phpbb.com/docs/dev/3.2.x/development/git.html)

Tracker ticket:
https://tracker.phpbb.com/browse/PHPBB3-15544