### PR TITLE
[ticket/15935] Don't install APCu if it's already installed

### DIFF
--- a/travis/setup-php-extensions.sh
+++ b/travis/setup-php-extensions.sh
@@ -56,10 +56,13 @@ fi
 # APCu
 if [ `php -r "echo (int) (version_compare(PHP_VERSION, '7.0.0-dev', '>=') && version_compare(PHP_VERSION, '7.3.0-dev', '<'));"` == "1" ]
 then
-	echo 'Enabling APCu PHP extension'
-	printf "\n" | pecl install apcu
-	echo 'apc.enabled=1' >> "$php_ini_file"
-	echo 'apc.enable_cli=1' >> "$php_ini_file"
+	if ! [ "$(pecl info pecl/apcu)" ]
+	then
+		echo 'Enabling APCu PHP extension'
+		printf "\n" | pecl install apcu
+		echo 'apc.enabled=1' >> "$php_ini_file"
+		echo 'apc.enable_cli=1' >> "$php_ini_file"
+	fi
 fi
 
 


### PR DESCRIPTION
Backport of #5506 which was merged into master only.

Travis fails when the APCu install fails due to it already being installed
A check is added here to make sure that it does nothing in that case

PHPBB3-15935

Checklist:

- [x] Correct branch: master for new features; 3.2.x for fixes
- [ ] Tests pass
- [x] Code follows coding guidelines: [master](https://area51.phpbb.com/docs/dev/master/development/coding_guidelines.html) and [3.2.x](https://area51.phpbb.com/docs/dev/3.2.x/development/coding_guidelines.html)
- [x] Commit follows commit message [format](https://area51.phpbb.com/docs/dev/3.2.x/development/git.html)

Tracker ticket (set the ticket ID to **your ticket ID**):

https://tracker.phpbb.com/browse/PHPBB3-15935
