### PR TITLE
[ticket/15592] Fix attachments place inline button if BBCode is disabled

### DIFF
--- a/phpBB/styles/prosilver/template/posting_attach_body.html
+++ b/phpBB/styles/prosilver/template/posting_attach_body.html
@@ -38,7 +38,7 @@
 							<td class="attach-name">
 								<span class="file-name ellipsis-text"></span>
 								<span class="attach-controls">
-									<input type="button" value="{L_PLACE_INLINE}" class="button2 hidden file-inline-bbcode" />&nbsp;
+									{% if S_BBCODE_ALLOWED %}<input type="button" value="{{ lang('PLACE_INLINE') }}" class="button2 hidden file-inline-bbcode" />&nbsp;{% endif %}
 									<input type="button" value="{L_DELETE_FILE}" class="button2 file-delete" />
 								</span>
 								<span class="clear"></span>
@@ -64,7 +64,7 @@
 								<span class="file-name ellipsis-text"><a href="{attach_row.U_VIEW_ATTACHMENT}">{attach_row.FILENAME}</a></span>
 								{% EVENT posting_attach_body_attach_row_controls_prepend %}
 								<span class="attach-controls">
-									<!-- IF S_INLINE_ATTACHMENT_OPTIONS --><input type="button" value="{L_PLACE_INLINE}" class="button2 file-inline-bbcode" />&nbsp; <!-- ENDIF -->
+									{% if S_BBCODE_ALLOWED and S_INLINE_ATTACHMENT_OPTIONS %}<input type="button" value="{{ lang('PLACE_INLINE') }}" class="button2 file-inline-bbcode" />&nbsp;{% endif %}
 									<input type="submit" name="delete_file[{attach_row.ASSOC_INDEX}]" value="{L_DELETE_FILE}" class="button2 file-delete" />
 								</span>
 								{% EVENT posting_attach_body_attach_row_controls_append %}


### PR DESCRIPTION
Checklist:

- [x] Correct branch: master for new features; 3.3.x & 3.2.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master](https://area51.phpbb.com/docs/dev/master/development/coding_guidelines.html), [3.3.x](https://area51.phpbb.com/docs/dev/3.3.x/development/coding_guidelines.html) and [3.2.x](https://area51.phpbb.com/docs/dev/3.2.x/development/coding_guidelines.html)
- [x] Commit follows commit message [format](https://area51.phpbb.com/docs/dev/3.3.x/development/git.html)

Tracker ticket (set the ticket ID to **your ticket ID**):

https://tracker.phpbb.com/browse/PHPBB3-15592
