### PR TITLE
[ticket/16149] Always return default profile field data

### DIFF
--- a/phpBB/phpbb/profilefields/manager.php
+++ b/phpBB/phpbb/profilefields/manager.php
@@ -364,7 +364,7 @@ class manager
 
 			foreach ($user_ids as $user_id)
 			{
-				if (!isset($user_fields[$user_id][$used_ident]) && $this->profile_cache[$used_ident]['field_show_novalue'])
+				if (!isset($user_fields[$user_id][$used_ident]))
 				{
 					$user_fields[$user_id][$used_ident]['value'] = '';
 					$user_fields[$user_id][$used_ident]['data'] = $this->profile_cache[$used_ident];


### PR DESCRIPTION
I removed the check for `field_show_novalue` when un-initialized profile field rows are added to the result. It doesn't matter if or where the profile field is supposed to be displayed at this point. The caller of this function is responsible to check this. With this change, the function correctly returns information about all available profile fields for users who haven't updated their profile.

Checklist:

- [x] Correct branch: master for new features; 3.3.x & 3.2.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master](https://area51.phpbb.com/docs/dev/master/development/coding_guidelines.html), [3.3.x](https://area51.phpbb.com/docs/dev/3.3.x/development/coding_guidelines.html) and [3.2.x](https://area51.phpbb.com/docs/dev/3.2.x/development/coding_guidelines.html)
- [x] Commit follows commit message [format](https://area51.phpbb.com/docs/dev/3.3.x/development/git.html)

https://tracker.phpbb.com/browse/PHPBB3-16149
