### PR TITLE
[ticket/15949] Add ucp_profile_signature_posting_editor_options_prepend

### DIFF
--- a/phpBB/docs/events.md
+++ b/phpBB/docs/events.md
@@ -2420,6 +2420,13 @@ ucp_profile_register_details_after
 * Since: 3.1.4-RC1
 * Purpose: Add options in profile page fieldset - after confirm password field.
 
+ucp_profile_signature_posting_editor_options_prepend
+===
+* Locations:
+    + styles/prosilver/template/ucp_profile_signature.html
+* Since: 3.2.6-RC1
+* Purpose: Add options signature posting editor - before first option.
+
 ucp_register_buttons_before
 ===
 * Locations:

--- a/phpBB/styles/prosilver/template/ucp_profile_signature.html
+++ b/phpBB/styles/prosilver/template/ucp_profile_signature.html
@@ -24,6 +24,7 @@
 	<!-- INCLUDE posting_editor.html -->
 	<h3>{L_OPTIONS}</h3>
 	<fieldset>
+		{% EVENT ucp_profile_signature_posting_editor_options_prepend %}
 		<!-- IF S_BBCODE_ALLOWED -->
 			<div><label for="disable_bbcode"><input type="checkbox" name="disable_bbcode" id="disable_bbcode"{S_BBCODE_CHECKED} /> {L_DISABLE_BBCODE}</label></div>
 		<!-- ENDIF -->


### PR DESCRIPTION
PHPBB3-15949

It adds a template event in the signature posting editor to add custom options to be consistent with the default posting editor.

Checklist:

- [x] Correct branch: master for new features; 3.2.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master](https://area51.phpbb.com/docs/dev/master/development/coding_guidelines.html) and [3.2.x](https://area51.phpbb.com/docs/dev/3.2.x/development/coding_guidelines.html)
- [x] Commit follows commit message [format](https://area51.phpbb.com/docs/dev/3.2.x/development/git.html)

Tracker ticket (set the ticket ID to **your ticket ID**):

https://tracker.phpbb.com/browse/PHPBB3-15949