### PR TITLE
[ticket/16150] Make post subject link an absolute url

### DIFF
--- a/phpBB/styles/prosilver/template/mcp_topic.html
+++ b/phpBB/styles/prosilver/template/mcp_topic.html
@@ -118,7 +118,7 @@
 
 				<!-- EVENT mcp_topic_postrow_post_details_before -->
 				<p class="author">
-					<a href="#pr{postrow.POST_ID}" title="{postrow.MINI_POST}">
+					<a href="{postrow.U_MINI_POST}" title="{postrow.MINI_POST}">
 						<i class="icon fa-file fa-fw icon-lightgray icon-tiny" aria-hidden="true"></i><span class="sr-only">{postrow.MINI_POST}</span>
 					</a> {L_POSTED} {postrow.POST_DATE} {L_POST_BY_AUTHOR} {% EVENT mcp_topic_post_author_full_prepend %}<strong>{postrow.POST_AUTHOR_FULL}</strong>{% EVENT mcp_topic_post_author_full_append %}<!-- IF postrow.U_MCP_DETAILS --> [ <a href="{postrow.U_MCP_DETAILS}">{L_POST_DETAILS}</a> ]<!-- ENDIF -->
 				</p>

--- a/phpBB/styles/prosilver/template/posting_review.html
+++ b/phpBB/styles/prosilver/template/posting_review.html
@@ -13,7 +13,7 @@
 <!-- ENDIF -->
 
 	<div class="postbody" id="ppr{post_review_row.POST_ID}">
-		<h3><a href="#ppr{post_review_row.POST_ID}">{post_review_row.POST_SUBJECT}</a></h3>
+		<h3><a href="{post_review_row.U_MINI_POST}">{post_review_row.POST_SUBJECT}</a></h3>
 		<p class="author">
 			<!-- IF S_IS_BOT -->
 				<span><i class="icon fa-file fa-fw icon-lightgray icon-md" aria-hidden="true"></i><span class="sr-only">{post_review_row.MINI_POST}</span></span>

--- a/phpBB/styles/prosilver/template/posting_topic_review.html
+++ b/phpBB/styles/prosilver/template/posting_topic_review.html
@@ -24,7 +24,7 @@
 	<!-- ENDIF -->
 
 		<div class="postbody" id="pr{topic_review_row.POST_ID}">
-			<h3><a href="#pr{topic_review_row.POST_ID}">{topic_review_row.POST_SUBJECT}</a></h3>
+			<h3><a href="{topic_review_row.U_MINI_POST}">{topic_review_row.POST_SUBJECT}</a></h3>
 
 			<!-- IF (topic_review_row.POSTER_QUOTE and topic_review_row.DECODED_MESSAGE) or topic_review_row.U_MCP_DETAILS -->
 			<ul class="post-buttons">

--- a/phpBB/styles/prosilver/template/viewtopic_body.html
+++ b/phpBB/styles/prosilver/template/viewtopic_body.html
@@ -224,7 +224,7 @@
 			<div id="post_content{postrow.POST_ID}"<!-- IF postrow.S_POST_HIDDEN --> style="display: none;"<!-- ENDIF -->>
 
 			<!-- EVENT viewtopic_body_post_subject_before -->
-			<h3 <!-- IF postrow.S_FIRST_ROW -->class="first"<!-- ENDIF -->><!-- IF postrow.POST_ICON_IMG --><img src="{T_ICONS_PATH}{postrow.POST_ICON_IMG}" width="{postrow.POST_ICON_IMG_WIDTH}" height="{postrow.POST_ICON_IMG_HEIGHT}" alt="{postrow.POST_ICON_IMG_ALT}" title="{postrow.POST_ICON_IMG_ALT}" /> <!-- ENDIF --><a href="#p{postrow.POST_ID}">{postrow.POST_SUBJECT}</a></h3>
+			<h3 <!-- IF postrow.S_FIRST_ROW -->class="first"<!-- ENDIF -->><!-- IF postrow.POST_ICON_IMG --><img src="{T_ICONS_PATH}{postrow.POST_ICON_IMG}" width="{postrow.POST_ICON_IMG_WIDTH}" height="{postrow.POST_ICON_IMG_HEIGHT}" alt="{postrow.POST_ICON_IMG_ALT}" title="{postrow.POST_ICON_IMG_ALT}" /> <!-- ENDIF --><a href="{postrow.U_MINI_POST}">{postrow.POST_SUBJECT}</a></h3>
 
 		<!-- DEFINE $SHOW_POST_BUTTONS = (postrow.U_EDIT or postrow.U_DELETE or postrow.U_REPORT or postrow.U_WARN or postrow.U_INFO or postrow.U_QUOTE) -->
 		<!-- EVENT viewtopic_body_post_buttons_list_before -->

