### PR TITLE
[ticket/16307] Fix SQL time reporting when debug.sql_explain parameter is set

### DIFF
--- a/phpBB/phpbb/db/driver/driver.php
+++ b/phpBB/phpbb/db/driver/driver.php
@@ -1037,12 +1037,6 @@ abstract class driver implements driver_interface
 	function sql_report($mode, $query = '')
 	{
 		global $cache, $starttime, $phpbb_root_path, $phpbb_path_helper;
-		global $request;
-
-		if (is_object($request) && !$request->variable('explain', false))
-		{
-			return false;
-		}
 
 		if (!$query && $this->query_hold != '')
 		{


### PR DESCRIPTION
Checklist:

- [x] Correct branch: master for new features; 3.3.x & 3.2.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master](https://area51.phpbb.com/docs/dev/master/development/coding_guidelines.html), [3.3.x](https://area51.phpbb.com/docs/dev/3.3.x/development/coding_guidelines.html) and [3.2.x](https://area51.phpbb.com/docs/dev/3.2.x/development/coding_guidelines.html)
- [x] Commit follows commit message [format](https://area51.phpbb.com/docs/dev/3.3.x/development/git.html)

In addition to #5267.
This code https://github.com/phpbb/phpbb/blob/3.3.x/phpBB/includes/functions.php#L4323 is preventing SQL report page (when `?explain=1`) from being displayed to non-admins.

<a href="https://tracker.phpbb.com/browse/PHPBB3-16307">PHPBB3-16307</a>.
