### PR TITLE
[ticket/16034] Fix [url=] links being incorrectly shortened

### DIFF
--- a/phpBB/phpbb/textformatter/s9e/link_helper.php
+++ b/phpBB/phpbb/textformatter/s9e/link_helper.php
@@ -60,8 +60,10 @@ class link_helper
 		$length = $end - $start;
 		$text   = substr($parser->getText(), $start, $length);
 
-		// Create a tag that consumes the link's text
-		$parser->addSelfClosingTag('LINK_TEXT', $start, $length)->setAttribute('text', $text);
+		// Create a tag that consumes the link's text and make it depends on this tag
+		$link_text_tag = $parser->addSelfClosingTag('LINK_TEXT', $start, $length);
+		$link_text_tag->setAttribute('text', $text);
+		$tag->cascadeInvalidationTo($link_text_tag);
 	}
 
 	/**

--- a/tests/text_formatter/s9e/default_formatting_test.php
+++ b/tests/text_formatter/s9e/default_formatting_test.php
@@ -254,6 +254,10 @@ class phpbb_textformatter_s9e_default_formatting_test extends phpbb_test_case
 				'<a href="http://example.org/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx" class="postlink">xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx</a>'
 			),
 			array(
+				'[url=http://example.org/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx]http://example.org/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx[/url]',
+				'<a href="http://example.org/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx" class="postlink">http://example.org/xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx</a>'
+			),
+			array(
 				'[quote="[url=http://example.org]xxx[/url]"]...[/quote]',
 				'<blockquote><div><cite><a href="http://example.org" class="postlink">xxx</a> wrote:</cite>...</div></blockquote>'
 			),


### PR DESCRIPTION
Links that were created by a [url=] BBCode are not meant to be shortened. However, if the text content of the link is a valid URL, that valid URL gets shortened.

Checklist:

- [x] Correct branch: master for new features; 3.2.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master](https://area51.phpbb.com/docs/dev/master/development/coding_guidelines.html) and [3.2.x](https://area51.phpbb.com/docs/dev/3.2.x/development/coding_guidelines.html)
- [x] Commit follows commit message [format](https://area51.phpbb.com/docs/dev/3.2.x/development/git.html)

Tracker ticket (set the ticket ID to **your ticket ID**):

https://tracker.phpbb.com/browse/PHPBB3-16034