### PR TITLE
[ticket/16258] Fix sample Sphinx configuration file causing incomplete delta indexing

### DIFF
--- a/phpBB/docs/sphinx.sample.conf
+++ b/phpBB/docs/sphinx.sample.conf
@@ -41,7 +41,7 @@ source source_phpbb_{SPHINX_ID}_main
 }
 source source_phpbb_{SPHINX_ID}_delta : source_phpbb_{SPHINX_ID}_main
 {
-	sql_query_pre =
+	sql_query_pre = SET NAMES 'utf8'
 	sql_query_range =
 	sql_range_step =
 	sql_query = SELECT \
@@ -61,7 +61,7 @@ source source_phpbb_{SPHINX_ID}_delta : source_phpbb_{SPHINX_ID}_main
 						WHERE \
 							p.topic_id = t.topic_id \
 							AND p.post_id >= ( SELECT max_doc_id FROM phpbb_sphinx WHERE counter_id=1 )
-	sql_query_pre =
+	sql_query_post_index =
 }
 index index_phpbb_{SPHINX_ID}_main
 {


### PR DESCRIPTION
Changes to sample Sphinx configuration file so all recent posts are included in delta index.

When using sample Sphinx configuration file from ./docs, the Sphinx indexer only includes most recent post in delta index and not all posts since the indexer was last run for the main index. The Sphinx configuration generated by the ACP module does not suffer the same problem and uses the correct values. This change brings both configuration files into line.

Checklist:

- [ ] Correct branch: master for new features; 3.3.x & 3.2.x for fixes
- [ ] Tests pass
- [ ] Code follows coding guidelines: [master](https://area51.phpbb.com/docs/dev/master/development/coding_guidelines.html), [3.3.x](https://area51.phpbb.com/docs/dev/3.3.x/development/coding_guidelines.html) and [3.2.x](https://area51.phpbb.com/docs/dev/3.2.x/development/coding_guidelines.html)
- [ ] Commit follows commit message [format](https://area51.phpbb.com/docs/dev/3.3.x/development/git.html)

Tracker ticket (set the ticket ID to **your ticket ID**):

https://tracker.phpbb.com/browse/PHPBB3-16258
