### PR TITLE
[ticket/16329] Add configuration options for Plupload

### DIFF
--- a/phpBB/includes/acp/acp_attachments.php
+++ b/phpBB/includes/acp/acp_attachments.php
@@ -170,7 +170,7 @@ class acp_attachments
 						'img_min_thumb_filesize'	=> array('lang' => 'MIN_THUMB_FILESIZE',	'validate' => 'int:0:999999999999999',	'type' => 'number:0:999999999999999', 'explain' => true, 'append' => ' ' . $user->lang['BYTES']),
 						'img_max'					=> array('lang' => 'MAX_IMAGE_SIZE',		'validate' => 'int:0:9999',	'type' => 'dimension:0:9999', 'explain' => true, 'append' => ' ' . $user->lang['PIXEL']),
 						'img_strip_metadata'		=> array('lang' => 'IMAGE_STRIP_METADATA',	'validate' => 'bool',	'type' => 'radio:yes_no', 'explain' => true),
-						'img_quality'				=> array('lang' => 'IMAGE_QUALITY',			'validate' => 'int:1:100',	'type' => 'number:1:100', 'explain' => true, 'append' => '&nbsp;&percnt;'),
+						'img_quality'				=> array('lang' => 'IMAGE_QUALITY',			'validate' => 'int:50:90',	'type' => 'number:50:90', 'explain' => true, 'append' => ' &percnt;'),
 						'img_link'					=> array('lang' => 'IMAGE_LINK_SIZE',		'validate' => 'int:0:9999',	'type' => 'dimension:0:9999', 'explain' => true, 'append' => ' ' . $user->lang['PIXEL']),
 					)
 				);

--- a/phpBB/includes/acp/acp_attachments.php
+++ b/phpBB/includes/acp/acp_attachments.php
@@ -169,6 +169,8 @@ class acp_attachments
 						'img_max_thumb_width'		=> array('lang' => 'MAX_THUMB_WIDTH',		'validate' => 'int:0:999999999999999',	'type' => 'number:0:999999999999999', 'explain' => true, 'append' => ' ' . $user->lang['PIXEL']),
 						'img_min_thumb_filesize'	=> array('lang' => 'MIN_THUMB_FILESIZE',	'validate' => 'int:0:999999999999999',	'type' => 'number:0:999999999999999', 'explain' => true, 'append' => ' ' . $user->lang['BYTES']),
 						'img_max'					=> array('lang' => 'MAX_IMAGE_SIZE',		'validate' => 'int:0:9999',	'type' => 'dimension:0:9999', 'explain' => true, 'append' => ' ' . $user->lang['PIXEL']),
+						'img_strip_metadata'		=> array('lang' => 'IMAGE_STRIP_METADATA',	'validate' => 'bool',	'type' => 'radio:yes_no', 'explain' => true),
+						'img_quality'				=> array('lang' => 'IMAGE_QUALITY',			'validate' => 'int:1:100',	'type' => 'number:1:100', 'explain' => true, 'append' => '&nbsp;&percnt;'),
 						'img_link'					=> array('lang' => 'IMAGE_LINK_SIZE',		'validate' => 'int:0:9999',	'type' => 'dimension:0:9999', 'explain' => true, 'append' => ' ' . $user->lang['PIXEL']),
 					)
 				);

