### PR TITLE
[ticket/15819] Add core event to functions_posting to modify notifications

### DIFF
--- a/phpBB/includes/functions_posting.php
+++ b/phpBB/includes/functions_posting.php
@@ -2282,6 +2282,19 @@ function submit_post($mode, $subject, $username, $topic_type, &$poll_ary, &$data
 		'post_subject'		=> $subject,
 	));
 
+	/**
+	* This event allows you to modify the notification data upon submission
+	*
+	* @event core.modify_submit_notification_data
+	* @var	array	notification_data	The notification data to be inserted in to the database
+	* @var	array	data_ary			The data array with a lot of the post submission data
+	* @var 	string	mode				The posting mode
+	* @var	int		poster_id			The poster id
+	* @since 3.2.4-RC1
+	*/
+	$vars = array('notification_data', 'data_ary', 'mode', 'poster_id');
+	extract($phpbb_dispatcher->trigger_event('core.modify_submit_notification_data', compact($vars)));
+
 	/* @var $phpbb_notifications \phpbb\notification\manager */
 	$phpbb_notifications = $phpbb_container->get('notification_manager');
 


### PR DESCRIPTION
Events added to allow modifying notification data before in the database.
Useful to change variables in the notification message, such as usernames.
Includes some other residual data to allow this event to be versatile.

PHPBB3-15819

Checklist:

- [x] Correct branch: master for new features; 3.2.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master](https://area51.phpbb.com/docs/dev/master/development/coding_guidelines.html) and [3.2.x](https://area51.phpbb.com/docs/dev/3.2.x/development/coding_guidelines.html)
- [x] Commit follows commit message [format](https://area51.phpbb.com/docs/dev/3.2.x/development/git.html)

Tracker ticket (set the ticket ID to **your ticket ID**):

https://tracker.phpbb.com/browse/PHPBB3-15819