--- a/tests/functional/download_test.php
+++ b/tests/functional/download_test.php
@@ -55,7 +55,7 @@ class phpbb_functional_download_test extends phpbb_functional_test_case
 
 		// Test creating a reply
 		$post2 = $this->create_post($this->data['forums']['Download #1'], $post['topic_id'], 'Re: Download Topic #1-#2', 'This is a test post posted by the testing framework.', array('upload_files' => 1));
-		$crawler = self::request('GET', "viewtopic.php?t={$post2['topic_id']}&sid={$this->sid}");
+		$crawler = self::request('GET', "viewtopic.php?p={$post2['post_id']}&sid={$this->sid}");
 
 		$this->assertContains('Re: Download Topic #1-#2', $crawler->filter('html')->text());
 		$this->data['posts']['Re: Download Topic #1-#2'] = (int) $post2['post_id'];

--- a/tests/functional/feed_test.php
+++ b/tests/functional/feed_test.php
@@ -337,7 +337,7 @@ class phpbb_functional_feed_test extends phpbb_functional_test_case
 
 		// Test creating a reply
 		$post2 = $this->create_post($this->data['forums']['Feeds #news'], $post['topic_id'], 'Re: Feeds #news - Topic #2', 'This is a test post posted by the testing framework.');
-		$crawler = self::request('GET', "viewtopic.php?t={$post2['topic_id']}&sid={$this->sid}");
+		$crawler = self::request('GET', "viewtopic.php?p={$post2['post_id']}&sid={$this->sid}");
 
 		self::assertContains('Re: Feeds #news - Topic #2', $crawler->filter('html')->text());
 		$this->data['posts']['Re: Feeds #news - Topic #2'] = (int) $post2['post_id'];
@@ -493,7 +493,7 @@ class phpbb_functional_feed_test extends phpbb_functional_test_case
 
 		// Test creating a reply
 		$post2 = $this->create_post($this->data['forums']['Feeds #1'], $post['topic_id'], 'Re: Feeds #1 - Topic #2', 'This is a test post posted by the testing framework.');
-		$crawler = self::request('GET', "viewtopic.php?t={$post2['topic_id']}&sid={$this->sid}");
+		$crawler = self::request('GET', "viewtopic.php?p={$post2['post_id']}&sid={$this->sid}");
 
 		self::assertContains('Re: Feeds #1 - Topic #2', $crawler->filter('html')->text());
 		$this->data['posts']['Re: Feeds #1 - Topic #2'] = (int) $post2['post_id'];
@@ -1222,7 +1222,7 @@ class phpbb_functional_feed_test extends phpbb_functional_test_case
 
 		// Test creating a reply with 1 missing attachment
 		$post2 = $this->create_post($this->data['forums']['Feeds #1'], $this->data['topics']['Feeds #1 - Topic #3'], 'Re: Feeds #1 - Topic #3-1', 'This is a test post posted by the testing framework. [attachment=0]Attachment #0[/attachment]');
-		$crawler = self::request('GET', "viewtopic.php?t={$post2['topic_id']}&sid={$this->sid}");
+		$crawler = self::request('GET', "viewtopic.php?p={$post2['post_id']}&sid={$this->sid}");
 
 		self::assertContains('Re: Feeds #1 - Topic #3-1', $crawler->filter('html')->text());
 		$this->data['posts']['Re: Feeds #1 - Topic #3-1'] = (int) $post2['post_id'];

--- a/tests/functional/posting_test.php
+++ b/tests/functional/posting_test.php
@@ -29,7 +29,7 @@ class phpbb_functional_posting_test extends phpbb_functional_test_case
 		// Test creating a reply with bbcode
 		$post2 = $this->create_post(2, $post['topic_id'], 'Re: Test Topic 1', 'This is a test [b]post[/b] posted by the testing framework.');
 
