### PR TITLE
[ticket/15879] Add core.posting_modify_uninit_data

### DIFF
--- a/phpBB/posting.php
+++ b/phpBB/posting.php
@@ -597,6 +597,20 @@ if (isset($post_data['post_text']))
 // Set some default variables
 $uninit = array('post_attachment' => 0, 'poster_id' => $user->data['user_id'], 'enable_magic_url' => 0, 'topic_status' => 0, 'topic_type' => POST_NORMAL, 'post_subject' => '', 'topic_title' => '', 'post_time' => 0, 'post_edit_reason' => '', 'notify_set' => 0);
 
+/**
+* This event allows you to modify the default variables for post_data, and unset them in post_data if needed
+*
+* @event core.posting_modify_uninit_data
+* @var	array	post_data	Array with post data
+* @var	array	uninit		Array with default vars to put into post_data, if they aren't there
+* @since 3.2.5-RC1
+*/
+$vars = array(
+	'post_data',
+	'uninit',
+);
+extract($phpbb_dispatcher->trigger_event('core.posting_modify_uninit_data', compact($vars)));
+
 foreach ($uninit as $var_name => $default_value)
 {
 	if (!isset($post_data[$var_name]))
@@ -606,24 +620,9 @@ foreach ($uninit as $var_name => $default_value)
 }
 unset($uninit);
 
-$attachment_user_id = $post_data['poster_id'];
-/**
-* This event allows you to modify the poster_id used in get_submitted_attachment_data
-*
-* @event core.posting_modify_attachment_user_id
-* @var	array	post_data	Array with post data
-* @var	int		attachment_user_id	Poster ID used to get attachment data
-* @since 3.2.5-RC1
-*/
-$vars = array(
-	'post_data',
-	'attachment_user_id',
-);
-extract($phpbb_dispatcher->trigger_event('core.posting_modify_attachment_user_id', compact($vars)));
-
 // Always check if the submitted attachment data is valid and belongs to the user.
 // Further down (especially in submit_post()) we do not check this again.
-$message_parser->get_submitted_attachment_data($attachment_user_id);
+$message_parser->get_submitted_attachment_data($post_data['poster_id']);
 
 if ($post_data['post_attachment'] && !$submit && !$refresh && !$preview && $mode == 'edit')
 {

--- a/phpBB/posting.php
+++ b/phpBB/posting.php
@@ -600,6 +600,7 @@ $uninit = array('post_attachment' => 0, 'poster_id' => $user->data['user_id'], '
 /**
 * This event allows you to modify the default variables for post_data, and unset them in post_data if needed
 *
+<<<<<<< HEAD
 * @event core.posting_modify_uninit_data
 * @var	array	post_data	Array with post data
 * @var	array	uninit		Array with default vars to put into post_data, if they aren't there
@@ -608,6 +609,14 @@ $uninit = array('post_attachment' => 0, 'poster_id' => $user->data['user_id'], '
 $vars = array(
 	'post_data',
 	'uninit',
+=======
+* @event core.posting_modify_attachment_user_id
+* @var	int		attachment_user_id	Poster ID used to get attachment data
+* @since 3.2.5-RC1
+*/
+$vars = array(
+	'attachment_user_id',
+>>>>>>> parent of 838b5159a... add $post_data to event
 );
 extract($phpbb_dispatcher->trigger_event('core.posting_modify_uninit_data', compact($vars)));
 

--- a/phpBB/posting.php
+++ b/phpBB/posting.php
@@ -606,9 +606,22 @@ foreach ($uninit as $var_name => $default_value)
 }
 unset($uninit);
 
+$attachment_user_id = $post_data['poster_id'];
+/**
+* This event allows you to modify the poster_id used in get_submitted_attachment_data
+*
+* @event core.posting_modify_attachment_user_id
+* @var	int		attachment_user_id	Poster ID used to get attachment data
+* @since 3.2.5-RC1
+*/
+$vars = array(
+	'attachment_user_id',
+);
+extract($phpbb_dispatcher->trigger_event('core.posting_modify_attachment_user_id', compact($vars)));
+
 // Always check if the submitted attachment data is valid and belongs to the user.
 // Further down (especially in submit_post()) we do not check this again.
-$message_parser->get_submitted_attachment_data($post_data['poster_id']);
+$message_parser->get_submitted_attachment_data($attachment_user_id);
 
 if ($post_data['post_attachment'] && !$submit && !$refresh && !$preview && $mode == 'edit')
 {

--- a/phpBB/posting.php
+++ b/phpBB/posting.php
@@ -611,10 +611,12 @@ $attachment_user_id = $post_data['poster_id'];
 * This event allows you to modify the poster_id used in get_submitted_attachment_data
 *
 * @event core.posting_modify_attachment_user_id
+* @var	array	post_data	Array with post data
 * @var	int		attachment_user_id	Poster ID used to get attachment data
 * @since 3.2.5-RC1
 */
 $vars = array(
+	'post_data',
 	'attachment_user_id',
 );
 extract($phpbb_dispatcher->trigger_event('core.posting_modify_attachment_user_id', compact($vars)));


### PR DESCRIPTION
Allows the modification of default variables put into post_data.
Also allows you to unset variables in post_data to inherit the default ones.

PHPBB3-15879

Checklist:

- [x] Correct branch: master for new features; 3.2.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master](https://area51.phpbb.com/docs/dev/master/development/coding_guidelines.html) and [3.2.x](https://area51.phpbb.com/docs/dev/3.2.x/development/coding_guidelines.html)
- [x] Commit follows commit message [format](https://area51.phpbb.com/docs/dev/3.2.x/development/git.html)

Tracker ticket (set the ticket ID to **your ticket ID**):

https://tracker.phpbb.com/browse/PHPBB3-15879
