### PR TITLE
[ticket/15977] Move control panels to controllers

### DIFF
--- a/phpBB/adm/style/overall_header.html
+++ b/phpBB/adm/style/overall_header.html
@@ -8,7 +8,7 @@
 <title>{PAGE_TITLE}</title>
 
 <link href="{T_FONT_AWESOME_LINK}" rel="stylesheet">
-<link href="style/admin.css?assets_version={T_ASSETS_VERSION}" rel="stylesheet" type="text/css" media="screen" />
+<link href="{T_TEMPLATE_PATH}/admin.css?assets_version={T_ASSETS_VERSION}" rel="stylesheet" type="text/css" media="screen" />
 
 <script type="text/javascript">
 // <![CDATA[
@@ -109,9 +109,11 @@ function popup(url, width, height, name)
 	<div id="page-body">
 		<div id="tabs">
 			<ul>
-			<!-- BEGIN t_block1 -->
-				<li class="tab<!-- IF t_block1.S_SELECTED --> activetab<!-- ENDIF -->"><a href="{t_block1.U_TITLE}">{t_block1.L_TITLE}</a></li>
-			<!-- END t_block1 -->
+				{% for category in acp_menu %}
+					<li class="tab{{ category.S_SELECTED ? ' activetab' : '' }}">
+						<a href="{{ category.U_VIEW }}">{{ category.TITLE }}</a>
+					</li>
+				{% endfor %}
 			</ul>
 		</div>
 
@@ -119,31 +121,33 @@ function popup(url, width, height, name)
 				<div id="content">
 					<div id="menu">
 						<p>{L_LOGGED_IN_AS}<br /><strong>{USERNAME}</strong> [&nbsp;<a href="{U_LOGOUT}">{L_LOGOUT}</a>&nbsp;][&nbsp;<a href="{U_ADM_LOGOUT}">{L_ADM_LOGOUT}</a>&nbsp;]&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</p>
-						<!-- DEFINE $LI_USED = 0 -->
-						<!-- BEGIN l_block1 -->
-							<!-- IF l_block1.S_SELECTED -->
 
-						<!-- BEGIN l_block2 -->
-							<!-- IF .l_block1.l_block2.l_block3 -->
-							<!-- IF $LI_USED --></ul></div><!-- ENDIF -->
-							<div class="menu-block">
-								<a class="header" href="javascript:void(0);">{l_block1.l_block2.L_TITLE}</a>
-								<ul>
-							<!-- DEFINE $LI_USED = 1 -->
-							<!-- ENDIF -->
-
-							<!-- BEGIN l_block3 -->
-								<li<!-- IF l_block1.l_block2.l_block3.S_SELECTED --> id="activemenu"<!-- ENDIF -->><a href="{l_block1.l_block2.l_block3.U_TITLE}"><span>{l_block1.l_block2.l_block3.L_TITLE}</span></a></li>
-								<!-- DEFINE $LI_USED = 1 -->
-							<!-- END l_block3 -->
-						<!-- END l_block2 -->
-
-							<!-- ENDIF -->
-						<!-- END l_block1 -->
-						<!-- IF $LI_USED -->
-								</ul>
-							</div>
-						<!-- ENDIF -->
+						{% for item in acp_menu_items %}
+							{% if item.CHILDREN %}
+								<div class="menu-block{{ item.S_SELECTED ? ' active' : '' }}">
+									<a class="header" href="javascript:void(0);">{{ item.TITLE }}</a>
+									<ul>
+										{% for child in item.CHILDREN %}
+											<li{% if child.S_SELECTED %} id="activemenu"{% endif %}>
+												<a href="{{ child.U_VIEW }}">
+													<span>{{ child.TITLE }}</span>
+												</a>
+											</li>
+										{% endfor %}
+									</ul>
+								</div>
+							{% else %}
+								<div class="menu-block no-header{{ item.S_SELECTED ? ' active' : '' }}">
+									<ul>
+										<li{% if item.S_SELECTED %} id="activemenu"{% endif %}>
+											<a href="{{ item.U_VIEW }}">
+												<span>{{ item.TITLE }}</span>
+											</a>
+										</li>
+									</ul>
+								</div>
+							{% endif %}
+						{% endfor %}
 					</div>
 
 					<div id="main">

--- a/phpBB/config/default/container/acp/info/services_management.yml
+++ b/phpBB/config/default/container/acp/info/services_management.yml
@@ -1,7 +1,7 @@
 services:
 # Main category
     phpbb.acp.info.management:
-        class: phpbb\acp\info\management
+        class: phpbb\acp\info\management\management
         parent: cp.info.base
         shared: false
         tags: { name: phpbb.acp }

--- a/phpBB/config/default/container/acp/info/services_management.yml
+++ b/phpBB/config/default/container/acp/info/services_management.yml
@@ -1,0 +1,16 @@
+services:
+# Main category
+    phpbb.acp.info.management:
+        class: phpbb\acp\info\management
+        parent: cp.info.base
+        shared: false
+        tags: { name: phpbb.acp }
+
+# Subcategories
+
+# Items
+    phpbb.acp.info.index:
+        class: phpbb\acp\info\management\index
+        parent: phpbb.acp.info.management
+        shared: false
+        tags: { name: phpbb.acp }

--- a/phpBB/config/default/container/acp/info/services_settings.yml
+++ b/phpBB/config/default/container/acp/info/services_settings.yml
@@ -1,0 +1,111 @@
+services:
+# Main category
+    phpbb.acp.info.settings:
+        class: phpbb\acp\info\settings
+        parent: cp.info.base
+        shared: false
+        tags: { name: phpbb.acp }
+
+# Subcategories
+    phpbb.acp.info.settings.client:
+        class: phpbb\acp\info\settings\client
+        parent: phpbb.acp.info.settings
+        shared: false
+        tags: { name: phpbb.acp }
+
+    phpbb.acp.info.settings.general:
+        class: phpbb\acp\info\settings\general
+        parent: phpbb.acp.info.settings
+        shared: false
+        tags: { name: phpbb.acp }
+
+    phpbb.acp.info.settings.server.cat:
+        class: phpbb\acp\info\settings\server_cat
+        parent: phpbb.acp.info.settings
+        shared: false
+        tags: { name: phpbb.acp }
+
+# Items
+    phpbb.acp.info.settings.auth:
+        class: phpbb\acp\info\settings\auth
+        parent: phpbb.acp.info.settings.server.cat
+        shared: false
+        tags: { name: phpbb.acp }
+
+    phpbb.acp.info.settings.avatar:
+        class: phpbb\acp\info\settings\avatar
+        parent: phpbb.acp.info.settings.general
+        shared: false
+        tags: { name: phpbb.acp }
+
+    phpbb.acp.info.settings.board:
+        class: phpbb\acp\info\settings\board
+        parent: phpbb.acp.info.settings.general
+        shared: false
+        tags: { name: phpbb.acp }
+
+    phpbb.acp.info.settings.cookie:
+        class: phpbb\acp\info\settings\cookie
+        parent: phpbb.acp.info.settings.server.cat
+        shared: false
+        tags: { name: phpbb.acp }
+
+    phpbb.acp.info.settings.email:
+        class: phpbb\acp\info\settings\email
+        parent: phpbb.acp.info.settings.client
+        shared: false
+        tags: { name: phpbb.acp }
+
+    phpbb.acp.info.settings.features:
+        class: phpbb\acp\info\settings\features
+        parent: phpbb.acp.info.settings.general
+        shared: false
+        tags: { name: phpbb.acp }
+
+    phpbb.acp.info.settings.feed:
+        class: phpbb\acp\info\settings\feed
+        parent: phpbb.acp.info.settings.general
+        shared: false
+        tags: { name: phpbb.acp }
+
+    phpbb.acp.info.settings.load:
+        class: phpbb\acp\info\settings\load
+        parent: phpbb.acp.info.settings.server.cat
+        shared: false
+        tags: { name: phpbb.acp }
+
+    phpbb.acp.info.settings.pm:
+        class: phpbb\acp\info\settings\pm
+        parent: phpbb.acp.info.settings.general
+        shared: false
+        tags: { name: phpbb.acp }
+
+    phpbb.acp.info.settings.post:
+        class: phpbb\acp\info\settings\post
+        parent: phpbb.acp.info.settings.general
+        shared: false
+        tags: { name: phpbb.acp }
+
+    phpbb.acp.info.settings.registration:
+        class: phpbb\acp\info\settings\registration
+        parent: phpbb.acp.info.settings.general
+        shared: false
+        tags: { name: phpbb.acp }
+
+    phpbb.acp.info.settings.security:
+        class: phpbb\acp\info\settings\security
+        parent: phpbb.acp.info.settings.server.cat
+        shared: false
+        tags: { name: phpbb.acp }
+
+    phpbb.acp.info.settings.server:
+        class: phpbb\acp\info\settings\server
+        parent: phpbb.acp.info.settings.server.cat
+        shared: false
+        tags: { name: phpbb.acp }
+
+    phpbb.acp.info.settings.signature:
+        class: phpbb\acp\info\settings\signature
+        parent: phpbb.acp.info.settings.general
+        shared: false
+        tags: { name: phpbb.acp }

--- a/phpBB/config/default/container/acp/info/services_settings.yml
+++ b/phpBB/config/default/container/acp/info/services_settings.yml
@@ -1,7 +1,7 @@
 services:
 # Main category
     phpbb.acp.info.settings:
-        class: phpbb\acp\info\settings
+        class: phpbb\acp\info\settings\settings
         parent: cp.info.base
         shared: false
         tags: { name: phpbb.acp }

--- a/phpBB/config/default/container/acp/services_acp.yml
+++ b/phpBB/config/default/container/acp/services_acp.yml
@@ -1,0 +1,33 @@
+imports:
+    - { resource: info/services_management.yml }
+    - { resource: info/services_settings.yml }
+
+services:
+    acp.collection:
+        class: phpbb\di\service_collection
+        arguments:
+            - '@service_container'
+        tags:
+            - { name: service_collection, tag: phpbb.acp }
+
+    acp.functions:
+        class: phpbb\acp\functions\acp
+        arguments:
+            - '@auth'
+            - '@config'
+            - '@service_container'
+            - '@dbal.conn'
+            - '@dispatcher'
+            - '@controller.helper'
+            - '@language'
+            - '@path_helper'
+            - '@request'
+            - '@template'
+            - '@user'
+
+    acp.helper:
+        class: phpbb\acp\controller\helper
+        parent: controller.helper
+        calls:
+            - [set_acp_functions, ['@acp.functions']]
+            - [set_language, ['@language']]

--- a/phpBB/config/default/container/acp/services_management.yml
+++ b/phpBB/config/default/container/acp/services_management.yml
@@ -1,0 +1,19 @@
+services:
+    phpbb.acp.index:
+        class: phpbb\acp\controller\index
+        arguments:
+            - '@auth'
+            - '@cache.driver'
+            - '@config'
+            - '@service_container'
+            - '@cp.manager'
+            - '@dbal.conn'
+            - '@dispatcher'
+            - '@filesystem'
+            - '@acp.helper'
+            - '@language'
+            - '@log'
+            - '@path_helper'
+            - '@request'
+            - '@template'
+            - '@user'

--- a/phpBB/config/default/container/acp/services_settings.yml
+++ b/phpBB/config/default/container/acp/services_settings.yml
@@ -1,0 +1,17 @@
+services:
+    phpbb.acp.settings:
+        class: phpbb\acp\controller\settings
+        arguments:
+            - '@cache.driver'
+            - '@config'
+            - '@service_container'
+            - '@cp.manager'
+            - '@dbal.conn'
+            - '@dispatcher'
+            - '@acp.helper'
+            - '@language'
+            - '@log'
+            - '@path_helper'
+            - '@request'
+            - '@template'
+            - '@user'

--- a/phpBB/config/default/container/services.yml
+++ b/phpBB/config/default/container/services.yml
@@ -1,10 +1,12 @@
 imports:
