### PR TITLE
[ticket/15422] Remove redundant BBCode helpline

### DIFF
--- a/phpBB/adm/style/acp_posting_buttons.html
+++ b/phpBB/adm/style/acp_posting_buttons.html
@@ -5,27 +5,6 @@
 	var bbcode = new Array();
 	var bbtags = new Array('[b]','[/b]','[i]','[/i]','[u]','[/u]','[quote]','[/quote]','[code]','[/code]','[list]','[/list]','[list=]','[/list]','[img]','[/img]','[url]','[/url]','[flash=]', '[/flash]','[size=]','[/size]'<!-- BEGIN custom_tags -->, {custom_tags.BBCODE_NAME}<!-- END custom_tags -->);
 
-	// Helpline messages
-	var help_line = {
-		b: '{LA_BBCODE_B_HELP}',
-		i: '{LA_BBCODE_I_HELP}',
-		u: '{LA_BBCODE_U_HELP}',
-		q: '{LA_BBCODE_Q_HELP}',
-		c: '{LA_BBCODE_C_HELP}',
-		l: '{LA_BBCODE_L_HELP}',
-		o: '{LA_BBCODE_O_HELP}',
-		p: '{LA_BBCODE_P_HELP}',
-		w: '{LA_BBCODE_W_HELP}',
-		a: '{LA_BBCODE_A_HELP}',
-		s: '{LA_BBCODE_S_HELP}',
-		f: '{LA_BBCODE_F_HELP}',
-		y: '{LA_BBCODE_Y_HELP}',
-		d: '{LA_BBCODE_D_HELP}'
-		<!-- BEGIN custom_tags -->
-			,cb_{custom_tags.BBCODE_ID}{L_COLON} '{custom_tags.A_BBCODE_HELPLINE}'
-		<!-- END custom_tags -->
-	}
-
 // ]]>
 </script>
 
@@ -65,7 +44,7 @@
 	</select>
 	<!-- EVENT acp_posting_buttons_custom_tags_before -->
 	<!-- BEGIN custom_tags -->
-	<input type="button" class="button2" name="addbbcode{custom_tags.BBCODE_ID}" value="{custom_tags.BBCODE_TAG}" onclick="bbstyle({custom_tags.BBCODE_ID})" title="{custom_tags.BBCODE_HELPLINE}" />
+	<input type="button" class="button2" name="addbbcode{custom_tags.BBCODE_ID}" value="{custom_tags.BBCODE_TAG}" onclick="bbstyle({custom_tags.BBCODE_ID})" title="{{ custom_tags.BBCODE_HELPLINE|e('html_attr') }}" />
 	<!-- END custom_tags -->
 </div>
 <!-- EVENT acp_posting_buttons_after -->

