### PR TITLE
[ticket/15951] Add core events to mcp

### DIFF
--- a/phpBB/includes/mcp/mcp_main.php
+++ b/phpBB/includes/mcp/mcp_main.php
@@ -821,16 +821,38 @@ function mcp_restore_topic($topic_ids)
 */
 function mcp_delete_topic($topic_ids, $is_soft = false, $soft_delete_reason = '', $action = 'delete_topic')
 {
-	global $auth, $user, $db, $phpEx, $phpbb_root_path, $request, $phpbb_container, $phpbb_log;
+	global $auth, $user, $db, $phpEx, $phpbb_root_path, $request, $phpbb_container, $phpbb_log, $phpbb_dispatcher;
 
-	$check_permission = ($is_soft) ? 'm_softdelete' : 'm_delete';
-	if (!phpbb_check_ids($topic_ids, TOPICS_TABLE, 'topic_id', array($check_permission)))
+	$forum_id = $request->variable('f', 0);
+	$check_permission = ($is_soft) ? ['m_softdelete'] : ['m_delete'];
+	/**
+	* This event allows you to modify the current user's checked permissions when deleting a topic
+	*
+	* @event core.mcp_delete_topic_modify_permissions
+	* @var	array	topic_ids				The array of topic IDs to be deleted
+	* @var	int		forum_id				The current forum ID
+	* @var	bool	is_soft					Boolean designating whether we're soft deleting or not
+	* @var	string	soft_delete_reason		The reason we're soft deleting
+	* @var	string	action					The current delete action
+	* @var	array	check_permission		The array with a permission to check for, can be set to false to not check them
+	* @since 3.2.6-RC1
+	*/
+	$vars = array(
+		'topic_ids',
+		'forum_id',
+		'is_soft',
+		'soft_delete_reason',
+		'action',
+		'check_permission',
+	);
+	extract($phpbb_dispatcher->trigger_event('core.mcp_delete_topic_modify_permissions', compact($vars)));
+
+	if (!phpbb_check_ids($topic_ids, TOPICS_TABLE, 'topic_id', $check_permission))
 	{
 		return;
 	}
 
 	$redirect = $request->variable('redirect', build_url(array('action', 'quickmod')));
-	$forum_id = $request->variable('f', 0);
 
 	$s_hidden_fields = array(
 		'topic_id_list'	=> $topic_ids,

--- a/phpBB/includes/mcp/mcp_main.php
+++ b/phpBB/includes/mcp/mcp_main.php
@@ -963,6 +963,28 @@ function mcp_delete_topic($topic_ids, $is_soft = false, $soft_delete_reason = ''
 			$s_hidden_fields['delete_permanent'] = '1';
 		}
 
+		/**
+		* This event allows you to modify the hidden form fields when deleting topics
+		*
+		* @event core.mcp_delete_topic_modify_hidden_fields
+		* @var	string	l_confirm				The mode we are deleting in (DELETE_TOPIC(S), DELETE_TOPIC(S)_PERMANENTLY)
+		* @var	array	s_hidden_fields			The array holding the hidden form fields
+		* @var	array	topic_ids				The array of topic IDs to be deleted
+		* @var	int		forum_id				The current forum ID
+		* @var	bool	only_softdeleted		If the topic_ids are all soft deleted, this is true
+		* @var	bool	only_shadow				If the topic_ids are all shadow topics, this is true
+		* @since 3.2.6-RC1
+		*/
+		$vars = array(
+			'l_confirm',
+			's_hidden_fields',
+			'topic_ids',
+			'forum_id',
+			'only_softdeleted',
+			'only_shadow',
+		);
+		extract($phpbb_dispatcher->trigger_event('core.mcp_delete_topic_modify_hidden_fields', compact($vars)));
+
 		confirm_box(false, $l_confirm, build_hidden_fields($s_hidden_fields), 'confirm_delete_body.html');
 	}
 

--- a/phpBB/mcp.php
+++ b/phpBB/mcp.php
@@ -125,6 +125,26 @@ if (!$auth->acl_getf_global('m_'))
 		}
 	}
 
+	/**
+	* Allow modification of the permissions to access the mcp file
+	*
+	* @event core.mcp_modify_permissions
+	* @var	array		user_quickmod_actions			Array holding the quickmod actions and their respectiev permissions
+	* @var	array		topic_info						An array of the current topic's data
+	* @var	bool		allow_user						Boolean holding if the user can access the mcp
+	* @var	int			forum_id						The current forum ID
+	* @var	int			topic_id						The current topic ID
+	* @since 3.2.6-RC1
+	*/
+	$vars = array(
+		'user_quickmod_actions',
+		'topic_info',
+		'allow_user',
+		'forum_id',
+		'topic_id',
+	);
+	extract($phpbb_dispatcher->trigger_event('core.mcp_modify_permissions', compact($vars)));
+
 	if (!$allow_user)
 	{
 		send_status_line(403, 'Forbidden');


### PR DESCRIPTION
Allow modification of permissions for normal users to access the mcp
Also allows modification of the hidden form fields when deleting topics
This lets normal users delete their own topics with replies

Checklist:

- [x] Correct branch: master for new features; 3.2.x for fixes
- [ ] Tests pass
- [x] Code follows coding guidelines: [master](https://area51.phpbb.com/docs/dev/master/development/coding_guidelines.html) and [3.2.x](https://area51.phpbb.com/docs/dev/3.2.x/development/coding_guidelines.html)
- [x] Commit follows commit message [format](https://area51.phpbb.com/docs/dev/3.2.x/development/git.html)

Tracker ticket (set the ticket ID to **your ticket ID**):

https://tracker.phpbb.com/browse/PHPBB3-15951
