### PR TITLE
[ticket/15925] Add core events for sync and mcp functions

### DIFF
--- a/phpBB/includes/functions_admin.php
+++ b/phpBB/includes/functions_admin.php
@@ -2118,6 +2118,22 @@ function sync($mode, $where_type = '', $where_ids = '', $resync_parents = false,
 					$topic_data[$topic_id]['last_poster_name'] = ($row['poster_id'] == ANONYMOUS) ? $row['post_username'] : $row['username'];
 					$topic_data[$topic_id]['last_poster_colour'] = $row['user_colour'];
 				}
+
+				/**
+				* Event to modify the topic_data when syncing topics
+				*
+				* @event core.sync_modify_topic_data
+				* @var	array	topic_data		Array with the topics' data we are syncing
+				* @var	array	row				Array with some of the current user and post data
+				* @var	int		topic_id		The current topic_id of $row
+				* @since 3.2.6-RC1
+				*/
+				$vars = array(
+					'topic_data',
+					'row',
+					'topic_id',
+				);
+				extract($phpbb_dispatcher->trigger_event('core.sync_modify_topic_data', compact($vars)));
 			}
 			$db->sql_freeresult($result);
 

--- a/phpBB/includes/functions_admin.php
+++ b/phpBB/includes/functions_admin.php
@@ -1841,9 +1841,9 @@ function sync($mode, $where_type = '', $where_ids = '', $resync_parents = false,
 				*
 				* @event core.sync_forum_last_post_info_sql
 				* @var	array	sql_ary		SQL array with some post and user data from the last posts list
-				* @since 3.2.6-RC1
+				* @since 3.3.3-RC1
 				*/
-				$vars = array('sql_ary');
+				$vars = ['sql_ary'];
 				extract($phpbb_dispatcher->trigger_event('core.sync_forum_last_post_info_sql', compact($vars)));
 				$result = $db->sql_query($db->sql_build_query('SELECT', $sql_ary));
 
@@ -1894,13 +1894,13 @@ function sync($mode, $where_type = '', $where_ids = '', $resync_parents = false,
 			* @var	array	forum_data		Array with data to update for all forum ids
 			* @var	array	post_info		Array with some post and user data from the last posts list
 			* @var	array	fieldnames		Array with the partial column names that are being updated
-			* @since 3.2.6-RC1
+			* @since 3.3.3-RC1
 			*/
-			$vars = array(
+			$vars = [
 				'forum_data',
 				'post_info',
 				'fieldnames',
-			);
+			];
 			extract($phpbb_dispatcher->trigger_event('core.sync_modify_forum_data', compact($vars)));
 			unset($post_info);
 
@@ -2082,19 +2082,19 @@ function sync($mode, $where_type = '', $where_ids = '', $resync_parents = false,
 					AND u.user_id = p.poster_id',
 			);
 
-			$custom_fieldnames = array();
+			$custom_fieldnames = [];
 			/**
 			* Event to modify the SQL array to get the post and user data from all topics' last posts
 			*
 			* @event core.sync_topic_last_post_info_sql
 			* @var	array	sql_ary					SQL array with some post and user data from the last posts list
 			* @var	array	custom_fieldnames		Empty array for custom fieldnames to update the topics_table with
-			* @since 3.2.6-RC1
+			* @since 3.3.1-RC1
 			*/
-			$vars = array(
+			$vars = [
 				'sql_ary',
 				'custom_fieldnames',
-			);
+			];
 			extract($phpbb_dispatcher->trigger_event('core.sync_topic_last_post_info_sql', compact($vars)));
 			$result = $db->sql_query($db->sql_build_query('SELECT', $sql_ary));
 
@@ -2126,13 +2126,13 @@ function sync($mode, $where_type = '', $where_ids = '', $resync_parents = false,
 				* @var	array	topic_data		Array with the topics' data we are syncing
 				* @var	array	row				Array with some of the current user and post data
 				* @var	int		topic_id		The current topic_id of $row
-				* @since 3.2.6-RC1
+				* @since 3.3.1-RC1
 				*/
-				$vars = array(
+				$vars = [
 					'topic_data',
 					'row',
 					'topic_id',
-				);
+				];
 				extract($phpbb_dispatcher->trigger_event('core.sync_modify_topic_data', compact($vars)));
 			}
 			$db->sql_freeresult($result);
@@ -2251,6 +2251,7 @@ function sync($mode, $where_type = '', $where_ids = '', $resync_parents = false,
 
 			// Add custom fieldnames
 			$fieldnames = array_merge($fieldnames, $custom_fieldnames);
+			unset($custom_fieldnames);
 
 			if ($sync_extra)
 			{

--- a/phpBB/includes/functions_admin.php
+++ b/phpBB/includes/functions_admin.php
@@ -1841,7 +1841,7 @@ function sync($mode, $where_type = '', $where_ids = '', $resync_parents = false,
 				*
 				* @event core.sync_forum_last_post_info_sql
 				* @var	array	sql_ary		SQL array with some post and user data from the last posts list
-				* @since 3.3.3-RC1
+				* @since 3.3.4-RC1
 				*/
 				$vars = ['sql_ary'];
 				extract($phpbb_dispatcher->trigger_event('core.sync_forum_last_post_info_sql', compact($vars)));
@@ -1894,7 +1894,7 @@ function sync($mode, $where_type = '', $where_ids = '', $resync_parents = false,
 			* @var	array	forum_data		Array with data to update for all forum ids
 			* @var	array	post_info		Array with some post and user data from the last posts list
 			* @var	array	fieldnames		Array with the partial column names that are being updated
-			* @since 3.3.3-RC1
+			* @since 3.3.4-RC1
 			*/
 			$vars = [
 				'forum_data',
@@ -2089,7 +2089,7 @@ function sync($mode, $where_type = '', $where_ids = '', $resync_parents = false,
 			* @event core.sync_topic_last_post_info_sql
 			* @var	array	sql_ary					SQL array with some post and user data from the last posts list
 			* @var	array	custom_fieldnames		Empty array for custom fieldnames to update the topics_table with
-			* @since 3.3.1-RC1
+			* @since 3.3.4-RC1
 			*/
 			$vars = [
 				'sql_ary',
@@ -2126,7 +2126,7 @@ function sync($mode, $where_type = '', $where_ids = '', $resync_parents = false,
 				* @var	array	topic_data		Array with the topics' data we are syncing
 				* @var	array	row				Array with some of the current user and post data
 				* @var	int		topic_id		The current topic_id of $row
-				* @since 3.3.1-RC1
+				* @since 3.3.4-RC1
 				*/
 				$vars = [
 					'topic_data',

--- a/phpBB/includes/functions_admin.php
+++ b/phpBB/includes/functions_admin.php
@@ -1841,7 +1841,7 @@ function sync($mode, $where_type = '', $where_ids = '', $resync_parents = false,
 				*
 				* @event core.sync_forum_last_post_info_sql
 				* @var	array	sql_ary		SQL array with some post and user data from the last posts list
-				* @since 3.3.4-RC1
+				* @since 3.3.5-RC1
 				*/
 				$vars = ['sql_ary'];
 				extract($phpbb_dispatcher->trigger_event('core.sync_forum_last_post_info_sql', compact($vars)));
@@ -1894,7 +1894,7 @@ function sync($mode, $where_type = '', $where_ids = '', $resync_parents = false,
 			* @var	array	forum_data		Array with data to update for all forum ids
 			* @var	array	post_info		Array with some post and user data from the last posts list
 			* @var	array	fieldnames		Array with the partial column names that are being updated
-			* @since 3.3.4-RC1
+			* @since 3.3.5-RC1
 			*/
 			$vars = [
 				'forum_data',
@@ -2089,7 +2089,7 @@ function sync($mode, $where_type = '', $where_ids = '', $resync_parents = false,
 			* @event core.sync_topic_last_post_info_sql
 			* @var	array	sql_ary					SQL array with some post and user data from the last posts list
 			* @var	array	custom_fieldnames		Empty array for custom fieldnames to update the topics_table with
-			* @since 3.3.4-RC1
+			* @since 3.3.5-RC1
 			*/
 			$vars = [
 				'sql_ary',
@@ -2126,7 +2126,7 @@ function sync($mode, $where_type = '', $where_ids = '', $resync_parents = false,
 				* @var	array	topic_data		Array with the topics' data we are syncing
 				* @var	array	row				Array with some of the current user and post data
 				* @var	int		topic_id		The current topic_id of $row
-				* @since 3.3.4-RC1
+				* @since 3.3.5-RC1
 				*/
 				$vars = [
 					'topic_data',

--- a/phpBB/includes/functions_admin.php
+++ b/phpBB/includes/functions_admin.php
@@ -1877,7 +1877,6 @@ function sync($mode, $where_type = '', $where_ids = '', $resync_parents = false,
 						}
 					}
 				}
-				unset($post_info);
 			}
 
 			// 6: Now do that thing
@@ -1887,6 +1886,23 @@ function sync($mode, $where_type = '', $where_ids = '', $resync_parents = false,
 			{
 				array_push($fieldnames, 'posts_approved', 'posts_unapproved', 'posts_softdeleted', 'topics_approved', 'topics_unapproved', 'topics_softdeleted');
 			}
+
+			/**
+			* Event to modify the SQL array to get the post and user data from all forums' last posts
+			*
+			* @event core.sync_modify_forum_data
+			* @var	array	forum_data		Array with data to update for all forum ids
+			* @var	array	post_info		Array with some post and user data from the last posts list
+			* @var	array	fieldnames		Array with the partial column names that are being updated
+			* @since 3.2.6-RC1
+			*/
+			$vars = array(
+				'forum_data',
+				'post_info',
+				'fieldnames',
+			);
+			extract($phpbb_dispatcher->trigger_event('core.sync_modify_forum_data', compact($vars)));
+			unset($post_info);
 
 			foreach ($forum_data as $forum_id => $row)
 			{

--- a/phpBB/includes/functions_posting.php
+++ b/phpBB/includes/functions_posting.php
@@ -356,12 +356,12 @@ function update_post_information($type, $ids, $return_update_sql = false)
 		* @event core.update_post_info_modify_posts_sql
 		* @var	string	type				The table being updated (forum or topic)
 		* @var	array	sql_ary				SQL array to get some of the last posts' data
-		* @since 3.2.6-RC1
+		* @since 3.3.3-RC1
 		*/
-		$vars = array(
+		$vars = [
 			'type',
 			'sql_ary',
-		);
+		];
 		extract($phpbb_dispatcher->trigger_event('core.update_post_info_modify_posts_sql', compact($vars)));
 		$result = $db->sql_query($db->sql_build_query('SELECT', $sql_ary));
 
@@ -385,14 +385,15 @@ function update_post_information($type, $ids, $return_update_sql = false)
 		* @var	string	type				The table being updated (forum or topic)
 		* @var	array	rowset				Array with the posts data
 		* @var	array	update_sql			Array with SQL data to update the forums or topics table with
-		* @since 3.2.6-RC1
+		* @since 3.3.3-RC1
 		*/
-		$vars = array(
+		$vars = [
 			'type',
 			'rowset',
 			'update_sql',
-		);
+		];
 		extract($phpbb_dispatcher->trigger_event('core.update_post_info_modify_sql', compact($vars)));
+		unset($rowset);
 	}
 	unset($empty_forums, $ids, $last_post_ids);
 

--- a/phpBB/includes/functions_posting.php
+++ b/phpBB/includes/functions_posting.php
@@ -356,7 +356,7 @@ function update_post_information($type, $ids, $return_update_sql = false)
 		* @event core.update_post_info_modify_posts_sql
 		* @var	string	type				The table being updated (forum or topic)
 		* @var	array	sql_ary				SQL array to get some of the last posts' data
-		* @since 3.3.4-RC1
+		* @since 3.3.5-RC1
 		*/
 		$vars = [
 			'type',
@@ -385,7 +385,7 @@ function update_post_information($type, $ids, $return_update_sql = false)
 		* @var	string	type				The table being updated (forum or topic)
 		* @var	array	rowset				Array with the posts data
 		* @var	array	update_sql			Array with SQL data to update the forums or topics table with
-		* @since 3.3.4-RC1
+		* @since 3.3.5-RC1
 		*/
 		$vars = [
 			'type',

--- a/phpBB/includes/functions_posting.php
+++ b/phpBB/includes/functions_posting.php
@@ -365,8 +365,10 @@ function update_post_information($type, $ids, $return_update_sql = false)
 		extract($phpbb_dispatcher->trigger_event('core.update_post_info_modify_posts_sql', compact($vars)));
 		$result = $db->sql_query($db->sql_build_query('SELECT', $sql_ary));
 
+		$rowset = array();
 		while ($row = $db->sql_fetchrow($result))
 		{
+			$rowset[] = $row;
 			$update_sql[$row["{$type}_id"]][] = $type . '_last_post_id = ' . (int) $row['post_id'];
 			$update_sql[$row["{$type}_id"]][] = "{$type}_last_post_subject = '" . $db->sql_escape($row['post_subject']) . "'";
 			$update_sql[$row["{$type}_id"]][] = $type . '_last_post_time = ' . (int) $row['post_time'];
@@ -375,6 +377,22 @@ function update_post_information($type, $ids, $return_update_sql = false)
 			$update_sql[$row["{$type}_id"]][] = "{$type}_last_poster_name = '" . (($row['poster_id'] == ANONYMOUS) ? $db->sql_escape($row['post_username']) : $db->sql_escape($row['username'])) . "'";
 		}
 		$db->sql_freeresult($result);
+
+		/**
+		* Event to modify the update_sql array to add new update data for forum or topic last posts
+		*
+		* @event core.update_post_info_modify_sql
+		* @var	string	type				The table being updated (forum or topic)
+		* @var	array	rowset				Array with the posts data
+		* @var	array	update_sql			Array with SQL data to update the forums or topics table with
+		* @since 3.2.6-RC1
+		*/
+		$vars = array(
+			'type',
+			'rowset',
+			'update_sql',
+		);
+		extract($phpbb_dispatcher->trigger_event('core.update_post_info_modify_sql', compact($vars)));
 	}
 	unset($empty_forums, $ids, $last_post_ids);
 

--- a/phpBB/includes/functions_posting.php
+++ b/phpBB/includes/functions_posting.php
@@ -256,7 +256,7 @@ function generate_smilies($mode, $forum_id)
 */
 function update_post_information($type, $ids, $return_update_sql = false)
 {
-	global $db;
+	global $db, $phpbb_dispatcher;
 
 	if (empty($ids))
 	{
@@ -340,11 +340,30 @@ function update_post_information($type, $ids, $return_update_sql = false)
 
 	if (count($last_post_ids))
 	{
-		$sql = 'SELECT p.' . $type . '_id, p.post_id, p.post_subject, p.post_time, p.poster_id, p.post_username, u.user_id, u.username, u.user_colour
-			FROM ' . POSTS_TABLE . ' p, ' . USERS_TABLE . ' u
-			WHERE p.poster_id = u.user_id
-				AND ' . $db->sql_in_set('p.post_id', $last_post_ids);
-		$result = $db->sql_query($sql);
+		$sql_ary = array(
+			'SELECT'	=> 'p.' . $type . '_id, p.post_id, p.post_subject, p.post_time, p.poster_id, p.post_username, u.user_id, u.username, u.user_colour',
+			'FROM'		=> array(
+				POSTS_TABLE	=> 'p',
+				USERS_TABLE => 'u',
+			),
+			'WHERE'		=> $db->sql_in_set('p.post_id', $last_post_ids) . '
+				AND p.poster_id = u.user_id',
+		);
+
+		/**
+		* Event to modify the SQL array to get the post and user data from all last posts
+		*
+		* @event core.update_post_info_modify_posts_sql
+		* @var	string	type				The table being updated (forum or topic)
+		* @var	array	sql_ary				SQL array to get some of the last posts' data
+		* @since 3.2.6-RC1
+		*/
+		$vars = array(
+			'type',
+			'sql_ary',
+		);
+		extract($phpbb_dispatcher->trigger_event('core.update_post_info_modify_posts_sql', compact($vars)));
+		$result = $db->sql_query($db->sql_build_query('SELECT', $sql_ary));
 
 		while ($row = $db->sql_fetchrow($result))
 		{

--- a/phpBB/includes/functions_posting.php
+++ b/phpBB/includes/functions_posting.php
@@ -356,7 +356,7 @@ function update_post_information($type, $ids, $return_update_sql = false)
 		* @event core.update_post_info_modify_posts_sql
 		* @var	string	type				The table being updated (forum or topic)
 		* @var	array	sql_ary				SQL array to get some of the last posts' data
-		* @since 3.3.3-RC1
+		* @since 3.3.4-RC1
 		*/
 		$vars = [
 			'type',
@@ -385,7 +385,7 @@ function update_post_information($type, $ids, $return_update_sql = false)
 		* @var	string	type				The table being updated (forum or topic)
 		* @var	array	rowset				Array with the posts data
 		* @var	array	update_sql			Array with SQL data to update the forums or topics table with
-		* @since 3.3.3-RC1
+		* @since 3.3.4-RC1
 		*/
 		$vars = [
 			'type',

--- a/phpBB/includes/mcp/mcp_main.php
+++ b/phpBB/includes/mcp/mcp_main.php
@@ -1573,7 +1573,7 @@ function mcp_fork_topic($topic_ids)
 				* @var	array	sql_ary			SQL Array with the post's data
 				* @var	array	row				Post data
 				* @var	array	counter			Array with post counts
-				* @since 3.3.3-RC1
+				* @since 3.3.4-RC1
 				*/
 				$vars = [
 					'new_topic_id',

--- a/phpBB/includes/mcp/mcp_main.php
+++ b/phpBB/includes/mcp/mcp_main.php
@@ -1573,7 +1573,7 @@ function mcp_fork_topic($topic_ids)
 				* @var	array	sql_ary			SQL Array with the post's data
 				* @var	array	row				Post data
 				* @var	array	counter			Array with post counts
-				* @since 3.3.4-RC1
+				* @since 3.3.5-RC1
 				*/
 				$vars = [
 					'new_topic_id',

--- a/phpBB/includes/mcp/mcp_main.php
+++ b/phpBB/includes/mcp/mcp_main.php
@@ -1563,6 +1563,26 @@ function mcp_fork_topic($topic_ids)
 						$counter[$row['poster_id']] = 1;
 					}
 				}
+
+				/**
+				* Modify the forked post's sql array before it's inserted into the database.
+				*
+				* @event core.mcp_main_modify_fork_post_sql
+				* @var	int		new_topic_id	The newly created topic ID
+				* @var	int		to_forum_id		The forum ID where the forked topic has been moved to
+				* @var	array	sql_ary			SQL Array with the post's data
+				* @var	array	row				Post data
+				* @var	array	counter			Array with post counts
+				* @since 3.2.6-RC1
+				*/
+				$vars = array(
+					'new_topic_id',
+					'to_forum_id',
+					'sql_ary',
+					'row',
+					'counter',
+				);
+				extract($phpbb_dispatcher->trigger_event('core.mcp_main_modify_fork_post_sql', compact($vars)));
 				$db->sql_query('INSERT INTO ' . POSTS_TABLE . ' ' . $db->sql_build_array('INSERT', $sql_ary));
 				$new_post_id = $db->sql_nextid();
 

--- a/phpBB/includes/mcp/mcp_main.php
+++ b/phpBB/includes/mcp/mcp_main.php
@@ -1573,15 +1573,15 @@ function mcp_fork_topic($topic_ids)
 				* @var	array	sql_ary			SQL Array with the post's data
 				* @var	array	row				Post data
 				* @var	array	counter			Array with post counts
-				* @since 3.2.6-RC1
+				* @since 3.3.3-RC1
 				*/
-				$vars = array(
+				$vars = [
 					'new_topic_id',
 					'to_forum_id',
 					'sql_ary',
 					'row',
 					'counter',
-				);
+				];
 				extract($phpbb_dispatcher->trigger_event('core.mcp_main_modify_fork_post_sql', compact($vars)));
 				$db->sql_query('INSERT INTO ' . POSTS_TABLE . ' ' . $db->sql_build_array('INSERT', $sql_ary));
 				$new_post_id = $db->sql_nextid();


### PR DESCRIPTION
Add core events to modify topic and forum info when syncing
Also add core events to account for missing variables when using mcp functions
Custom post, topic, or forum columns use these events to account for their data

PHPBB3-15925

Checklist:

- [x] Correct branch: master for new features; 3.2.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master](https://area51.phpbb.com/docs/dev/master/development/coding_guidelines.html) and [3.2.x](https://area51.phpbb.com/docs/dev/3.2.x/development/coding_guidelines.html)
- [x] Commit follows commit message [format](https://area51.phpbb.com/docs/dev/3.2.x/development/git.html)

Tracker ticket (set the ticket ID to **your ticket ID**):

https://tracker.phpbb.com/browse/PHPBB3-15925
