### PR TITLE
[ticket/15917] Unapproved topics message for forums with no other posts

### DIFF
--- a/phpBB/language/en/common.php
+++ b/phpBB/language/en/common.php
@@ -780,6 +780,10 @@ $lang = array_merge($lang, array(
 	'TOPIC_REVIEW'		=> 'Topic review',
 	'TOPIC_TITLE'		=> 'Topic title',
 	'TOPIC_UNAPPROVED'	=> 'This topic has not been approved.',
+	'TOPIC_UNAPPROVED_FORUM'	=> array(
+		1	=> 'Topic awaiting approval',
+		2	=> 'Topics awaiting approval',
+	),
 	'TOPIC_DELETED'		=> 'This topic has been deleted.',
 	'TOTAL_ATTACHMENTS'	=> 'Attachment(s)',
 	'TOTAL_LOGS'		=> array(

--- a/phpBB/styles/prosilver/template/forumlist_body.html
+++ b/phpBB/styles/prosilver/template/forumlist_body.html
@@ -104,9 +104,9 @@
 								<br />{forumrow.LAST_POST_TIME}
 							<!-- ELSE -->
 							{% if forumrow.U_UNAPPROVED_TOPICS %}
-								{{ lang('TOPIC_UNAPPROVED_FORUM', forumrow.TOPICS) }}<br />
+								{{ lang('TOPIC_UNAPPROVED_FORUM', forumrow.TOPICS) }}
 							{% else %}
-								{{ lang('NO_POSTS') }}<br />
+								{{ lang('NO_POSTS') }}
 							{% endif %}
 							<!-- ENDIF -->
 						</span>

--- a/phpBB/styles/prosilver/template/forumlist_body.html
+++ b/phpBB/styles/prosilver/template/forumlist_body.html
@@ -103,7 +103,11 @@
 								<!-- ENDIF -->
 								<br />{forumrow.LAST_POST_TIME}
 							<!-- ELSE -->
-								{L_NO_POSTS}<br />&nbsp;
+							{% if forumrow.U_UNAPPROVED_TOPICS %}
+								{{ lang('TOPIC_UNAPPROVED_FORUM', forumrow.TOPICS) }}<br />
+							{% else %}
+								{{ lang('NO_POSTS') }}<br />
+							{% endif %}
 							<!-- ENDIF -->
 						</span>
 					</dd>


### PR DESCRIPTION
Fix for a minor bug whereby if a forum had no posts and someone added a topic which required approval, for privileged users it would say "No posts" in the forumlist while in the topic/post count it would have a number that indicated there were posts.

This change makes it so in this rare case (which has actually happened at .com a few times recently), instead of "No posts" it will either say "Topic awaiting approval" or "Topics awaiting approval".

Checklist:

- [x] Correct branch: master for new features; 3.2.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master](https://area51.phpbb.com/docs/dev/master/development/coding_guidelines.html) and [3.2.x](https://area51.phpbb.com/docs/dev/3.2.x/development/coding_guidelines.html)
- [x] Commit follows commit message [format](https://area51.phpbb.com/docs/dev/3.2.x/development/git.html)

https://tracker.phpbb.com/browse/PHPBB3-15917