### PR TITLE
[ticket/15886] Use getMockBuilder instead of removed getMock()

### DIFF
--- a/tests/group/helper_test_case.php
+++ b/tests/group/helper_test_case.php
@@ -59,7 +59,7 @@ class phpbb_group_helper_test_case extends phpbb_test_case
 		global $phpbb_dispatcher, $phpbb_root_path, $phpEx;
 
 		// Set up authentication data for testing
-		$auth = $this->getMock('\phpbb\auth\auth');
+		$auth = $this->getMockBuilder('\phpbb\auth\auth')->disableOriginalConstructor()->getMock();
 		$auth->expects($this->any())
 			->method('acl_get')
 			->with($this->stringContains('_'), $this->anything())

--- a/tests/notification/group_request_test.php
+++ b/tests/notification/group_request_test.php
@@ -49,7 +49,7 @@ class phpbb_notification_group_request_test extends phpbb_tests_notification_bas
 			$this->cache->get_driver()
 		));
 		$this->container->set('group_helper', new \phpbb\group\helper(
-			$this->getMock('\phpbb\auth\auth'),
+			$this->getMockBuilder('\phpbb\auth\auth')->disableOriginalConstructor()->getMock(),
 			$this->cache,
 			$this->config,
 			new \phpbb\language\language(
@@ -61,7 +61,7 @@ class phpbb_notification_group_request_test extends phpbb_tests_notification_bas
 					new phpbb_mock_request()
 				),
 				new \phpbb\filesystem\filesystem(),
-				$this->getMock('\phpbb\request\request'),
+				$this->getMockBuilder('\phpbb\request\request')->disableOriginalConstructor()->getMock(),
 				$phpbb_root_path,
 				$phpEx
 			),


### PR DESCRIPTION
PHPBB3-15886

Checklist:

- [x] Correct branch: master for new features; 3.3.x & 3.2.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master](https://area51.phpbb.com/docs/dev/master/development/coding_guidelines.html), [3.3.x](https://area51.phpbb.com/docs/dev/3.3.x/development/coding_guidelines.html) and [3.2.x](https://area51.phpbb.com/docs/dev/3.2.x/development/coding_guidelines.html)
- [x] Commit follows commit message [format](https://area51.phpbb.com/docs/dev/3.3.x/development/git.html)

Tracker ticket (set the ticket ID to **your ticket ID**):

https://tracker.phpbb.com/browse/PHPBB3-15886
