### PR TITLE
CSS: remove redundant 'li' in 'ul > li' selectors

### DIFF
--- a/phpBB/styles/prosilver/theme/bidi.css
+++ b/phpBB/styles/prosilver/theme/bidi.css
@@ -61,7 +61,7 @@
 	margin-left: 7px;
 }
 
-.rtl ul.linklist > li.rightside,
+.rtl ul.linklist > .rightside,
 .rtl p.rightside,
 .rtl a.rightside {
 	text-align: left;

--- a/phpBB/styles/prosilver/theme/buttons.css
+++ b/phpBB/styles/prosilver/theme/buttons.css
@@ -194,7 +194,7 @@ button::-moz-focus-inner {
 
 
 /* stylelint-disable selector-no-qualifying-type */
-ul.linklist.bulletin > li.small-icon:before {
+ul.linklist.bulletin > .small-icon:before {
 	display: none;
 }
 /* stylelint-enable selector-no-qualifying-type */

--- a/phpBB/styles/prosilver/theme/common.css
+++ b/phpBB/styles/prosilver/theme/common.css
@@ -270,7 +270,7 @@ ul.linklist > li {
 	list-style-type: none;
 }
 
-ul.linklist > li.rightside,
+ul.linklist > .rightside,
 p.rightside,
 a.rightside {
 	text-align: right;
@@ -339,11 +339,11 @@ ul.linklist.bulletin > li:before {
 }
 
 ul.linklist.bulletin > li:first-child:before,
-ul.linklist.bulletin > li.rightside:last-child:before {
+ul.linklist.bulletin > .rightside:last-child:before {
 	content: none;
 }
 
-ul.linklist.bulletin > li.no-bulletin:before {
+ul.linklist.bulletin > .no-bulletin:before {
 	content: none;
 }
 


### PR DESCRIPTION
No functional change; just remove a few redundant 'li' in CSS selectors (since ul must be succeeded by li).