### PR TITLE
[ticket/16058] Travis CI: "sudo: required" not longer is

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: php
-sudo: required
 
 matrix:
   include:


### PR DESCRIPTION
[Travis are now recommending removing the __sudo__ tag](https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration).

"_If you currently specify __sudo:__ in your __.travis.yml__, we recommend removing that configuration_"

https://tracker.phpbb.com/browse/PHPBB3-16058