+    - { resource: acp/* }
     - { resource: services_attachment.yml }
     - { resource: services_auth.yml }
     - { resource: services_avatar.yml }
     - { resource: services_captcha.yml }
     - { resource: services_console.yml }
     - { resource: services_content.yml }
+    - { resource: services_cp.yml }
     - { resource: services_cron.yml }
     - { resource: services_db.yml }
     - { resource: services_event.yml }

--- a/phpBB/config/default/container/services_cp.yml
+++ b/phpBB/config/default/container/services_cp.yml
@@ -1,0 +1,32 @@
+services:
+    cp.manager:
+        class: phpbb\cp\manager
+        arguments:
+            - '@cache.driver'
+            - '@config'
+            - '@dispatcher'
+            - '@ext.manager'
+            - '@language'
+            - '@cp.panel.admin'
+            - '@template'
+            - '@user'
+
+    cp.panel.admin:
+        class: phpbb\cp\panel\admin
+        arguments:
+            - '@acp.collection'
+            - '@auth'
+            - '@language'
+            - '@path_helper'
+            - '@template'
+            - '@user'
+
+    cp.info.base:
+        class: phpbb\cp\info\base
+        abstract: true
+        arguments:
+            - '@auth'
+            - '@config'
+            - '@controller.helper'
+            - '@language'
+            - '@request'

--- a/phpBB/config/default/container/services_event.yml
+++ b/phpBB/config/default/container/services_event.yml
@@ -9,6 +9,7 @@ services:
         arguments:
             - '@template'
             - '@language'
+            - '@user'
             - '%debug.exceptions%'
         tags:
             - { name: kernel.event_subscriber }

--- a/phpBB/config/default/routing/acp/management.yml
+++ b/phpBB/config/default/routing/acp/management.yml
@@ -1,0 +1,3 @@
+phpbb_acp_index:
+    path: /index
+    defaults: { _controller: phpbb.acp.index:handle }

--- a/phpBB/config/default/routing/acp/settings.yml
+++ b/phpBB/config/default/routing/acp/settings.yml
@@ -1,0 +1,56 @@
+
+phpbb_acp_settings_auth:
+    path: /settings/auth
+    defaults: { _controller: phpbb.acp.settings:handle, mode: 'auth' }
+
+phpbb_acp_settings_avatar:
+    path: /settings/avatar
+    defaults: { _controller: phpbb.acp.settings:handle, mode: 'avatar' }
+
+phpbb_acp_settings_board:
+    path: /settings/board
+    defaults: { _controller: phpbb.acp.settings:handle, mode: 'settings' }
+
+phpbb_acp_settings_cookie:
+    path: /settings/cookie
+    defaults: { _controller: phpbb.acp.settings:handle, mode: 'cookie' }
+
+phpbb_acp_settings_email:
+    path: /settings/email
+    defaults: { _controller: phpbb.acp.settings:handle, mode: 'email' }
+
+phpbb_acp_settings_features:
+    path: /settings/features
+    defaults: { _controller: phpbb.acp.settings:handle, mode: 'features' }
+
+phpbb_acp_settings_feed:
+    path: /settings/feed
+    defaults: { _controller: phpbb.acp.settings:handle, mode: 'feed' }
+
+phpbb_acp_settings_load:
+    path: /settings/load
+    defaults: { _controller: phpbb.acp.settings:handle, mode: 'load' }
+
+phpbb_acp_settings_pm:
+    path: /settings/pm
+    defaults: { _controller: phpbb.acp.settings:handle, mode: 'message' }
+
+phpbb_acp_settings_post:
+    path: /settings/post
+    defaults: { _controller: phpbb.acp.settings:handle, mode: 'post' }
+
+phpbb_acp_settings_registration:
+    path: /settings/registration
+    defaults: { _controller: phpbb.acp.settings:handle, mode: 'registration' }
+
+phpbb_acp_settings_security:
+    path: /settings/security
+    defaults: { _controller: phpbb.acp.settings:handle, mode: 'security' }
+
+phpbb_acp_settings_server:
+    path: /settings/server
+    defaults: { _controller: phpbb.acp.settings:handle, mode: 'server' }
+
+phpbb_acp_settings_signature:
+    path: /settings/signature
+    defaults: { _controller: phpbb.acp.settings:handle, mode: 'signature' }

--- a/phpBB/config/default/routing/routing.yml
+++ b/phpBB/config/default/routing/routing.yml
@@ -8,6 +8,14 @@
 # instantiate the 'foo_service' service and call the 'method' method.
 #
 
+phpbb_acp_default:
+    path: /admin
+    defaults: { _controller: phpbb.acp.index:handle }
+
+phpbb_acp_routing:
+    resource: acp/*
+    prefix: /admin
+
 phpbb_cron_routing:
     resource: cron.yml
     prefix: /cron

--- a/phpBB/includes/functions.php
+++ b/phpBB/includes/functions.php
@@ -4462,7 +4462,7 @@ function page_header($page_title = '', $display_online_list = false, $item_id = 
 		'S_FORUM_ID'			=> $forum_id,
 		'S_TOPIC_ID'			=> $topic_id,
 
-		'S_LOGIN_ACTION'		=> ((!defined('ADMIN_START')) ? append_sid("{$phpbb_root_path}ucp.$phpEx", 'mode=login') : append_sid("{$phpbb_admin_path}index.$phpEx", false, true, $user->session_id)),
+		'S_LOGIN_ACTION'		=> ((!defined('ADMIN_START')) ? append_sid("{$phpbb_root_path}ucp.$phpEx", 'mode=login') : $controller_helper->route('phpbb_acp_index', array(), true, $user->session_id)),
 		'S_LOGIN_REDIRECT'		=> build_hidden_fields(array('redirect' => $phpbb_path_helper->remove_web_root_path(build_url()))),
 
 		'S_ENABLE_FEEDS'			=> ($config['feed_enable']) ? true : false,

--- a/phpBB/phpbb/acp/controller/helper.php
+++ b/phpBB/phpbb/acp/controller/helper.php
@@ -64,9 +64,9 @@ class helper extends \phpbb\controller\helper
 	{
 		$this->acp_functions->adm_page_header($page_title);
 
-		$this->template->set_filenames(array(
+		$this->template->set_filenames([
 			'body'	=> $template_file,
-		));
+		]);
 
 		$this->acp_functions->adm_page_footer();
 
@@ -77,10 +77,10 @@ class helper extends \phpbb\controller\helper
 	{
 		$s_errors = (bool) count($errors);
 
-		$this->template->assign_vars(array(
+		$this->template->assign_vars([
 			'S_ERROR'		=> $s_errors,
 			'ERROR_MESSAGE'	=> $s_errors ? implode('<br>', $errors) : '',
-		));
+		]);
 	}
 
 	/**
@@ -94,10 +94,10 @@ class helper extends \phpbb\controller\helper
 	 * @param int		$code			The HTTP status code (e.g. 404, 500, 503, etc.)
 	 * @return Response|JsonResponse	A Response instance
 	 */
-	public function message($message, array $parameters = array(), $title = 'INFORMATION', $code = 200)
+	public function message($message, array $parameters = [], $title = 'INFORMATION', $code = 200)
 	{
 		array_unshift($parameters, $message);
-		$message_text = call_user_func_array(array($this->lang, 'lang'), $parameters);
+		$message_text = call_user_func_array([$this->lang, 'lang'], $parameters);
 		$message_title = $this->lang->lang($title);
 
 		return $this->display_message($message_title, $message_text, $code);
@@ -113,10 +113,10 @@ class helper extends \phpbb\controller\helper
 	 * @param int		$code			The HTTP status code (e.g. 404, 500, 503, etc.)
 	 * @return Response|JsonResponse	A Response instance
 	 */
-	public function message_back($link, $message, array $parameters = array(), $title = 'INFORMATION', $code = 200)
+	public function message_back($link, $message, array $parameters = [], $title = 'INFORMATION', $code = 200)
 	{
 		array_unshift($parameters, $message);
-		$message_text = call_user_func_array(array($this->lang, 'lang'), $parameters);
+		$message_text = call_user_func_array([$this->lang, 'lang'], $parameters);
 		$message_text .= $this->acp_functions->adm_back_link($link);
 		$message_title = $this->lang->lang($title);
 
@@ -134,30 +134,28 @@ class helper extends \phpbb\controller\helper
 	 */
 	protected function display_message($title, $message, $code)
 	{
-		$code = in_array($code, [E_USER_NOTICE, E_USER_WARNING]) ? 200 : $code;
-
 		if ($this->request->is_ajax())
 		{
 			global $refresh_data;
 
 			return new JsonResponse(
-				array(
+				[
 					'MESSAGE_TITLE'		=> $title,
 					'MESSAGE_TEXT'		=> $message,
 					'S_USER_WARNING'	=> false,
 					'S_USER_NOTICE'		=> false,
 					'REFRESH_DATA'		=> (!empty($refresh_data)) ? $refresh_data : null
-				),
+				],
 				$code
 			);
 		}
 
-		$this->template->assign_vars(array(
+		$this->template->assign_vars([
 			'MESSAGE_TITLE'	=> $title,
 			'MESSAGE_TEXT'	=> $message,
 
 			'S_USER_NOTICE'	=> $code === 200,
-		));
+		]);
 
 		return $this->render('message_body.html', $title, $code);
 	}

--- a/phpBB/phpbb/acp/controller/helper.php
+++ b/phpBB/phpbb/acp/controller/helper.php
@@ -1,0 +1,164 @@
+<?php
+/**
+ *
+ * This file is part of the phpBB Forum Software package.
+ *
+ * @copyright (c) phpBB Limited <https://www.phpbb.com>
+ * @license GNU General Public License, version 2 (GPL-2.0)
+ *
+ * For full copyright and license information, please see
+ * the docs/CREDITS.txt file.
+ *
+ */
+
+namespace phpbb\acp\controller;
+
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\JsonResponse;
+
+class helper extends \phpbb\controller\helper
+{
+	/** @var \phpbb\acp\functions\acp */
+	protected $acp_functions;
+
+	/** @var \phpbb\language\language */
+	protected $lang;
+
+	/**
+	 * Set ACP functions.
+	 *
+	 * @param \phpbb\acp\functions\acp	$acp_functions	ACP Functions
+	 * @return void
+	 */
+	public function set_acp_functions(\phpbb\acp\functions\acp $acp_functions)
+	{
+		$this->acp_functions = $acp_functions;
+	}
+
+	/**
+	 * Set language object.
+	 *
+	 * @param \phpbb\language\language	$lang		Language object
+	 * @return void
+	 */
+	public function set_language(\phpbb\language\language $lang)
+	{
+		$this->lang = $lang;
+	}
+
+	/**
+	 * Automate setting up the page and creating the response object.
+	 *
+	 * @param string	$template_file			The template handle to render
+	 * @param string	$page_title				The title of the page to output
+	 * @param int		$status_code			The status code to be sent to the page header
+	 * @param bool		$display_online_list	Do we display online users list
+	 * @param int		$item_id				Restrict online users to item id
+	 * @param string	$item					Restrict online users to a certain session item,
+	 *                     							e.g. forum for session_forum_id
+	 * @param bool		$send_headers			Whether headers should be sent by page_header().
+	 * 												Defaults to false for controllers.
+	 * @return Response							Object containing rendered page
+	 */
+	public function render($template_file, $page_title = '', $status_code = 200, $display_online_list = false, $item_id = 0, $item = 'forum', $send_headers = false)
+	{
+		$this->acp_functions->adm_page_header($page_title);
+
+		$this->template->set_filenames(array(
+			'body'	=> $template_file,
+		));
+
+		$this->acp_functions->adm_page_footer();
+
+		return new Response($this->template->assign_display('body'), $status_code);
+	}
+
+	public function assign_errors(array $errors)
+	{
+		$s_errors = (bool) count($errors);
+
+		$this->template->assign_vars(array(
+			'S_ERROR'		=> $s_errors,
+			'ERROR_MESSAGE'	=> $s_errors ? implode('<br>', $errors) : '',
+		));
+	}
+
+	/**
+	 * Output a message.
+	 *
+	 * In case of an error, please throw an exception instead
+	 *
+	 * @param string	$message		The message to display
+	 * @param array		$parameters		The parameters to use with the language variable
+	 * @param string	$title			Title for the message
+	 * @param int		$code			The HTTP status code (e.g. 404, 500, 503, etc.)
+	 * @return Response|JsonResponse	A Response instance
+	 */
+	public function message($message, array $parameters = array(), $title = 'INFORMATION', $code = 200)
+	{
+		array_unshift($parameters, $message);
+		$message_text = call_user_func_array(array($this->lang, 'lang'), $parameters);
+		$message_title = $this->lang->lang($title);
+
+		return $this->display_message($message_title, $message_text, $code);
+	}
+
+	/**
+	 * Output a message with a "back to previous page"-link.
+	 *
+	 * @param string	$link			The link to the previous page
+	 * @param string	$message		The message text
+	 * @param array		$parameters		The parameter to use with the language variable
+	 * @param string	$title			The message title
+	 * @param int		$code			The HTTP status code (e.g. 404, 500, 503, etc.)
+	 * @return Response|JsonResponse	A Response instance
+	 */
+	public function message_back($link, $message, array $parameters = array(), $title = 'INFORMATION', $code = 200)
+	{
+		array_unshift($parameters, $message);
+		$message_text = call_user_func_array(array($this->lang, 'lang'), $parameters);
+		$message_text .= $this->acp_functions->adm_back_link($link);
+		$message_title = $this->lang->lang($title);
+
+		return $this->display_message($message_title, $message_text, $code);
+	}
+
+	/**
+	 * Display the message.
+	 *
+	 * @param string	$title			The message title
+	 * @param string	$message		The message text
+	 * @param int		$code			The HTTP status code (e.g. 404, 500, 503, etc.)
+	 * @return Response|JsonResponse	A Response instance
+	 * @access public
+	 */
+	protected function display_message($title, $message, $code)
+	{
+		$code = in_array($code, [E_USER_NOTICE, E_USER_WARNING]) ? 200 : $code;
+
+		if ($this->request->is_ajax())
+		{
+			global $refresh_data;
+
+			return new JsonResponse(
+				array(
+					'MESSAGE_TITLE'		=> $title,
+					'MESSAGE_TEXT'		=> $message,
+					'S_USER_WARNING'	=> false,
+					'S_USER_NOTICE'		=> false,
+					'REFRESH_DATA'		=> (!empty($refresh_data)) ? $refresh_data : null
+				),
+				$code
+			);
+		}
+
+		$this->template->assign_vars(array(
+			'MESSAGE_TITLE'	=> $title,
+			'MESSAGE_TEXT'	=> $message,
+
+			'S_USER_NOTICE'	=> $code === 200,
+		));
+
+		return $this->render('message_body.html', $title, $code);
+	}
+}

--- a/phpBB/phpbb/acp/controller/index.php
+++ b/phpBB/phpbb/acp/controller/index.php
@@ -1,0 +1,794 @@
+<?php
+
+namespace phpbb\acp\controller;
+
+use phpbb\auth\auth;
+use phpbb\cache\driver\driver_interface as cache;
+use phpbb\config\config;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use phpbb\cp\manager as cp_manager;
+use phpbb\db\driver\driver_interface as db;
+use phpbb\event\dispatcher;
+use phpbb\filesystem\filesystem;
+use phpbb\language\language;
+use phpbb\log\log;
+use phpbb\path_helper;
+use phpbb\request\request;
+use phpbb\template\template;
+use phpbb\user;
+
+/**
+ * ACP Controller: Index
+ */
+class index
+{
+	/** @var auth */
+	protected $auth;
+
+	/** @var cache */
+	protected $cache;
+
+	/** @var config */
+	protected $config;
+
+	/** @var ContainerInterface */
+	protected $container;
+
+	/** @var cp_manager */
+	protected $cp_helper;
+
+	/** @var db */
+	protected $db;
+
+	/** @var dispatcher */
+	protected $dispatcher;
+
+	/** @var filesystem */
+	protected $filesystem;
+
+	/** @var helper */
+	protected $helper;
+
+	/** @var language */
+	protected $lang;
+
+	/** @var log */
+	protected $log;
+
+	/** @var path_helper */
+	protected $path_helper;
+
+	/** @var request */
+	protected $request;
+
+	/** @var template */
+	protected $template;
+
+	/** @var user */
+	protected $user;
+
+	/** @var string */
+	protected $admin_path;
+
+	/** @var string */
+	protected $root_path;
+
+	/** @var string */
+	protected $php_ext;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param auth					$auth			Auth object
+	 * @param cache					$cache			Cache object
+	 * @param config				$config			Config object
+	 * @param ContainerInterface	$container		Service container object
+	 * @param cp_manager			$cp_manager		Control panel manager object
+	 * @param db					$db				Database object
+	 * @param dispatcher			$dispatcher		Event dispatcher object
+	 * @param filesystem			$filesystem		Filesystem object
+	 * @param helper				$helper			ACP Controller helper object
+	 * @param language				$lang			Language object
+	 * @param log					$log			Log object
+	 * @param path_helper			$path_helper	Path helper object
+	 * @param request				$request		Request object
+	 * @param template				$template		Template object
+	 * @param user					$user			User object
+	 */
+	public function __construct(
+		auth $auth,
+		cache $cache,
+		config $config,
+		ContainerInterface $container,
+		cp_manager $cp_manager,
+		db $db,
+		dispatcher $dispatcher,
+		filesystem $filesystem,
+		helper $helper,
+		language $lang,
+		log $log,
+		path_helper $path_helper,
+		request $request,
+		template $template,
+		user $user
+	)
+	{
+		$this->auth			= $auth;
+		$this->cache		= $cache;
+		$this->config		= $config;
+		$this->container	= $container;
+		$this->cp_manager	= $cp_manager;
+		$this->db			= $db;
+		$this->dispatcher	= $dispatcher;
+		$this->filesystem	= $filesystem;
+		$this->helper		= $helper;
+		$this->lang			= $lang;
+		$this->log			= $log;
+		$this->path_helper	= $path_helper;
+		$this->request		= $request;
+		$this->template		= $template;
+		$this->user			= $user;
+
+		$this->root_path	= $path_helper->update_web_root_path($path_helper->get_phpbb_root_path());
+		$this->php_ext		= $path_helper->get_php_ext();
+		$this->admin_path	= $this->root_path . $path_helper->get_adm_relative_path();
+	}
+
+	public function handle()
+	{
+		$this->cp_manager->build('acp', 'phpbb.acp.info.index');
+
+		// Show restore permissions notice
+		if ($this->user->data['user_perm_from'] && $this->auth->acl_get('a_switchperm'))
+		{
+			$sql = 'SELECT user_id, username, user_colour
+					FROM ' . USERS_TABLE . '
+					WHERE user_id = ' . $this->user->data['user_perm_from'];
+			$result = $this->db->sql_query($sql);
+			$user_row = $this->db->sql_fetchrow($result);
+			$this->db->sql_freeresult($result);
+
+			$perm_from = get_username_string('full', $user_row['user_id'], $user_row['username'], $user_row['user_colour']);
+
+			$this->template->assign_vars(array(
+				'S_RESTORE_PERMISSIONS'		=> true,
+				'U_RESTORE_PERMISSIONS'		=> append_sid("{$this->root_path}ucp.$this->php_ext", 'mode=restore_perm'),
+				'PERM_FROM'					=> $perm_from,
+				'L_PERMISSIONS_TRANSFERRED_EXPLAIN'	=> sprintf($this->lang->lang('PERMISSIONS_TRANSFERRED_EXPLAIN'), $perm_from, append_sid("{$this->root_path}ucp.$this->php_ext", 'mode=restore_perm')),
+			));
+
+			return $this->helper->render('acp_main', $this->lang->lang('ACP_MAIN'));
+		}
+
+		$action = $this->request->variable('action', '');
+
+		if ($action)
+		{
+			if ($action === 'admlogout')
+			{
+				$this->user->unset_admin();
+				redirect(append_sid("{$this->root_path}index.$this->php_ext"));
+			}
+
+			if (!confirm_box(true))
+			{
+				switch ($action)
+				{
+					case 'online':
+						$confirm = true;
+						$confirm_lang = 'RESET_ONLINE_CONFIRM';
+					break;
+					case 'stats':
+						$confirm = true;
+						$confirm_lang = 'RESYNC_STATS_CONFIRM';
+					break;
+					case 'user':
+						$confirm = true;
+						$confirm_lang = 'RESYNC_POSTCOUNTS_CONFIRM';
+					break;
+					case 'date':
+						$confirm = true;
+						$confirm_lang = 'RESET_DATE_CONFIRM';
+					break;
+					case 'db_track':
+						$confirm = true;
+						$confirm_lang = 'RESYNC_POST_MARKING_CONFIRM';
+					break;
+					case 'purge_cache':
+						$confirm = true;
+						$confirm_lang = 'PURGE_CACHE_CONFIRM';
+					break;
+					case 'purge_sessions':
+						$confirm = true;
+						$confirm_lang = 'PURGE_SESSIONS_CONFIRM';
+					break;
+
+					default:
+						$confirm = true;
+						$confirm_lang = 'CONFIRM_OPERATION';
+				}
+
+				if ($confirm)
+				{
+					confirm_box(false, $this->lang->lang($confirm_lang), build_hidden_fields(array(
+						'action'	=> $action,
+					)));
+				}
+			}
+			else
+			{
+				switch ($action)
+				{
+
+					case 'online':
+						if (!$this->auth->acl_get('a_board'))
+						{
+							send_status_line(403, 'Forbidden');
+							trigger_error($this->lang->lang('NO_AUTH_OPERATION') . adm_back_link($this->helper->route('phpbb_acp_index')), E_USER_WARNING);
+						}
+
+						$this->config->set('record_online_users', 1, false);
+						$this->config->set('record_online_date', time(), false);
+						$this->log->add('admin', $this->user->data['user_id'], $this->user->ip, 'LOG_RESET_ONLINE');
+
+						if ($this->request->is_ajax())
+						{
+							trigger_error('RESET_ONLINE_SUCCESS');
+						}
+					break;
+
+					case 'stats':
+						if (!$this->auth->acl_get('a_board'))
+						{
+							send_status_line(403, 'Forbidden');
+							trigger_error($this->lang->lang('NO_AUTH_OPERATION') . adm_back_link($this->helper->route('phpbb_acp_index')), E_USER_WARNING);
+						}
+
+						$sql = 'SELECT COUNT(post_id) AS stat
+							FROM ' . POSTS_TABLE . '
+							WHERE post_visibility = ' . ITEM_APPROVED;
+						$result = $this->db->sql_query($sql);
+						$this->config->set('num_posts', (int) $this->db->sql_fetchfield('stat'), false);
+						$this->db->sql_freeresult($result);
+
+						$sql = 'SELECT COUNT(topic_id) AS stat
+							FROM ' . TOPICS_TABLE . '
+							WHERE topic_visibility = ' . ITEM_APPROVED;
+						$result = $this->db->sql_query($sql);
+						$this->config->set('num_topics', (int) $this->db->sql_fetchfield('stat'), false);
+						$this->db->sql_freeresult($result);
+
+						$sql = 'SELECT COUNT(user_id) AS stat
+							FROM ' . USERS_TABLE . '
+							WHERE user_type IN (' . USER_NORMAL . ',' . USER_FOUNDER . ')';
+						$result = $this->db->sql_query($sql);
+						$this->config->set('num_users', (int) $this->db->sql_fetchfield('stat'), false);
+						$this->db->sql_freeresult($result);
+
+						$sql = 'SELECT COUNT(attach_id) as stat
+							FROM ' . ATTACHMENTS_TABLE . '
+							WHERE is_orphan = 0';
+						$result = $this->db->sql_query($sql);
+						$this->config->set('num_files', (int) $this->db->sql_fetchfield('stat'), false);
+						$this->db->sql_freeresult($result);
+
+						$sql = 'SELECT SUM(filesize) as stat
+							FROM ' . ATTACHMENTS_TABLE . '
+							WHERE is_orphan = 0';
+						$result = $this->db->sql_query($sql);
+						$this->config->set('upload_dir_size', (float) $this->db->sql_fetchfield('stat'), false);
+						$this->db->sql_freeresult($result);
+
+						if (!function_exists('update_last_username'))
+						{
+							include($this->root_path . 'includes/functions_user.' . $this->php_ext);
+						}
+						update_last_username();
+
+						$this->log->add('admin', $this->user->data['user_id'], $this->user->ip, 'LOG_RESYNC_STATS');
+
+						if ($this->request->is_ajax())
+						{
+							trigger_error('RESYNC_STATS_SUCCESS');
+						}
+					break;
+
+					case 'user':
+						if (!$this->auth->acl_get('a_board'))
+						{
+							send_status_line(403, 'Forbidden');
+							trigger_error($this->lang->lang('NO_AUTH_OPERATION') . adm_back_link($this->helper->route('phpbb_acp_index')), E_USER_WARNING);
+						}
+
+						// Resync post counts
+						$start = $max_post_id = 0;
+
+						// Find the maximum post ID, we can only stop the cycle when we've reached it
+						$sql = 'SELECT MAX(forum_last_post_id) as max_post_id
+							FROM ' . FORUMS_TABLE;
+						$result = $this->db->sql_query($sql);
+						$max_post_id = (int) $this->db->sql_fetchfield('max_post_id');
+						$this->db->sql_freeresult($result);
+
+						// No maximum post id? :o
+						if (!$max_post_id)
+						{
+							$sql = 'SELECT MAX(post_id) as max_post_id
+								FROM ' . POSTS_TABLE;
+							$result = $this->db->sql_query($sql);
+							$max_post_id = (int) $this->db->sql_fetchfield('max_post_id');
+							$this->db->sql_freeresult($result);
+						}
+
+						// Still no maximum post id? Then we are finished
+						if (!$max_post_id)
+						{
+							$this->log->add('admin', $this->user->data['user_id'], $this->user->ip, 'LOG_RESYNC_POSTCOUNTS');
+							break;
+						}
+
+						$step = ($this->config['num_posts']) ? (max((int) ($this->config['num_posts'] / 5), 20000)) : 20000;
+						$this->db->sql_query('UPDATE ' . USERS_TABLE . ' SET user_posts = 0');
+
+						while ($start < $max_post_id)
+						{
+							$sql = 'SELECT COUNT(post_id) AS num_posts, poster_id
+								FROM ' . POSTS_TABLE . '
+								WHERE post_id BETWEEN ' . ($start + 1) . ' AND ' . ($start + $step) . '
+									AND post_postcount = 1 AND post_visibility = ' . ITEM_APPROVED . '
+								GROUP BY poster_id';
+							$result = $this->db->sql_query($sql);
+
+							if ($row = $this->db->sql_fetchrow($result))
+							{
+								do
+								{
+									$sql = 'UPDATE ' . USERS_TABLE . " SET user_posts = user_posts + {$row['num_posts']} WHERE user_id = {$row['poster_id']}";
+									$this->db->sql_query($sql);
+								}
+								while ($row = $this->db->sql_fetchrow($result));
+							}
+							$this->db->sql_freeresult($result);
+
+							$start += $step;
+						}
+
+						$this->log->add('admin', $this->user->data['user_id'], $this->user->ip, 'LOG_RESYNC_POSTCOUNTS');
+
+						if ($this->request->is_ajax())
+						{
+							trigger_error('RESYNC_POSTCOUNTS_SUCCESS');
+						}
+					break;
+
+					case 'date':
+						if (!$this->auth->acl_get('a_board'))
+						{
+							send_status_line(403, 'Forbidden');
+							trigger_error($this->lang->lang('NO_AUTH_OPERATION') . adm_back_link($this->helper->route('phpbb_acp_index')), E_USER_WARNING);
+						}
+
+						$this->config->set('board_startdate', time() - 1);
+						$this->log->add('admin', $this->user->data['user_id'], $this->user->ip, 'LOG_RESET_DATE');
+
+						if ($this->request->is_ajax())
+						{
+							trigger_error('RESET_DATE_SUCCESS');
+						}
+					break;
+
+					case 'db_track':
+						switch ($this->db->get_sql_layer())
+						{
+							case 'sqlite3':
+								$this->db->sql_query('DELETE FROM ' . TOPICS_POSTED_TABLE);
+							break;
+
+							default:
+								$this->db->sql_query('TRUNCATE TABLE ' . TOPICS_POSTED_TABLE);
+							break;
+						}
+
+						// This can get really nasty... therefore we only do the last six months
+						$get_from_time = time() - (6 * 4 * 7 * 24 * 60 * 60);
+
+						// Select forum ids, do not include categories
+						$sql = 'SELECT forum_id
+							FROM ' . FORUMS_TABLE . '
+							WHERE forum_type <> ' . FORUM_CAT;
+						$result = $this->db->sql_query($sql);
+
+						$forum_ids = array();
+						while ($row = $this->db->sql_fetchrow($result))
+						{
+							$forum_ids[] = $row['forum_id'];
+						}
+						$this->db->sql_freeresult($result);
+
+						// Any global announcements? ;)
+						$forum_ids[] = 0;
+
+						// Now go through the forums and get us some topics...
+						foreach ($forum_ids as $forum_id)
+						{
+							$sql = 'SELECT p.poster_id, p.topic_id
+								FROM ' . POSTS_TABLE . ' p, ' . TOPICS_TABLE . ' t
+								WHERE t.forum_id = ' . $forum_id . '
+									AND t.topic_moved_id = 0
+									AND t.topic_last_post_time > ' . $get_from_time . '
+									AND t.topic_id = p.topic_id
+									AND p.poster_id <> ' . ANONYMOUS . '
+								GROUP BY p.poster_id, p.topic_id';
+							$result = $this->db->sql_query($sql);
+
+							$posted = array();
+							while ($row = $this->db->sql_fetchrow($result))
+							{
+								$posted[$row['poster_id']][] = $row['topic_id'];
+							}
+							$this->db->sql_freeresult($result);
+
+							$sql_ary = array();
+							foreach ($posted as $user_id => $topic_row)
+							{
+								foreach ($topic_row as $topic_id)
+								{
+									$sql_ary[] = array(
+										'user_id'		=> (int) $user_id,
+										'topic_id'		=> (int) $topic_id,
+										'topic_posted'	=> 1,
+									);
+								}
+							}
+							unset($posted);
+
+							if (count($sql_ary))
+							{
+								$this->db->sql_multi_insert(TOPICS_POSTED_TABLE, $sql_ary);
+							}
+						}
+
+						$this->log->add('admin', $this->user->data['user_id'], $this->user->ip, 'LOG_RESYNC_POST_MARKING');
+
+						if ($this->request->is_ajax())
+						{
+							trigger_error('RESYNC_POST_MARKING_SUCCESS');
+						}
+					break;
+
+					case 'purge_cache':
+						$this->config->increment('assets_version', 1);
+						$this->cache->purge();
+
+						// Remove old renderers from the text_formatter service. Since this
+						// operation is performed after the cache is purged, there is not "current"
+						// renderer and in effect all renderers will be purged
+						$this->container->get('text_formatter.cache')->tidy();
+
+						// Clear permissions
+						$this->auth->acl_clear_prefetch();
+						phpbb_cache_moderators($this->db, $this->cache, $this->auth);
+
+						$this->log->add('admin', $this->user->data['user_id'], $this->user->ip, 'LOG_PURGE_CACHE');
+
+						if ($this->request->is_ajax())
+						{
+							trigger_error('PURGE_CACHE_SUCCESS');
+						}
+					break;
+
+					case 'purge_sessions':
+						if ((int) $this->user->data['user_type'] !== USER_FOUNDER)
+						{
+							send_status_line(403, 'Forbidden');
+							trigger_error($this->lang->lang('NO_AUTH_OPERATION') . adm_back_link($this->helper->route('phpbb_acp_index')), E_USER_WARNING);
+						}
+
+						$tables = array(CONFIRM_TABLE, SESSIONS_TABLE);
+
+						foreach ($tables as $table)
+						{
+							switch ($this->db->get_sql_layer())
+							{
+								case 'sqlite3':
+									$this->db->sql_query("DELETE FROM $table");
+								break;
+
+								default:
+									$this->db->sql_query("TRUNCATE TABLE $table");
+								break;
+							}
+						}
+
+						// let's restore the admin session
+						$reinsert_ary = array(
+							'session_id'			=> (string) $this->user->session_id,
+							'session_page'			=> (string) substr($this->user->page['page'], 0, 199),
+							'session_forum_id'		=> $this->user->page['forum'],
+							'session_user_id'		=> (int) $this->user->data['user_id'],
+							'session_start'			=> (int) $this->user->data['session_start'],
+							'session_last_visit'	=> (int) $this->user->data['session_last_visit'],
+							'session_time'			=> (int) $this->user->time_now,
+							'session_browser'		=> (string) trim(substr($this->user->browser, 0, 149)),
+							'session_forwarded_for'	=> (string) $this->user->forwarded_for,
+							'session_ip'			=> (string) $this->user->ip,
+							'session_autologin'		=> (int) $this->user->data['session_autologin'],
+							'session_admin'			=> 1,
+							'session_viewonline'	=> (int) $this->user->data['session_viewonline'],
+						);
+
+						$sql = 'INSERT INTO ' . SESSIONS_TABLE . ' ' . $this->db->sql_build_array('INSERT', $reinsert_ary);
+						$this->db->sql_query($sql);
+
+						$this->log->add('admin', $this->user->data['user_id'], $this->user->ip, 'LOG_PURGE_SESSIONS');
+
+						if ($this->request->is_ajax())
+						{
+							trigger_error('PURGE_SESSIONS_SUCCESS');
+						}
+					break;
+				}
+			}
+		}
+
+		// Version check
+		$this->user->add_lang('install');
+
+		if ($this->auth->acl_get('a_server') && version_compare(PHP_VERSION, '5.4.0', '<'))
+		{
+			$this->template->assign_vars(array(
+				'S_PHP_VERSION_OLD'	=> true,
+				'L_PHP_VERSION_OLD'	=> sprintf($this->lang->lang('PHP_VERSION_OLD'), PHP_VERSION, '5.4.0', '<a href="https://www.phpbb.com/support/docs/en/3.2/ug/quickstart/requirements">', '</a>'),
+			));
+		}
+
+		if ($this->auth->acl_get('a_board'))
+		{
+			$version_helper = $this->container->get('version_helper');
+			try
+			{
+				$recheck = $this->request->variable('versioncheck_force', false);
+				$updates_available = $version_helper->get_update_on_branch($recheck);
+				$upgrades_available = $version_helper->get_suggested_updates();
+				if (!empty($upgrades_available))
+				{
+					$upgrades_available = array_pop($upgrades_available);
+				}
+
+				$this->template->assign_vars(array(
+					'S_VERSION_UP_TO_DATE'		=> empty($updates_available),
+					'S_VERSION_UPGRADEABLE'		=> !empty($upgrades_available),
+					'UPGRADE_INSTRUCTIONS'		=> !empty($upgrades_available) ? $this->lang->lang('UPGRADE_INSTRUCTIONS', $upgrades_available['current'], $upgrades_available['announcement']) : false,
+				));
+			}
+			catch (\RuntimeException $e)
+			{
+				$message = call_user_func_array(array($this->lang, 'lang'), array($e->getMessage()));
+				$this->template->assign_vars(array(
+					'S_VERSIONCHECK_FAIL'		=> true,
+					'VERSIONCHECK_FAIL_REASON'	=> ($e->getMessage() !== 'VERSIONCHECK_FAIL') ? $message : '',
+				));
+			}
+		}
+		else
+		{
+			// We set this template var to true, to not display an outdated version notice.
+			$this->template->assign_var('S_VERSION_UP_TO_DATE', true);
+		}
+
+		// Incomplete update?
+		if (phpbb_version_compare($this->config['version'], PHPBB_VERSION, '<'))
+		{
+			$this->template->assign_var('S_UPDATE_INCOMPLETE', true);
+		}
+
+		/**
+		 * Notice admin
+		 *
+		 * @event core.acp_main_notice
+		 * @since 3.1.0-RC3
+		 */
+		$this->dispatcher->dispatch('core.acp_main_notice');
+
+		// Get forum statistics
+		$total_posts = $this->config['num_posts'];
+		$total_topics = $this->config['num_topics'];
+		$total_users = $this->config['num_users'];
+		$total_files = $this->config['num_files'];
+
+		$start_date = $this->user->format_date($this->config['board_startdate']);
+
+		$boarddays = (time() - $this->config['board_startdate']) / 86400;
+
+		$posts_per_day = sprintf('%.2f', $total_posts / $boarddays);
+		$topics_per_day = sprintf('%.2f', $total_topics / $boarddays);
+		$users_per_day = sprintf('%.2f', $total_users / $boarddays);
+		$files_per_day = sprintf('%.2f', $total_files / $boarddays);
+
+		$upload_dir_size = get_formatted_filesize($this->config['upload_dir_size']);
+
+		$storage_avatar = $this->container->get('storage.avatar');
+		$avatar_dir_size = get_formatted_filesize($storage_avatar->get_size());
+
+		if ($posts_per_day > $total_posts)
+		{
+			$posts_per_day = $total_posts;
+		}
+
+		if ($topics_per_day > $total_topics)
+		{
+			$topics_per_day = $total_topics;
+		}
+
+		if ($users_per_day > $total_users)
+		{
+			$users_per_day = $total_users;
+		}
+
+		if ($files_per_day > $total_files)
+		{
+			$files_per_day = $total_files;
+		}
+
+		if ($this->config['allow_attachments'] || $this->config['allow_pm_attach'])
+		{
+			$sql = 'SELECT COUNT(attach_id) AS total_orphan
+				FROM ' . ATTACHMENTS_TABLE . '
+				WHERE is_orphan = 1
+					AND filetime < ' . (time() - 3*60*60);
+			$result = $this->db->sql_query($sql);
+			$total_orphan = (int) $this->db->sql_fetchfield('total_orphan');
+			$this->db->sql_freeresult($result);
+		}
+		else
+		{
+			$total_orphan = false;
+		}
+
+		$dbsize = get_database_size();
+
+		$this->template->assign_vars(array(
+			'TOTAL_POSTS'		=> $total_posts,
+			'POSTS_PER_DAY'		=> $posts_per_day,
+			'TOTAL_TOPICS'		=> $total_topics,
+			'TOPICS_PER_DAY'	=> $topics_per_day,
+			'TOTAL_USERS'		=> $total_users,
+			'USERS_PER_DAY'		=> $users_per_day,
+			'TOTAL_FILES'		=> $total_files,
+			'FILES_PER_DAY'		=> $files_per_day,
+			'START_DATE'		=> $start_date,
+			'AVATAR_DIR_SIZE'	=> $avatar_dir_size,
+			'DBSIZE'			=> $dbsize,
+			'UPLOAD_DIR_SIZE'	=> $upload_dir_size,
+			'TOTAL_ORPHAN'		=> $total_orphan,
+			'S_TOTAL_ORPHAN'	=> ($total_orphan === false) ? false : true,
+			'GZIP_COMPRESSION'	=> ($this->config['gzip_compress'] && @extension_loaded('zlib')) ? $this->lang->lang('ON') : $this->lang->lang('OFF'),
+			'DATABASE_INFO'		=> $this->db->sql_server_info(),
+			'PHP_VERSION_INFO'	=> PHP_VERSION,
+			'BOARD_VERSION'		=> $this->config['version'],
+
+			'U_ACTION'				=> $this->helper->route('phpbb_acp_index'),
+			'U_ADMIN_LOG'			=> $this->helper->route('phpbb_acp_index'), // @todo
+			'U_INACTIVE_USERS'		=> $this->helper->route('phpbb_acp_index'), // @todo
+			'U_VERSIONCHECK'		=> $this->helper->route('phpbb_acp_index'), // @todo
+			'U_VERSIONCHECK_FORCE'	=> $this->helper->route('phpbb_acp_index', array('versioncheck_force' => true)),
+			'U_ATTACH_ORPHAN'		=> $this->helper->route('phpbb_acp_index'), // @todo
+
+			'S_VERSIONCHECK'	=> ($this->auth->acl_get('a_board')) ? true : false,
+			'S_ACTION_OPTIONS'	=> ($this->auth->acl_get('a_board')) ? true : false,
+			'S_FOUNDER'			=> ($this->user->data['user_type'] == USER_FOUNDER) ? true : false,
+		));
+
+		$log_data = array();
+		$log_count = false;
+
+		if ($this->auth->acl_get('a_viewlogs'))
+		{
+			view_log('admin', $log_data, $log_count, 5);
+
+			foreach ($log_data as $row)
+			{
+				$this->template->assign_block_vars('log', array(
+					'USERNAME'	=> $row['username_full'],
+					'IP'		=> $row['ip'],
+					'DATE'		=> $this->user->format_date($row['time']),
+					'ACTION'	=> $row['action']
+				));
+			}
+		}
+
+		if ($this->auth->acl_get('a_user'))
+		{
+			$this->user->add_lang('memberlist');
+
+			$inactive = array();
+			$inactive_count = 0;
+
+			view_inactive_users($inactive, $inactive_count, 10);
+
+			foreach ($inactive as $row)
+			{
+				$this->template->assign_block_vars('inactive', array(
+					'INACTIVE_DATE'	=> $this->user->format_date($row['user_inactive_time']),
+					'REMINDED_DATE'	=> $this->user->format_date($row['user_reminded_time']),
+					'JOINED'		=> $this->user->format_date($row['user_regdate']),
+					'LAST_VISIT'	=> (!$row['user_lastvisit']) ? ' - ' : $this->user->format_date($row['user_lastvisit']),
+
+					'REASON'		=> $row['inactive_reason'],
+					'USER_ID'		=> $row['user_id'],
+					'POSTS'			=> ($row['user_posts']) ? $row['user_posts'] : 0,
+					'REMINDED'		=> $row['user_reminded'],
+
+					'REMINDED_EXPLAIN'	=> $this->lang->lang('USER_LAST_REMINDED', (int) $row['user_reminded'], $this->user->format_date($row['user_reminded_time'])),
+
+					'USERNAME_FULL'		=> get_username_string('full', $row['user_id'], $row['username'], $row['user_colour'], false, $this->helper->route('phpbb_acp_controller', array('slug' => 'manage-users'))),
+					'USERNAME'			=> get_username_string('username', $row['user_id'], $row['username'], $row['user_colour']),
+					'USER_COLOR'		=> get_username_string('colour', $row['user_id'], $row['username'], $row['user_colour']),
+
+					'U_USER_ADMIN'	=> $this->helper->route('phpbb_acp_controller', array('slug' => 'manage-users', 'u' => (int) $row['user_id'])),
+					'U_SEARCH_USER'	=> ($this->auth->acl_get('u_search')) ? append_sid("{$this->root_path}search.$this->php_ext", "author_id={$row['user_id']}&amp;sr=posts") : '',
+				));
+			}
+
+			$option_ary = array('activate' => 'ACTIVATE', 'delete' => 'DELETE');
+			if ($this->config['email_enable'])
+			{
+				$option_ary += array('remind' => 'REMIND');
+			}
+
+			$this->template->assign_vars(array(
+				'S_INACTIVE_USERS'		=> true,
+				'S_INACTIVE_OPTIONS'	=> build_select($option_ary)
+			));
+		}
+
+		// Warn if install is still present
+		if (!$this->container->getParameter('allow_install_dir') && file_exists($this->root_path . 'install') && !is_file($this->root_path . 'install'))
+		{
+			$this->template->assign_var('S_REMOVE_INSTALL', true);
+		}
+
+		// Warn if no search index is created
+		if ($this->config['num_posts'] && class_exists($this->config['search_type']))
+		{
+			$error = false;
+			$search_type = $this->config['search_type'];
+
+			/** @var \phpbb\search\fulltext_mysql $search */
+			$search = new $search_type($error, $this->root_path, $this->php_ext, $this->auth, $this->config, $this->db, $this->user, $this->dispatcher);
+
+			if (!$search->index_created())
+			{
+				$this->template->assign_vars(array(
+					'S_SEARCH_INDEX_MISSING'	=> true,
+					'L_NO_SEARCH_INDEX'			=> $this->lang->lang('NO_SEARCH_INDEX', $search->get_name(), '<a href="' . $this->helper->route('phpbb_acp_controller', array('slug' => 'search-index')) . '">', '</a>'),
+				));
+			}
+		}
+
+		if (!defined('PHPBB_DISABLE_CONFIG_CHECK') && file_exists($this->root_path . 'config.' . $this->php_ext) && $this->filesystem->is_writable($this->root_path . 'config.' . $this->php_ext))
+		{
+			// World-Writable? (000x)
+			$this->template->assign_var('S_WRITABLE_CONFIG', (bool) (@fileperms($this->root_path . 'config.' . $this->php_ext) & 0x0002));
+		}
+
+		if (extension_loaded('mbstring'))
+		{
+			$this->template->assign_vars(array(
+				'S_MBSTRING_LOADED'						=> true,
+				'S_MBSTRING_FUNC_OVERLOAD_FAIL'			=> (intval(@ini_get('mbstring.func_overload')) & (MB_OVERLOAD_MAIL | MB_OVERLOAD_STRING)),
+				'S_MBSTRING_ENCODING_TRANSLATION_FAIL'	=> (@ini_get('mbstring.encoding_translation') != 0),
+				'S_MBSTRING_HTTP_INPUT_FAIL'			=> !in_array(@ini_get('mbstring.http_input'), array('pass', '')),
+				'S_MBSTRING_HTTP_OUTPUT_FAIL'			=> !in_array(@ini_get('mbstring.http_output'), array('pass', '')),
+			));
+		}
+
+		// Fill dbms version if not yet filled
+		if (empty($this->config['dbms_version']))
+		{
+			$this->config->set('dbms_version', $this->db->sql_server_info(true));
+		}
+
+		return $this->helper->render('acp_main.html', $this->lang->lang('ACP_MAIN'));
+	}
+}

--- a/phpBB/phpbb/acp/controller/index.php
+++ b/phpBB/phpbb/acp/controller/index.php
@@ -35,7 +35,7 @@ class index
 	protected $container;
 
 	/** @var cp_manager */
-	protected $cp_helper;
+	protected $cp_manager;
 
 	/** @var db */
 	protected $db;
@@ -154,7 +154,7 @@ class index
 				'S_RESTORE_PERMISSIONS'		=> true,
 				'U_RESTORE_PERMISSIONS'		=> append_sid("{$this->root_path}ucp.$this->php_ext", 'mode=restore_perm'),
 				'PERM_FROM'					=> $perm_from,
-				'L_PERMISSIONS_TRANSFERRED_EXPLAIN'	=> sprintf($this->lang->lang('PERMISSIONS_TRANSFERRED_EXPLAIN'), $perm_from, append_sid("{$this->root_path}ucp.$this->php_ext", 'mode=restore_perm')),
+				'L_PERMISSIONS_TRANSFERRED_EXPLAIN'	=> $this->lang->lang('PERMISSIONS_TRANSFERRED_EXPLAIN', $perm_from, append_sid("{$this->root_path}ucp.$this->php_ext", 'mode=restore_perm')),
 			));
 
 			return $this->helper->render('acp_main', $this->lang->lang('ACP_MAIN'));
@@ -538,7 +538,7 @@ class index
 		{
 			$this->template->assign_vars(array(
 				'S_PHP_VERSION_OLD'	=> true,
-				'L_PHP_VERSION_OLD'	=> sprintf($this->lang->lang('PHP_VERSION_OLD'), PHP_VERSION, '5.4.0', '<a href="https://www.phpbb.com/support/docs/en/3.2/ug/quickstart/requirements">', '</a>'),
+				'L_PHP_VERSION_OLD'	=> $this->lang->lang('PHP_VERSION_OLD', PHP_VERSION, '5.4.0', '<a href="https://www.phpbb.com/support/docs/en/3.2/ug/quickstart/requirements">', '</a>'),
 			));
 		}
 

--- a/phpBB/phpbb/acp/controller/settings.php
+++ b/phpBB/phpbb/acp/controller/settings.php
@@ -1,0 +1,1248 @@
+<?php
+/**
+ *
+ * This file is part of the phpBB Forum Software package.
+ *
+ * @copyright (c) phpBB Limited <https://www.phpbb.com>
+ * @license GNU General Public License, version 2 (GPL-2.0)
+ *
+ * For full copyright and license information, please see
+ * the docs/CREDITS.txt file.
+ *
+ */
+
+/**
+ * @todo add cron intervals to server settings? (database_gc, queue_interval, session_gc, search_gc, cache_gc, warnings_gc)
+ */
+
+namespace phpbb\acp\controller;
+
+use phpbb\cache\driver\driver_interface as cache;
+use phpbb\config\config;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use phpbb\cp\manager as cp_manager;
+use phpbb\db\driver\driver_interface as db;
+use phpbb\event\dispatcher;
+use phpbb\language\language;
+use phpbb\log\log;
+use phpbb\path_helper;
+use phpbb\request\request;
+use phpbb\template\template;
+use phpbb\user;
+
+/**
+ * ACP Controller: Settings
+ */
+class settings
+{
+	/** @var cache */
+	protected $cache;
+
+	/** @var config */
+	protected $config;
+
+	/** @var array */
+	protected $new_config = array();
+
+	/** @var ContainerInterface */
+	protected $container;
+
+	/** @var cp_manager */
+	protected $cp_manager;
+
+	/** @var db */
+	protected $db;
+
+	/** @var dispatcher */
+	protected $dispatcher;
+
+	/** @var helper */
+	protected $helper;
+
+	/** @var language */
+	protected $lang;
+
+	/** @var log */
+	protected $log;
+
+	/** @var path_helper */
+	protected $path_helper;
+
+	/** @var request */
+	protected $request;
+
+	/** @var template */
+	protected $template;
+
+	/** @var user */
+	protected $user;
+
+	/** @var string */
+	protected $root_path;
+
+	/** @var string */
+	protected $php_ext;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param cache					$cache			Cache object
+	 * @param config				$config			Config object
+	 * @param ContainerInterface	$container		Service container object
+	 * @param cp_manager			$cp_manager		Control panel manager object
+	 * @param db					$db				Database object
+	 * @param dispatcher			$dispatcher		Event dispatcher object
+	 * @param helper				$helper			Controller helper object
+	 * @param language				$lang			Language object
+	 * @param log					$log			Log object
+	 * @param path_helper			$path_helper	Path helper object
+	 * @param request				$request		Request object
+	 * @param template				$template		Template object
+	 * @param user					$user			User object
+	 */
+	public function __construct(
+		cache $cache,
+		config $config,
+		ContainerInterface $container,
+		cp_manager $cp_manager,
+		db $db,
+		dispatcher $dispatcher,
+		helper $helper,
+		language $lang,
+		log $log,
+		path_helper $path_helper,
+		request $request,
+		template $template,
+		user $user
+	)
+	{
+		$this->cache		= $cache;
+		$this->config		= $config;
+		$this->container	= $container;
+		$this->cp_manager	= $cp_manager;
+		$this->db			= $db;
+		$this->dispatcher	= $dispatcher;
+		$this->helper		= $helper;
+		$this->lang			= $lang;
+		$this->log			= $log;
+		$this->path_helper	= $path_helper;
+		$this->request		= $request;
+		$this->template		= $template;
+		$this->user			= $user;
+
+		$this->root_path	= $path_helper->update_web_root_path($path_helper->get_phpbb_root_path());
+		$this->php_ext		= $path_helper->get_php_ext();
+	}
+
+	public function handle($mode)
+	{
+		switch ($mode)
+		{
+			case 'message':
+				$active = 'pm';
+			break;
+			case 'settings':
+				$active = 'board';
+			break;
+			default:
+				$active = $mode;
+			break;
+		}
+
+		$this->cp_manager->build('acp', 'phpbb.acp.info.settings.' . $active);
+
+		$this->lang->add_lang('acp/board');
+
+		$submit = (isset($_POST['submit']) || isset($_POST['allow_quick_reply_enable'])) ? true : false;
+
+		$form_key = 'acp_board';
+		add_form_key($form_key);
+
+		$display_vars = array();
+
+		/**
+		 *	Validation types are:
+		 *		string, int, bool,
+		 *		script_path (absolute path in url - beginning with / and no trailing slash),
+		 *		rpath (relative), rwpath (relative, writable), path (relative path, but able to escape the root), wpath (writable)
+		 */
+		switch ($mode)
+		{
+			case 'settings':
+				$display_vars = array(
+					'title'	=> 'ACP_BOARD_SETTINGS',
+					'vars'	=> array(
+						'legend1'				=> 'ACP_BOARD_SETTINGS',
+						'sitename'				=> array('lang' => 'SITE_NAME',				'validate' => 'string',	'type' => 'text:40:255', 'explain' => false),
+						'site_desc'				=> array('lang' => 'SITE_DESC',				'validate' => 'string',	'type' => 'text:40:255', 'explain' => false),
+						'site_home_url'			=> array('lang' => 'SITE_HOME_URL',			'validate' => 'string',	'type' => 'url:40:255', 'explain' => true),
+						'site_home_text'		=> array('lang' => 'SITE_HOME_TEXT',		'validate' => 'string',	'type' => 'text:40:255', 'explain' => true),
+						'board_index_text'		=> array('lang' => 'BOARD_INDEX_TEXT',		'validate' => 'string',	'type' => 'text:40:255', 'explain' => true),
+						'board_disable'			=> array('lang' => 'DISABLE_BOARD',			'validate' => 'bool',	'type' => 'custom', 'function' => array($this, 'board_disable'), 'explain' => true),
+						'board_disable_msg'		=> false,
+						'default_lang'			=> array('lang' => 'DEFAULT_LANGUAGE',		'validate' => 'lang',	'type' => 'select', 'function' => 'language_select', 'params' => array('{CONFIG_VALUE}'), 'explain' => false),
+						'default_dateformat'	=> array('lang' => 'DEFAULT_DATE_FORMAT',	'validate' => 'string',	'type' => 'custom', 'function' => array($this, 'dateformat_select'), 'explain' => true),
+						'board_timezone'		=> array('lang' => 'SYSTEM_TIMEZONE',		'validate' => 'timezone',	'type' => 'custom', 'function' => array($this, 'timezone_select'), 'explain' => true),
+
+						'legend2'				=> 'BOARD_STYLE',
+						'default_style'			=> array('lang' => 'DEFAULT_STYLE',			'validate' => 'int',	'type' => 'select', 'function' => 'style_select', 'params' => array('{CONFIG_VALUE}', false), 'explain' => true),
+						'guest_style'			=> array('lang' => 'GUEST_STYLE',			'validate' => 'int',	'type' => 'select', 'function' => 'style_select', 'params' => array($this->guest_style_get(), false), 'explain' => true),
+						'override_user_style'	=> array('lang' => 'OVERRIDE_STYLE',		'validate' => 'bool',	'type' => 'radio:yes_no', 'explain' => true),
+
+						'legend3'				=> 'WARNINGS',
+						'warnings_expire_days'	=> array('lang' => 'WARNINGS_EXPIRE',		'validate' => 'int:0:9999',	'type' => 'number:0:9999', 'explain' => true, 'append' => ' ' . $this->lang->lang('DAYS')),
+
+						'legend4'					=> 'ACP_SUBMIT_CHANGES',
+					)
+				);
+			break;
+
+			case 'features':
+				$display_vars = array(
+					'title'	=> 'ACP_BOARD_FEATURES',
+					'vars'	=> array(
+						'legend1'						=> 'ACP_BOARD_FEATURES',
+						'allow_privmsg'					=> array('lang' => 'BOARD_PM',						'validate' => 'bool',	'type' => 'radio:yes_no', 'explain' => true),
+						'allow_topic_notify'			=> array('lang' => 'ALLOW_TOPIC_NOTIFY',			'validate' => 'bool',	'type' => 'radio:yes_no', 'explain' => false),
+						'allow_forum_notify'			=> array('lang' => 'ALLOW_FORUM_NOTIFY',			'validate' => 'bool',	'type' => 'radio:yes_no', 'explain' => false),
+						'allow_namechange'				=> array('lang' => 'ALLOW_NAME_CHANGE',				'validate' => 'bool',	'type' => 'radio:yes_no', 'explain' => false),
+						'allow_attachments'				=> array('lang' => 'ALLOW_ATTACHMENTS',				'validate' => 'bool',	'type' => 'radio:yes_no', 'explain' => false),
+						'allow_pm_attach'				=> array('lang' => 'ALLOW_PM_ATTACHMENTS',			'validate' => 'bool',	'type' => 'radio:yes_no', 'explain' => false),
+						'allow_pm_report'				=> array('lang' => 'ALLOW_PM_REPORT',				'validate' => 'bool',	'type' => 'radio:yes_no', 'explain' => true),
+						'allow_bbcode'					=> array('lang' => 'ALLOW_BBCODE',					'validate' => 'bool',	'type' => 'radio:yes_no', 'explain' => false),
+						'allow_smilies'					=> array('lang' => 'ALLOW_SMILIES',					'validate' => 'bool',	'type' => 'radio:yes_no', 'explain' => false),
+						'allow_sig'						=> array('lang' => 'ALLOW_SIG',						'validate' => 'bool',	'type' => 'radio:yes_no', 'explain' => false),
+						'allow_board_notifications'		=> array('lang' => 'ALLOW_BOARD_NOTIFICATIONS',		'validate' => 'bool',	'type' => 'radio:yes_no', 'explain' => false),
+						'allow_nocensors'				=> array('lang' => 'ALLOW_NO_CENSORS',				'validate' => 'bool',	'type' => 'radio:yes_no', 'explain' => true),
+						'allow_bookmarks'				=> array('lang' => 'ALLOW_BOOKMARKS',				'validate' => 'bool',	'type' => 'radio:yes_no', 'explain' => true),
+						'allow_birthdays'				=> array('lang' => 'ALLOW_BIRTHDAYS',				'validate' => 'bool',	'type' => 'radio:yes_no', 'explain' => true),
+						'display_last_subject'			=> array('lang' => 'DISPLAY_LAST_SUBJECT',			'validate' => 'bool',	'type' => 'radio:yes_no', 'explain' => true),
+						'allow_quick_reply'				=> array('lang' => 'ALLOW_QUICK_REPLY',				'validate' => 'bool',	'type' => 'custom', 'function' => array($this, 'quick_reply'), 'explain' => true),
+
+						'legend2'							=> 'ACP_SUBMIT_CHANGES',
+					)
+				);
+			break;
+
+			case 'avatar':
+				/* @var $phpbb_avatar_manager \phpbb\avatar\manager */
+				$phpbb_avatar_manager = $this->container->get('avatar.manager');
+				$avatar_drivers = $phpbb_avatar_manager->get_all_drivers();
+
+				$avatar_vars = array();
+				foreach ($avatar_drivers as $current_driver)
+				{
+					$driver = $phpbb_avatar_manager->get_driver($current_driver, false);
+
+					/*
+					* First grab the settings for enabling/disabling the avatar
+					* driver and afterwards grab additional settings the driver
+					* might have.
+					*/
+					$avatar_vars += $phpbb_avatar_manager->get_avatar_settings($driver);
+					$avatar_vars += $driver->prepare_form_acp($this->user);
+				}
+
+				$display_vars = array(
+					'title'	=> 'ACP_AVATAR_SETTINGS',
+					'vars'	=> array(
+						'legend1'				=> 'ACP_AVATAR_SETTINGS',
+
+						'avatar_min_width'		=> array('lang' => 'MIN_AVATAR_SIZE', 'validate' => 'int:0', 'type' => false, 'method' => false, 'explain' => false),
+						'avatar_min_height'		=> array('lang' => 'MIN_AVATAR_SIZE', 'validate' => 'int:0', 'type' => false, 'method' => false, 'explain' => false),
+						'avatar_max_width'		=> array('lang' => 'MAX_AVATAR_SIZE', 'validate' => 'int:0', 'type' => false, 'method' => false, 'explain' => false),
+						'avatar_max_height'		=> array('lang' => 'MAX_AVATAR_SIZE', 'validate' => 'int:0', 'type' => false, 'method' => false, 'explain' => false),
+
+						'allow_avatar'			=> array('lang' => 'ALLOW_AVATARS',			'validate' => 'bool',	'type' => 'radio:yes_no', 'explain' => true),
+						'avatar_min'			=> array('lang' => 'MIN_AVATAR_SIZE',		'validate' => 'int:0',	'type' => 'dimension:0', 'explain' => true, 'append' => ' ' . $this->lang->lang('PIXEL')),
+						'avatar_max'			=> array('lang' => 'MAX_AVATAR_SIZE',		'validate' => 'int:0',	'type' => 'dimension:0', 'explain' => true, 'append' => ' ' . $this->lang->lang('PIXEL')),
+					)
+				);
+
+				if (!empty($avatar_vars))
+				{
+					$display_vars['vars'] += $avatar_vars;
+				}
+			break;
+
+			case 'message':
+				$display_vars = array(
+					'title'	=> 'ACP_MESSAGE_SETTINGS',
+					'lang'	=> 'ucp',
+					'vars'	=> array(
+						'legend1'				=> 'GENERAL_SETTINGS',
+						'allow_privmsg'			=> array('lang' => 'BOARD_PM',				'validate' => 'bool',	'type' => 'radio:yes_no', 'explain' => true),
+						'pm_max_boxes'			=> array('lang' => 'BOXES_MAX',				'validate' => 'int:0:9999',	'type' => 'number:0:9999', 'explain' => true),
+						'pm_max_msgs'			=> array('lang' => 'BOXES_LIMIT',			'validate' => 'int:0:9999',	'type' => 'number:0:9999', 'explain' => true),
+						'full_folder_action'	=> array('lang' => 'FULL_FOLDER_ACTION',	'validate' => 'int',	'type' => 'select', 'function' => array($this, 'full_folder_select'), 'explain' => true),
+						'pm_edit_time'			=> array('lang' => 'PM_EDIT_TIME',			'validate' => 'int:0:99999',	'type' => 'number:0:99999', 'explain' => true, 'append' => ' ' . $this->lang->lang('MINUTES')),
+						'pm_max_recipients'		=> array('lang' => 'PM_MAX_RECIPIENTS',		'validate' => 'int:0:99999',	'type' => 'number:0:99999', 'explain' => true),
+
+						'legend2'				=> 'GENERAL_OPTIONS',
+						'allow_mass_pm'			=> array('lang' => 'ALLOW_MASS_PM',			'validate' => 'bool',	'type' => 'radio:yes_no', 'explain' => false),
+						'auth_bbcode_pm'		=> array('lang' => 'ALLOW_BBCODE_PM',		'validate' => 'bool',	'type' => 'radio:yes_no', 'explain' => false),
+						'auth_smilies_pm'		=> array('lang' => 'ALLOW_SMILIES_PM',		'validate' => 'bool',	'type' => 'radio:yes_no', 'explain' => false),
+						'allow_pm_attach'		=> array('lang' => 'ALLOW_PM_ATTACHMENTS',	'validate' => 'bool',	'type' => 'radio:yes_no', 'explain' => false),
+						'allow_sig_pm'			=> array('lang' => 'ALLOW_SIG_PM',			'validate' => 'bool',	'type' => 'radio:yes_no', 'explain' => false),
+						'print_pm'				=> array('lang' => 'ALLOW_PRINT_PM',		'validate' => 'bool',	'type' => 'radio:yes_no', 'explain' => false),
+						'forward_pm'			=> array('lang' => 'ALLOW_FORWARD_PM',		'validate' => 'bool',	'type' => 'radio:yes_no', 'explain' => false),
+						'auth_img_pm'			=> array('lang' => 'ALLOW_IMG_PM',			'validate' => 'bool',	'type' => 'radio:yes_no', 'explain' => false),
+						'auth_flash_pm'			=> array('lang' => 'ALLOW_FLASH_PM',		'validate' => 'bool',	'type' => 'radio:yes_no', 'explain' => true),
+						'enable_pm_icons'		=> array('lang' => 'ENABLE_PM_ICONS',		'validate' => 'bool',	'type' => 'radio:yes_no', 'explain' => false),
+
+						'legend3'					=> 'ACP_SUBMIT_CHANGES',
+					)
+				);
+			break;
+
+			case 'post':
+				$display_vars = array(
+					'title'	=> 'ACP_POST_SETTINGS',
+					'vars'	=> array(
+						'legend1'				=> 'GENERAL_OPTIONS',
+						'allow_topic_notify'	=> array('lang' => 'ALLOW_TOPIC_NOTIFY',	'validate' => 'bool',	'type' => 'radio:yes_no', 'explain' => false),
+						'allow_forum_notify'	=> array('lang' => 'ALLOW_FORUM_NOTIFY',	'validate' => 'bool',	'type' => 'radio:yes_no', 'explain' => false),
+						'allow_bbcode'			=> array('lang' => 'ALLOW_BBCODE',			'validate' => 'bool',	'type' => 'radio:yes_no', 'explain' => false),
+						'allow_post_flash'		=> array('lang' => 'ALLOW_POST_FLASH',		'validate' => 'bool',	'type' => 'radio:yes_no', 'explain' => true),
+						'allow_smilies'			=> array('lang' => 'ALLOW_SMILIES',			'validate' => 'bool',	'type' => 'radio:yes_no', 'explain' => false),
+						'allow_post_links'		=> array('lang' => 'ALLOW_POST_LINKS',		'validate' => 'bool',	'type' => 'radio:yes_no', 'explain' => true),
+						'allowed_schemes_links'	=> array('lang' => 'ALLOWED_SCHEMES_LINKS',	'validate' => 'string',	'type' => 'text:0:255', 'explain' => true),
+						'allow_nocensors'		=> array('lang' => 'ALLOW_NO_CENSORS',		'validate' => 'bool',	'type' => 'radio:yes_no', 'explain' => true),
+						'allow_bookmarks'		=> array('lang' => 'ALLOW_BOOKMARKS',		'validate' => 'bool',	'type' => 'radio:yes_no', 'explain' => true),
+						'enable_post_confirm'	=> array('lang' => 'VISUAL_CONFIRM_POST',	'validate' => 'bool',	'type' => 'radio:yes_no', 'explain' => true),
+						'allow_quick_reply'		=> array('lang' => 'ALLOW_QUICK_REPLY',		'validate' => 'bool',	'type' => 'custom', 'function' => array($this, 'quick_reply'), 'explain' => true),
+
+						'legend2'				=> 'POSTING',
+						'bump_type'				=> false,
+						'edit_time'				=> array('lang' => 'EDIT_TIME',				'validate' => 'int:0:99999',		'type' => 'number:0:99999', 'explain' => true, 'append' => ' ' . $this->lang->lang('MINUTES')),
+						'delete_time'			=> array('lang' => 'DELETE_TIME',			'validate' => 'int:0:99999',		'type' => 'number:0:99999', 'explain' => true, 'append' => ' ' . $this->lang->lang('MINUTES')),
+						'display_last_edited'	=> array('lang' => 'DISPLAY_LAST_EDITED',	'validate' => 'bool',		'type' => 'radio:yes_no', 'explain' => true),
+						'flood_interval'		=> array('lang' => 'FLOOD_INTERVAL',		'validate' => 'int:0:9999999999',		'type' => 'number:0:9999999999', 'explain' => true, 'append' => ' ' . $this->lang->lang('SECONDS')),
+						'bump_interval'			=> array('lang' => 'BUMP_INTERVAL',			'validate' => 'int:0',		'type' => 'custom', 'function' => array($this, 'bump_interval'), 'explain' => true),
+						'topics_per_page'		=> array('lang' => 'TOPICS_PER_PAGE',		'validate' => 'int:1:9999',		'type' => 'number:1:9999', 'explain' => false),
+						'posts_per_page'		=> array('lang' => 'POSTS_PER_PAGE',		'validate' => 'int:1:9999',		'type' => 'number:1:9999', 'explain' => false),
+						'smilies_per_page'		=> array('lang' => 'SMILIES_PER_PAGE',		'validate' => 'int:1:9999',		'type' => 'number:1:9999', 'explain' => false),
+						'hot_threshold'			=> array('lang' => 'HOT_THRESHOLD',			'validate' => 'int:0:9999',		'type' => 'number:0:9999', 'explain' => true),
+						'max_poll_options'		=> array('lang' => 'MAX_POLL_OPTIONS',		'validate' => 'int:2:127',	'type' => 'number:2:127', 'explain' => false),
+						'max_post_chars'		=> array('lang' => 'CHAR_LIMIT',			'validate' => 'int:0:999999',		'type' => 'number:0:999999', 'explain' => true),
+						'min_post_chars'		=> array('lang' => 'MIN_CHAR_LIMIT',		'validate' => 'int:1:999999',		'type' => 'number:1:999999', 'explain' => true),
+						'max_post_smilies'		=> array('lang' => 'SMILIES_LIMIT',			'validate' => 'int:0:9999',		'type' => 'number:0:9999', 'explain' => true),
+						'max_post_urls'			=> array('lang' => 'MAX_POST_URLS',			'validate' => 'int:0:9999',		'type' => 'number:0:9999', 'explain' => true),
+						'max_post_font_size'	=> array('lang' => 'MAX_POST_FONT_SIZE',	'validate' => 'int:0:9999',		'type' => 'number:0:9999', 'explain' => true, 'append' => ' %'),
+						'max_quote_depth'		=> array('lang' => 'QUOTE_DEPTH_LIMIT',		'validate' => 'int:0:9999',		'type' => 'number:0:9999', 'explain' => true),
+						'max_post_img_width'	=> array('lang' => 'MAX_POST_IMG_WIDTH',	'validate' => 'int:0:9999',		'type' => 'number:0:9999', 'explain' => true, 'append' => ' ' . $this->lang->lang('PIXEL')),
+						'max_post_img_height'	=> array('lang' => 'MAX_POST_IMG_HEIGHT',	'validate' => 'int:0:9999',		'type' => 'number:0:9999', 'explain' => true, 'append' => ' ' . $this->lang->lang('PIXEL')),
+
+						'legend3'					=> 'ACP_SUBMIT_CHANGES',
+					)
+				);
+			break;
+
+			case 'signature':
+				$display_vars = array(
+					'title'	=> 'ACP_SIGNATURE_SETTINGS',
+					'vars'	=> array(
+						'legend1'				=> 'GENERAL_OPTIONS',
+						'allow_sig'				=> array('lang' => 'ALLOW_SIG',				'validate' => 'bool',	'type' => 'radio:yes_no', 'explain' => false),
+						'allow_sig_bbcode'		=> array('lang' => 'ALLOW_SIG_BBCODE',		'validate' => 'bool',	'type' => 'radio:yes_no', 'explain' => false),
+						'allow_sig_img'			=> array('lang' => 'ALLOW_SIG_IMG',			'validate' => 'bool',	'type' => 'radio:yes_no', 'explain' => false),
+						'allow_sig_flash'		=> array('lang' => 'ALLOW_SIG_FLASH',		'validate' => 'bool',	'type' => 'radio:yes_no', 'explain' => false),
+						'allow_sig_smilies'		=> array('lang' => 'ALLOW_SIG_SMILIES',		'validate' => 'bool',	'type' => 'radio:yes_no', 'explain' => false),
+						'allow_sig_links'		=> array('lang' => 'ALLOW_SIG_LINKS',		'validate' => 'bool',	'type' => 'radio:yes_no', 'explain' => true),
+
+						'legend2'				=> 'GENERAL_SETTINGS',
+						'max_sig_chars'			=> array('lang' => 'MAX_SIG_LENGTH',		'validate' => 'int:0:9999',	'type' => 'number:0:9999', 'explain' => true),
+						'max_sig_urls'			=> array('lang' => 'MAX_SIG_URLS',			'validate' => 'int:0:9999',	'type' => 'number:0:9999', 'explain' => true),
+						'max_sig_font_size'		=> array('lang' => 'MAX_SIG_FONT_SIZE',		'validate' => 'int:0:9999',	'type' => 'number:0:9999', 'explain' => true, 'append' => ' %'),
+						'max_sig_smilies'		=> array('lang' => 'MAX_SIG_SMILIES',		'validate' => 'int:0:9999',	'type' => 'number:0:9999', 'explain' => true),
+						'max_sig_img_width'		=> array('lang' => 'MAX_SIG_IMG_WIDTH',		'validate' => 'int:0:9999',	'type' => 'number:0:9999', 'explain' => true, 'append' => ' ' . $this->lang->lang('PIXEL')),
+						'max_sig_img_height'	=> array('lang' => 'MAX_SIG_IMG_HEIGHT',	'validate' => 'int:0:9999',	'type' => 'number:0:9999', 'explain' => true, 'append' => ' ' . $this->lang->lang('PIXEL')),
+
+						'legend3'					=> 'ACP_SUBMIT_CHANGES',
+					)
+				);
+			break;
+
+			case 'registration':
+				$display_vars = array(
+					'title'	=> 'ACP_REGISTER_SETTINGS',
+					'vars'	=> array(
+						'legend1'				=> 'GENERAL_SETTINGS',
+						'max_name_chars'		=> array('lang' => 'USERNAME_LENGTH', 'validate' => 'int:8:180', 'type' => false, 'method' => false, 'explain' => false,),
+						'max_pass_chars'		=> array('lang' => 'PASSWORD_LENGTH', 'validate' => 'int:8:255', 'type' => false, 'method' => false, 'explain' => false,),
+
+						'require_activation'	=> array('lang' => 'ACC_ACTIVATION',	'validate' => 'int',	'type' => 'select', 'function' => array($this, 'select_acc_activation'), 'explain' => true),
+						'new_member_post_limit'	=> array('lang' => 'NEW_MEMBER_POST_LIMIT', 'validate' => 'int:0:255', 'type' => 'number:0:255', 'explain' => true, 'append' => ' ' . $this->lang->lang('POSTS')),
+						'new_member_group_default'=> array('lang' => 'NEW_MEMBER_GROUP_DEFAULT', 'validate' => 'bool', 'type' => 'radio:yes_no', 'explain' => true),
+						'min_name_chars'		=> array('lang' => 'USERNAME_LENGTH',	'validate' => 'int:1',	'type' => 'custom:5:180', 'function' => array($this, 'username_length'), 'explain' => true),
+						'min_pass_chars'		=> array('lang' => 'PASSWORD_LENGTH',	'validate' => 'int:1',	'type' => 'custom', 'function' => array($this, 'password_length'), 'explain' => true),
+						'allow_name_chars'		=> array('lang' => 'USERNAME_CHARS',	'validate' => 'string',	'type' => 'select', 'function' => array($this, 'select_username_chars'), 'explain' => true),
+						'pass_complex'			=> array('lang' => 'PASSWORD_TYPE',		'validate' => 'string',	'type' => 'select', 'function' => array($this, 'select_password_chars'), 'explain' => true),
+						'chg_passforce'			=> array('lang' => 'FORCE_PASS_CHANGE',	'validate' => 'int:0:999',	'type' => 'number:0:999', 'explain' => true, 'append' => ' ' . $this->lang->lang('DAYS')),
+
+						'legend2'				=> 'GENERAL_OPTIONS',
+						'allow_namechange'		=> array('lang' => 'ALLOW_NAME_CHANGE',		'validate' => 'bool',	'type' => 'radio:yes_no', 'explain' => false),
+						'allow_emailreuse'		=> array('lang' => 'ALLOW_EMAIL_REUSE',		'validate' => 'bool',	'type' => 'radio:yes_no', 'explain' => true),
+						'enable_confirm'		=> array('lang' => 'VISUAL_CONFIRM_REG',	'validate' => 'bool',	'type' => 'radio:yes_no', 'explain' => true),
+						'max_login_attempts'	=> array('lang' => 'MAX_LOGIN_ATTEMPTS',	'validate' => 'int:0:999',	'type' => 'number:0:999', 'explain' => true),
+						'max_reg_attempts'		=> array('lang' => 'REG_LIMIT',				'validate' => 'int:0:9999',	'type' => 'number:0:9999', 'explain' => true),
+
+						'legend3'			=> 'COPPA',
+						'coppa_enable'		=> array('lang' => 'ENABLE_COPPA',		'validate' => 'bool',	'type' => 'radio:yes_no', 'explain' => true),
+						'coppa_mail'		=> array('lang' => 'COPPA_MAIL',		'validate' => 'string',	'type' => 'textarea:5:40', 'explain' => true),
+						'coppa_fax'			=> array('lang' => 'COPPA_FAX',			'validate' => 'string',	'type' => 'text:25:100', 'explain' => false),
+
+						'legend4'			=> 'ACP_SUBMIT_CHANGES',
+					)
+				);
+			break;
+
+			case 'feed':
+				$display_vars = array(
+					'title'	=> 'ACP_FEED_MANAGEMENT',
+					'vars'	=> array(
+						'legend1'					=> 'ACP_FEED_GENERAL',
+						'feed_enable'				=> array('lang' => 'ACP_FEED_ENABLE',				'validate' => 'bool',	'type' => 'radio:enabled_disabled',	'explain' => true ),
+						'feed_item_statistics'		=> array('lang' => 'ACP_FEED_ITEM_STATISTICS',		'validate' => 'bool',	'type' => 'radio:enabled_disabled',	'explain' => true),
+						'feed_http_auth'			=> array('lang' => 'ACP_FEED_HTTP_AUTH',			'validate' => 'bool',	'type' => 'radio:enabled_disabled',	'explain' => true),
+
+						'legend2'					=> 'ACP_FEED_POST_BASED',
+						'feed_limit_post'			=> array('lang' => 'ACP_FEED_LIMIT',				'validate' => 'int:5:9999',	'type' => 'number:5:9999',				'explain' => true),
+						'feed_overall'				=> array('lang' => 'ACP_FEED_OVERALL',				'validate' => 'bool',	'type' => 'radio:enabled_disabled',	'explain' => true ),
+						'feed_forum'				=> array('lang' => 'ACP_FEED_FORUM',				'validate' => 'bool',	'type' => 'radio:enabled_disabled',	'explain' => true ),
+						'feed_topic'				=> array('lang' => 'ACP_FEED_TOPIC',				'validate' => 'bool',	'type' => 'radio:enabled_disabled',	'explain' => true ),
+
+						'legend3'					=> 'ACP_FEED_TOPIC_BASED',
+						'feed_limit_topic'			=> array('lang' => 'ACP_FEED_LIMIT',				'validate' => 'int:5:9999',	'type' => 'number:5:9999',				'explain' => true),
+						'feed_topics_new'			=> array('lang' => 'ACP_FEED_TOPICS_NEW',			'validate' => 'bool',	'type' => 'radio:enabled_disabled',	'explain' => true ),
+						'feed_topics_active'		=> array('lang' => 'ACP_FEED_TOPICS_ACTIVE',		'validate' => 'bool',	'type' => 'radio:enabled_disabled',	'explain' => true ),
+						'feed_news_id'				=> array('lang' => 'ACP_FEED_NEWS',					'validate' => 'string',	'type' => 'custom', 'function' => array($this, 'select_news_forums'), 'explain' => true),
+
+						'legend4'					=> 'ACP_FEED_SETTINGS_OTHER',
+						'feed_overall_forums'		=> array('lang'	=> 'ACP_FEED_OVERALL_FORUMS',		'validate' => 'bool',	'type' => 'radio:enabled_disabled',	'explain' => true ),
+						'feed_exclude_id'			=> array('lang' => 'ACP_FEED_EXCLUDE_ID',			'validate' => 'string',	'type' => 'custom', 'function' => array($this, 'select_exclude_forums'), 'explain' => true),
+					)
+				);
+			break;
+
+			case 'cookie':
+				$display_vars = array(
+					'title'	=> 'ACP_COOKIE_SETTINGS',
+					'vars'	=> array(
+						'legend1'		=> 'ACP_COOKIE_SETTINGS',
+						'cookie_domain'	=> array('lang' => 'COOKIE_DOMAIN',	'validate' => 'string',	'type' => 'text::255', 'explain' => true),
+						'cookie_name'	=> array('lang' => 'COOKIE_NAME',	'validate' => 'string',	'type' => 'text::16', 'explain' => true),
+						'cookie_path'	=> array('lang'	=> 'COOKIE_PATH',	'validate' => 'string',	'type' => 'text::255', 'explain' => true),
+						'cookie_secure'	=> array('lang' => 'COOKIE_SECURE',	'validate' => 'bool',	'type' => 'radio:enabled_disabled', 'explain' => true),
+						'cookie_notice'	=> array('lang' => 'COOKIE_NOTICE',	'validate' => 'bool',	'type' => 'radio:enabled_disabled', 'explain' => true),
+					)
+				);
+			break;
+
+			case 'load':
+				$display_vars = array(
+					'title'	=> 'ACP_LOAD_SETTINGS',
+					'vars'	=> array(
+						'legend1'			=> 'GENERAL_SETTINGS',
+						'limit_load'		=> array('lang' => 'LIMIT_LOAD',		'validate' => 'int:0:9999',	'type' => 'number:0:9999', 'explain' => true),
+						'session_length'	=> array('lang' => 'SESSION_LENGTH',	'validate' => 'int:60:9999999999',	'type' => 'number:60:9999999999', 'explain' => true, 'append' => ' ' . $this->lang->lang('SECONDS')),
+						'active_sessions'	=> array('lang' => 'LIMIT_SESSIONS',	'validate' => 'int:0:9999',	'type' => 'number:0:9999', 'explain' => true),
+						'load_online_time'	=> array('lang' => 'ONLINE_LENGTH',		'validate' => 'int:0:999',	'type' => 'number:0:999', 'explain' => true, 'append' => ' ' . $this->lang->lang('MINUTES')),
+						'read_notification_expire_days'	=> array('lang' => 'READ_NOTIFICATION_EXPIRE_DAYS',	'validate' => 'int:0',	'type' => 'number:0', 'explain' => true, 'append' => ' ' . $this->lang->lang('DAYS')),
+
+						'legend2'				=> 'GENERAL_OPTIONS',
+						'load_notifications'	=> array('lang' => 'LOAD_NOTIFICATIONS',	'validate' => 'bool',	'type' => 'radio:yes_no', 'explain' => true),
+						'load_db_track'			=> array('lang' => 'YES_POST_MARKING',		'validate' => 'bool',	'type' => 'radio:yes_no', 'explain' => true),
+						'load_db_lastread'		=> array('lang' => 'YES_READ_MARKING',		'validate' => 'bool',	'type' => 'radio:yes_no', 'explain' => true),
+						'load_anon_lastread'	=> array('lang' => 'YES_ANON_READ_MARKING',	'validate' => 'bool',	'type' => 'radio:yes_no', 'explain' => true),
+						'load_online'			=> array('lang' => 'YES_ONLINE',			'validate' => 'bool',	'type' => 'radio:yes_no', 'explain' => true),
+						'load_online_guests'	=> array('lang' => 'YES_ONLINE_GUESTS',		'validate' => 'bool',	'type' => 'radio:yes_no', 'explain' => true),
+						'load_onlinetrack'		=> array('lang' => 'YES_ONLINE_TRACK',		'validate' => 'bool',	'type' => 'radio:yes_no', 'explain' => true),
+						'load_birthdays'		=> array('lang' => 'YES_BIRTHDAYS',			'validate' => 'bool',	'type' => 'radio:yes_no', 'explain' => true),
+						'load_unreads_search'	=> array('lang' => 'YES_UNREAD_SEARCH',		'validate' => 'bool',	'type' => 'radio:yes_no', 'explain' => false),
+						'load_moderators'		=> array('lang' => 'YES_MODERATORS',		'validate' => 'bool',	'type' => 'radio:yes_no', 'explain' => false),
+						'load_jumpbox'			=> array('lang' => 'YES_JUMPBOX',			'validate' => 'bool',	'type' => 'radio:yes_no', 'explain' => false),
+						'load_user_activity'	=> array('lang' => 'LOAD_USER_ACTIVITY',	'validate' => 'bool',	'type' => 'radio:yes_no', 'explain' => true),
+						'load_user_activity_limit'		=> array('lang' => 'LOAD_USER_ACTIVITY_LIMIT',		'validate' => 'int:0:99999999',	'type' => 'number:0:99999999', 'explain' => true),
+						'load_tplcompile'		=> array('lang' => 'RECOMPILE_STYLES',		'validate' => 'bool',	'type' => 'radio:yes_no', 'explain' => true),
+						'allow_cdn'				=> array('lang' => 'ALLOW_CDN',				'validate' => 'bool',	'type' => 'radio:yes_no', 'explain' => true),
+						'enable_accurate_pm_button'	=> array('lang' => 'YES_ACCURATE_PM_BUTTON',	'validate' => 'bool',	'type' => 'radio:yes_no', 'explain' => true),
+						'allow_live_searches'	=> array('lang' => 'ALLOW_LIVE_SEARCHES',	'validate' => 'bool',	'type' => 'radio:yes_no', 'explain' => true),
+
+						'legend3'				=> 'CUSTOM_PROFILE_FIELDS',
+						'load_cpf_memberlist'	=> array('lang' => 'LOAD_CPF_MEMBERLIST',	'validate' => 'bool',	'type' => 'radio:yes_no', 'explain' => false),
+						'load_cpf_pm'			=> array('lang' => 'LOAD_CPF_PM',			'validate' => 'bool',	'type' => 'radio:yes_no', 'explain'	=> false),
+						'load_cpf_viewprofile'	=> array('lang' => 'LOAD_CPF_VIEWPROFILE',	'validate' => 'bool',	'type' => 'radio:yes_no', 'explain' => false),
+						'load_cpf_viewtopic'	=> array('lang' => 'LOAD_CPF_VIEWTOPIC',	'validate' => 'bool',	'type' => 'radio:yes_no', 'explain' => false),
+
+						'legend4'					=> 'ACP_SUBMIT_CHANGES',
+					)
+				);
+			break;
+
+			case 'auth':
+				$display_vars = array(
+					'title'	=> 'ACP_AUTH_SETTINGS',
+					'vars'	=> array(
+						'legend1'		=> 'ACP_AUTH_SETTINGS',
+						'auth_method'	=> array('lang' => 'AUTH_METHOD',	'validate' => 'string',	'type' => 'select:1:toggable', 'function' => array($this, 'select_auth_method'), 'explain' => false),
+					)
+				);
+			break;
+
+			case 'server':
+				$display_vars = array(
+					'title'	=> 'ACP_SERVER_SETTINGS',
+					'vars'	=> array(
+						'legend1'				=> 'ACP_SERVER_SETTINGS',
+						'gzip_compress'			=> array('lang' => 'ENABLE_GZIP',		'validate' => 'bool',	'type' => 'radio:yes_no', 'explain' => true),
+						'use_system_cron'		=> array('lang' => 'USE_SYSTEM_CRON',		'validate' => 'bool',	'type' => 'radio:yes_no', 'explain' => true),
+
+						'legend2'				=> 'PATH_SETTINGS',
+						'enable_mod_rewrite'	=> array('lang' => 'MOD_REWRITE_ENABLE',	'validate' => 'bool',	'type' => 'custom', 'function' => array($this, 'enable_mod_rewrite'), 'explain' => true),
+						'smilies_path'			=> array('lang' => 'SMILIES_PATH',		'validate' => 'rpath',	'type' => 'text:20:255', 'explain' => true),
+						'icons_path'			=> array('lang' => 'ICONS_PATH',		'validate' => 'rpath',	'type' => 'text:20:255', 'explain' => true),
+						'upload_icons_path'		=> array('lang' => 'UPLOAD_ICONS_PATH',	'validate' => 'rpath',	'type' => 'text:20:255', 'explain' => true),
+						'ranks_path'			=> array('lang' => 'RANKS_PATH',		'validate' => 'rpath',	'type' => 'text:20:255', 'explain' => true),
+
+						'legend3'				=> 'SERVER_URL_SETTINGS',
+						'force_server_vars'		=> array('lang' => 'FORCE_SERVER_VARS',	'validate' => 'bool',			'type' => 'radio:yes_no', 'explain' => true),
+						'server_protocol'		=> array('lang' => 'SERVER_PROTOCOL',	'validate' => 'string',			'type' => 'text:10:10', 'explain' => true),
+						'server_name'			=> array('lang' => 'SERVER_NAME',		'validate' => 'string',			'type' => 'text:40:255', 'explain' => true),
+						'server_port'			=> array('lang' => 'SERVER_PORT',		'validate' => 'int:0:99999',			'type' => 'number:0:99999', 'explain' => true),
+						'script_path'			=> array('lang' => 'SCRIPT_PATH',		'validate' => 'script_path',	'type' => 'text::255', 'explain' => true),
+
+						'legend4'					=> 'ACP_SUBMIT_CHANGES',
+					)
+				);
+			break;
+
+			case 'security':
+				$display_vars = array(
+					'title'	=> 'ACP_SECURITY_SETTINGS',
+					'vars'	=> array(
+						'legend1'				=> 'ACP_SECURITY_SETTINGS',
+						'allow_autologin'		=> array('lang' => 'ALLOW_AUTOLOGIN',		'validate' => 'bool',	'type' => 'radio:yes_no', 'explain' => true),
+						'allow_password_reset'	=> array('lang' => 'ALLOW_PASSWORD_RESET',	'validate' => 'bool',	'type' => 'radio:yes_no', 'explain' => true),
+						'max_autologin_time'	=> array('lang' => 'AUTOLOGIN_LENGTH',		'validate' => 'int:0:99999',	'type' => 'number:0:99999',	'explain' => true,	'append' => ' ' . $this->lang->lang('DAYS')),
+						'ip_check'				=> array('lang' => 'IP_VALID',				'validate' => 'int',	'type' => 'custom', 'function' => array($this, 'select_ip_check'), 'explain' => true),
+						'browser_check'			=> array('lang' => 'BROWSER_VALID',			'validate' => 'bool',	'type' => 'radio:yes_no', 'explain' => true),
+						'forwarded_for_check'	=> array('lang' => 'FORWARDED_FOR_VALID',	'validate' => 'bool',	'type' => 'radio:yes_no', 'explain' => true),
+						'referer_validation'	=> array('lang' => 'REFERRER_VALID',		'validate' => 'int:0:3','type' => 'custom', 'function' => array($this, 'select_ref_check'), 'explain' => true),
+						'remote_upload_verify'	=> array('lang' => 'UPLOAD_CERT_VALID',	'validate' => 'bool',	'type' => 'radio:yes_no', 'explain' => true),
+						'check_dnsbl'			=> array('lang' => 'CHECK_DNSBL',			'validate' => 'bool',	'type' => 'radio:yes_no', 'explain' => true),
+						'email_check_mx'		=> array('lang' => 'EMAIL_CHECK_MX',		'validate' => 'bool',	'type' => 'radio:yes_no', 'explain' => true),
+						'max_pass_chars'		=> array('lang' => 'PASSWORD_LENGTH', 'validate' => 'int:8:255', 'type' => false, 'method' => false, 'explain' => false,),
+						'min_pass_chars'		=> array('lang' => 'PASSWORD_LENGTH',	'validate' => 'int:1',	'type' => 'custom', 'function' => array($this, 'password_length'), 'explain' => true),
+						'pass_complex'			=> array('lang' => 'PASSWORD_TYPE',			'validate' => 'string',	'type' => 'select', 'function' => array($this, 'select_password_chars'), 'explain' => true),
+						'chg_passforce'			=> array('lang' => 'FORCE_PASS_CHANGE',		'validate' => 'int:0:999',	'type' => 'number:0:999', 'explain' => true, 'append' => ' ' . $this->lang->lang('DAYS')),
+						'max_login_attempts'	=> array('lang' => 'MAX_LOGIN_ATTEMPTS',	'validate' => 'int:0:999',	'type' => 'number:0:999', 'explain' => true),
+						'ip_login_limit_max'	=> array('lang' => 'IP_LOGIN_LIMIT_MAX',	'validate' => 'int:0:999',	'type' => 'number:0:999', 'explain' => true),
+						'ip_login_limit_time'	=> array('lang' => 'IP_LOGIN_LIMIT_TIME',	'validate' => 'int:0:99999',	'type' => 'number:0:99999', 'explain' => true, 'append' => ' ' . $this->lang->lang('SECONDS')),
+						'ip_login_limit_use_forwarded'	=> array('lang' => 'IP_LOGIN_LIMIT_USE_FORWARDED',	'validate' => 'bool',	'type' => 'radio:yes_no', 'explain' => true),
+						'tpl_allow_php'			=> array('lang' => 'TPL_ALLOW_PHP',			'validate' => 'bool',	'type' => 'radio:yes_no', 'explain' => true),
+						'form_token_lifetime'	=> array('lang' => 'FORM_TIME_MAX',			'validate' => 'int:-1:99999',	'type' => 'number:-1:99999', 'explain' => true, 'append' => ' ' . $this->lang->lang('SECONDS')),
+						'form_token_sid_guests'	=> array('lang' => 'FORM_SID_GUESTS',		'validate' => 'bool',	'type' => 'radio:yes_no', 'explain' => true),
+
+					)
+				);
+			break;
+
+			case 'email':
+				$display_vars = array(
+					'title'	=> 'ACP_EMAIL_SETTINGS',
+					'vars'	=> array(
+						'legend1'				=> 'GENERAL_SETTINGS',
+						'email_enable'			=> array('lang' => 'ENABLE_EMAIL',			'validate' => 'bool',	'type' => 'radio:enabled_disabled', 'explain' => true),
+						'board_email_form'		=> array('lang' => 'BOARD_EMAIL_FORM',		'validate' => 'bool',	'type' => 'radio:enabled_disabled', 'explain' => true),
+						'email_package_size'	=> array('lang' => 'EMAIL_PACKAGE_SIZE',	'validate' => 'int:0',	'type' => 'number:0:99999', 'explain' => true),
+						'board_contact'			=> array('lang' => 'CONTACT_EMAIL',			'validate' => 'email',	'type' => 'email:25:100', 'explain' => true),
+						'board_contact_name'	=> array('lang' => 'CONTACT_EMAIL_NAME',	'validate' => 'string',	'type' => 'text:25:50', 'explain' => true),
+						'board_email'			=> array('lang' => 'ADMIN_EMAIL',			'validate' => 'email',	'type' => 'email:25:100', 'explain' => true),
+						'email_force_sender'	=> array('lang' => 'EMAIL_FORCE_SENDER',	'validate' => 'bool',	'type' => 'radio:yes_no', 'explain' => true),
+						'board_email_sig'		=> array('lang' => 'EMAIL_SIG',				'validate' => 'string',	'type' => 'textarea:5:30', 'explain' => true),
+						'board_hide_emails'		=> array('lang' => 'BOARD_HIDE_EMAILS',		'validate' => 'bool',	'type' => 'radio:yes_no', 'explain' => true),
+						'send_test_email'		=> array('lang' => 'SEND_TEST_EMAIL',		'validate' => 'bool',	'type' => 'custom', 'function' => array($this, 'send_test_email'), 'explain' => true),
+
+						'legend2'				=> 'SMTP_SETTINGS',
+						'smtp_delivery'			=> array('lang' => 'USE_SMTP',				'validate' => 'bool',	'type' => 'radio:yes_no', 'explain' => true),
+						'smtp_host'				=> array('lang' => 'SMTP_SERVER',			'validate' => 'string',	'type' => 'text:25:50', 'explain' => true),
+						'smtp_port'				=> array('lang' => 'SMTP_PORT',				'validate' => 'int:0:99999',	'type' => 'number:0:99999', 'explain' => true),
+						'smtp_auth_method'		=> array('lang' => 'SMTP_AUTH_METHOD',		'validate' => 'string',	'type' => 'select', 'function' => array($this, 'mail_auth_select'), 'explain' => true),
+						'smtp_username'			=> array('lang' => 'SMTP_USERNAME',			'validate' => 'string',	'type' => 'text:25:255', 'explain' => true),
+						'smtp_password'			=> array('lang' => 'SMTP_PASSWORD',			'validate' => 'string',	'type' => 'password:25:255', 'explain' => true),
+						'smtp_verify_peer'		=> array('lang' => 'SMTP_VERIFY_PEER',		'validate' => 'bool',	'type' => 'radio:yes_no', 'explain' => true),
+						'smtp_verify_peer_name'	=> array('lang' => 'SMTP_VERIFY_PEER_NAME',	'validate' => 'bool',	'type' => 'radio:yes_no', 'explain' => true),
+						'smtp_allow_self_signed'=> array('lang' => 'SMTP_ALLOW_SELF_SIGNED','validate' => 'bool',	'type' => 'radio:yes_no', 'explain' => true),
+
+						'legend3'					=> 'ACP_SUBMIT_CHANGES',
+					)
+				);
+			break;
+
+			default:
+				trigger_error('NO_MODE', E_USER_ERROR);
+			break;
+		}
+
+		/**
+		 * Event to add and/or modify acp_board configurations
+		 *
+		 * @event core.acp_board_config_edit_add
+		 * @var	array	display_vars	Array of config values to display and process
+		 * @var	string	mode			Mode of the config page we are displaying
+		 * @var	boolean	submit			Do we display the form or process the submission
+		 * @since 3.1.0-a4
+		 */
+		$vars = array('display_vars', 'mode', 'submit');
+		extract($this->dispatcher->trigger_event('core.acp_board_config_edit_add', compact($vars)));
+
+		if (isset($display_vars['lang']))
+		{
+			$this->lang->add_lang($display_vars['lang']);
+		}
+
+		$this->new_config = clone $this->config;
+		$cfg_array = (isset($_REQUEST['config'])) ? $this->request->variable('config', array('' => ''), true) : $this->new_config;
+		$error = array();
+
+		// We validate the complete config if wished
+		validate_config_vars($display_vars['vars'], $cfg_array, $error);
+
+		if ($submit && !check_form_key($form_key))
+		{
+			$error[] = $this->lang->lang('FORM_INVALID');
+		}
+		// Do not write values if there is an error
+		if (count($error))
+		{
+			$submit = false;
+		}
+
+		// We go through the display_vars to make sure no one is trying to set variables he/she is not allowed to...
+		foreach ($display_vars['vars'] as $config_name => $data)
+		{
+			if (!isset($cfg_array[$config_name]) || strpos($config_name, 'legend') !== false)
+			{
+				continue;
+			}
+
+			if ($config_name == 'auth_method' || $config_name == 'feed_news_id' || $config_name == 'feed_exclude_id')
+			{
+				continue;
+			}
+
+			if ($config_name == 'guest_style')
+			{
+				if (isset($cfg_array[$config_name]))
+				{
+					$this->guest_style_set($cfg_array[$config_name]);
+				}
+				continue;
+			}
+
+			$this->new_config[$config_name] = $config_value = $cfg_array[$config_name];
+
+			if ($submit)
+			{
+				if (strpos($data['type'], 'password') === 0 && $config_value === '********')
+				{
+					// Do not update password fields if the content is ********,
+					// because that is the password replacement we use to not
+					// send the password to the output
+					continue;
+				}
+				$this->config->set($config_name, $config_value);
+
+				if ($config_name == 'allow_quick_reply' && isset($_POST['allow_quick_reply_enable']))
+				{
+					enable_bitfield_column_flag(FORUMS_TABLE, 'forum_flags', round(log(FORUM_FLAG_QUICK_REPLY, 2)));
+				}
+			}
+		}
+
+		// Invalidate the text_formatter cache when posting options are changed
+		if ($mode == 'post' && $submit)
+		{
+			$this->container->get('text_formatter.cache')->invalidate();
+		}
+
+		// Store news and exclude ids
+		if ($mode == 'feed' && $submit)
+		{
+			$this->cache->destroy('_feed_news_forum_ids');
+			$this->cache->destroy('_feed_excluded_forum_ids');
+
+			$this->store_feed_forums(FORUM_OPTION_FEED_NEWS, 'feed_news_id');
+			$this->store_feed_forums(FORUM_OPTION_FEED_EXCLUDE, 'feed_exclude_id');
+		}
+
+		if ($mode == 'auth')
+		{
+			// Retrieve a list of auth plugins and check their config values
+			/* @var $auth_providers \phpbb\auth\provider_collection */
+			$auth_providers = $this->container->get('auth.provider_collection');
+
+			$updated_auth_settings = false;
+			$old_auth_config = array();
+			foreach ($auth_providers as $provider)
+			{
+				/** @var \phpbb\auth\provider\provider_interface $provider */
+				if ($fields = $provider->acp())
+				{
+					// Check if we need to create config fields for this plugin and save config when submit was pressed
+					foreach ($fields as $field)
+					{
+						if (!isset($this->config[$field]))
+						{
+							$this->config->set($field, '');
+						}
+
+						if (!isset($cfg_array[$field]) || strpos($field, 'legend') !== false)
+						{
+							continue;
+						}
+
+						if (substr($field, -9) === '_password' && $cfg_array[$field] === '********')
+						{
+							// Do not update password fields if the content is ********,
+							// because that is the password replacement we use to not
+							// send the password to the output
+							continue;
+						}
+
+						$old_auth_config[$field] = $this->new_config[$field];
+						$config_value = $cfg_array[$field];
+						$this->new_config[$field] = $config_value;
+
+						if ($submit)
+						{
+							$updated_auth_settings = true;
+							$this->config->set($field, $config_value);
+						}
+					}
+				}
+				unset($fields);
+			}
+
+			if ($submit && (($cfg_array['auth_method'] != $this->new_config['auth_method']) || $updated_auth_settings))
+			{
+				$method = basename($cfg_array['auth_method']);
+				if (array_key_exists('auth.provider.' . $method, $auth_providers))
+				{
+					$provider = $auth_providers['auth.provider.' . $method];
+					if ($error = $provider->init())
+					{
+						foreach ($old_auth_config as $config_name => $config_value)
+						{
+							$this->config->set($config_name, $config_value);
+						}
+						trigger_error($error . adm_back_link($this->helper->get_current_url()), E_USER_WARNING);
+					}
+					$this->config->set('auth_method', basename($cfg_array['auth_method']));
+				}
+				else
+				{
+					trigger_error('NO_AUTH_PLUGIN', E_USER_ERROR);
+				}
+			}
+		}
+
+		if ($mode == 'email' && $this->request->is_set_post('send_test_email'))
+		{
+			if ($this->config['email_enable'])
+			{
+				include_once($this->root_path . 'includes/functions_messenger.' . $this->php_ext);
+
+				$messenger = new \messenger(false);
+				$messenger->template('test');
+				$messenger->set_addresses($this->user->data);
+				$messenger->anti_abuse_headers($this->config, $this->user);
+				$messenger->assign_vars(array(
+					'USERNAME'	=> htmlspecialchars_decode($this->user->data['username']),
+				));
+				$messenger->send(NOTIFY_EMAIL);
+
+				trigger_error($this->lang->lang('TEST_EMAIL_SENT') . adm_back_link($this->helper->get_current_url()));
+			}
+			else
+			{
+				$this->user->add_lang('memberlist');
+				trigger_error($this->lang->lang('EMAIL_DISABLED') . adm_back_link($this->helper->get_current_url()), E_USER_WARNING);
+			}
+		}
+
+		if ($submit)
+		{
+			$this->log->add('admin', $this->user->data['user_id'], $this->user->ip, 'LOG_CONFIG_' . strtoupper($mode));
+
+			$message = $this->lang->lang('CONFIG_UPDATED');
+			$message_code = E_USER_NOTICE;
+			if (!$this->config['email_enable'] && in_array($mode, array('email', 'registration')) &&
+				in_array($this->config['require_activation'], array(USER_ACTIVATION_SELF, USER_ACTIVATION_ADMIN)))
+			{
+				$message .= '<br /><br />' . $this->lang->lang('ACC_ACTIVATION_WARNING');
+				$message_code = E_USER_WARNING;
+			}
+
+			return $this->helper->message_back($this->helper->get_current_url(), $message, [], 'INFORMATION', $message_code);
+		}
+
+		$this->template->assign_vars(array(
+			'L_TITLE'			=> $this->lang->lang($display_vars['title']),
+			'L_TITLE_EXPLAIN'	=> $this->lang->lang($display_vars['title'] . '_EXPLAIN'),
+
+			'S_ERROR'			=> (count($error)) ? true : false,
+			'ERROR_MSG'			=> implode('<br />', $error),
+
+			'U_ACTION'			=> $this->helper->get_current_url()
+		));
+
+		// Output relevant page
+		foreach ($display_vars['vars'] as $config_key => $vars)
+		{
+			if (!is_array($vars) && strpos($config_key, 'legend') === false)
+			{
+				continue;
+			}
+
+			if (strpos($config_key, 'legend') !== false)
+			{
+				$this->template->assign_block_vars('options', array(
+						'S_LEGEND'		=> true,
+						'LEGEND'		=> $this->lang->is_set($vars) ? $this->lang->lang($vars) : $vars)
+				);
+
+				continue;
+			}
+
+			$type = explode(':', $vars['type']);
+
+			$l_explain = '';
+			if ($vars['explain'] && isset($vars['lang_explain']))
+			{
+				$l_explain = $this->lang->is_set($vars['lang_explain']) ? $this->lang->lang($vars['lang_explain']) : $vars['lang_explain'];
+			}
+			else if ($vars['explain'])
+			{
+				$l_explain = $this->lang->is_set([$vars['lang'] . '_EXPLAIN']) ? $this->lang->lang($vars['lang'] . '_EXPLAIN') : '';
+			}
+
+			$content = build_cfg_template($type, $config_key, $this->new_config, $config_key, $vars);
+
+			if (empty($content))
+			{
+				continue;
+			}
+
+			$this->template->assign_block_vars('options', array(
+				'KEY'			=> $config_key,
+				'TITLE'			=> $this->lang->is_set($vars['lang']) ? $this->lang->lang($vars['lang']) : $vars['lang'],
+				'S_EXPLAIN'		=> $vars['explain'],
+				'TITLE_EXPLAIN'	=> $l_explain,
+				'CONTENT'		=> $content,
+			));
+
+			unset($display_vars['vars'][$config_key]);
+		}
+
+		if ($mode == 'auth')
+		{
+			$this->template->assign_var('S_AUTH', true);
+
+			foreach ($auth_providers as $provider)
+			{
+				$auth_tpl = $provider->get_acp_template($this->new_config);
+				if ($auth_tpl)
+				{
+					if (array_key_exists('BLOCK_VAR_NAME', $auth_tpl))
+					{
+						foreach ($auth_tpl['BLOCK_VARS'] as $block_vars)
+						{
+							$this->template->assign_block_vars($auth_tpl['BLOCK_VAR_NAME'], $block_vars);
+						}
+					}
+					$this->template->assign_vars($auth_tpl['TEMPLATE_VARS']);
+					$this->template->assign_block_vars('auth_tpl', array(
+						'TEMPLATE_FILE'	=> $auth_tpl['TEMPLATE_FILE'],
+					));
+				}
+			}
+		}
+
+		return $this->helper->render('acp_board.html', $this->lang->lang($display_vars['title']));
+	}
+
+	/**
+	 * Select auth method
+	 */
+	function select_auth_method($selected_method, $key = '')
+	{
+		/* @var $auth_providers \phpbb\auth\provider_collection */
+		$auth_providers = $this->container->get('auth.provider_collection');
+		$auth_plugins = array();
+
+		foreach ($auth_providers as $key => $value)
+		{
+			if (!($value instanceof \phpbb\auth\provider\provider_interface))
+			{
+				continue;
+			}
+			$auth_plugins[] = str_replace('auth.provider.', '', $key);
+		}
+
+		sort($auth_plugins);
+
+		$auth_select = '';
+		foreach ($auth_plugins as $method)
+		{
+			$selected = ($selected_method == $method) ? ' selected="selected"' : '';
+			$auth_select .= "<option value=\"$method\"$selected data-toggle-setting=\"#auth_{$method}_settings\">" . ucfirst($method) . '</option>';
+		}
+
+		return $auth_select;
+	}
+
+	/**
+	 * Select mail authentication method
+	 */
+	function mail_auth_select($selected_method, $key = '')
+	{
+		$auth_methods = array('PLAIN', 'LOGIN', 'CRAM-MD5', 'DIGEST-MD5', 'POP-BEFORE-SMTP');
+		$s_smtp_auth_options = '';
+
+		foreach ($auth_methods as $method)
+		{
+			$s_smtp_auth_options .= '<option value="' . $method . '"' . (($selected_method == $method) ? ' selected="selected"' : '') . '>' . $this->lang->lang('SMTP_' . str_replace('-', '_', $method)) . '</option>';
+		}
+
+		return $s_smtp_auth_options;
+	}
+
+	/**
+	 * Select full folder action
+	 */
+	function full_folder_select($value, $key = '')
+	{
+		return '<option value="1"' . (($value == 1) ? ' selected="selected"' : '') . '>' . $this->lang->lang('DELETE_OLDEST_MESSAGES') . '</option><option value="2"' . (($value == 2) ? ' selected="selected"' : '') . '>' . $this->lang->lang('HOLD_NEW_MESSAGES_SHORT') . '</option>';
+	}
+
+	/**
+	 * Select ip validation
+	 */
+	function select_ip_check($value, $key = '')
+	{
+		$radio_ary = array(4 => 'ALL', 3 => 'CLASS_C', 2 => 'CLASS_B', 0 => 'NO_IP_VALIDATION');
+
+		return h_radio('config[ip_check]', $radio_ary, $value, $key);
+	}
+
+	/**
+	 * Select referer validation
+	 */
+	function select_ref_check($value, $key = '')
+	{
+		$radio_ary = array(REFERER_VALIDATE_PATH => 'REF_PATH', REFERER_VALIDATE_HOST => 'REF_HOST', REFERER_VALIDATE_NONE => 'NO_REF_VALIDATION');
+
+		return h_radio('config[referer_validation]', $radio_ary, $value, $key);
+	}
+
+	/**
+	 * Select account activation method
+	 */
+	function select_acc_activation($selected_value, $value)
+	{
+		$act_ary = array(
+			'ACC_DISABLE'	=> array(true, USER_ACTIVATION_DISABLE),
+			'ACC_NONE'		=> array(true, USER_ACTIVATION_NONE),
+			'ACC_USER'		=> array($this->config['email_enable'], USER_ACTIVATION_SELF),
+			'ACC_ADMIN'		=> array($this->config['email_enable'], USER_ACTIVATION_ADMIN),
+		);
+
+		$act_options = '';
+		foreach ($act_ary as $key => $data)
+		{
+			list($available, $value) = $data;
+			$selected = ($selected_value == $value) ? ' selected="selected"' : '';
+			$class = (!$available) ? ' class="disabled-option"' : '';
+			$act_options .= '<option value="' . $value . '"' . $selected . $class . '>' . $this->lang->lang($key) . '</option>';
+		}
+
+		return $act_options;
+	}
+
+	/**
+	 * Maximum/Minimum username length
+	 */
+	function username_length($value, $key = '')
+	{
+		return '<input id="' . $key . '" type="number" min="1" max="999" name="config[min_name_chars]" value="' . $value . '" /> ' . $this->lang->lang('MIN_CHARS') . '&nbsp;&nbsp;<input type="number" min="8" max="180" name="config[max_name_chars]" value="' . $this->new_config['max_name_chars'] . '" /> ' . $this->lang->lang('MAX_CHARS');
+	}
+
+	/**
+	 * Allowed chars in usernames
+	 */
+	function select_username_chars($selected_value, $key)
+	{
+		$user_char_ary = array('USERNAME_CHARS_ANY', 'USERNAME_ALPHA_ONLY', 'USERNAME_ALPHA_SPACERS', 'USERNAME_LETTER_NUM', 'USERNAME_LETTER_NUM_SPACERS', 'USERNAME_ASCII');
+		$user_char_options = '';
+		foreach ($user_char_ary as $user_type)
+		{
+			$selected = ($selected_value == $user_type) ? ' selected="selected"' : '';
+			$user_char_options .= '<option value="' . $user_type . '"' . $selected . '>' . $this->lang->lang($user_type) . '</option>';
+		}
+
+		return $user_char_options;
+	}
+
+	/**
+	 * Maximum/Minimum password length
+	 */
+	function password_length($value, $key)
+	{
+		return '<input id="' . $key . '" type="number" min="1" max="999" name="config[min_pass_chars]" value="' . $value . '" /> ' . $this->lang->lang('MIN_CHARS') . '&nbsp;&nbsp;<input type="number" min="8" max="255" name="config[max_pass_chars]" value="' . $this->new_config['max_pass_chars'] . '" /> ' . $this->lang->lang('MAX_CHARS');
+	}
+
+	/**
+	 * Required chars in passwords
+	 */
+	function select_password_chars($selected_value, $key)
+	{
+		$pass_type_ary = array('PASS_TYPE_ANY', 'PASS_TYPE_CASE', 'PASS_TYPE_ALPHA', 'PASS_TYPE_SYMBOL');
+		$pass_char_options = '';
+		foreach ($pass_type_ary as $pass_type)
+		{
+			$selected = ($selected_value == $pass_type) ? ' selected="selected"' : '';
+			$pass_char_options .= '<option value="' . $pass_type . '"' . $selected . '>' . $this->lang->lang($pass_type) . '</option>';
+		}
+
+		return $pass_char_options;
+	}
+
+	/**
+	 * Select bump interval
+	 */
+	function bump_interval($value, $key)
+	{
+		$s_bump_type = '';
+		$types = array('m' => 'MINUTES', 'h' => 'HOURS', 'd' => 'DAYS');
+		foreach ($types as $type => $lang)
+		{
+			$selected = ($this->new_config['bump_type'] == $type) ? ' selected="selected"' : '';
+			$s_bump_type .= '<option value="' . $type . '"' . $selected . '>' . $this->lang->lang($lang) . '</option>';
+		}
+
+		return '<input id="' . $key . '" type="text" size="3" maxlength="4" name="config[bump_interval]" value="' . $value . '" />&nbsp;<select name="config[bump_type]">' . $s_bump_type . '</select>';
+	}
+
+	/**
+	 * Board disable option and message
+	 */
+	function board_disable($value, $key)
+	{
+		$radio_ary = array(1 => 'YES', 0 => 'NO');
+
+		return h_radio('config[board_disable]', $radio_ary, $value) . '<br /><input id="' . $key . '" type="text" name="config[board_disable_msg]" maxlength="255" size="40" value="' . $this->new_config['board_disable_msg'] . '" />';
+	}
+
+	/**
+	 * Global quick reply enable/disable setting and button to enable in all forums
+	 */
+	function quick_reply($value, $key)
+	{
+		$radio_ary = array(1 => 'YES', 0 => 'NO');
+
+		return h_radio('config[allow_quick_reply]', $radio_ary, $value) .
+			'<br /><br /><input class="button2" type="submit" id="' . $key . '_enable" name="' . $key . '_enable" value="' . $this->user->lang['ALLOW_QUICK_REPLY_BUTTON'] . '" />';
+	}
+
+	/**
+	 * Select guest timezone
+	 */
+	function timezone_select($value, $key)
+	{
+		$timezone_select = phpbb_timezone_select($this->template, $this->user, $value, true);
+
+		return '<select name="config[' . $key . ']" id="' . $key . '">' . $timezone_select . '</select>';
+	}
+
+	/**
+	 * Get guest style
+	 */
+	public function guest_style_get()
+	{
+		$sql = 'SELECT user_style
+			FROM ' . USERS_TABLE . '
+			WHERE user_id = ' . ANONYMOUS;
+		$result = $this->db->sql_query($sql);
+
+		$style = (int) $this->db->sql_fetchfield('user_style');
+		$this->db->sql_freeresult($result);
+
+		return $style;
+	}
+
+	/**
+	 * Set guest style
+	 *
+	 * @param	int		$style_id	The style ID
+	 */
+	public function guest_style_set($style_id)
+	{
+		$sql = 'UPDATE ' . USERS_TABLE . '
+			SET user_style = ' . (int) $style_id . '
+			WHERE user_id = ' . ANONYMOUS;
+		$this->db->sql_query($sql);
+	}
+
+	/**
+	 * Select default dateformat
+	 */
+	function dateformat_select($value, $key)
+	{
+		// Let the format_date function operate with the acp values
+		$old_tz = $this->user->timezone;
+		try
+		{
+			$this->user->timezone = new \DateTimeZone($this->config['board_timezone']);
+		}
+		catch (\Exception $e)
+		{
+			// If the board timezone is invalid, we just use the users timezone.
+		}
+
+		$dateformat_options = '';
+		foreach ($this->lang->lang_raw('dateformats') as $format => $null)
+		{
+			$dateformat_options .= '<option value="' . $format . '"' . (($format == $value) ? ' selected="selected"' : '') . '>';
+			$dateformat_options .= $this->user->format_date(time(), $format, false) . ((strpos($format, '|') !== false) ? $this->lang->lang('VARIANT_DATE_SEPARATOR') . $this->user->format_date(time(), $format, true) : '');
+			$dateformat_options .= '</option>';
+		}
+
+		$dateformat_options .= '<option value="custom"';
+		if (!isset($this->lang->lang('dateformats')[$value]))
+		{
+			$dateformat_options .= ' selected="selected"';
+		}
+		$dateformat_options .= '>' . $this->lang->lang('CUSTOM_DATEFORMAT') . '</option>';
+
+		// Reset users date options
+		$this->user->timezone = $old_tz;
+
+		return "<select name=\"dateoptions\" id=\"dateoptions\" onchange=\"if (this.value === 'custom') { document.getElementById('" . addslashes($key) . "').value = '" . addslashes($value) . "'; } else { document.getElementById('" . addslashes($key) . "').value = this.value; }\">$dateformat_options</select>
+		<input type=\"text\" name=\"config[$key]\" id=\"$key\" value=\"$value\" maxlength=\"64\" />";
+	}
+
+	/**
+	 * Select multiple forums
+	 */
+	function select_news_forums($value, $key)
+	{
+		$forum_list = make_forum_select(false, false, true, true, true, false, true);
+
+		// Build forum options
+		$s_forum_options = '<select id="' . $key . '" name="' . $key . '[]" multiple="multiple">';
+		foreach ($forum_list as $f_id => $f_row)
+		{
+			$f_row['selected'] = phpbb_optionget(FORUM_OPTION_FEED_NEWS, $f_row['forum_options']);
+
+			$s_forum_options .= '<option value="' . $f_id . '"' . (($f_row['selected']) ? ' selected="selected"' : '') . (($f_row['disabled']) ? ' disabled="disabled" class="disabled-option"' : '') . '>' . $f_row['padding'] . $f_row['forum_name'] . '</option>';
+		}
+		$s_forum_options .= '</select>';
+
+		return $s_forum_options;
+	}
+
+	function select_exclude_forums($value, $key)
+	{
+		$forum_list = make_forum_select(false, false, true, true, true, false, true);
+
+		// Build forum options
+		$s_forum_options = '<select id="' . $key . '" name="' . $key . '[]" multiple="multiple">';
+		foreach ($forum_list as $f_id => $f_row)
+		{
+			$f_row['selected'] = phpbb_optionget(FORUM_OPTION_FEED_EXCLUDE, $f_row['forum_options']);
+
+			$s_forum_options .= '<option value="' . $f_id . '"' . (($f_row['selected']) ? ' selected="selected"' : '') . (($f_row['disabled']) ? ' disabled="disabled" class="disabled-option"' : '') . '>' . $f_row['padding'] . $f_row['forum_name'] . '</option>';
+		}
+		$s_forum_options .= '</select>';
+
+		return $s_forum_options;
+	}
+
+	function store_feed_forums($option, $key)
+	{
+		// Get key
+		$values = $this->request->variable($key, array(0 => 0));
+
+		// Empty option bit for all forums
+		$sql = 'UPDATE ' . FORUMS_TABLE . '
+			SET forum_options = forum_options - ' . (1 << $option) . '
+			WHERE ' . $this->db->sql_bit_and('forum_options', $option, '<> 0');
+		$this->db->sql_query($sql);
+
+		// Already emptied for all...
+		if (count($values))
+		{
+			// Set for selected forums
+			$sql = 'UPDATE ' . FORUMS_TABLE . '
+				SET forum_options = forum_options + ' . (1 << $option) . '
+				WHERE ' . $this->db->sql_in_set('forum_id', $values);
+			$this->db->sql_query($sql);
+		}
+
+		// Empty sql cache for forums table because options changed
+		$this->cache->destroy('sql', FORUMS_TABLE);
+	}
+
+	/**
+	 * Option to enable/disable removal of 'app.php' from URLs
+	 *
+	 * Note that if mod_rewrite is on, URLs without app.php will still work,
+	 * but any paths generated by the controller helper url() method will not
+	 * contain app.php.
+	 *
+	 * @param int $value The current config value
+	 * @param string $key The config key
+	 * @return string The HTML for the form field
+	 */
+	function enable_mod_rewrite($value, $key)
+	{
+		// Determine whether mod_rewrite is enabled on the server
+		// NOTE: This only works on Apache servers on which PHP is NOT
+		// installed as CGI. In that case, there is no way for PHP to
+		// determine whether or not the Apache module is enabled.
+		//
+		// To be clear on the value of $mod_rewite:
+		// null = Cannot determine whether or not the server has mod_rewrite
+		//        enabled
+		// false = Can determine that the server does NOT have mod_rewrite
+		//         enabled
+		// true = Can determine that the server DOES have mod_rewrite_enabled
+		$mod_rewrite = null;
+		if (function_exists('apache_get_modules'))
+		{
+			$mod_rewrite = (bool) in_array('mod_rewrite', apache_get_modules());
+		}
+
+		// If $message is false, mod_rewrite is enabled.
+		// Otherwise, it is not and we need to:
+		// 1) disable the form field
+		// 2) make sure the config value is set to 0
+		// 3) append the message to the return
+		$value = ($mod_rewrite === false) ? 0 : $value;
+		$message = $mod_rewrite === null ? 'MOD_REWRITE_INFORMATION_UNAVAILABLE' : ($mod_rewrite === false ? 'MOD_REWRITE_DISABLED' : false);
+
+		// Let's do some friendly HTML injection if we want to disable the
+		// form field because h_radio() has no pretty way of doing so
+		$field_name = 'config[enable_mod_rewrite]' . ($message === 'MOD_REWRITE_DISABLED' ? '" disabled="disabled' : '');
+
+		return h_radio($field_name, array(1 => 'YES', 0 => 'NO'), $value) .
+			($message !== false ? '<br /><span>' . $this->lang->lang($message) . '</span>' : '');
+	}
+
+	function send_test_email($value, $key)
+	{
+		return '<input class="button2" type="submit" id="' . $key . '" name="' . $key . '" value="' . $this->lang->lang('SEND_TEST_EMAIL') . '" />';
+	}
+}

--- a/phpBB/phpbb/acp/controller/settings.php
+++ b/phpBB/phpbb/acp/controller/settings.php
@@ -777,15 +777,15 @@ class settings
 			$this->log->add('admin', $this->user->data['user_id'], $this->user->ip, 'LOG_CONFIG_' . strtoupper($mode));
 
 			$message = $this->lang->lang('CONFIG_UPDATED');
-			$message_code = E_USER_NOTICE;
 			if (!$this->config['email_enable'] && in_array($mode, array('email', 'registration')) &&
 				in_array($this->config['require_activation'], array(USER_ACTIVATION_SELF, USER_ACTIVATION_ADMIN)))
 			{
 				$message .= '<br /><br />' . $this->lang->lang('ACC_ACTIVATION_WARNING');
-				$message_code = E_USER_WARNING;
+
+				// @todo a "warning" class?
 			}
 
-			return $this->helper->message_back($this->helper->get_current_url(), $message, [], 'INFORMATION', $message_code);
+			return $this->helper->message_back($this->helper->get_current_url(), $message);
 		}
 
 		$this->template->assign_vars(array(

--- a/phpBB/phpbb/acp/functions/acp.php
+++ b/phpBB/phpbb/acp/functions/acp.php
@@ -1,0 +1,228 @@
+<?php
+/**
+ *
+ * This file is part of the phpBB Forum Software package.
+ *
+ * @copyright (c) phpBB Limited <https://www.phpbb.com>
+ * @license GNU General Public License, version 2 (GPL-2.0)
+ *
+ * For full copyright and license information, please see
+ * the docs/CREDITS.txt file.
+ *
+ */
+
+namespace phpbb\acp\functions;
+
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+class acp
+{
+	protected $auth;
+	protected $config;
+	protected $container;
+	protected $db;
+	protected $dispatcher;
+	protected $helper;
+	protected $lang;
+	protected $request;
+	protected $template;
+	protected $user;
+
+	protected $admin_path;
+	protected $root_path;
+	protected $php_ext;
+
+	public function __construct(
+		\phpbb\auth\auth $auth,
+		\phpbb\config\config $config,
+		ContainerInterface $container,
+		\phpbb\db\driver\driver_interface $db,
+		\phpbb\event\dispatcher $dispatcher,
+		\phpbb\controller\helper $helper,
+		\phpbb\language\language $lang,
+		\phpbb\path_helper $path_helper,
+		\phpbb\request\request $request,
+		\phpbb\template\template $template,
+		\phpbb\user $user
+	)
+	{
+		$this->auth			= $auth;
+		$this->config		= $config;
+		$this->container	= $container;
+		$this->db			= $db;
+		$this->dispatcher	= $dispatcher;
+		$this->helper		= $helper;
+		$this->lang			= $lang;
+		$this->request		= $request;
+		$this->template		= $template;
+		$this->user			= $user;
+
+		$this->root_path	= $path_helper->update_web_root_path($path_helper->get_phpbb_root_path());
+		$this->admin_path	= $this->root_path . $path_helper->get_adm_relative_path();
+		$this->php_ext		= $path_helper->get_php_ext();
+	}
+
+	public function adm_back_link($link)
+	{
+		return '<br /><br /><a href="' . $link . '">&laquo; ' . $this->lang->lang('BACK_TO_PREV') . '</a>';
+	}
+
+	public function adm_page_header($page_title)
+	{
+		global $SID, $_SID;
+
+		if (defined('HEADER_INC'))
+		{
+			return;
+		}
+
+		define('HEADER_INC', true);
+
+		// A listener can set this variable to `true` when it overrides this function
+		$adm_page_header_override = false;
+
+		/**
+		 * Execute code and/or overwrite adm_page_header()
+		 *
+		 * @event core.adm_page_header
+		 * @var	string	page_title					Page title
+		 * @var	bool	adm_page_header_override	Shall we return instead of
+		 *											running the rest of adm_page_header()
+		 * @since 3.1.0-a1
+		 */
+		$vars = array('page_title', 'adm_page_header_override');
+		extract($this->dispatcher->trigger_event('core.adm_page_header', compact($vars)));
+
+		if ($adm_page_header_override)
+		{
+			return;
+		}
+
+		$this->user->update_session_infos();
+
+		// gzip_compression
+		if ($this->config['gzip_compress'])
+		{
+			if (@extension_loaded('zlib') && !headers_sent())
+			{
+				ob_start('ob_gzhandler');
+			}
+		}
+
+		$phpbb_version_parts = explode('.', PHPBB_VERSION, 3);
+		$phpbb_major = $phpbb_version_parts[0] . '.' . $phpbb_version_parts[1];
+
+		$this->template->assign_vars(array(
+			'PAGE_TITLE'			=> $page_title,
+			'USERNAME'				=> $this->user->data['username'],
+
+			'SID'					=> $SID,
+			'_SID'					=> $_SID,
+			'SESSION_ID'			=> $this->user->session_id,
+			'ROOT_PATH'				=> $this->root_path,
+			'ADMIN_ROOT_PATH'		=> $this->admin_path,
+			'PHPBB_VERSION'			=> PHPBB_VERSION,
+			'PHPBB_MAJOR'			=> $phpbb_major,
+
+			'U_LOGOUT'				=> append_sid("{$this->root_path}ucp.{$this->php_ext}", 'mode=logout'),
+			'U_ADM_LOGOUT'			=> $this->helper->route('phpbb_acp_index', array('action' => 'admlogout')),
+			'U_ADM_INDEX'			=> $this->helper->route('phpbb_acp_index'),
+			'U_INDEX'				=> append_sid("{$this->root_path}index.{$this->php_ext}"),
+
+			'T_IMAGES_PATH'			=> "{$this->root_path}images/",
+			'T_SMILIES_PATH'		=> "{$this->root_path}{$this->config['smilies_path']}/",
+			'T_AVATAR_GALLERY_PATH'	=> "{$this->root_path}{$this->config['avatar_gallery_path']}/",
+			'T_ICONS_PATH'			=> "{$this->root_path}{$this->config['icons_path']}/",
+			'T_RANKS_PATH'			=> "{$this->root_path}{$this->config['ranks_path']}/",
+			'T_FONT_AWESOME_LINK'	=> !empty($this->config['allow_cdn']) && !empty($this->config['load_font_awesome_url']) ? $this->config['load_font_awesome_url'] : "{$this->root_path}assets/css/font-awesome.min.css?assets_version=" . $this->config['assets_version'],
+
+			'T_ASSETS_VERSION'		=> $this->config['assets_version'],
+
+			'ICON_MOVE_UP'				=> '<img src="' . htmlspecialchars($this->admin_path) . 'images/icon_up.gif" alt="' . $this->lang->lang('MOVE_UP') . '" title="' . $this->lang->lang('MOVE_UP') . '" />',
+			'ICON_MOVE_UP_DISABLED'		=> '<img src="' . htmlspecialchars($this->admin_path) . 'images/icon_up_disabled.gif" alt="' . $this->lang->lang('MOVE_UP') . '" title="' . $this->lang->lang('MOVE_UP') . '" />',
+			'ICON_MOVE_DOWN'			=> '<img src="' . htmlspecialchars($this->admin_path) . 'images/icon_down.gif" alt="' . $this->lang->lang('MOVE_DOWN') . '" title="' . $this->lang->lang('MOVE_DOWN') . '" />',
+			'ICON_MOVE_DOWN_DISABLED'	=> '<img src="' . htmlspecialchars($this->admin_path) . 'images/icon_down_disabled.gif" alt="' . $this->lang->lang('MOVE_DOWN') . '" title="' . $this->lang->lang('MOVE_DOWN') . '" />',
+			'ICON_EDIT'					=> '<img src="' . htmlspecialchars($this->admin_path) . 'images/icon_edit.gif" alt="' . $this->lang->lang('EDIT') . '" title="' . $this->lang->lang('EDIT') . '" />',
+			'ICON_EDIT_DISABLED'		=> '<img src="' . htmlspecialchars($this->admin_path) . 'images/icon_edit_disabled.gif" alt="' . $this->lang->lang('EDIT') . '" title="' . $this->lang->lang('EDIT') . '" />',
+			'ICON_DELETE'				=> '<img src="' . htmlspecialchars($this->admin_path) . 'images/icon_delete.gif" alt="' . $this->lang->lang('DELETE') . '" title="' . $this->lang->lang('DELETE') . '" />',
+			'ICON_DELETE_DISABLED'		=> '<img src="' . htmlspecialchars($this->admin_path) . 'images/icon_delete_disabled.gif" alt="' . $this->lang->lang('DELETE') . '" title="' . $this->lang->lang('DELETE') . '" />',
+			'ICON_SYNC'					=> '<img src="' . htmlspecialchars($this->admin_path) . 'images/icon_sync.gif" alt="' . $this->lang->lang('RESYNC') . '" title="' . $this->lang->lang('RESYNC') . '" />',
+			'ICON_SYNC_DISABLED'		=> '<img src="' . htmlspecialchars($this->admin_path) . 'images/icon_sync_disabled.gif" alt="' . $this->lang->lang('RESYNC') . '" title="' . $this->lang->lang('RESYNC') . '" />',
+
+			'S_USER_LANG'			=> $this->lang->lang('USER_LANG'),
+			'S_CONTENT_DIRECTION'	=> $this->lang->lang('DIRECTION'),
+			'S_CONTENT_ENCODING'	=> 'UTF-8',
+			'S_CONTENT_FLOW_BEGIN'	=> ($this->lang->lang('DIRECTION') == 'ltr') ? 'left' : 'right',
+			'S_CONTENT_FLOW_END'	=> ($this->lang->lang('DIRECTION') == 'ltr') ? 'right' : 'left',
+
+			'CONTAINER_EXCEPTION'	=> $this->container->hasParameter('container_exception') ? $this->container->getParameter('container_exception') : false,
+		));
+
+		// An array of http headers that phpbb will set. The following event may override these.
+		$http_headers = array(
+			// application/xhtml+xml not used because of IE
+			'Content-type' => 'text/html; charset=UTF-8',
+			'Cache-Control' => 'private, no-cache="set-cookie"',
+			'Expires' => gmdate('D, d M Y H:i:s', time()) . ' GMT',
+		);
+
+		/**
+		 * Execute code and/or overwrite _common_ template variables after they have been assigned.
+		 *
+		 * @event core.adm_page_header_after
+		 * @var	string	page_title			Page title
+		 * @var	array	http_headers			HTTP headers that should be set by phpbb
+		 *
+		 * @since 3.1.0-RC3
+		 */
+		$vars = array('page_title', 'http_headers');
+		extract($this->dispatcher->trigger_event('core.adm_page_header_after', compact($vars)));
+
+		foreach ($http_headers as $header_name => $header_value)
+		{
+			header((string) $header_name . ': ' . (string) $header_value);
+		}
+
+		return;
+	}
+
+	public function adm_page_footer($copyright_html = true)
+	{
+		// A listener can set this variable to `true` when it overrides this function
+		$adm_page_footer_override = false;
+
+		/**
+		 * Execute code and/or overwrite adm_page_footer()
+		 *
+		 * @event core.adm_page_footer
+		 * @var	bool	copyright_html				Shall we display the copyright?
+		 * @var	bool	adm_page_footer_override	Shall we return instead of
+		 *											running the rest of adm_page_footer()
+		 * @since 3.1.0-a1
+		 */
+		$vars = array('copyright_html', 'adm_page_footer_override');
+		extract($this->dispatcher->trigger_event('core.adm_page_footer', compact($vars)));
+
+		if ($adm_page_footer_override)
+		{
+			return;
+		}
+
+		phpbb_check_and_display_sql_report($this->request, $this->auth, $this->db);
+
+		$this->template->assign_vars(array(
+				'DEBUG_OUTPUT'		=> phpbb_generate_debug_output($this->db, $this->config, $this->auth, $this->user, $this->dispatcher),
+				'TRANSLATION_INFO'	=> $this->lang->is_set('TRANSLATION_INFO') ? $this->lang->lang('TRANSLATION_INFO') : '',
+				'S_COPYRIGHT_HTML'	=> $copyright_html,
+				'CREDIT_LINE'		=> $this->lang->lang('POWERED_BY', '<a href="https://www.phpbb.com/">phpBB</a>&reg; Forum Software &copy; phpBB Limited'),
+				'T_JQUERY_LINK'		=> !empty($this->config['allow_cdn']) && !empty($this->config['load_jquery_url']) ? $this->config['load_jquery_url'] : "{$this->root_path}assets/javascript/jquery.min.js",
+				'S_ALLOW_CDN'		=> !empty($this->config['allow_cdn']),
+				'VERSION'			=> $this->config['version'])
+		);
+
+		$this->template->display('body');
+
+		garbage_collection();
+		exit_handler();
+	}
+}

--- a/phpBB/phpbb/acp/info/management.php
+++ b/phpBB/phpbb/acp/info/management.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace phpbb\acp\info;
+
+class management extends \phpbb\cp\info\base
+{
+	public function get_title()
+	{
+		return $this->lang->lang('ACP_BOARD_MANAGEMENT');
+	}
+
+	public function get_auth()
+	{
+		return parent::get_auth();
+	}
+
+	public function get_route()
+	{
+		return $this->helper->route('phpbb_acp_index');
+	}
+}

--- a/phpBB/phpbb/acp/info/management/index.php
+++ b/phpBB/phpbb/acp/info/management/index.php
@@ -2,11 +2,16 @@
 
 namespace phpbb\acp\info\management;
 
-class index extends \phpbb\acp\info\management
+class index extends management
 {
 	public function get_title()
 	{
 		return $this->lang->lang('ACP_INDEX');
+	}
+
+	public function get_auth()
+	{
+		return parent::get_auth();
 	}
 
 	public function get_route()

--- a/phpBB/phpbb/acp/info/management/index.php
+++ b/phpBB/phpbb/acp/info/management/index.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace phpbb\acp\info\management;
+
+class index extends \phpbb\acp\info\management
+{
+	public function get_title()
+	{
+		return $this->lang->lang('ACP_INDEX');
+	}
+
+	public function get_route()
+	{
+		return $this->helper->route('phpbb_acp_index');
+	}
+}

--- a/phpBB/phpbb/acp/info/management/management.php
+++ b/phpBB/phpbb/acp/info/management/management.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace phpbb\acp\info;
+namespace phpbb\acp\info\management;
 
 class management extends \phpbb\cp\info\base
 {

--- a/phpBB/phpbb/acp/info/settings.php
+++ b/phpBB/phpbb/acp/info/settings.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace phpbb\acp\info;
+
+class settings extends \phpbb\cp\info\base
+{
+	public function get_title()
+	{
+		return $this->lang->lang('ACP_BOARD_CONFIGURATION');
+	}
+
+	public function get_auth()
+	{
+		return parent::get_auth() && $this->auth->acl_get('a_board');
+	}
+
+	public function get_route()
+	{
+		return $this->helper->route('phpbb_acp_settings_board');
+	}
+}

--- a/phpBB/phpbb/acp/info/settings/auth.php
+++ b/phpBB/phpbb/acp/info/settings/auth.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace phpbb\acp\info\settings;
+
+class auth extends client
+{
+	public function get_title()
+	{
+		return $this->lang->lang('ACP_AUTH_SETTINGS');
+	}
+
+	public function get_auth()
+	{
+		return parent::get_auth() && $this->auth->acl_get('a_server');
+	}
+
+	public function get_route()
+	{
+		return $this->helper->route('phpbb_acp_settings_auth');
+	}
+}

--- a/phpBB/phpbb/acp/info/settings/avatar.php
+++ b/phpBB/phpbb/acp/info/settings/avatar.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace phpbb\acp\info\settings;
+
+class avatar extends general
+{
+	public function get_title()
+	{
+		return $this->lang->lang('ACP_AVATAR_SETTINGS');
+	}
+
+	public function get_auth()
+	{
+		return parent::get_auth() && $this->auth->acl_get('a_board');
+	}
+
+	public function get_route()
+	{
+		return $this->helper->route('phpbb_acp_settings_avatar');
+	}
+}

--- a/phpBB/phpbb/acp/info/settings/board.php
+++ b/phpBB/phpbb/acp/info/settings/board.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace phpbb\acp\info\settings;
+
+class board extends general
+{
+	public function get_title()
+	{
+		return $this->lang->lang('ACP_BOARD_SETTINGS');
+	}
+
+	public function get_auth()
+	{
+		return parent::get_auth() && $this->auth->acl_get('a_board');
+	}
+
+	public function get_route()
+	{
+		return $this->helper->route('phpbb_acp_settings_board');
+	}
+}

--- a/phpBB/phpbb/acp/info/settings/client.php
+++ b/phpBB/phpbb/acp/info/settings/client.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace phpbb\acp\info\settings;
+
+class client extends \phpbb\acp\info\settings
+{
+	public function get_title()
+	{
+		return $this->lang->lang('ACP_CLIENT_COMMUNICATION');
+	}
+
+	public function get_auth()
+	{
+		return parent::get_auth();
+	}
+
+	public function get_route()
+	{
+		return $this->helper->route('phpbb_acp_settings_auth');
+	}
+}

--- a/phpBB/phpbb/acp/info/settings/client.php
+++ b/phpBB/phpbb/acp/info/settings/client.php
@@ -2,7 +2,7 @@
 
 namespace phpbb\acp\info\settings;
 
-class client extends \phpbb\acp\info\settings
+class client extends settings
 {
 	public function get_title()
 	{

--- a/phpBB/phpbb/acp/info/settings/cookie.php
+++ b/phpBB/phpbb/acp/info/settings/cookie.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace phpbb\acp\info\settings;
+
+class cookie extends server_cat
+{
+	public function get_title()
+	{
+		return $this->lang->lang('ACP_COOKIE_SETTINGS');
+	}
+
+	public function get_auth()
+	{
+		return parent::get_auth() && $this->auth->acl_get('a_server');
+	}
+
+	public function get_route()
+	{
+		return $this->helper->route('phpbb_acp_settings_cookie');
+	}
+}

--- a/phpBB/phpbb/acp/info/settings/email.php
+++ b/phpBB/phpbb/acp/info/settings/email.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace phpbb\acp\info\settings;
+
+class email extends client
+{
+	public function get_title()
+	{
+		return $this->lang->lang('ACP_EMAIL_SETTINGS');
+	}
+
+	public function get_auth()
+	{
+		return parent::get_auth() && $this->auth->acl_get('a_server');
+	}
+
+	public function get_route()
+	{
+		return $this->helper->route('phpbb_acp_settings_email');
+	}
+}

--- a/phpBB/phpbb/acp/info/settings/features.php
+++ b/phpBB/phpbb/acp/info/settings/features.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace phpbb\acp\info\settings;
+
+class features extends general
+{
+	public function get_title()
+	{
+		return $this->lang->lang('ACP_BOARD_FEATURES');
+	}
+
+	public function get_auth()
+	{
+		return parent::get_auth() && $this->auth->acl_get('a_board');
+	}
+
+	public function get_route()
+	{
+		return $this->helper->route('phpbb_acp_settings_features');
+	}
+}

--- a/phpBB/phpbb/acp/info/settings/feed.php
+++ b/phpBB/phpbb/acp/info/settings/feed.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace phpbb\acp\info\settings;
+
+class feed extends general
+{
+	public function get_title()
+	{
+		return $this->lang->lang('ACP_FEED_SETTINGS');
+	}
+
+	public function get_auth()
+	{
+		return parent::get_auth() && $this->auth->acl_get('a_board');
+	}
+
+	public function get_route()
+	{
+		return $this->helper->route('phpbb_acp_settings_feed');
+	}
+}

--- a/phpBB/phpbb/acp/info/settings/general.php
+++ b/phpBB/phpbb/acp/info/settings/general.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace phpbb\acp\info\settings;
+
+class general extends \phpbb\acp\info\settings
+{
+	public function get_title()
+	{
+		return $this->lang->lang('ACP_GENERAL_CONFIGURATION');
+	}
+
+	public function get_auth()
+	{
+		return parent::get_auth();
+	}
+
+	public function get_route()
+	{
+		return $this->helper->route('phpbb_acp_settings_board');
+	}
+}

--- a/phpBB/phpbb/acp/info/settings/general.php
+++ b/phpBB/phpbb/acp/info/settings/general.php
@@ -2,7 +2,7 @@
 
 namespace phpbb\acp\info\settings;
 
-class general extends \phpbb\acp\info\settings
+class general extends settings
 {
 	public function get_title()
 	{

--- a/phpBB/phpbb/acp/info/settings/load.php
+++ b/phpBB/phpbb/acp/info/settings/load.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace phpbb\acp\info\settings;
+
+class load extends server_cat
+{
+	public function get_title()
+	{
+		return $this->lang->lang('ACP_LOAD_SETTINGS');
+	}
+
+	public function get_auth()
+	{
+		return parent::get_auth() && $this->auth->acl_get('a_server');
+	}
+
+	public function get_route()
+	{
+		return $this->helper->route('phpbb_acp_settings_load');
+	}
+}

--- a/phpBB/phpbb/acp/info/settings/pm.php
+++ b/phpBB/phpbb/acp/info/settings/pm.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace phpbb\acp\info\settings;
+
+class pm extends general
+{
+	public function get_title()
+	{
+		return $this->lang->lang('ACP_MESSAGE_SETTINGS');
+	}
+
+	public function get_auth()
+	{
+		return parent::get_auth() && $this->auth->acl_get('a_board');
+	}
+
+	public function get_route()
+	{
+		return $this->helper->route('phpbb_acp_settings_pm');
+	}
+}

--- a/phpBB/phpbb/acp/info/settings/post.php
+++ b/phpBB/phpbb/acp/info/settings/post.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace phpbb\acp\info\settings;
+
+class post extends general
+{
+	public function get_title()
+	{
+		return $this->lang->lang('ACP_POST_SETTINGS');
+	}
+
+	public function get_auth()
+	{
+		return parent::get_auth() && $this->auth->acl_get('a_board');
+	}
+
+	public function get_route()
+	{
+		return $this->helper->route('phpbb_acp_settings_post');
+	}
+}

--- a/phpBB/phpbb/acp/info/settings/registration.php
+++ b/phpBB/phpbb/acp/info/settings/registration.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace phpbb\acp\info\settings;
+
+class registration extends general
+{
+	public function get_title()
+	{
+		return $this->lang->lang('ACP_REGISTER_SETTINGS');
+	}
+
+	public function get_auth()
+	{
+		return parent::get_auth() && $this->auth->acl_get('a_board');
+	}
+
+	public function get_route()
+	{
+		return $this->helper->route('phpbb_acp_settings_registration');
+	}
+}

--- a/phpBB/phpbb/acp/info/settings/security.php
+++ b/phpBB/phpbb/acp/info/settings/security.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace phpbb\acp\info\settings;
+
+class security extends server_cat
+{
+	public function get_title()
+	{
+		return $this->lang->lang('ACP_SECURITY_SETTINGS');
+	}
+
+	public function get_auth()
+	{
+		return parent::get_auth() && $this->auth->acl_get('a_server');
+	}
+
+	public function get_route()
+	{
+		return $this->helper->route('phpbb_acp_settings_security');
+	}
+}

--- a/phpBB/phpbb/acp/info/settings/server.php
+++ b/phpBB/phpbb/acp/info/settings/server.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace phpbb\acp\info\settings;
+
+class server extends server_cat
+{
+	public function get_title()
+	{
+		return $this->lang->lang('ACP_SERVER_SETTINGS');
+	}
+
+	public function get_auth()
+	{
+		return parent::get_auth() && $this->auth->acl_get('a_server');
+	}
+
+	public function get_route()
+	{
+		return $this->helper->route('phpbb_acp_settings_server');
+	}
+}

--- a/phpBB/phpbb/acp/info/settings/server_cat.php
+++ b/phpBB/phpbb/acp/info/settings/server_cat.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace phpbb\acp\info\settings;
+
+class server_cat extends \phpbb\acp\info\settings
+{
+	public function get_title()
+	{
+		return $this->lang->lang('ACP_SERVER_CONFIGURATION');
+	}
+
+	public function get_auth()
+	{
+		return parent::get_auth();
+	}
+
+	public function get_route()
+	{
+		return $this->helper->route('phpbb_acp_settings_server');
+	}
+}

--- a/phpBB/phpbb/acp/info/settings/server_cat.php
+++ b/phpBB/phpbb/acp/info/settings/server_cat.php
@@ -2,7 +2,7 @@
 
 namespace phpbb\acp\info\settings;
 
-class server_cat extends \phpbb\acp\info\settings
+class server_cat extends settings
 {
 	public function get_title()
 	{

--- a/phpBB/phpbb/acp/info/settings/settings.php
+++ b/phpBB/phpbb/acp/info/settings/settings.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace phpbb\acp\info;
+namespace phpbb\acp\info\settings;
 
 class settings extends \phpbb\cp\info\base
 {

--- a/phpBB/phpbb/acp/info/settings/signature.php
+++ b/phpBB/phpbb/acp/info/settings/signature.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace phpbb\acp\info\settings;
+
+class signature extends general
+{
+	public function get_title()
+	{
+		return $this->lang->lang('ACP_SIGNATURE_SETTINGS');
+	}
+
+	public function get_auth()
+	{
+		return parent::get_auth() && $this->auth->acl_get('a_board');
+	}
+
+	public function get_route()
+	{
+		return $this->helper->route('phpbb_acp_settings_signature');
+	}
+}

--- a/phpBB/phpbb/cp/info/base.php
+++ b/phpBB/phpbb/cp/info/base.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace phpbb\cp\info;
+
+abstract class base
+{
+	protected $auth;
+	protected $config;
+	protected $helper;
+	protected $lang;
+	protected $request;
+
+	public function __construct(
+		\phpbb\auth\auth $auth,
+		\phpbb\config\config $config,
+		\phpbb\controller\helper $helper,
+		\phpbb\language\language $lang,
+		\phpbb\request\request $request
+	)
+	{
+		$this->auth		= $auth;
+		$this->config	= $config;
+		$this->helper	= $helper;
+		$this->lang		= $lang;
+		$this->request	= $request;
+	}
+
+	abstract public function get_title();
+
+	public function get_auth()
+	{
+		return true;
+	}
+
+	public function get_route()
+	{
+		return '';
+	}
+}

--- a/phpBB/phpbb/cp/manager.php
+++ b/phpBB/phpbb/cp/manager.php
@@ -1,0 +1,266 @@
+<?php
+
+namespace phpbb\cp;
+
+class manager
+{
+	protected $acp_collection;
+
+	protected $cache;
+
+	protected $config;
+
+	protected $dispatcher;
+
+	protected $extension_manager;
+
+	protected $language;
+
+	protected $panel_admin;
+
+	protected $template;
+
+	protected $user;
+
+	protected $class;
+
+	/** @var \phpbb\cp\panel\admin */
+	protected $panel;
+
+	public function __construct(
+		\phpbb\cache\driver\driver_interface $cache,
+		\phpbb\config\config $config,
+		\phpbb\event\dispatcher $dispatcher,
+		\phpbb\extension\manager $extension_manager,
+		\phpbb\language\language $language,
+		panel\admin $panel_admin,
+		\phpbb\template\template $template,
+		\phpbb\user $user
+	)
+	{
+		$this->cache				= $cache;
+		$this->config				= $config;
+		$this->dispatcher			= $dispatcher;
+		$this->extension_manager	= $extension_manager;
+		$this->language				= $language;
+		$this->panel_admin			= $panel_admin;
+		$this->template				= $template;
+		$this->user					= $user;
+	}
+
+	public function build($class, $active)
+	{
+		switch ($class)
+		{
+			case 'acp':
+				$this->panel = $this->panel_admin;
+			break;
+
+			case 'mcp':
+
+			break;
+
+			case 'ucp':
+
+			break;
+
+			default:
+				throw new \phpbb\exception\http_exception(404, 'CP_NOT_EXIST');
+			break;
+		}
+
+		$this->class = (string) $class;
+
+		# Panel language
+		$this->include_language();
+
+		# Panel build
+		$this->panel->build();
+
+		# Panel menu
+		$authorised = $this->build_menu($active);
+
+		if (!$authorised)
+		{
+			throw new \phpbb\exception\http_exception(403, 'NOT_AUTHORISED');
+		}
+	}
+
+	protected function build_menu($active)
+	{
+		$class = $this->class;
+
+		if (!($menu = $this->cache->get('_' . $class . '_menu')))
+		{
+			$menu = $this->panel->get_menu();
+
+			/**
+			 * Event to add or modify CP menu items
+			 *
+			 * @event core.cp_menu_modify
+			 * @var string	class	The control panel class (acp|mcp|ucp)
+			 * @var	array	menu	The control panel menu array
+			 * @since 4.0.0 @todo
+			 */
+			$vars = array('class', 'menu');
+			extract($this->dispatcher->trigger_event('core.cp_menu_modify', compact($vars)));
+		}
+
+		$collection = $this->panel->get_collection();
+
+		$s_auth = false;
+
+		foreach ($menu as $category_service => $subcategories)
+		{
+			/** @var \phpbb\cp\info\base $category */
+			$category = $collection[$category_service];
+
+			$category_auth = $category->get_auth();
+
+			if ($category_service === $active)
+			{
+				$s_auth = $category_auth;
+			}
+
+			if (!$category_auth)
+			{
+				continue;
+			}
+
+			$category_children = [];
+			$category_selected = false;
+
+			foreach ($subcategories as $subcategory_service => $items)
+			{
+				/** @var \phpbb\cp\info\base $subcategory */
+				$subcategory = $collection[$subcategory_service];
+
+				$subcategory_auth = $subcategory->get_auth();
+
+				if ($subcategory_service === $active)
+				{
+					$s_auth = $subcategory_auth;
+				}
+
+				if (!$subcategory_auth)
+				{
+					continue;
+				}
+
+				$subcategory_children = [];
+				$subcategory_selected = false;
+
+				if ($items !== null)
+				{
+					foreach ($items as $item_service)
+					{
+						/** @var \phpbb\cp\info\base $item */
+						$item = $collection[$item_service];
+
+						$item_auth = $item->get_auth();
+
+						if ($item_service === $active)
+						{
+							$s_auth = $item_auth;
+						}
+
+						if (!$item_auth)
+						{
+							continue;
+						}
+
+						$item_selected = $item_service === $active;
+						$subcategory_selected = $subcategory_selected ? $subcategory_selected : $item_selected;
+
+						$subcategory_children[] = $this->get_template_variables($item, $item_selected);
+					}
+				}
+
+				$subcategory_selected = $subcategory_service === $active || $subcategory_selected;
+				$category_selected = $category_selected ? $category_selected : $subcategory_selected;
+
+				$subcategory_vars = $this->get_template_variables($subcategory, $subcategory_selected);
+
+				if ($subcategory_children)
+				{
+					$subcategory_vars['CHILDREN'] = $subcategory_children;
+				}
+
+				$category_children[] = $subcategory_vars;
+			}
+
+			$category_selected = $category_service === $active || $category_selected;
+			$category_vars = $this->get_template_variables($category, $category_selected);
+
+			if ($category_children)
+			{
+				$category_vars['CHILDREN'] = $category_children;
+
+				if ($category_selected)
+				{
+					$this->template->assign_block_vars_array($this->class . '_menu_items', $category_children);
+				}
+			}
+
+			$this->template->assign_block_vars($this->class . '_menu', $category_vars);
+		}
+
+		return $s_auth;
+	}
+
+	/**
+	 * X
+	 *
+	 * @param \phpbb\cp\info\base	$item
+	 * @param bool					$selected
+	 * @return array
+	 * @access protected
+	 */
+	protected function get_template_variables($item, $selected)
+	{
+		return [
+			'TITLE'			=> $item->get_title(),
+			'S_SELECTED'	=> $selected,
+			'U_VIEW'		=> $item->get_route(),
+		];
+	}
+
+	protected function include_language()
+	{
+		switch ($this->class)
+		{
+			case 'acp':
+				$this->language->add_lang('acp/common');
+			break;
+
+			case 'mcp':
+			case 'ucp':
+				$this->language->add_lang($this->class);
+			break;
+		}
+
+		$files = [];
+
+		$finder = $this->extension_manager->get_finder();
+
+		$language_array = array_unique([
+			$this->user->data['user_lang'],
+			$this->config['default_lang'],
+			\phpbb\language\language::FALLBACK_LANGUAGE,
+		]);
+
+		foreach ($language_array as $language_iso)
+		{
+			$files += $finder
+				->prefix('info_' . $this->class . '_')
+				->suffix('.php')
+				->extension_directory('language/' . $language_iso . '/')
+				->find();
+		}
+
+		foreach ($files as $language_file => $extension_name)
+		{
+			$this->language->add_lang($language_file, $extension_name);
+		}
+	}
+}

--- a/phpBB/phpbb/cp/panel/admin.php
+++ b/phpBB/phpbb/cp/panel/admin.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace phpbb\cp\panel;
+
+class admin
+{
+	protected $acp_collection;
+	protected $auth;
+	protected $lang;
+	protected $path_helper;
+	protected $template;
+	protected $user;
+	protected $admin_path;
+	protected $root_path;
+
+	public function __construct(
+		$acp_collection,
+		\phpbb\auth\auth $auth,
+		\phpbb\language\language $lang,
+		\phpbb\path_helper $path_helper,
+		\phpbb\template\template $template,
+		\phpbb\user $user
+	)
+	{
+		$this->acp_collection	= $acp_collection;
+		$this->auth				= $auth;
+		$this->lang				= $lang;
+		$this->path_helper		= $path_helper;
+		$this->template			= $template;
+		$this->user				= $user;
+
+		$this->root_path		= $path_helper->get_phpbb_root_path();
+		$this->admin_path		= $this->root_path . $path_helper->get_adm_relative_path();
+	}
+
+	public function build()
+	{
+		define('ADMIN_START', true);
+
+		if (!function_exists('get_database_size'))
+		{
+			include($this->root_path . 'includes/functions_admin.php');
+		}
+
+		if (!function_exists('adm_page_header'))
+		{
+			include($this->root_path . 'includes/functions_acp.php');
+		}
+
+		// Have they authenticated (again) as an admin for this session?
+		if (!isset($user->data['session_admin']) || !$this->user->data['session_admin'])
+		{
+	#		login_box('', $this->lang->lang('LOGIN_ADMIN_CONFIRM'), $this->lang->lang('LOGIN_ADMIN_SUCCESS'), true, false);
+		}
+
+		// Is user any type of admin? No, then stop here, each script needs to
+		// check specific permissions but this is a catchall
+		if (!$this->auth->acl_get('a_'))
+		{
+			throw new \phpbb\exception\http_exception(403, 'NO_ADMIN');
+		}
+
+		// We define the admin variables now, because the user is now able to use the admin related features...
+		define('IN_ADMIN', true);
+
+		$this->template->set_custom_style(array(
+			array(
+				'name' 		=> 'adm',
+				'ext_path' 	=> 'style',
+			),
+		), $this->admin_path . 'style');
+
+		$this->template->assign_var('T_ASSETS_PATH', $this->path_helper->update_web_root_path($this->root_path) . 'assets');
+		$this->template->assign_var('T_TEMPLATE_PATH', $this->path_helper->update_web_root_path($this->admin_path) . 'style');
+	}
+
+	public function get_collection()
+	{
+		return $this->acp_collection;
+	}
+
+	public function get_menu()
+	{
+		return [
+			'phpbb.acp.info.management'	=> [
+				'phpbb.acp.info.index'		=> null,
+			],
+			'phpbb.acp.info.settings'	=> [
+				'phpbb.acp.info.settings.general'	=> [
+					'phpbb.acp.info.settings.board',
+					'phpbb.acp.info.settings.features',
+					'phpbb.acp.info.settings.post',
+					'phpbb.acp.info.settings.pm',
+					'phpbb.acp.info.settings.avatar',
+					'phpbb.acp.info.settings.signature',
+					'phpbb.acp.info.settings.registration',
+					'phpbb.acp.info.settings.feed',
+				],
+				'phpbb.acp.info.settings.server.cat'	=> [
+					'phpbb.acp.info.settings.server',
+					'phpbb.acp.info.settings.cookie',
+					'phpbb.acp.info.settings.security',
+					'phpbb.acp.info.settings.load',
+				],
+				'phpbb.acp.info.settings.client'	=> [
+					'phpbb.acp.info.settings.auth',
+					'phpbb.acp.info.settings.email',
+				],
+			],
+		];
+	}
+}

--- a/phpBB/phpbb/event/kernel_exception_subscriber.php
+++ b/phpBB/phpbb/event/kernel_exception_subscriber.php
@@ -44,6 +44,13 @@ class kernel_exception_subscriber implements EventSubscriberInterface
 	*/
 	protected $language;
 
+	/**
+	 * User object
+	 *
+	 * @var \phpbb\user
+	 */
+	protected $user;
+
 	/** @var \phpbb\request\type_cast_helper */
 	protected $type_caster;
 
@@ -54,11 +61,12 @@ class kernel_exception_subscriber implements EventSubscriberInterface
 	* @param \phpbb\language\language	$language	Language object
 	* @param bool						$debug		Set to true to show full exception messages
 	*/
-	public function __construct(\phpbb\template\template $template, \phpbb\language\language $language, $debug = false)
+	public function __construct(\phpbb\template\template $template, \phpbb\language\language $language, \phpbb\user $user, $debug = false)
 	{
 		$this->debug = $debug || defined('DEBUG');
 		$this->template = $template;
 		$this->language = $language;
+		$this->user = $user;
 		$this->type_caster = new \phpbb\request\type_cast_helper();
 	}
 
@@ -89,7 +97,14 @@ class kernel_exception_subscriber implements EventSubscriberInterface
 
 		if (!$event->getRequest()->isXmlHttpRequest())
 		{
-			page_header($this->language->lang('INFORMATION'));
+			if (defined('IN_ADMIN') && isset($this->user->data['session_admin']) && $this->user->data['session_admin'])
+			{
+				adm_page_header($this->language->lang('INFORMATION'));
+			}
+			else
+			{
+				page_header($this->language->lang('INFORMATION'));
+			}
 
 			$this->template->assign_vars(array(
 				'MESSAGE_TITLE' => $this->language->lang('INFORMATION'),
@@ -100,7 +115,14 @@ class kernel_exception_subscriber implements EventSubscriberInterface
 				'body' => 'message_body.html',
 			));
 
-			page_footer(true, false, false);
+			if (defined('IN_ADMIN') && isset($user->data['session_admin']) && $user->data['session_admin'])
+			{
+				adm_page_footer();
+			}
+			else
+			{
+				page_footer(true, false, false);
+			}
 
 			$response = new Response($this->template->assign_display('body'), 500);
 		}


### PR DESCRIPTION
Checklist:

- [x] Correct branch: master for new features; 3.2.x for fixes
- [ ] Tests pass
- [ ] Code follows coding guidelines: [master](https://area51.phpbb.com/docs/dev/master/development/coding_guidelines.html) and [3.2.x](https://area51.phpbb.com/docs/dev/3.2.x/development/coding_guidelines.html)
- [ ] Commit follows commit message [format](https://area51.phpbb.com/docs/dev/3.2.x/development/git.html)

Tracker ticket - https://tracker.phpbb.com/browse/PHPBB3-15977

---

## Terminology

- **Category:** General
  - **Item:** ACP index
  - **Subcategory:** Client communication
    - **Item:** Email settings

--- 
## Proposed structure:
> ℹ️  everything below with **acp** will also have a **mcp** and **ucp** counter part.

> ⚠️ The only thing not being adhered to is using the routing prefix in the file structure and naming. While the route prefix is `/admin`, `/mod`, `/user`, the file structure uses `acp`, `mcp`, `ucp`, as these terms are way more descriptive and known.

- config
  - container
    - services_cp.yml
    - acp
      - services_acp.yml
      - services_*category1*.yml
      - services_*category2*.yml
      - ...
      - info
        - services_*category1*.yml
        - services_*category2*.yml
        - ...
  - routing
    - acp
      - *category1*.yml
      - *category2*.yml
      - ...
- phpbb
  - [acp](#acp-explanation)
    - [controller](#controllers)
      - [helper.php](#ACP-controller-helper) `extends \phpbb\controller\helper`
      - *category1_item1*.php
      - ...
    - [functions](#functions)
      - acp.php
      - ...
    - info
      - *category1*
        - *category1*.php `extends \phpbb\cp\info\base`
        - *category1_item*.php `extends category1`
        - ...
      - *category2*
        - *category2*.php `extends \phpbb\cp\info\base`
        - *category2_item*.php `extends category2`
  - [cp](#cp-explanation)
    - [manager.php](#manager)
    - [info](#info)
      - base
    - [panel](#panel)
      - admin
      - mod
      - user

---
## *CP Explanation<a id="acp-explanation"></a>
### ACP controller helper <a id="acp-controller-helper"></a>
This will be only available for the ACP panel, as it needs a different header and footer than the rest, so it can not use the regular controller helper to render pages.

### <a id="controllers">Controllers</a>
Controllers work as per usual, with a `return $this->helper->render()`.
They do however have to call a single method from the `phpbb\cp\manager` (*control panel manager*). This should be like `$this->cp_manager->build('acp', 'phpbb.acp.info.index');`. Where the first parameter is the control panel to build and the second parameter is the active item.

This will however mean that every controller has to include the `cp.manager` as a service. We could add a wrapper function to the `controller.helper` for ease of access, as this service has to be included anyway.

### Functions <a id="functions"></a>
Added into its own directory, as there will / should be quite a few function files. While most are currently in `includes/` or within a module itself, they should be moved to services so a dedicated directory for that from the beginning.

---
## CP Explanation<a id="cp-explanation"></a>
### Manager <a id="manager"></a>
The manager for the Control Panels will do a couple of things:
- Call the `build()` function for the panel
- Include the language for the panel
  - `acp/common`, `mcp`, `ucp` respectively.
  - extension's language files prefixed with `info_*cp_`
- Build the menu for the panel
- Check authentication for the panel's active item
### Panel <a id="panel"></a>
Each panel (acp/mcp/ucp) will have its own class here, with 3 functions.
- `build()`<br>
This is to setup the core things for this panel, eg some base authentication and in case of the ACP, set up the template's custom style.
- `get_menu()`<br>
This will return the core *(phpBB's native)* control panel menu.
```php
return [
	'category1'	=> [
    	'item1'	=> null,
        'subcategory1'	=> [
        	'item2',
            'item3',
        ],
    ],
];
```
- `get_collection()`<br>
This will return all the services tagged for this control panel, the service collection.
### Info <a id="info"></a>
The info base class will be extended by all categories, which in turn are extended by their subcategories, which in turn are extended by their items:
- Category1 `extends \phpbb\cp\info\base`
  - Item1 `extends category1`
  - Subcategory1 `extends category1`
    - Item 2 `extends subcategory1`

This will build a class hierarchy and allow for easy authentication checking, as every info class should include a call to the `parent::get_auth()`.
This way only the active item's auth has to be checked and autommatically the entire *'path' (parents)* is checked aswell.