### PR TITLE
[ticket/16054] Restore ability to login from any template.

### DIFF
--- a/phpBB/includes/functions.php
+++ b/phpBB/includes/functions.php
@@ -2526,9 +2526,6 @@ function login_box($redirect = '', $l_explain = '', $l_success = '', $admin = fa
 		));
 	}
 
-	// Add form token for login box
-	add_form_key($form_name, '_LOGIN');
-
 	$s_hidden_fields = build_hidden_fields($s_hidden_fields);
 
 	$login_box_template_data = array(
@@ -2662,9 +2659,6 @@ function login_forum_box($forum_data)
 	extract($phpbb_dispatcher->trigger_event('core.login_forum_box', compact($vars)));
 
 	page_header($user->lang['LOGIN']);
-
-	// Add form token for login box
-	add_form_key('login', '_LOGIN');
 
 	$template->assign_vars(array(
 		'FORUM_NAME'			=> isset($forum_data['forum_name']) ? $forum_data['forum_name'] : '',
@@ -4439,6 +4433,10 @@ function page_header($page_title = '', $display_online_list = false, $item_id = 
 	$notification_mark_hash = generate_link_hash('mark_all_notifications_read');
 
 	$s_login_redirect = build_hidden_fields(array('redirect' => $phpbb_path_helper->remove_web_root_path(build_url())));
+
+	// Add form token for login box, in case page is presenting a login form.
+	add_form_key('login', '_LOGIN');
+
 	/**
 	 * Workaround for missing template variable in pre phpBB 3.2.6 styles.
 	 * @deprecated 3.2.7 (To be removed: 3.3.0-a1)

--- a/phpBB/index.php
+++ b/phpBB/index.php
@@ -211,9 +211,6 @@ if ($show_birthdays)
 	$template->assign_block_vars_array('birthdays', $birthdays);
 }
 
-// Add form token for login box
-add_form_key('login', '_LOGIN');
-
 // Assign index specific vars
 $template->assign_vars(array(
 	'TOTAL_POSTS'	=> $user->lang('TOTAL_POSTS_COUNT', (int) $config['num_posts']),

--- a/phpBB/viewforum.php
+++ b/phpBB/viewforum.php
@@ -198,9 +198,6 @@ if (!($forum_data['forum_type'] == FORUM_POST || (($forum_data['forum_flags'] & 
 // We also make this circumstance available to the template in case we want to display a notice. ;)
 if (!$auth->acl_gets('f_read', 'f_list_topics', $forum_id))
 {
-	// Add form token for login box
-	add_form_key('login', '_LOGIN');
-
 	$template->assign_vars(array(
 		'S_NO_READ_ACCESS'		=> true,
 	));


### PR DESCRIPTION
PHPBB3-16054

Moving the login form's add_form_key() work into page_header(), so that the
template variables required for presenting a login form are again available
to any template that chooses to consume them.

Checklist:

- [x] Correct branch: master for new features; 3.3.x & 3.2.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master](https://area51.phpbb.com/docs/dev/master/development/coding_guidelines.html), [3.3.x](https://area51.phpbb.com/docs/dev/3.3.x/development/coding_guidelines.html) and [3.2.x](https://area51.phpbb.com/docs/dev/3.2.x/development/coding_guidelines.html)
- [x] Commit follows commit message [format](https://area51.phpbb.com/docs/dev/3.3.x/development/git.html)

Tracker ticket (set the ticket ID to **your ticket ID**):

https://tracker.phpbb.com/browse/PHPBB3-16054