-		$crawler = self::request('GET', "viewtopic.php?t={$post2['topic_id']}&sid={$this->sid}");
+		$crawler = self::request('GET', "viewtopic.php?p={$post2['post_id']}&sid={$this->sid}");
 		$this->assertContains('This is a test post posted by the testing framework.', $crawler->filter('html')->text());
 
 		// Test quoting a message
@@ -161,7 +161,7 @@ class phpbb_functional_posting_test extends phpbb_functional_test_case
 		{
 			$this->set_quote_depth($quote_depth);
 
-			$post = $this->create_post(2, $topic['topic_id'], 'Re: Test Topic 1', $text);
+			$post = $this->create_post(2, $topic['topic_id'], "Re: Test Topic 1#$quote_depth", $text);
 			$url  = "viewtopic.php?p={$post['post_id']}&sid={$this->sid}";
 
 			$crawler = self::request('GET', $url);

--- a/tests/functional/prune_shadow_topic_test.php
+++ b/tests/functional/prune_shadow_topic_test.php
@@ -77,7 +77,7 @@ class phpbb_functional_prune_shadow_topic_test extends phpbb_functional_test_cas
 
 		// Test creating a reply
 		$post2 = $this->create_post($this->data['forums']['Prune Shadow'], $this->post['topic_id'], 'Re: Prune Shadow #1-#2', 'This is a test post posted by the testing framework.');
-		$crawler = self::request('GET', "viewtopic.php?t={$post2['topic_id']}&sid={$this->sid}");
+		$crawler = self::request('GET', "viewtopic.php?p={$post2['post_id']}&sid={$this->sid}");
 
 		$this->assertContains('Re: Prune Shadow #1-#2', $crawler->filter('html')->text());
 		$this->data['posts']['Re: Prune Shadow #1-#2'] = (int) $post2['post_id'];

--- a/tests/functional/visibility_softdelete_test.php
+++ b/tests/functional/visibility_softdelete_test.php
@@ -97,7 +97,7 @@ class phpbb_functional_visibility_softdelete_test extends phpbb_functional_test_
 
 		// Test creating a reply
 		$post2 = $this->create_post($this->data['forums']['Soft Delete #1'], $post['topic_id'], 'Re: Soft Delete Topic #1-#2', 'This is a test post posted by the testing framework.');
-		$crawler = self::request('GET', "viewtopic.php?t={$post2['topic_id']}&sid={$this->sid}");
+		$crawler = self::request('GET', "viewtopic.php?p={$post2['post_id']}&sid={$this->sid}");
 
 		$this->assertContains('Re: Soft Delete Topic #1-#2', $crawler->filter('html')->text());
 		$this->data['posts']['Re: Soft Delete Topic #1-#2'] = (int) $post2['post_id'];
@@ -114,7 +114,7 @@ class phpbb_functional_visibility_softdelete_test extends phpbb_functional_test_
 
 		// Test creating another reply
 		$post3 = $this->create_post($this->data['forums']['Soft Delete #1'], $post['topic_id'], 'Re: Soft Delete Topic #1-#3', 'This is another test post posted by the testing framework.');
-		$crawler = self::request('GET', "viewtopic.php?t={$post3['topic_id']}&sid={$this->sid}");
+		$crawler = self::request('GET', "viewtopic.php?p={$post3['post_id']}&sid={$this->sid}");
 
 		$this->assertContains('Re: Soft Delete Topic #1-#3', $crawler->filter('html')->text());
 		$this->data['posts']['Re: Soft Delete Topic #1-#3'] = (int) $post3['post_id'];


### PR DESCRIPTION
The previous version was relative to a &start= which was
sometimes wrong.

PHPBB3-16150

Checklist:

- [x] Correct branch: master for new features; 3.3.x & 3.2.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master](https://area51.phpbb.com/docs/dev/master/development/coding_guidelines.html), [3.3.x](https://area51.phpbb.com/docs/dev/3.3.x/development/coding_guidelines.html) and [3.2.x](https://area51.phpbb.com/docs/dev/3.2.x/development/coding_guidelines.html)
- [x] Commit follows commit message [format](https://area51.phpbb.com/docs/dev/3.3.x/development/git.html)

Tracker ticket (set the ticket ID to **your ticket ID**):

https://tracker.phpbb.com/browse/PHPBB3-16150