--- a/phpBB/assets/javascript/editor.js
+++ b/phpBB/assets/javascript/editor.js
@@ -18,16 +18,9 @@ var is_win = ((clientPC.indexOf('win') !== -1) || (clientPC.indexOf('16bit') !==
 var baseHeight;
 
 /**
-* Shows the help messages in the helpline window
-*/
-function helpline(help) {
-	document.forms[form_name].helpbox.value = help_line[help];
-}
-
-/**
 * Fix a bug involving the TextRange object. From
 * http://www.frostjedi.com/terra/scripts/demo/caretBug.html
-*/ 
+*/
 function initInsertions() {
 	var doc;
 
@@ -104,8 +97,8 @@ function bbfontstyle(bbopen, bbclose) {
 	}
 	// IE
 	else if (document.selection) {
-		var range = textarea.createTextRange(); 
-		range.move("character", new_pos); 
+		var range = textarea.createTextRange();
+		range.move("character", new_pos);
 		range.select();
 		storeCaret(textarea);
 	}

--- a/phpBB/includes/functions_display.php
+++ b/phpBB/includes/functions_display.php
@@ -1117,7 +1117,6 @@ function display_custom_bbcodes()
 			'BBCODE_TAG'		=> $row['bbcode_tag'],
 			'BBCODE_TAG_CLEAN'	=> str_replace('=', '-', $row['bbcode_tag']),
 			'BBCODE_HELPLINE'	=> $row['bbcode_helpline'],
-			'A_BBCODE_HELPLINE'	=> str_replace(array('&amp;', '&quot;', "'", '&lt;', '&gt;'), array('&', '"', "\'", '<', '>'), $row['bbcode_helpline']),
 		);
 
 		/**

--- a/phpBB/styles/prosilver/template/posting_buttons.html
+++ b/phpBB/styles/prosilver/template/posting_buttons.html
@@ -10,27 +10,6 @@
 	var bbtags = new Array('[b]','[/b]','[i]','[/i]','[u]','[/u]','[quote]','[/quote]','[code]','[/code]','[list]','[/list]','[list=]','[/list]','[img]','[/img]','[url]','[/url]','[flash=]', '[/flash]','[size=]','[/size]'<!-- BEGIN custom_tags -->, {custom_tags.BBCODE_NAME}<!-- END custom_tags -->);
 	var imageTag = false;
 
-	// Helpline messages
-	var help_line = {
-		b: '{LA_BBCODE_B_HELP}',
-		i: '{LA_BBCODE_I_HELP}',
-		u: '{LA_BBCODE_U_HELP}',
-		q: '{LA_BBCODE_Q_HELP}',
-		c: '{LA_BBCODE_C_HELP}',
-		l: '{LA_BBCODE_L_HELP}',
-		o: '{LA_BBCODE_O_HELP}',
-		p: '{LA_BBCODE_P_HELP}',
-		w: '{LA_BBCODE_W_HELP}',
-		a: '{LA_BBCODE_A_HELP}',
-		s: '{LA_BBCODE_S_HELP}',
-		f: '{LA_BBCODE_F_HELP}',
-		y: '{LA_BBCODE_Y_HELP}',
-		d: '{LA_BBCODE_D_HELP}'
-		<!-- BEGIN custom_tags -->
-			,cb_{custom_tags.BBCODE_ID}: '{custom_tags.A_BBCODE_HELPLINE}'
-		<!-- END custom_tags -->
-	}
-
 	function change_palette()
 	{
 		phpbb.toggleDisplay('colour_palette');
@@ -117,7 +96,7 @@
 	<!-- EVENT posting_editor_buttons_custom_tags_before -->
 
 	<!-- BEGIN custom_tags -->
-	<button type="button" class="button button-secondary bbcode-{custom_tags.BBCODE_TAG_CLEAN}" name="addbbcode{custom_tags.BBCODE_ID}" value="{custom_tags.BBCODE_TAG}" onclick="bbstyle({custom_tags.BBCODE_ID})" title="{custom_tags.BBCODE_HELPLINE}">
+	<button type="button" class="button button-secondary bbcode-{custom_tags.BBCODE_TAG_CLEAN}" name="addbbcode{custom_tags.BBCODE_ID}" value="{custom_tags.BBCODE_TAG}" onclick="bbstyle({custom_tags.BBCODE_ID})" title="{{ custom_tags.BBCODE_HELPLINE|e('html_attr') }}">
 		{custom_tags.BBCODE_TAG}
 	</button>
 	<!-- END custom_tags -->


### PR DESCRIPTION
PHPBB3-15422

Checklist:

- [x] Correct branch: master for new features; 3.3.x & 3.2.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master](https://area51.phpbb.com/docs/dev/master/development/coding_guidelines.html), [3.3.x](https://area51.phpbb.com/docs/dev/3.3.x/development/coding_guidelines.html) and [3.2.x](https://area51.phpbb.com/docs/dev/3.2.x/development/coding_guidelines.html)
- [x] Commit follows commit message [format](https://area51.phpbb.com/docs/dev/3.3.x/development/git.html)

Tracker ticket (set the ticket ID to **your ticket ID**):

https://tracker.phpbb.com/browse/PHPBB3-15422

--- 

Follow up of https://github.com/phpbb/phpbb/pull/5188

He was on the right track with his PR already, as those `LA_` variables are functions, and do not have to be defined anywhere. And the 'regular' help lines are still used in `title` attributes.

Some small unrelated (automatic) changes to the editor.js file, removing redundant spaces. Gotta love phpstorm.
