### PR TITLE
[ticket/16141] plupload chunk_size incorrect when 'unlimited' is involved.

### DIFF
--- a/phpBB/phpbb/plupload/plupload.php
+++ b/phpBB/phpbb/plupload/plupload.php
@@ -314,7 +314,7 @@ class plupload
 		{
 			$max = min($limit_post, ($max ? $max : $limit_post));
 		}
-		
+
 		// $config['max_filesize'] is not a limiter to chunk size.
 
 		return floor($max / 2);

--- a/phpBB/phpbb/plupload/plupload.php
+++ b/phpBB/phpbb/plupload/plupload.php
@@ -305,14 +305,14 @@ class plupload
 
 		if ($limit_upload > 0)
 		{
-			$max = min($limit_upload, $max ? $max : $limit_upload);
+			$max = min($limit_upload, ($max ? $max : $limit_upload));
 		}
 
 		$limit_post = $this->php_ini->getBytes('post_max_size');
 
 		if ($limit_post > 0)
 		{
-			$max = min($limit_post, $max ? $max : $limit_post);
+			$max = min($limit_post, ($max ? $max : $limit_post));
 		}
 		
 		// $config['max_filesize'] is not a limiter to chunk size.

--- a/tests/plupload/plupload_test.php
+++ b/tests/plupload/plupload_test.php
@@ -54,4 +54,72 @@ class phpbb_plupload_test extends phpbb_test_case
 
 		$this->assertEquals($expected, $plupload->generate_resize_string());
 	}
+
+	public function data_get_chunk_size()
+	{
+		return [
+			[[
+				'memory_limit' => -1,
+				'upload_max_filesize' => 0,
+				'post_max_size' => 0,
+			], 0],
+			[[
+				'memory_limit' => -1,
+				'upload_max_filesize' => 500,
+				'post_max_size' => 400,
+			], 200],
+			[[
+				'memory_limit' => 100,
+				'upload_max_filesize' => 0,
+				'post_max_size' => 300,
+			], 50],
+			[[
+				'memory_limit' => 300,
+				'upload_max_filesize' => 200,
+				'post_max_size' => 0,
+			], 100],
+			[[
+				'memory_limit' => 3000,
+				'upload_max_filesize' => 800,
+				'post_max_size' => 900,
+			], 400],
+			[[
+				'memory_limit' => 2000,
+				'upload_max_filesize' => 1000,
+				'post_max_size' => 600,
+			], 300],
+		];
+	}
+
+	/**
+	 * @dataProvider data_get_chunk_size
+	 */
+	public function test_get_chunk_size($limits_ary, $expected)
+	{
+		global $phpbb_root_path, $phpEx;
+
+		$lang = new \phpbb\language\language(new \phpbb\language\language_file_loader($phpbb_root_path, $phpEx));
+		$config = new \phpbb\config\config([]);
+
+		$ini_wrapper = $this->getMockBuilder('\bantu\IniGetWrapper\IniGetWrapper')
+			->setMethods(['getBytes'])
+			->getMock();
+		$ini_wrapper->method('getBytes')
+			->will($this->returnValueMap([
+				['memory_limit', $limits_ary['memory_limit']],
+				['upload_max_filesize', $limits_ary['upload_max_filesize']],
+				['post_max_size', $limits_ary['post_max_size']]
+			]));
+
+		$plupload = new \phpbb\plupload\plupload(
+			'',
+			$config,
+			new phpbb_mock_request,
+			new \phpbb\user($lang, '\phpbb\datetime'),
+			$ini_wrapper,
+			new \phpbb\mimetype\guesser(array(new \phpbb\mimetype\extension_guesser))
+		);
+
+		$this->assertEquals($expected, $plupload->get_chunk_size());
+	}
 }

--- a/tests/plupload/plupload_test.php
+++ b/tests/plupload/plupload_test.php
@@ -88,6 +88,11 @@ class phpbb_plupload_test extends phpbb_test_case
 				'upload_max_filesize' => 1000,
 				'post_max_size' => 600,
 			], 300],
+			[[
+				'memory_limit' => 1000,
+				'upload_max_filesize' => 2000,
+				'post_max_size' => 3000,
+			], 500],
 		];
 	}
 


### PR DESCRIPTION
PHPBB3-16141

Change get_chunk_size() calculation to correctly calculate limits without
letting a zero "unlimited" value always win.  Also ensure get_chunk_size()
can only return zero if all of the limits were in fact set to unlimited.

Checklist:

- [x] Correct branch: master for new features; 3.3.x & 3.2.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master](https://area51.phpbb.com/docs/dev/master/development/coding_guidelines.html), [3.3.x](https://area51.phpbb.com/docs/dev/3.3.x/development/coding_guidelines.html) and [3.2.x](https://area51.phpbb.com/docs/dev/3.2.x/development/coding_guidelines.html)
- [x] Commit follows commit message [format](https://area51.phpbb.com/docs/dev/3.3.x/development/git.html)

Tracker ticket (set the ticket ID to **your ticket ID**):

https://tracker.phpbb.com/browse/PHPBB3-16141
