### PR TITLE
[ticket/15945] Allow redirection to subdomains

### DIFF
--- a/phpBB/includes/functions.php
+++ b/phpBB/includes/functions.php
@@ -1728,7 +1728,7 @@ function generate_board_url($without_script_path = false)
 */
 function redirect($url, $return = false, $disable_cd_check = false)
 {
-	global $user, $phpbb_path_helper, $phpbb_dispatcher;
+	global $user, $phpbb_path_helper, $phpbb_dispatcher, $config;
 
 	if (!$user->is_setup())
 	{
@@ -1746,9 +1746,23 @@ function redirect($url, $return = false, $disable_cd_check = false)
 		// Malformed url
 		trigger_error('INSECURE_REDIRECT', E_USER_WARNING);
 	}
+	else if (!$disable_cd_check && !empty($config['cookie_domain']) && !empty($url_parts['host']) && !empty($url_parts['scheme']))
+	{
+		if (strpos($config['cookie_domain'], '.') === 0 && substr($url_parts['host'], -strlen($config['cookie_domain'])) !== $config['cookie_domain'] && substr($config['cookie_domain'], 1) !== $url_parts['host'])
+		{
+			trigger_error('INSECURE_REDIRECT', E_USER_WARNING);
+		}
+	else if (strpos($config['cookie_domain'], '.') !== 0 && substr($url_parts['host'], -strlen($config['cookie_domain'])-1) !== '.' . $config['cookie_domain'] && $url_parts['host'] !== $config['cookie_domain'])
+	{
+			trigger_error('INSECURE_REDIRECT', E_USER_WARNING);
+		}
+		else
+		{
+			$disable_cd_check = true;
+		}
+	}
 	else if (!empty($url_parts['scheme']) && !empty($url_parts['host']))
 	{
-		// Attention: only able to redirect within the same domain if $disable_cd_check is false (yourdomain.com -> www.yourdomain.com will not work)
 		if (!$disable_cd_check && $url_parts['host'] !== $user->host)
 		{
 			trigger_error('INSECURE_REDIRECT', E_USER_WARNING);


### PR DESCRIPTION
This change improves the way phpBB prevents redirection to outside
domains through the redirection function. This change allows phpBB to
redirect any domain or subdomain that is covered under the cookie
settings.

PHPBB3-15945

Checklist:

- [x] Correct branch: master for features
- [x] Tests pass
- [x] Code follows coding guidelines: 3.2.x
- [x] Commit follows commit message format

Tracker ticket :

https://tracker.phpbb.com/browse/PHPBB3-15945