### PR TITLE
[ticket/16342] Increase default hashing costs for Argon2 passwords

### DIFF
--- a/phpBB/config/default/container/services_password.yml
+++ b/phpBB/config/default/container/services_password.yml
@@ -1,7 +1,7 @@
 parameters:
-    passwords.driver.argon2_memory_cost: 1024
+    passwords.driver.argon2_memory_cost: 65536
     passwords.driver.argon2_threads: 2
-    passwords.driver.argon2_time_cost: 2
+    passwords.driver.argon2_time_cost: 4
     passwords.driver.bcrypt_cost: 10
 
 services:

--- a/phpBB/phpbb/passwords/driver/argon2i.php
+++ b/phpBB/phpbb/passwords/driver/argon2i.php
@@ -33,7 +33,7 @@ class argon2i extends base_native
 	* @param int $threads Number of threads to use (optional)
 	* @param int $time_cost Maximum amount of time (optional)
 	*/
-	public function __construct(\phpbb\config\config $config, helper $helper, $memory_cost = 1024, $threads = 2, $time_cost = 2)
+	public function __construct(\phpbb\config\config $config, helper $helper, $memory_cost = 65536, $threads = 2, $time_cost = 4)
 	{
 		parent::__construct($config, $helper);
 
@@ -42,8 +42,8 @@ class argon2i extends base_native
 		 * See https://wiki.php.net/rfc/sodium.argon.hash and PHPBB3-16266
 		 * Don't allow cost factors to be below default settings where possible
 		 */
-		$this->memory_cost = max($memory_cost, defined('PASSWORD_ARGON2_DEFAULT_MEMORY_COST') ? PASSWORD_ARGON2_DEFAULT_MEMORY_COST : 1024);
-		$this->time_cost   = max($time_cost, defined('PASSWORD_ARGON2_DEFAULT_TIME_COST') ? PASSWORD_ARGON2_DEFAULT_TIME_COST : 2);
+		$this->memory_cost = max($memory_cost, defined('PASSWORD_ARGON2_DEFAULT_MEMORY_COST') ? PASSWORD_ARGON2_DEFAULT_MEMORY_COST : 65536);
+		$this->time_cost   = max($time_cost, defined('PASSWORD_ARGON2_DEFAULT_TIME_COST') ? PASSWORD_ARGON2_DEFAULT_TIME_COST : 4);
 		$this->threads     = (defined('PASSWORD_ARGON2_PROVIDER') && PASSWORD_ARGON2_PROVIDER == 'sodium') ?
 									PASSWORD_ARGON2_DEFAULT_THREADS : max($threads, defined('PASSWORD_ARGON2_DEFAULT_THREADS') ? PASSWORD_ARGON2_DEFAULT_THREADS : 1);
 	}

--- a/tests/passwords/drivers_test.php
+++ b/tests/passwords/drivers_test.php
@@ -24,8 +24,8 @@ class phpbb_passwords_helper_test extends \phpbb_test_case
 		
 		// Initialize argon2 default options
 		$this->argon2_default_cost_options = [
-			'memory_cost' => 1024,
-			'time_cost'   => 2,
+			'memory_cost' => 65536,
+			'time_cost'   => 4,
 			'threads'     => 2
 		];
 


### PR DESCRIPTION
Time bumped to 4, new PHP default.  
Memory bumped to 65536, new PHP default.
Threads left at 2 even though some PHP installations will default to 1.

Checklist:

- [x] Correct branch: master for new features; 3.3.x & 3.2.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master](https://area51.phpbb.com/docs/dev/master/development/coding_guidelines.html), [3.3.x](https://area51.phpbb.com/docs/dev/3.3.x/development/coding_guidelines.html) and [3.2.x](https://area51.phpbb.com/docs/dev/3.2.x/development/coding_guidelines.html)
- [x] Commit follows commit message [format](https://area51.phpbb.com/docs/dev/3.3.x/development/git.html)

Tracker ticket (set the ticket ID to **your ticket ID**):

https://tracker.phpbb.com/browse/PHPBB3-16342
