### PR TITLE
[ticket/15841] Allow postrow pm link to be modified by event

### DIFF
--- a/phpBB/viewtopic.php
+++ b/phpBB/viewtopic.php
@@ -2115,7 +2115,7 @@ for ($i = 0, $end = count($post_list); $i < $end; ++$i)
 		array(
 			'ID'		=> 'pm',
 			'NAME' 		=> $user->lang['SEND_PRIVATE_MESSAGE'],
-			'U_CONTACT'	=> $u_pm,
+			'U_CONTACT'	=> $post_row['U_PM'],
 		),
 		array(
 			'ID'		=> 'email',


### PR DESCRIPTION
Allow postrow.contact pm link to be modified by event above
All other variables in postrow.contact can be modified by the event already
This lets you hide all contact info on a per user basis

PHPBB3-15841

Checklist:

- [ ] Correct branch: master for new features; 3.2.x for fixes
- [ ] Tests pass
- [ ] Code follows coding guidelines: [master](https://area51.phpbb.com/docs/dev/master/development/coding_guidelines.html) and [3.2.x](https://area51.phpbb.com/docs/dev/3.2.x/development/coding_guidelines.html)
- [ ] Commit follows commit message [format](https://area51.phpbb.com/docs/dev/3.2.x/development/git.html)

Tracker ticket (set the ticket ID to **your ticket ID**):

https://tracker.phpbb.com/browse/PHPBB3-15841
