### PR TITLE
[ticket/16354] Improve installer error handling and cache issues

### DIFF
--- a/phpBB/install/startup.php
+++ b/phpBB/install/startup.php
@@ -156,7 +156,7 @@ function installer_shutdown_function($display_errors)
 			else
 			{
 				// Language system is not available
-				die('The installer has detected an issue with a cached file. Try reloading the page and/or manually clearing the cache to resolve the issue. If you require further assistance, please visit the <a href="https://www.phpbb.com/community/">phpBB support forums</a>.');
+				die('The installer has detected an issue with a cached file. Try reloading the page and/or manually clearing the cache to resolve the issue. If you require further assistance, please visit the <a href="https://www.phpbb.com/community/" target="_blank">phpBB support forums</a>.');
 			}
 		}
 		else if ($error['type'] & $supported_error_levels)

--- a/phpBB/install/startup.php
+++ b/phpBB/install/startup.php
@@ -85,13 +85,7 @@ function installer_msg_handler($errno, $msg_text, $errfile, $errline)
 			return;
 		break;
 		case E_USER_ERROR:
-			$msg = '<b>General Error:</b><br />' . $msg_text . '<br /> in file ' . $errfile . ' on line ' . $errline;
-
-			$backtrace = get_backtrace();
-			if ($backtrace)
-			{
-				$msg .= '<br /><br />BACKTRACE<br />' . $backtrace;
-			}
+			$msg = '<b>General Error:</b><br>' . $msg_text . '<br> in file ' . $errfile . ' on line ' . $errline . '<br><br>';
 
 			throw new \phpbb\exception\runtime_exception($msg);
 		break;

--- a/phpBB/phpbb/filesystem/filesystem.php
+++ b/phpBB/phpbb/filesystem/filesystem.php
@@ -637,7 +637,7 @@ class filesystem implements filesystem_interface
 	}
 
 	/**
-	 * Try to resolve real path when PHP's realpath failes to do so
+	 * Try to resolve real path when PHP's realpath fails to do so
 	 *
 	 * @param string	$path
 	 * @return bool|string


### PR DESCRIPTION
This will introduce a shutdown function that will try display a nicer error message and also try to recover from typical issues that are caused by the installer cache.

Checklist:

- [x] Correct branch: master for new features; 3.3.x & 3.2.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master](https://area51.phpbb.com/docs/dev/master/development/coding_guidelines.html), [3.3.x](https://area51.phpbb.com/docs/dev/3.3.x/development/coding_guidelines.html) and [3.2.x](https://area51.phpbb.com/docs/dev/3.2.x/development/coding_guidelines.html)
- [x] Commit follows commit message [format](https://area51.phpbb.com/docs/dev/3.3.x/development/git.html)

Tracker ticket (set the ticket ID to **your ticket ID**):

https://tracker.phpbb.com/browse/PHPBB3-16354
