### PR TITLE
[ticket/15876] MySQL 5.7+ support for Q&A captcha plugin

### DIFF
--- a/phpBB/phpbb/captcha/plugins/qa.php
+++ b/phpBB/phpbb/captcha/plugins/qa.php
@@ -107,8 +107,7 @@ class qa
 
 			$sql = 'SELECT q.question_id, q.lang_iso
 				FROM ' . $this->table_captcha_questions . ' q, ' . $this->table_captcha_answers . ' a
-				WHERE q.question_id = a.question_id
-				GROUP BY lang_iso';
+				WHERE q.question_id = a.question_id';
 			$result = $db->sql_query($sql, 7200);
 
 			while ($row = $db->sql_fetchrow($result))


### PR DESCRIPTION
Add MySQL 5.7+ support for Q&A captcha plugin

Checklist:

- [x] Correct branch: master for new features; 3.2.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master](https://area51.phpbb.com/docs/dev/master/development/coding_guidelines.html) and [3.2.x](https://area51.phpbb.com/docs/dev/3.2.x/development/coding_guidelines.html)
- [x] Commit follows commit message [format](https://area51.phpbb.com/docs/dev/3.2.x/development/git.html)

Tracker ticket: https://tracker.phpbb.com/browse/PHPBB3-15876