### PR TITLE
[ticket/16206] Remove no longer needed workaround for PHP bug #66834

### DIFF
--- a/phpBB/phpbb/di/service_collection.php
+++ b/phpBB/phpbb/di/service_collection.php
@@ -49,21 +49,6 @@ class service_collection extends \ArrayObject
 		return new service_collection_iterator($this);
 	}
 
-	// Because of a PHP issue we have to redefine offsetExists
-	// (even with a call to the parent):
-	// 		https://bugs.php.net/bug.php?id=66834
-	// 		https://bugs.php.net/bug.php?id=67067
-	// But it triggers a sniffer issue that we have to skip
-	// @codingStandardsIgnoreStart
-	/**
-	* {@inheritdoc}
-	*/
-	public function offsetExists($index)
-	{
-		return parent::offsetExists($index);
-	}
-	// @codingStandardsIgnoreEnd
-
 	/**
 	* {@inheritdoc}
 	*/
@@ -76,11 +61,11 @@ class service_collection extends \ArrayObject
 	* Add a service to the collection
 	*
 	* @param string $name The service name
-	* @return null
+	* @return void
 	*/
 	public function add($name)
 	{
-		$this->offsetSet($name, null);
+		$this->offsetSet($name, false);
 	}
 
 	/**


### PR DESCRIPTION
PHPBB-16206

Checklist:

- [x] Correct branch: master for new features; 3.3.x & 3.2.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master](https://area51.phpbb.com/docs/dev/master/development/coding_guidelines.html), [3.3.x](https://area51.phpbb.com/docs/dev/3.3.x/development/coding_guidelines.html) and [3.2.x](https://area51.phpbb.com/docs/dev/3.2.x/development/coding_guidelines.html)
- [x] Commit follows commit message [format](https://area51.phpbb.com/docs/dev/3.3.x/development/git.html)

Tracker ticket (set the ticket ID to **your ticket ID**):

https://tracker.phpbb.com/browse/PHPBB3-16206

Problem is / was, that `isset()` also checks if value is not `null`.
This is an issue for the test environment, where the actual items for the service collections are not added.
So wasn't a PHP bug after all 😅 

Referencing #5732 