### PR TITLE
[ticket/15941] Replace MAX to speed up query in update_post_information

### DIFF
--- a/phpBB/includes/functions_posting.php
+++ b/phpBB/includes/functions_posting.php
@@ -202,11 +202,13 @@ function update_post_information($type, $ids, $return_update_sql = false)
 
 	if (count($ids) == 1)
 	{
-		$sql = 'SELECT MAX(p.post_id) as last_post_id
+		$sql = 'SELECT p.post_id as last_post_id
 			FROM ' . POSTS_TABLE . " p $topic_join
 			WHERE " . $db->sql_in_set('p.' . $type . '_id', $ids) . "
 				$topic_condition
-				AND p.post_visibility = " . ITEM_APPROVED;
+				AND p.post_visibility = " . ITEM_APPROVED . "
+			ORDER BY p.post_id DESC";
+		$result = $db->sql_query_limit($sql, 1);
 	}
 	else
 	{
@@ -216,8 +218,8 @@ function update_post_information($type, $ids, $return_update_sql = false)
 				$topic_condition
 				AND p.post_visibility = " . ITEM_APPROVED . "
 			GROUP BY p.{$type}_id";
+		$result = $db->sql_query($sql);
 	}
-	$result = $db->sql_query($sql);
 
 	$last_post_ids = array();
 	while ($row = $db->sql_fetchrow($result))

--- a/phpBB/includes/functions_posting.php
+++ b/phpBB/includes/functions_posting.php
@@ -200,7 +200,7 @@ function update_post_information($type, $ids, $return_update_sql = false)
 		$topic_condition = '';
 	}
 
-	if (count($ids) === 1)
+	if (count($ids) == 1)
 	{
 		$sql = 'SELECT p.post_id as last_post_id
 			FROM ' . POSTS_TABLE . " p $topic_join

--- a/phpBB/includes/functions_posting.php
+++ b/phpBB/includes/functions_posting.php
@@ -200,7 +200,7 @@ function update_post_information($type, $ids, $return_update_sql = false)
 		$topic_condition = '';
 	}
 
-	if (count($ids) == 1)
+	if (count($ids) === 1)
 	{
 		$sql = 'SELECT p.post_id as last_post_id
 			FROM ' . POSTS_TABLE . " p $topic_join


### PR DESCRIPTION
Replace MAX SQL function with faster query using order by and limit.
The ajacent query could also be optimized to eliminate the usage of MAX.
Note that adding a compound key as suggested by EXPLAIN SQL yields an
improvement, but not nearly as fast as ORDER + LIMIT.

PHPBB3-15941

Checklist:

- [x] Correct branch: master for new features; 3.2.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master](https://area51.phpbb.com/docs/dev/master/development/coding_guidelines.html) and [3.2.x](https://area51.phpbb.com/docs/dev/3.2.x/development/coding_guidelines.html)
- [x] Commit follows commit message [format](https://area51.phpbb.com/docs/dev/3.2.x/development/git.html)

Tracker ticket (set the ticket ID to **your ticket ID**):

https://tracker.phpbb.com/browse/PHPBB3-15941
