### PR TITLE
[ticket/16066] Fix FORM_INVALID always returned for banned user.

### DIFF
--- a/phpBB/includes/functions.php
+++ b/phpBB/includes/functions.php
@@ -2364,7 +2364,7 @@ function login_box($redirect = '', $l_explain = '', $l_success = '', $admin = fa
 		}
 
 		// Check form key
-		if ($password && !check_form_key($form_name))
+		if ($password && !defined('IN_CHECK_BAN') && !check_form_key($form_name))
 		{
 			$result = array(
 				'status' => false,


### PR DESCRIPTION
PHPBB3-16066

After the introduction of add_form_key() and check_form_key() calls to
login_box() in phpBB 3.2.6 and later, if a banned user attempts to login,
they receive a "The submitted form was invalid. Try submitting again."
A recursive call into login_box() by the check_ban() processing was not
taken into account by the phpBB 3.2.6 change, and was impossible to succeed.

Checklist:

- [x] Correct branch: master for new features; 3.3.x & 3.2.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master](https://area51.phpbb.com/docs/dev/master/development/coding_guidelines.html), [3.3.x](https://area51.phpbb.com/docs/dev/3.3.x/development/coding_guidelines.html) and [3.2.x](https://area51.phpbb.com/docs/dev/3.2.x/development/coding_guidelines.html)
- [x] Commit follows commit message [format](https://area51.phpbb.com/docs/dev/3.3.x/development/git.html)

Tracker ticket (set the ticket ID to **your ticket ID**):

https://tracker.phpbb.com/browse/PHPBB3-16066
