### PR TITLE
[ticket/15883] New error message for when users try adding invalid usernames to a group

### DIFF
--- a/phpBB/includes/acp/acp_groups.php
+++ b/phpBB/includes/acp/acp_groups.php
@@ -29,6 +29,9 @@ class acp_groups
 		global $phpbb_root_path, $phpbb_admin_path, $phpEx;
 		global $request, $phpbb_container, $phpbb_dispatcher;
 
+		/** @var \phpbb\language\language $language Language object */
+		$language = $phpbb_container->get('language');
+
 		$user->add_lang('acp/groups');
 		$this->tpl_name = 'acp_groups';
 		$this->page_title = 'ACP_GROUPS_MANAGE';
@@ -293,7 +296,7 @@ class acp_groups
 				// Add user/s to group
 				if ($error = group_user_add($group_id, false, $name_ary, $group_name, $default, $leader, 0, $group_row))
 				{
-					$display_message = $user->lang[$error];
+					$display_message = $language->lang($error);
 
 					if ($error == 'GROUP_USERS_INVALID')
 					{
@@ -302,7 +305,7 @@ class acp_groups
 						$actual_user_id_ary = false;
 						user_get_id_name($actual_user_id_ary, $actual_name_ary, false, true);
 
-						$display_message = sprintf($user->lang['GROUP_USERS_INVALID'], implode($user->lang['COMMA_SEPARATOR'], array_diff($name_ary, $actual_name_ary)));
+						$display_message = $language->lang('GROUP_USERS_INVALID', implode($language->lang('COMMA_SEPARATOR'), array_udiff($name_ary, $actual_name_ary, 'strcasecmp')));
 					}
 
 					trigger_error($display_message . adm_back_link($this->u_action . '&amp;action=list&amp;g=' . $group_id), E_USER_WARNING);

--- a/phpBB/includes/acp/acp_groups.php
+++ b/phpBB/includes/acp/acp_groups.php
@@ -302,7 +302,7 @@ class acp_groups
 					{
 						// Find which users don't exist
 						$actual_name_ary = $name_ary;
-						$actual_user_id_ary = false;
+						$actual_user_id_ary = [];
 						user_get_id_name($actual_user_id_ary, $actual_name_ary, false, true);
 
 						$display_message = $language->lang('GROUP_USERS_INVALID', implode($language->lang('COMMA_SEPARATOR'), array_udiff($name_ary, $actual_name_ary, 'strcasecmp')));

--- a/phpBB/includes/acp/acp_groups.php
+++ b/phpBB/includes/acp/acp_groups.php
@@ -293,7 +293,19 @@ class acp_groups
 				// Add user/s to group
 				if ($error = group_user_add($group_id, false, $name_ary, $group_name, $default, $leader, 0, $group_row))
 				{
-					trigger_error($user->lang[$error] . adm_back_link($this->u_action . '&amp;action=list&amp;g=' . $group_id), E_USER_WARNING);
+					$display_message = $user->lang[$error];
+
+					if ($error == 'GROUP_USERS_INVALID')
+					{
+						// Find which users don't exist
+						$actual_name_ary = $name_ary;
+						$actual_user_id_ary = false;
+						user_get_id_name($actual_user_id_ary, $actual_name_ary, false, true);
+
+						$display_message = sprintf($user->lang['GROUP_USERS_INVALID'], implode($user->lang['COMMA_SEPARATOR'], array_diff($name_ary, $actual_name_ary)));
+					}
+
+					trigger_error($display_message . adm_back_link($this->u_action . '&amp;action=list&amp;g=' . $group_id), E_USER_WARNING);
 				}
 
 				$message = ($leader) ? 'GROUP_MODS_ADDED' : 'GROUP_USERS_ADDED';

--- a/phpBB/includes/functions_user.php
+++ b/phpBB/includes/functions_user.php
@@ -26,8 +26,8 @@ if (!defined('IN_PHPBB'))
 * @param array &$user_id_ary The user ids to check or empty if usernames used
 * @param array &$username_ary The usernames to check or empty if user ids used
 * @param mixed $user_type Array of user types to check, false if not restricting by user type
-* @param bool $update_references If false, the supplied array is unset and appears unchanged from where it was called
-* @return null
+* @param boolean $update_references If false, the supplied array is unset and appears unchanged from where it was called
+* @return boolean|string Returns false on success, error string on failure
 */
 function user_get_id_name(&$user_id_ary, &$username_ary, $user_type = false, $update_references = false)
 {

--- a/phpBB/includes/functions_user.php
+++ b/phpBB/includes/functions_user.php
@@ -26,8 +26,9 @@ if (!defined('IN_PHPBB'))
 * @param array &$user_id_ary The user ids to check or empty if usernames used
 * @param array &$username_ary The usernames to check or empty if user ids used
 * @param mixed $user_type Array of user types to check, false if not restricting by user type
+* @param bool $update_references If false, the supplied array is unset and appears unchanged from where it was called
 */
-function user_get_id_name(&$user_id_ary, &$username_ary, $user_type = false)
+function user_get_id_name(&$user_id_ary, &$username_ary, $user_type = false, $update_references = false)
 {
 	global $db;
 
@@ -50,7 +51,13 @@ function user_get_id_name(&$user_id_ary, &$username_ary, $user_type = false)
 	}
 
 	$sql_in = ($which_ary == 'user_id_ary') ? array_map('intval', ${$which_ary}) : array_map('utf8_clean_string', ${$which_ary});
-	unset(${$which_ary});
+
+	// By unsetting the array here, the values passed in at the point user_get_id_name() was called will be retained.
+	// Otherwise, if we don't unset (as the array was passed by reference) the original array will be updated below.
+	if ($update_references === false)
+	{
+		unset(${$which_ary});
+	}
 
 	$user_id_ary = $username_ary = array();
 
@@ -2674,6 +2681,13 @@ function group_user_add($group_id, $user_id_ary = false, $username_ary = false, 
 	if (empty($user_id_ary) || $result !== false)
 	{
 		return 'NO_USER';
+	}
+
+	// Because the item that gets passed into the previous function is unset, the reference is lost and our original
+	// array is retained - so we know there's a problem if there's a different number of ids to usernames now.
+	if (count($user_id_ary) != count($username_ary))
+	{
+		return 'GROUP_USERS_INVALID';
 	}
 
 	// Remove users who are already members of this group

--- a/phpBB/includes/functions_user.php
+++ b/phpBB/includes/functions_user.php
@@ -27,6 +27,7 @@ if (!defined('IN_PHPBB'))
 * @param array &$username_ary The usernames to check or empty if user ids used
 * @param mixed $user_type Array of user types to check, false if not restricting by user type
 * @param bool $update_references If false, the supplied array is unset and appears unchanged from where it was called
+* @return null
 */
 function user_get_id_name(&$user_id_ary, &$username_ary, $user_type = false, $update_references = false)
 {

--- a/phpBB/includes/ucp/ucp_groups.php
+++ b/phpBB/includes/ucp/ucp_groups.php
@@ -32,6 +32,9 @@ class ucp_groups
 		global $db, $user, $auth, $cache, $template;
 		global $request, $phpbb_container, $phpbb_log;
 
+		/** @var \phpbb\language\language $language Language object */
+		$language = $phpbb_container->get('language');
+
 		$user->add_lang('groups');
 
 		$return_page = '<br /><br />' . sprintf($user->lang['RETURN_PAGE'], '<a href="' . $this->u_action . '">', '</a>');
@@ -1054,10 +1057,12 @@ class ucp_groups
 
 						if (confirm_box(true))
 						{
+							$return_manage_page = '<br /><br />' . $language->lang('RETURN_PAGE', '<a href="' . $this->u_action . '&amp;action=list&amp;g=' . $group_id . '">', '</a>');
+
 							// Add user/s to group
 							if ($error = group_user_add($group_id, false, $name_ary, $group_name, $default, 0, 0, $group_row))
 							{
-								$display_message = $user->lang[$error];
+								$display_message = $language->lang($error);
 
 								if ($error == 'GROUP_USERS_INVALID')
 								{
@@ -1066,13 +1071,13 @@ class ucp_groups
 									$actual_user_id_ary = false;
 									user_get_id_name($actual_user_id_ary, $actual_name_ary, false, true);
 
-									$display_message = sprintf($user->lang['GROUP_USERS_INVALID'], implode($user->lang['COMMA_SEPARATOR'], array_diff($name_ary, $actual_name_ary)));
+									$display_message = $language->lang('GROUP_USERS_INVALID', implode($language->lang('COMMA_SEPARATOR'), array_udiff($name_ary, $actual_name_ary, 'strcasecmp')));
 								}
 
-								trigger_error($display_message . $return_page);
+								trigger_error($display_message . $return_manage_page);
 							}
 
-							trigger_error($user->lang['GROUP_USERS_ADDED'] . '<br /><br />' . sprintf($user->lang['RETURN_PAGE'], '<a href="' . $this->u_action . '&amp;action=list&amp;g=' . $group_id . '">', '</a>'));
+							trigger_error($language->lang('GROUP_USERS_ADDED') . $return_manage_page);
 						}
 						else
 						{

--- a/phpBB/includes/ucp/ucp_groups.php
+++ b/phpBB/includes/ucp/ucp_groups.php
@@ -1057,7 +1057,19 @@ class ucp_groups
 							// Add user/s to group
 							if ($error = group_user_add($group_id, false, $name_ary, $group_name, $default, 0, 0, $group_row))
 							{
-								trigger_error($user->lang[$error] . $return_page);
+								$display_message = $user->lang[$error];
+
+								if ($error == 'GROUP_USERS_INVALID')
+								{
+									// Find which users don't exist
+									$actual_name_ary = $name_ary;
+									$actual_user_id_ary = false;
+									user_get_id_name($actual_user_id_ary, $actual_name_ary, false, true);
+
+									$display_message = sprintf($user->lang['GROUP_USERS_INVALID'], implode($user->lang['COMMA_SEPARATOR'], array_diff($name_ary, $actual_name_ary)));
+								}
+
+								trigger_error($display_message . $return_page);
 							}
 
 							trigger_error($user->lang['GROUP_USERS_ADDED'] . '<br /><br />' . sprintf($user->lang['RETURN_PAGE'], '<a href="' . $this->u_action . '&amp;action=list&amp;g=' . $group_id . '">', '</a>'));

--- a/phpBB/includes/ucp/ucp_groups.php
+++ b/phpBB/includes/ucp/ucp_groups.php
@@ -1068,7 +1068,7 @@ class ucp_groups
 								{
 									// Find which users don't exist
 									$actual_name_ary = $name_ary;
-									$actual_user_id_ary = false;
+									$actual_user_id_ary = [];
 									user_get_id_name($actual_user_id_ary, $actual_name_ary, false, true);
 
 									$display_message = $language->lang('GROUP_USERS_INVALID', implode($language->lang('COMMA_SEPARATOR'), array_udiff($name_ary, $actual_name_ary, 'strcasecmp')));

--- a/phpBB/language/en/acp/groups.php
+++ b/phpBB/language/en/acp/groups.php
@@ -111,6 +111,7 @@ $lang = array_merge($lang, array(
 	'GROUP_USERS_ADDED'				=> 'New users added to group successfully.',
 	'GROUP_USERS_EXIST'				=> 'The selected users are already members.',
 	'GROUP_USERS_REMOVE'			=> 'Users removed from group and new defaults set successfully.',
+	'GROUP_USERS_INVALID'			=> 'No users were added to the group as the following usernames do not exist: %s',
 
 	'LEGEND_EXPLAIN'				=> 'These are the groups which are displayed in the group legend:',
 	'LEGEND_SETTINGS'				=> 'Legend settings',


### PR DESCRIPTION
Update the ACP and the UCP so that when bulk adding users to a group, if invalid usernames are submitted alongside valid usernames then a message will be displayed to inform the user what the invalid usernames are.

I'm using the old `$user->lang[]` format for now so I don't interfere with PR #5447.

PHPBB3-15883

Checklist:

- [x] Correct branch: master for new features; 3.2.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master](https://area51.phpbb.com/docs/dev/master/development/coding_guidelines.html) and [3.2.x](https://area51.phpbb.com/docs/dev/3.2.x/development/coding_guidelines.html)
- [x] Commit follows commit message [format](https://area51.phpbb.com/docs/dev/3.2.x/development/git.html)

Tracker ticket:

https://tracker.phpbb.com/browse/PHPBB3-15883
