### PR TITLE
[captcha/qa] fix warning around using count() with NULL variable

### DIFF
--- a/phpBB/phpbb/captcha/plugins/qa.php
+++ b/phpBB/phpbb/captcha/plugins/qa.php
@@ -21,7 +21,7 @@ class qa
 {
 	var $confirm_id;
 	var $answer;
-	var $question_ids;
+	var $question_ids = [];
 	var $question_text;
 	var $question_lang;
 	var $question_strict;


### PR DESCRIPTION
The QA captcha plugin gives the following warnings when the user's language doesn't have any questions set. The code runs `count()` on a NULL variable:
```
[phpBB Debug] PHP Warning: in file [ROOT]/phpbb/captcha/plugins/qa.php on line 87: count(): Parameter must be an array or an object that implements Countable
[phpBB Debug] PHP Warning: in file [ROOT]/phpbb/captcha/plugins/qa.php on line 104: count(): Parameter must be an array or an object that implements Countable
```