### PR TITLE
[ticket/15257] Provide error messages for non enableable extensions

### DIFF
--- a/phpBB/includes/acp/acp_extensions.php
+++ b/phpBB/includes/acp/acp_extensions.php
@@ -168,10 +168,7 @@ class acp_extensions
 				}
 
 				$extension = $this->ext_manager->get_extension($ext_name);
-				if (!$extension->is_enableable())
-				{
-					trigger_error($this->user->lang['EXTENSION_NOT_ENABLEABLE'] . adm_back_link($this->u_action), E_USER_WARNING);
-				}
+				$this->extension_is_enableable($extension);
 
 				if ($this->ext_manager->is_enabled($ext_name))
 				{
@@ -199,10 +196,7 @@ class acp_extensions
 				}
 
 				$extension = $this->ext_manager->get_extension($ext_name);
-				if (!$extension->is_enableable())
-				{
-					trigger_error($this->user->lang['EXTENSION_NOT_ENABLEABLE'] . adm_back_link($this->u_action), E_USER_WARNING);
-				}
+				$this->extension_is_enableable($extension);
 
 				try
 				{
@@ -656,6 +650,23 @@ class acp_extensions
 				'AUTHOR_HOMEPAGE'	=> (isset($author['homepage'])) ? $author['homepage'] : '',
 				'AUTHOR_ROLE'		=> (isset($author['role'])) ? $author['role'] : '',
 			));
+		}
+	}
+
+	/**
+	 * Trigger an error message if the extension is not enableable.
+	 *
+	 * @param phpbb\extension\extension_interface $extension
+	 */
+	protected function extension_is_enableable($extension)
+	{
+		if(!$extension->is_enableable()) {
+			$error_message_list = $extension->get_activation_errors();
+
+			\array_unshift($error_message_list, $this->user->lang('CLI_EXTENSION_ENABLE_FAILURE'));
+
+			$error_message = \implode('<br />', $error_message_list);
+			trigger_error($error_message . adm_back_link($this->u_action), E_USER_WARNING);
 		}
 	}
 }

--- a/phpBB/phpbb/console/command/extension/enable.php
+++ b/phpBB/phpbb/console/command/extension/enable.php
@@ -69,7 +69,12 @@ class enable extends command
 		}
 		else
 		{
-			$io->error($this->user->lang('CLI_EXTENSION_ENABLE_FAILURE', $name));
+			$error_message_list = $extension->get_activation_errors();
+
+			\array_unshift($error_message_list, $this->user->lang('CLI_EXTENSION_ENABLE_FAILURE'));
+
+			$error_message = \implode('<br />', $error_message_list);
+			$io->error($error_message, $name);
 			return 1;
 		}
 	}

--- a/phpBB/phpbb/extension/base.php
+++ b/phpBB/phpbb/extension/base.php
@@ -38,6 +38,9 @@ class base implements \phpbb\extension\extension_interface
 	/** @var string[] */
 	private $migrations = false;
 
+	/** @var string[] */
+	private $activation_errors;
+
 	/**
 	* Constructor
 	*
@@ -55,6 +58,8 @@ class base implements \phpbb\extension\extension_interface
 
 		$this->extension_name = $extension_name;
 		$this->extension_path = $extension_path;
+
+		$this->activation_errors = array();
 	}
 
 	/**
@@ -62,7 +67,15 @@ class base implements \phpbb\extension\extension_interface
 	*/
 	public function is_enableable()
 	{
-		return true;
+		return 0 === \count($this->activation_errors);
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	public function get_activation_errors()
+	{
+		return $this->activation_errors;
 	}
 
 	/**

--- a/phpBB/phpbb/extension/extension_interface.php
+++ b/phpBB/phpbb/extension/extension_interface.php
@@ -27,6 +27,13 @@ interface extension_interface
 	public function is_enableable();
 
 	/**
+	 * Returns the errors generated when trying to enable the extension.
+	 *
+	 * @return string[]
+	 */
+	public function get_activation_errors();
+
+	/**
 	* enable_step is executed on enabling an extension until it returns false.
 	*
 	* Calls to this function can be made in subsequent requests, when the


### PR DESCRIPTION
This pull request is an alternate proposal of #5555

The main differences are:

- A function is added to the extension interface to retrieve the errors of the extension in the form of an array.
- phpBB's internationalized extension error always goes first. This way it is ensured that the first displayed error is understandable by anyone.

The reason for this alternate PR is mainly consistency:

1. `is_enableable` always returning `bool` simplifies error checking.
2. Error logic is simplified if only an array is used, instead of an `bool|string|array` approach.

**Todo**
- [ ] Implement test functions
- [ ] Try to extract logic from `extension_is_enableable`.
- [ ] Add info about `array_push`ing errors to the errors array for extension developers.

**Questions**

1. Should a `add_error_message` function be added to populate the array? I assumed that error checks are carried out when the extension class is instantiated, as I supposed that the `is_enableable` is also checked at that time.

**Note:** I want to remark that this is a friendly alternate approach :hugs: , I didn't want to fill the other PR with noise and that's why I decided to open a new one :wink: 

Checklist:

- [X] Correct branch: master for new features; 3.2.x for fixes
- [ ] Tests pass
- [X] Code follows coding guidelines: [master](https://area51.phpbb.com/docs/dev/master/development/coding_guidelines.html) and [3.2.x](https://area51.phpbb.com/docs/dev/3.2.x/development/coding_guidelines.html)
- [X] Commit follows commit message [format](https://area51.phpbb.com/docs/dev/3.2.x/development/git.html)

Tracker ticket (set the ticket ID to **your ticket ID**):

https://tracker.phpbb.com/browse/PHPBB3-15257

---
### Alternative approach
The following approach refactors my suggested changes. The code is simplified for the sake of brevity.

```php
<?php //extension_interface.php
interface extension_interface
{
    /**
    * Add an error to the error list.
    *
    * @param string $error Error message.
    */
    public function add_activation_error($error);

    /**
    * Returns the error list as a unique string separated by <br /> tags.
    *
    * @return string
    */
    public function get_formatted_error_list();
}
```

```php
<?php // base.php
class base implements \phpbb\extension\extension_interface {
	/**
	 * {@inheritDoc}
	 */
	public function add_activation_error($error)
	{
		\array_unshift($this->activation_errors, $error);
	}

	/**
	 * {@inheritDoc}
	 */
	public function get_formatted_error_list()
	{
		return \implode('<br />', $this->activation_errors);
	}
}
```

```php
<?php // acp_extensions.php
class acp_extensions {
	/**
	 * Trigger an error message if the extension is not enableable.
	 *
	 * @param phpbb\extension\extension_interface $extension
	 */
	protected function extension_is_enableable($extension)
	{
		if(!$extension->is_enableable()) {
			$extension->add_error_message($this->user->lang('CLI_EXTENSION_ENABLE_FAILURE'));

			$error_message = $extension->get_formatted_error_list();

			trigger_error($error_message . adm_back_link($this->u_action), E_USER_WARNING);
		}
	}
}