### PR TITLE
[ticket/15954] Add safeguards to include() calls

### DIFF
--- a/phpBB/includes/mcp/mcp_ban.php
+++ b/phpBB/includes/mcp/mcp_ban.php
@@ -34,7 +34,10 @@ class mcp_ban
 		}
 
 		// Include the admin banning interface...
-		include($phpbb_root_path . 'includes/acp/acp_ban.' . $phpEx);
+		if (!class_exists('acp_ban'))
+		{
+			include($phpbb_root_path . 'includes/acp/acp_ban.' . $phpEx);
+		}
 
 		$bansubmit		= $request->is_set_post('bansubmit');
 		$unbansubmit	= $request->is_set_post('unbansubmit');

--- a/phpBB/includes/mcp/mcp_front.php
+++ b/phpBB/includes/mcp/mcp_front.php
@@ -290,7 +290,10 @@ function mcp_front_view($id, $mode, $action)
 
 		if ($total)
 		{
-			include($phpbb_root_path . 'includes/functions_privmsgs.' . $phpEx);
+			if (!function_exists('get_recipient_strings'))
+			{
+				include($phpbb_root_path . 'includes/functions_privmsgs.' . $phpEx);
+			}
 
 			$sql_ary = array(
 				'SELECT'	=> 'r.report_id, r.report_time, p.msg_id, p.message_subject, p.message_time, p.to_address, p.bcc_address, p.message_attachment, u.username, u.username_clean, u.user_colour, u.user_id, u2.username as author_name, u2.username_clean as author_name_clean, u2.user_colour as author_colour, u2.user_id as author_id',

--- a/phpBB/includes/mcp/mcp_main.php
+++ b/phpBB/includes/mcp/mcp_main.php
@@ -176,7 +176,7 @@ class mcp_main
 			case 'front':
 				if (!function_exists('mcp_front_view'))
 				{
-					mcp_front_view($id, $mode, $action);
+					include($phpbb_root_path . 'includes/mcp/mcp_front.' . $phpEx);
 				}
 
 				$user->add_lang('acp/common');

--- a/phpBB/includes/mcp/mcp_main.php
+++ b/phpBB/includes/mcp/mcp_main.php
@@ -174,7 +174,10 @@ class mcp_main
 		switch ($mode)
 		{
 			case 'front':
-				include($phpbb_root_path . 'includes/mcp/mcp_front.' . $phpEx);
+				if (!function_exists('mcp_front_view'))
+				{
+					mcp_front_view($id, $mode, $action);
+				}
 
 				$user->add_lang('acp/common');
 
@@ -185,7 +188,10 @@ class mcp_main
 			break;
 
 			case 'forum_view':
-				include($phpbb_root_path . 'includes/mcp/mcp_forum.' . $phpEx);
+				if (!function_exists('mcp_forum_view'))
+				{
+					include($phpbb_root_path . 'includes/mcp/mcp_forum.' . $phpEx);
+				}
 
 				$user->add_lang('viewforum');
 
@@ -208,7 +214,10 @@ class mcp_main
 			break;
 
 			case 'topic_view':
-				include($phpbb_root_path . 'includes/mcp/mcp_topic.' . $phpEx);
+				if (!function_exists('mcp_topic_view'))
+				{
+					include($phpbb_root_path . 'includes/mcp/mcp_topic.' . $phpEx);
+				}
 
 				mcp_topic_view($id, $mode, $action);
 
@@ -217,7 +226,10 @@ class mcp_main
 			break;
 
 			case 'post_details':
-				include($phpbb_root_path . 'includes/mcp/mcp_post.' . $phpEx);
+				if (!function_exists('mcp_post_details'))
+				{
+					include($phpbb_root_path . 'includes/mcp/mcp_post.' . $phpEx);
+				}
 
 				mcp_post_details($id, $mode, $action);
 

--- a/phpBB/includes/mcp/mcp_topic.php
+++ b/phpBB/includes/mcp/mcp_topic.php
@@ -93,7 +93,11 @@ function mcp_topic_view($id, $mode, $action)
 	// Restore or pprove posts?
 	if (($action == 'restore' || $action == 'approve') && $auth->acl_get('m_approve', $topic_info['forum_id']))
 	{
-		include($phpbb_root_path . 'includes/mcp/mcp_queue.' . $phpEx);
+		if (!class_exists('mcp_queue'))
+		{
+			include($phpbb_root_path . 'includes/mcp/mcp_queue.' . $phpEx);
+		}
+
 		include_once($phpbb_root_path . 'includes/functions_posting.' . $phpEx);
 		include_once($phpbb_root_path . 'includes/functions_messenger.' . $phpEx);
 

--- a/phpBB/includes/ucp/ucp_groups.php
+++ b/phpBB/includes/ucp/ucp_groups.php
@@ -399,7 +399,10 @@ class ucp_groups
 				$action		= (isset($_POST['addusers'])) ? 'addusers' : $request->variable('action', '');
 				$group_id	= $request->variable('g', 0);
 
-				include($phpbb_root_path . 'includes/functions_display.' . $phpEx);
+				if (!function_exists('phpbb_get_user_rank'))
+				{
+					include($phpbb_root_path . 'includes/functions_display.' . $phpEx);
+				}
 
 				add_form_key('ucp_groups');
 

--- a/phpBB/includes/ucp/ucp_main.php
+++ b/phpBB/includes/ucp/ucp_main.php
@@ -245,7 +245,10 @@ class ucp_main
 
 			case 'subscribed':
 
-				include($phpbb_root_path . 'includes/functions_display.' . $phpEx);
+				if (!function_exists('topic_status'))
+				{
+					include($phpbb_root_path . 'includes/functions_display.' . $phpEx);
+				}
 
 				$user->add_lang('viewforum');
 
@@ -481,7 +484,10 @@ class ucp_main
 					break;
 				}
 
-				include($phpbb_root_path . 'includes/functions_display.' . $phpEx);
+				if (!function_exists('topic_status'))
+				{
+					include($phpbb_root_path . 'includes/functions_display.' . $phpEx);
+				}
 
 				$user->add_lang('viewforum');
 

--- a/phpBB/includes/ucp/ucp_pm.php
+++ b/phpBB/includes/ucp/ucp_pm.php
@@ -82,7 +82,10 @@ class ucp_pm
 			$mode = 'view';
 		}
 
-		include($phpbb_root_path . 'includes/functions_privmsgs.' . $phpEx);
+		if (!function_exists('get_folder'))
+		{
+			include($phpbb_root_path . 'includes/functions_privmsgs.' . $phpEx);
+		}
 
 		switch ($mode)
 		{
@@ -104,7 +107,10 @@ class ucp_pm
 					break;
 				}
 
-				include($phpbb_root_path . 'includes/ucp/ucp_pm_compose.' . $phpEx);
+				if (!function_exists('compose_pm'))
+				{
+					include($phpbb_root_path . 'includes/ucp/ucp_pm_compose.' . $phpEx);
+				}
 				compose_pm($id, $mode, $action, $user_folders);
 
 				$tpl_file = 'posting_body';
@@ -114,7 +120,10 @@ class ucp_pm
 				set_user_message_limit();
 				get_folder($user->data['user_id']);
 
-				include($phpbb_root_path . 'includes/ucp/ucp_pm_options.' . $phpEx);
+				if (!function_exists('message_options'))
+				{
+					include($phpbb_root_path . 'includes/ucp/ucp_pm_options.' . $phpEx);
+				}
 				message_options($id, $mode, $global_privmsgs_rules, $global_rule_conditions);
 
 				$tpl_file = 'ucp_pm_options';
@@ -125,8 +134,10 @@ class ucp_pm
 				get_folder($user->data['user_id']);
 				$this->p_name = 'pm';
 
-				// Call another module... please do not try this at home... Hoochie Coochie Man
-				include($phpbb_root_path . 'includes/ucp/ucp_main.' . $phpEx);
+				if (!class_exists('ucp_main'))
+				{
+					include($phpbb_root_path . 'includes/ucp/ucp_main.' . $phpEx);
+				}
 
 				$module = new ucp_main($this);
 				$module->u_action = $this->u_action;
@@ -375,7 +386,10 @@ class ucp_pm
 
 				if ($action == 'view_folder')
 				{
-					include($phpbb_root_path . 'includes/ucp/ucp_pm_viewfolder.' . $phpEx);
+					if (!function_exists('view_folder'))
+					{
+						include($phpbb_root_path . 'includes/ucp/ucp_pm_viewfolder.' . $phpEx);
+					}
 					view_folder($id, $mode, $folder_id, $folder);
 
 					$tpl_file = 'ucp_pm_viewfolder';
@@ -393,7 +407,10 @@ class ucp_pm
 						trigger_error('NO_MESSAGE');
 					}
 
-					include($phpbb_root_path . 'includes/ucp/ucp_pm_viewmessage.' . $phpEx);
+					if (!function_exists('view_message'))
+					{
+						include($phpbb_root_path . 'includes/ucp/ucp_pm_viewmessage.' . $phpEx);
+					}
 					view_message($id, $mode, $folder_id, $msg_id, $folder, $message_row);
 
 					$tpl_file = ($view == 'print') ? 'ucp_pm_viewmessage_print' : 'ucp_pm_viewmessage';

--- a/phpBB/includes/ucp/ucp_pm_compose.php
+++ b/phpBB/includes/ucp/ucp_pm_compose.php
@@ -33,9 +33,20 @@ function compose_pm($id, $mode, $action, $user_folders = array())
 	// Needed for handle_message_list_actions()
 	global $refresh, $submit, $preview;
 
-	include($phpbb_root_path . 'includes/functions_posting.' . $phpEx);
-	include($phpbb_root_path . 'includes/functions_display.' . $phpEx);
-	include($phpbb_root_path . 'includes/message_parser.' . $phpEx);
+	if (!function_exists('generate_smilies'))
+	{
+		include($phpbb_root_path . 'includes/functions_posting.' . $phpEx);
+	}
+
+	if (!function_exists('display_custom_bbcodes'))
+	{
+		include($phpbb_root_path . 'includes/functions_display.' . $phpEx);
+	}
+
+	if (!class_exists('parse_message'))
+	{
+		include($phpbb_root_path . 'includes/message_parser.' . $phpEx);
+	}
 
 	if (!$action)
 	{

--- a/phpBB/includes/ucp/ucp_profile.php
+++ b/phpBB/includes/ucp/ucp_profile.php
@@ -469,8 +469,15 @@ class ucp_profile
 					trigger_error('NO_AUTH_SIGNATURE');
 				}
 
-				include($phpbb_root_path . 'includes/functions_posting.' . $phpEx);
-				include($phpbb_root_path . 'includes/functions_display.' . $phpEx);
+				if (!function_exists('generate_smilies'))
+				{
+					include($phpbb_root_path . 'includes/functions_posting.' . $phpEx);
+				}
+
+				if (!function_exists('display_custom_bbcodes'))
+				{
+					include($phpbb_root_path . 'includes/functions_display.' . $phpEx);
+				}
 
 				$preview	= $request->is_set_post('preview');
 


### PR DESCRIPTION
All functions and classes that are being checked for are actually the ones being used, except for the check in ucp_groups.php: https://github.com/kasimi/phpbb/commit/75007697ae55632200eb7f2c6579026e23fe3d7d#diff-ec446c980dec86d6991a822a459adfe6R404 I couldn't find out which of the functions in `includes/functions_display.php` is needed so I picked a random one for the `function_exists()` check.

PHPBB3-15954

Checklist:

- [x] Correct branch: master for new features; 3.2.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master](https://area51.phpbb.com/docs/dev/master/development/coding_guidelines.html) and [3.2.x](https://area51.phpbb.com/docs/dev/3.2.x/development/coding_guidelines.html)
- [x] Commit follows commit message [format](https://area51.phpbb.com/docs/dev/3.2.x/development/git.html)

https://tracker.phpbb.com/browse/PHPBB3-15954