--- a/phpBB/install/schemas/schema_data.sql
+++ b/phpBB/install/schemas/schema_data.sql
@@ -155,7 +155,7 @@ INSERT INTO phpbb_config (config_name, config_value) VALUES ('img_max_height', '
 INSERT INTO phpbb_config (config_name, config_value) VALUES ('img_max_thumb_width', '400');
 INSERT INTO phpbb_config (config_name, config_value) VALUES ('img_max_width', '0');
 INSERT INTO phpbb_config (config_name, config_value) VALUES ('img_min_thumb_filesize', '12000');
-INSERT INTO phpbb_config (config_name, config_value) VALUES ('img_quality', '90');
+INSERT INTO phpbb_config (config_name, config_value) VALUES ('img_quality', '85');
 INSERT INTO phpbb_config (config_name, config_value) VALUES ('img_strip_metadata', '1');
 INSERT INTO phpbb_config (config_name, config_value) VALUES ('ip_check', '3');
 INSERT INTO phpbb_config (config_name, config_value) VALUES ('ip_login_limit_max', '50');

--- a/phpBB/install/schemas/schema_data.sql
+++ b/phpBB/install/schemas/schema_data.sql
@@ -156,7 +156,7 @@ INSERT INTO phpbb_config (config_name, config_value) VALUES ('img_max_thumb_widt
 INSERT INTO phpbb_config (config_name, config_value) VALUES ('img_max_width', '0');
 INSERT INTO phpbb_config (config_name, config_value) VALUES ('img_min_thumb_filesize', '12000');
 INSERT INTO phpbb_config (config_name, config_value) VALUES ('img_quality', '85');
-INSERT INTO phpbb_config (config_name, config_value) VALUES ('img_strip_metadata', '1');
+INSERT INTO phpbb_config (config_name, config_value) VALUES ('img_strip_metadata', '0');
 INSERT INTO phpbb_config (config_name, config_value) VALUES ('ip_check', '3');
 INSERT INTO phpbb_config (config_name, config_value) VALUES ('ip_login_limit_max', '50');
 INSERT INTO phpbb_config (config_name, config_value) VALUES ('ip_login_limit_time', '21600');

--- a/phpBB/install/schemas/schema_data.sql
+++ b/phpBB/install/schemas/schema_data.sql
@@ -155,6 +155,8 @@ INSERT INTO phpbb_config (config_name, config_value) VALUES ('img_max_height', '
 INSERT INTO phpbb_config (config_name, config_value) VALUES ('img_max_thumb_width', '400');
 INSERT INTO phpbb_config (config_name, config_value) VALUES ('img_max_width', '0');
 INSERT INTO phpbb_config (config_name, config_value) VALUES ('img_min_thumb_filesize', '12000');
+INSERT INTO phpbb_config (config_name, config_value) VALUES ('img_quality', '90');
+INSERT INTO phpbb_config (config_name, config_value) VALUES ('img_strip_metadata', '1');
 INSERT INTO phpbb_config (config_name, config_value) VALUES ('ip_check', '3');
 INSERT INTO phpbb_config (config_name, config_value) VALUES ('ip_login_limit_max', '50');
 INSERT INTO phpbb_config (config_name, config_value) VALUES ('ip_login_limit_time', '21600');

--- a/phpBB/language/en/acp/attachments.php
+++ b/phpBB/language/en/acp/attachments.php
@@ -111,6 +111,10 @@ $lang = array_merge($lang, array(
 
 	'IMAGE_LINK_SIZE'			=> 'Image link dimensions',
 	'IMAGE_LINK_SIZE_EXPLAIN'	=> 'Display image attachment as an inline text link if image is larger than this. To disable this behaviour, set the values to 0px by 0px.',
+	'IMAGE_QUALITY'				=> 'Quality for image compression',
+	'IMAGE_QUALITY_EXPLAIN'		=> 'Higher value means lower compression/larger file size. Default 90%. Setting is only effective if max image dimensions set to value other than 0px v 0px, but will then apply to all uploaded JPEG images',
+	'IMAGE_STRIP_METADATA'		=> 'Strip image metadata',
+	'IMAGE_STRIP_METADATA_EXPLAIN'	=> 'Strip Exif metadata eg author name, GPS coordinates & camera details (JPEG only). Setting is only effective if max image dimensions set to value other than 0px v 0px.',
 
 	'MAX_ATTACHMENTS'				=> 'Maximum number of attachments per post',
 	'MAX_ATTACHMENTS_PM'			=> 'Maximum number of attachments per private message',

--- a/phpBB/language/en/acp/attachments.php
+++ b/phpBB/language/en/acp/attachments.php
@@ -111,10 +111,10 @@ $lang = array_merge($lang, array(
 
 	'IMAGE_LINK_SIZE'			=> 'Image link dimensions',
 	'IMAGE_LINK_SIZE_EXPLAIN'	=> 'Display image attachment as an inline text link if image is larger than this. To disable this behaviour, set the values to 0px by 0px.',
-	'IMAGE_QUALITY'				=> 'Quality for image compression',
-	'IMAGE_QUALITY_EXPLAIN'		=> 'Higher value means lower compression/larger file size. Default 90%. Setting is only effective if max image dimensions set to value other than 0px v 0px, but will then apply to all uploaded JPEG images',
-	'IMAGE_STRIP_METADATA'		=> 'Strip image metadata',
-	'IMAGE_STRIP_METADATA_EXPLAIN'	=> 'Strip Exif metadata eg author name, GPS coordinates & camera details (JPEG only). Setting is only effective if max image dimensions set to value other than 0px v 0px.',
+	'IMAGE_QUALITY'				=> 'Quality of uploaded image attachments (JPEG only)',
+	'IMAGE_QUALITY_EXPLAIN'		=> 'Specify value between 50% (smaller file size) and 90% (higher quality). Quality higher than 90% increases filesize and is disabled. Setting only applies if max image dimensions set to value other than 0px by 0px.',
+	'IMAGE_STRIP_METADATA'		=> 'Strip image metadata (JPEG only)',
+	'IMAGE_STRIP_METADATA_EXPLAIN'	=> 'Strip Exif metadata eg author name, GPS coordinates & camera details. Setting only applies if max image dimensions set to value other than 0px by 0px.',
 
 	'MAX_ATTACHMENTS'				=> 'Maximum number of attachments per post',
 	'MAX_ATTACHMENTS_PM'			=> 'Maximum number of attachments per private message',

--- a/phpBB/language/en/acp/attachments.php
+++ b/phpBB/language/en/acp/attachments.php
@@ -112,9 +112,9 @@ $lang = array_merge($lang, array(
 	'IMAGE_LINK_SIZE'			=> 'Image link dimensions',
 	'IMAGE_LINK_SIZE_EXPLAIN'	=> 'Display image attachment as an inline text link if image is larger than this. To disable this behaviour, set the values to 0px by 0px.',
 	'IMAGE_QUALITY'				=> 'Quality of uploaded image attachments (JPEG only)',
-	'IMAGE_QUALITY_EXPLAIN'		=> 'Specify value between 50% (smaller file size) and 90% (higher quality). Quality higher than 90% increases filesize and is disabled. Setting only applies if max image dimensions set to value other than 0px by 0px.',
+	'IMAGE_QUALITY_EXPLAIN'		=> 'Specify value between 50% (smaller file size) and 90% (higher quality). Quality higher than 90% increases filesize and is disabled. Setting only applies if maximum image dimensions are set to a value other than 0px by 0px.',
 	'IMAGE_STRIP_METADATA'		=> 'Strip image metadata (JPEG only)',
-	'IMAGE_STRIP_METADATA_EXPLAIN'	=> 'Strip Exif metadata eg author name, GPS coordinates & camera details. Setting only applies if max image dimensions set to value other than 0px by 0px.',
+	'IMAGE_STRIP_METADATA_EXPLAIN'	=> 'Strip Exif metadata, e.g. author name, GPS coordinates and camera details. Setting only applies if maximum image dimensions are set to a value other than 0px by 0px.',
 
 	'MAX_ATTACHMENTS'				=> 'Maximum number of attachments per post',
 	'MAX_ATTACHMENTS_PM'			=> 'Maximum number of attachments per private message',

--- a/phpBB/phpbb/db/migration/data/v32x/add_plupload_config.php
+++ b/phpBB/phpbb/db/migration/data/v32x/add_plupload_config.php
@@ -13,18 +13,18 @@
 
 namespace phpbb\db\migration\data\v32x;
 
-class enable_plupload_config extends \phpbb\db\migration\migration
+class add_plupload_config extends \phpbb\db\migration\migration
 {
 	static public function depends_on()
 	{
-		return ['\phpbb\db\migration\data\v32x\v329',];
+		return ['\phpbb\db\migration\data\v32x\v329'];
 	}
 
 	public function update_data()
 	{
 		return [
 			['config.add', ['img_quality', '85']],
-			['config.add', ['img_strip_metadata', '1']],
+			['config.add', ['img_strip_metadata', '0']],
 		];
 	}
 }

--- a/phpBB/phpbb/db/migration/data/v32x/enable_plupload_config.php
+++ b/phpBB/phpbb/db/migration/data/v32x/enable_plupload_config.php
@@ -23,7 +23,7 @@ class enable_plupload_config extends \phpbb\db\migration\migration
 	public function update_data()
 	{
 		return [
-			['config.add', ['img_quality', '90']],
+			['config.add', ['img_quality', '85']],
 			['config.add', ['img_strip_metadata', '1']],
 		];
 	}

--- a/phpBB/phpbb/db/migration/data/v32x/enable_plupload_config.php
+++ b/phpBB/phpbb/db/migration/data/v32x/enable_plupload_config.php
@@ -17,16 +17,14 @@ class enable_plupload_config extends \phpbb\db\migration\migration
 {
 	static public function depends_on()
 	{
-		return array(
-			'\phpbb\db\migration\data\v32x\v329',
-		);
+		return ['\phpbb\db\migration\data\v32x\v329',];
 	}
 
 	public function update_data()
 	{
-		return array(
-			array('config.add', array('img_quality', '90')),
-			array('config.add', array('img_strip_metadata', '1')),
-		);
+		return [
+			['config.add', ['img_quality', '90']],
+			['config.add', ['img_strip_metadata', '1']],
+		];
 	}
 }

--- a/phpBB/phpbb/db/migration/data/v32x/enable_plupload_config.php
+++ b/phpBB/phpbb/db/migration/data/v32x/enable_plupload_config.php
@@ -1,0 +1,32 @@
+<?php
+/**
+*
+* This file is part of the phpBB Forum Software package.
+*
+* @copyright (c) phpBB Limited <https://www.phpbb.com>
+* @license GNU General Public License, version 2 (GPL-2.0)
+*
+* For full copyright and license information, please see
+* the docs/CREDITS.txt file.
+*
+*/
+
+namespace phpbb\db\migration\data\v32x;
+
+class enable_plupload_config extends \phpbb\db\migration\migration
+{
+	static public function depends_on()
+	{
+		return array(
+			'\phpbb\db\migration\data\v32x\v329',
+		);
+	}
+
+	public function update_data()
+	{
+		return array(
+			array('config.add', array('img_quality', '90')),
+			array('config.add', array('img_strip_metadata', '1')),
+		);
+	}
+}

--- a/phpBB/phpbb/plupload/plupload.php
+++ b/phpBB/phpbb/plupload/plupload.php
@@ -263,11 +263,24 @@ class plupload
 		$resize = '';
 		if ($this->config['img_max_height'] > 0 && $this->config['img_max_width'] > 0)
 		{
-			$resize = sprintf(
-				'resize: {width: %d, height: %d, quality: 85},',
-				(int) $this->config['img_max_width'],
-				(int) $this->config['img_max_height']
-			);
+			if ($this->config['img_strip_metadata'] == 1)
+			{
+				$resize = sprintf(
+					'resize: {width: %d, height: %d, quality: %d, preserve_headers: false},',
+					(int) $this->config['img_max_width'],
+					(int) $this->config['img_max_height'],
+					(int) $this->config['img_quality']
+				);
+			}
+			else
+			{
+				$resize = sprintf(
+					'resize: {width: %d, height: %d, quality: %d},',
+					(int) $this->config['img_max_width'],
+					(int) $this->config['img_max_height'],
+					(int) $this->config['img_quality']
+				);
+			}
 		}
 
 		return $resize;

--- a/phpBB/phpbb/plupload/plupload.php
+++ b/phpBB/phpbb/plupload/plupload.php
@@ -263,24 +263,14 @@ class plupload
 		$resize = '';
 		if ($this->config['img_max_height'] > 0 && $this->config['img_max_width'] > 0)
 		{
-			if ($this->config['img_strip_metadata'] == 1)
-			{
-				$resize = sprintf(
-					'resize: {width: %d, height: %d, quality: %d, preserve_headers: false},',
-					(int) $this->config['img_max_width'],
-					(int) $this->config['img_max_height'],
-					(int) $this->config['img_quality']
-				);
-			}
-			else
-			{
-				$resize = sprintf(
-					'resize: {width: %d, height: %d, quality: %d},',
-					(int) $this->config['img_max_width'],
-					(int) $this->config['img_max_height'],
-					(int) $this->config['img_quality']
-				);
-			}
+			$preserve_headers_value = $this->config['img_strip_metadata'] ? 'false' : 'true';
+			$resize = sprintf(
+				'resize: {width: %d, height: %d, quality: %d, preserve_headers: %s},',
+				(int) $this->config['img_max_width'],
+				(int) $this->config['img_max_height'],
+				(int) $this->config['img_quality'],
+				$preserve_headers_value
+			);
 		}
 
 		return $resize;

--- a/tests/plupload/plupload_test.php
+++ b/tests/plupload/plupload_test.php
@@ -19,12 +19,16 @@ class phpbb_plupload_test extends phpbb_test_case
 			array(
 				0,
 				0,
+				85,
+				0,
 				'',
 			),
 			array(
 				130,
 				150,
-				'resize: {width: 130, height: 150, quality: 85},'
+				85,
+				1,
+				'resize: {width: 130, height: 150, quality: 85, preserve_headers: false},'
 			),
 		);
 	}
@@ -32,7 +36,7 @@ class phpbb_plupload_test extends phpbb_test_case
 	/**
 	* @dataProvider generate_resize_string_data
 	*/
-	public function test_generate_resize_string($config_width, $config_height, $expected)
+	public function test_generate_resize_string($config_width, $config_height, $config_quality, $config_metadata, $expected)
 	{
 		global $phpbb_root_path, $phpEx;
 
@@ -41,6 +45,8 @@ class phpbb_plupload_test extends phpbb_test_case
 		$config = new \phpbb\config\config(array(
 			'img_max_width'		=> $config_width,
 			'img_max_height'	=> $config_height,
+			'img_quality'		=> $config_quality,
+			'img_strip_metadata'	=> $config_metadata,
 			'upload_path'		=> 'files',
 		));
 		$plupload = new \phpbb\plupload\plupload(


### PR DESCRIPTION
Adds ACP options to configure the compression level used by Plupload (default 85%) and whether Exif metadata is stripped from image attachments (default yes).

Checklist:

- [x] Correct branch: master for new features; 3.3.x & 3.2.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master](https://area51.phpbb.com/docs/dev/master/development/coding_guidelines.html), [3.3.x](https://area51.phpbb.com/docs/dev/3.3.x/development/coding_guidelines.html) and [3.2.x](https://area51.phpbb.com/docs/dev/3.2.x/development/coding_guidelines.html)
- [x] Commit follows commit message [format](https://area51.phpbb.com/docs/dev/3.3.x/development/git.html)

Tracker ticket (set the ticket ID to **your ticket ID**):

https://tracker.phpbb.com/browse/PHPBB3-16329
https://tracker.phpbb.com/browse/PHPBB3-16330