### PR TITLE
[ticket/16389] Overhaul coding guidelines

### DIFF
--- a/phpBB/docs/assets/css/guidelines.css
+++ b/phpBB/docs/assets/css/guidelines.css
@@ -1,0 +1,43 @@
+body {
+	counter-reset: h2;
+}
+
+h2 {
+	font-size: 2em;
+	font-weight: bold;
+	counter-reset: h3;
+	counter-increment: h2;
+}
+
+h3 {
+	font-size: 1.3em;
+	color: #28313f;
+	counter-reset: h4;
+	counter-increment: h3;
+}
+
+h4 {
+	margin-top: 10px;
+	counter-increment: h4;
+}
+
+h2 a:before { content: counter(h2) "."; }
+h3 a:before { content: counter(h2) "." counter(h3)}
+h4 a:before { content: counter(h2) "." counter(h3) "." counter(h4); }
+
+h2 a:link,
+h2 a:visited,
+h3 a:link,
+h3 a:visited,
+h4 a:link,
+h4 a:visited {
+	font-size: 0.9em;
+	color: #ccc;
+	margin-right: 4px;
+}
+
+h2 a:hover,
+h3 a:hover,
+h4 a:hover {
+	color: #333;
+}

--- a/phpBB/docs/assets/css/stylesheet.css
+++ b/phpBB/docs/assets/css/stylesheet.css
@@ -123,7 +123,9 @@ pre {
 	border-width: 1px;
 	border-style: solid;
 	background-color: #FAFAFA;
-	padding: 0 4px
+	padding: 0 4px;
+	-moz-tab-size: 4;
+	tab-size: 4;
 }
 
 #wrap {
@@ -263,10 +265,9 @@ a:active	{ color: #368AD2; }
 	padding: 3px;
 	background-color: #FFFFFF;
 	border: 1px solid #C9D2D8;
-	font-size: 1em;
 	margin-bottom: 10px;
 	display: block;
-	font: 0.9em Monaco, "Andale Mono","Courier New", Courier, mono;
+	font: 1em Monaco, "Andale Mono","Courier New", Courier, mono;
 	line-height: 1.3em;
 }
 
@@ -342,4 +343,24 @@ a:active	{ color: #368AD2; }
 	clear: both;
 	content: '';
 	display: block;
+}
+
+.column1 {
+	float: left;
+	clear: left;
+	width: 49%;
+}
+
+.column2 {
+	float: right;
+	clear: right;
+	width: 49%;
+}
+
+@media all and (max-width: 700px) {
+	.column1, .column2 {
+		float: none;
+		width: auto;
+		clear: both;
+	}
 }

--- a/phpBB/docs/coding-guidelines.html
+++ b/phpBB/docs/coding-guidelines.html
@@ -1,14 +1,25 @@
 <!DOCTYPE html>
 <html dir="ltr" lang="en">
 <head>
-<meta charset="utf-8">
-<meta http-equiv="X-UA-Compatible" content="IE=edge">
-<meta name="keywords" content="" />
-<meta name="description" content="Proteus coding guidelines document" />
-<title>phpBB3 &bull; Coding Guidelines</title>
+	<meta charset="utf-8">
+	<meta http-equiv="X-UA-Compatible" content="IE=edge">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<meta name="keywords" content="">
+	<meta name="description" content="Proteus coding guidelines document">
+	<title>phpBB3 &bull; Coding Guidelines</title>
 
-<link href="assets/css/stylesheet.css" rel="stylesheet" type="text/css" media="screen" />
+	<link href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.1/styles/atom-one-dark-reasonable.min.css" rel="stylesheet">
+	<script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.1/highlight.min.js"></script>
+	<script>
+		document.addEventListener('DOMContentLoaded', () => {
+			document.querySelectorAll('pre').forEach((block) => {
+				hljs.highlightBlock(block);
+			});
+		});
+	</script>
 
+	<link href="assets/css/stylesheet.css" rel="stylesheet" type="text/css" media="screen">
+	<link href="assets/css/guidelines.css" rel="stylesheet" type="text/css" media="screen">
 </head>
 
 <body id="phpbb" class="section-docs">
@@ -19,12 +30,12 @@
 		<div class="headerbar">
 			<div class="inner">
 
-			<div id="doc-description">
-				<a href="../index.php" id="logo"><span class="site_logo"></span></a>
-				<h1>Coding Guidelines</h1>
-				<p>Proteus coding guidelines document</p>
-				<p style="display: none;"><a href="#start_here">Skip</a></p>
-			</div>
+				<div id="doc-description">
+					<a href="../index.php" id="logo"><span class="site_logo"></span></a>
+					<h1>Coding Guidelines</h1>
+					<p>Proteus coding guidelines document</p>
+					<p style="display: none;"><a href="#start_here">Skip</a></p>
+				</div>
 
 			</div>
 		</div>
@@ -33,1154 +44,1797 @@
 	<a name="start_here"></a>
 
 	<div id="page-body">
+		<!-- BEGIN DOCUMENT -->
 
-<!-- BEGIN DOCUMENT -->
+		<p class="paragraph main-description">
+			These are the phpBB Coding Guidelines for Proteus, all attempts should be made to follow them as closely as possible.
+		</p>
 
-<p class="paragraph main-description">
-	These are the phpBB Coding Guidelines for Proteus, all attempts should be made to follow them as closely as possible.
-</p>
+		<h1>Coding Guidelines</h1>
 
-<h1>Coding Guidelines</h1>
-
-	<div class="paragraph menu">
-		<div class="inner">
-
-		<div class="content">
-
-<ol>
-	<li><a href="#defaults">Defaults</a>
-	<ol style="list-style-type: lower-roman;">
-		<li><a href="#editorsettings">Editor Settings</a></li>
-		<li><a href="#fileheader">File Header</a></li>
-		<li><a href="#locations">File Locations</a></li>
-		<li><a href="#constants">Special Constants</a></li>
-	</ol>
-	</li>
-	<li><a href="#code">Code Layout/Guidelines</a>
-	<ol style="list-style-type: lower-roman;">
-		<li><a href="#namingvars">Variable/Function/Class Naming</a></li>
-		<li><a href="#codelayout">Code Layout</a></li>
-		<li><a href="#sql">SQL/SQL Layout</a></li>
-		<li><a href="#optimizing">Optimizations</a></li>
-		<li><a href="#general">General Guidelines</a></li>
-		<li><a href="#phprestrictions">Restrictions on the Use of PHP</a></li>
-	</ol>
-	</li>
-	<li><a href="#styling">Styling</a>
-	<ol style="list-style-type: lower-roman;">
-		<li><a href="#cfgfiles">Style Config Files</a></li>
-		<li><a href="#genstyling">General Styling Rules</a></li>
-	</ol></li>
-	<li><a href="#templating">Templating</a>
-	<ol style="list-style-type: lower-roman;">
-		<li><a href="#templates">General Templating</a></li>
-		<li><a href="#stylestree">Styles Tree</a></li>
-		<li><a href="#template-events">Template Events</a></li>
-	</ol></li>
-	<li><a href="#charsets">Character Sets and Encodings</a></li>
-	<li><a href="#translation">Translation (<abbr title="Internationalisation">i18n</abbr>/<abbr title="Localisation">L10n</abbr>) Guidelines</a>
-	<ol style="list-style-type: lower-roman;">
-		<li><a href="#standardisation">Standardisation</a></li>
-		<li><a href="#otherconsiderations">Other considerations</a></li>
-		<li><a href="#placeholders">Working with placeholders</a></li>
-		<li><a href="#usingplurals">Using plurals</a></li>
-		<li><a href="#writingstyle">Writing Style</a></li>
-	</ol>
-	</li>
-	<li><a href="#disclaimer">Copyright and disclaimer</a></li>
-</ol>
-
+		<div class="paragraph menu">
+			<div class="inner">
+				<div class="content">
+					<ol>
+						<li>
+							<a href="#defaults">Defaults</a>
+							<ol>
+								<li><a href="#defaults.editor_settings">Editor settings</a></li>
+								<li><a href="#defaults.file_layout">File layout</a></li>
+								<li><a href="#defaults.special_naming">Special naming</a></li>
+								<li><a href="#defaults.special_constants">Special constants</a></li>
+							</ol>
+						</li>
+						<li>
+							<a href="#standards">Standards</a>
+							<ol>
+								<li><a href="#standards.routing">Routing</a></li>
+								<li><a href="#standards.services">Services</a></li>
+								<li><a href="#standards.classes">Classes</a></li>
+								<li><a href="#standards.interfaces">Interfaces</a></li>
+								<li><a href="#standards.exceptions">Exceptions</a></li>
+								<li><a href="#standards.functions">Functions</a></li>
+								<li><a href="#standards.variables">Variables</a></li>
+								<li><a href="#standards.comments">Comments</a></li>
+								<li><a href="#standards.brackets">Brackets</a></li>
+								<li><a href="#standards.javascript">JavaScript</a></li>
+							</ol>
+						</li>
+						<li>
+							<a href="#code">Code</a>
+							<ol>
+								<li><a href="#code.tokens">Tokens</a></li>
+								<li><a href="#code.optimisation">Optimisation</a></li>
+								<li><a href="#code.security">Security</a></li>
+								<li><a href="#code.sql">SQL</a></li>
+							</ol>
+						</li>
+						<li>
+							<a href="#styling">Styling</a>
+							<ol>
+								<li><a href="#styling.config_files">Config files</a></li>
+								<li><a href="#styling.general_rules">General rules</a></li>
+							</ol>
+						</li>
+						<li>
+							<a href="#templating">Templating</a>
+							<ol>
+								<li><a href="#templating.general">General templating</a></li>
+								<li><a href="#templating.styles_tree">Styles tree</a></li>
+								<li><a href="#templating.template_events">Template events</a></li>
+							</ol>
+						</li>
+						<li>
+							<a href="#charsets">Character sets and Encodings</a>
+						</li>
+						<li>
+							<a href="#translation">Translation (<abbr title="Internationalisation">i18n</abbr>/<abbr title="Localisation">L10n</abbr>) Guidelines</a>
+							<ol>
+								<li><a href="#translation.standardisation">Standardisation</a></li>
+								<li><a href="#translation.considerations">Considerations</a></li>
+								<li><a href="#translation.placeholders">Placeholders</a></li>
+								<li><a href="#translation.plurals">Plurals</a></li>
+								<li><a href="#translation.writing_style">Writing style</a></li>
+							</ol>
+						</li>
+						<li>
+							<a href="#disclaimer">Copyright and Disclaimer</a>
+						</li>
+					</ol>
+				</div>
+			</div>
 		</div>
 
-		</div>
-	</div>
+		<hr>
 
-	<hr />
+		<h2 id="defaults">
+			<a href="#defaults"></a>
+			<span>Defaults</span>
+		</h2>
 
-<a name="defaults"></a><h2>1. Defaults</h2>
+		<div class="paragraph">
+			<div class="inner">
+				<div class="content">
+					<h3 id="defaults.editor_settings">
+						<a href="#defaults.editor_settings"></a>
+						<span>Editor settings</span>
+						<a href="#wrap" class="top">Back to Top</a>
+					</h3>
+					<ul>
+						<li>
+							<strong>Indentation:</strong>
+							<span>Use tabs instead of spaces. Tabs width should be 4 spaces.</span>
+						</li>
+						<li>
+							<strong>Line separator:</strong>
+							<span>Files should be saved with UNIX line feeds (<samp>LF</samp>), not <samp>CRLF</samp> or <samp>CR</samp>.</span>
+						</li>
+					</ul>
 
-	<div class="paragraph">
-		<div class="inner">
-
-		<div class="content">
-
-<a name="editorsettings"></a><h3>1.i. Editor Settings</h3>
-
-	<h4>Tabs vs Spaces:</h4>
-	<p>In order to make this as simple as possible, we will be using tabs, not spaces. We enforce 4 (four) spaces for one tab - therefore you need to set your tab width within your editor to 4 spaces. Make sure that when you <strong>save</strong> the file, it's saving tabs and not spaces. This way, we can each have the code be displayed the way we like it, without breaking the layout of the actual files.</p>
-	<p>Tabs in front of lines are no problem, but having them within the text can be a problem if you do not set it to the amount of spaces every one of us uses. Here is a short example of how it should look like:</p>
-
-	<div class="codebox"><pre>
-{TAB}$mode{TAB}{TAB}= $request->variable('mode', '');
-{TAB}$search_id{TAB}= $request->variable('search_id', '');</pre>
-	</div>
-
-	<p>If entered with tabs (replace the {TAB}) both equal signs need to be on the same column.</p>
-
-	<h3>Linefeeds:</h3>
-	<p>Ensure that your editor is saving files in the UNIX (LF) line ending format. This means that lines are terminated with a newline, not with Windows Line endings (CR/LF combo) as they are on Win32 or Classic Mac (CR) Line endings. Any decent editor should be able to do this, but it might not always be the default setting. Know your editor. If you want advice for an editor for your Operating System, just ask one of the developers. Some of them do their editing on Win32.</p>
-
-	<a name="fileheader"></a><h3>1.ii. File Layout</h3>
-
-	<h4>Standard header for new files:</h4>
-	<p>This template of the header must be included at the start of all phpBB files: </p>
-
-	<div class="codebox"><pre>
+					<h3 id="defaults.file_layout">
+						<a href="#defaults.file_layout"></a>
+						<span>File layout</span>
+						<a href="#wrap" class="top">Back to Top</a>
+					</h3>
+					<div class="inner">
+						<div class="column1">
+							<ul>
+								<li>
+									<strong>New line at end of file:</strong>
+									<span>All files should end with a <em>(empty)</em> new line.</span>
+								</li>
+								<li>
+									<strong>No PHP closing tag:</strong>
+									<span>Files containing only PHP code, should not have the PHP closing tag <samp>?></samp> at the end of the file.</span>
+								</li>
+								<li>
+									<strong>File header:</strong>
+									<span>All files should have the header documentation included at the start of the file.</span>
+								</li>
+							</ul>
+						</div>
+						<div class="column2">
+							<div class="codebox">
+								<pre class="php">
+&lt;?php
 /**
-*
-* This file is part of the phpBB Forum Software package.
-*
-* @copyright (c) phpBB Limited &lt;https://www.phpbb.com&gt;
-* @license GNU General Public License, version 2 (GPL-2.0)
-*
-* For full copyright and license information, please see
-* the docs/CREDITS.txt file.
-*
-*/</pre>
-	</div>
+ *
+ * This file is part of the phpBB Forum Software package.
+ *
+ * @copyright (c) phpBB Limited &lt;https://www.phpbb.com>
+ * @license GNU General Public License, version 2 (GPL-2.0)
+ *
+ * For full copyright and license information, please see
+ * the docs/CREDITS.txt file.
+ *
+ */
+</pre>
+							</div>
+						</div>
+					</div>
 
-	<p>Please see the <a href="#locations">File Locations section</a> for the correct package name.</p>
+					<h3 id="defaults.special_naming">
+						<a href="#defaults.special_naming"></a>
+						<span>Special naming</span>
+						<a href="#wrap" class="top">Back to Top</a>
+					</h3>
+					<ul>
+						<li>
+							<strong>Email</strong>
+							<span>is the term we use, without a dash “<kbd>-</kbd>” between “<kbd>e</kbd>” and “<kbd>m</kbd>”.</span>
+						</li>
+						<li>
+							<strong>Smilies</strong>
+							<span>is the plural form of a smiley.</span>
+						</li>
+					</ul>
 
-	<h4>PHP closing tags</h4>
+					<h3 id="defaults.special_constants">
+						<a href="#defaults.special_constants"></a>
+						<span>Special constants</span>
+						<a href="#wrap" class="top">Back to Top</a>
+					</h3>
+					<p>There are some special constants which will alter phpBB's internal functionality.</p>
 
-	<p>A file containg only PHP code should not end with the optional PHP closing tag <strong>?&gt;</strong> to avoid issues with whitespace following it.</p>
+					<table>
+						<tbody>
+							<tr><td><code>PHPBB_ADMIN_PATH</code></td><td>Overwrite $phpbb_admin_path</td></tr>
+							<tr><td><code>PHPBB_ROOT_PATH</code></td><td>Overwrite $phpbb_root_path</td></tr>
+							<tr><td><code>PHPBB_MSG_HANDLER</code></td><td>Overwrite message handler</td></tr>
+							<tr><td><code>PHPBB_DB_NEW_LINK</code></td><td>Overwrite new_link parameter for sql_connect</td></tr>
+							<tr><td><code>PHPBB_ACM_MEMCACHED_PORT</code></td><td>Overwrite memcached port, default is 11211</td></tr>
+							<tr><td><code>PHPBB_ACM_MEMCACHED_COMPRESS</code></td><td>Overwrite memcached compress setting, default is disabled</td></tr>
+							<tr><td><code>PHPBB_ACM_MEMCACHED_HOST</code></td><td>Overwrite memcached host name, default is localhost</td></tr>
+							<tr><td><code>PHPBB_ACM_REDIS_HOST</code></td><td>Overwrite redis host name, default is localhost</td></tr>
+							<tr><td><code>PHPBB_ACM_REDIS_PORT</code></td><td>Overwrite redis port, default is 6379</td></tr>
+							<tr><td><code>PHPBB_ACM_REDIS_PASSWORD</code></td><td>Overwrite redis password, default is empty</td></tr>
+							<tr><td><code>PHPBB_ACM_REDIS_DB</code></td><td>Overwrite redis default database</td></tr>
+							<tr><td><code>PHPBB_QA</code></td><td>Set board to QA-Mode, which means the updater also checks for RC-releases</td></tr>
+							<tr><td><code>PHPBB_DISABLE_CONFIG_CHECK</code></td><td>Disable ACP config.php writable check</td></tr>
+							<tr><td><code>PHPBB_USE_BOARD_URL_PATH</code></td><td>Use generate_board_url() for image paths instead of $phpbb_root_path</td></tr>
+						</tbody>
+					</table>
 
-	<h4>Newline at end of file</h4>
+					<h4 id="defaults.special_constants.phpbb_use_board_url">
+						<a href="#defaults.special_constants.phpbb_use_board_url"></a>
+						<span>PHPBB_USE_BOARD_URL</span>
+					</h4>
+					<p>
+						If the <code>PHPBB_USE_BOARD_URL_PATH</code> constant is set to <code>true</code>, phpBB uses <code>generate_board_url()</code> on all instances where web-accessible images are loaded.
+						<br>The <code>generate_board_url</code> function will return the board's absolute url with the script path included.
+						<br>The exact locations are:
+					</p>
 
-	<p>All files should end in a newline so the last line does not appear as modified in diffs, when a line is appended to the file.</p>
+					<ul>
+						<li>/phpbb/user.php - \phpbb\user::img()</li>
+						<li>/includes/functions_content.php - smiley_text()</li>
+					</ul>
 
-	<h4>Files containing inline code:</h4>
+					<p>Path locations for the following template variables are affected by this too:</p>
 
-	<p>For those files you have to put an empty comment directly after the header to prevent the documentor assigning the header to the first code element found.</p>
-
-	<div class="codebox"><pre>
-/**
-* {HEADER}
-*/
-
-/**
-*/
-{CODE}</pre>
-	</div>
-
-	<h4>Files containing only functions:</h4>
-
-	<p>Do not forget to comment the functions (especially the first function following the header). Each function should have at least a comment of what this function does. For more complex functions it is recommended to document the parameters too.</p>
-
-	<h4>Files containing only classes:</h4>
-
-	<p>Do not forget to comment the class. Classes need a separate @package definition, it is the same as the header package name. Apart from this special case the above statement for files containing only functions needs to be applied to classes and it's methods too.</p>
-
-	<h4>Code following the header but only functions/classes file:</h4>
-
-	<p>If this case is true, the best method to avoid documentation confusions is adding an ignore command, for example:</p>
-
-	<div class="codebox"><pre>
-/**
-* {HEADER}
-*/
-
-/**
-* @ignore
-*/
-Small code snipped, mostly one or two defines or an if statement
-
-/**
-* {DOCUMENTATION}
-*/
-class ...</pre>
-	</div>
-
-	<a name="locations"></a><h3>1.iii. File Locations</h3>
-
-	<p>Functions used by more than one page should be placed in functions.php, functions specific to one page should be placed on that page (at the bottom) or within the relevant sections functions file. Some files in <code>/includes</code> are holding functions responsible for special sections, for example uploading files, displaying &quot;things&quot;, user related functions and so forth.</p>
-
-	<p>The following packages are defined, and related new features/functions should be placed within the mentioned files/locations, as well as specifying the correct package name. The package names are bold within this list:</p>
-
-	<ul>
-		<li><strong>phpBB3</strong><br />Core files and all files not assigned to a separate package</li>
-		<li><strong>acm</strong><br /><code>/phpbb/cache</code><br />Cache System</li>
-		<li><strong>acp</strong><br /><code>/adm</code>, <code>/includes/acp</code>, <code>/includes/functions_admin.php</code><br />Administration Control Panel</li>
-		<li><strong>dbal</strong><br /><code>/phpbb/db</code>, <code>/includes/db</code><br />Database Abstraction Layer.
-			<ul>
-				<li><code>/phpbb/db/driver/</code><br />Database Abstraction Layer classes</li>
-				<li><code>/phpbb/db/migration/</code><br />Migrations are used for updating the database from one release to another</li>
-			</ul>
-		</li>
-		<li><strong>diff</strong><br /><code>/includes/diff</code><br />Diff Engine</li>
-		<li><strong>docs</strong><br /><code>/docs</code><br />phpBB Documentation</li>
-		<li><strong>images</strong><br /><code>/images</code><br />All global images not connected to styles</li>
-		<li><strong>install</strong><br /><code>/install</code><br />Installation System</li>
-		<li><strong>language</strong><br /><code>/language</code><br />All language files</li>
-		<li><strong>login</strong><br /><code>/phpbb/auth</code><br />Login Authentication Plugins</li>
-		<li><strong>VC</strong><br /><code>/includes/captcha</code><br />CAPTCHA</li>
-		<li><strong>mcp</strong><br /><code>mcp.php</code>, <code>/includes/mcp</code>, <code>report.php</code><br />Moderator Control Panel</li>
-		<li><strong>ucp</strong><br /><code>ucp.php</code>, <code>/includes/ucp</code><br />User Control Panel</li>
-		<li><strong>utf</strong><br /><code>/includes/utf</code><br />UTF8-related functions/classes</li>
-		<li><strong>search</strong><br /><code>/phpbb/search</code>, <code>search.php</code><br />Search System</li>
-		<li><strong>styles</strong><br /><code>/styles</code><br />phpBB Styles/Templates/Themes</li>
-	</ul>
-
-	<a name="constants"></a><h3>1.iv. Special Constants</h3>
-
-	<p>There are some special constants application developers are able to utilize to bend some of phpBB's internal functionality to suit their needs.</p>
-
-	<div class="codebox"><pre>
-PHPBB_MSG_HANDLER          (overwrite message handler)
-PHPBB_DB_NEW_LINK          (overwrite new_link parameter for sql_connect)
-PHPBB_ROOT_PATH            (overwrite $phpbb_root_path)
-PHPBB_ADMIN_PATH           (overwrite $phpbb_admin_path)
-PHPBB_USE_BOARD_URL_PATH   (use generate_board_url() for image paths instead of $phpbb_root_path)
-PHPBB_DISABLE_ACP_EDITOR   (disable ACP style editor for templates)
-PHPBB_DISABLE_CONFIG_CHECK (disable ACP config.php writeable check)
-
-PHPBB_ACM_MEMCACHED_PORT     (overwrite memcached port, default is 11211)
-PHPBB_ACM_MEMCACHED_COMPRESS (overwrite memcached compress setting, default is disabled)
-PHPBB_ACM_MEMCACHED_HOST     (overwrite memcached host name, default is localhost)
-
-PHPBB_ACM_REDIS_HOST        (overwrite redis host name, default is localhost)
-PHPBB_ACM_REDIS_PORT        (overwrite redis port, default is 6379)
-PHPBB_ACM_REDIS_PASSWORD    (overwrite redis password, default is empty)
-PHPBB_ACM_REDIS_DB          (overwrite redis default database)
-
-PHPBB_QA                   (Set board to QA-Mode, which means the updater also checks for RC-releases)
-</pre></div>
-
-<h4>PHPBB_USE_BOARD_URL_PATH</h4>
-
-<p>If the <code>PHPBB_USE_BOARD_URL_PATH</code> constant is set to true, phpBB uses generate_board_url() (this will return the boards url with the script path included) on all instances where web-accessible images are loaded. The exact locations are:</p>
-
-<ul>
-	<li>/phpbb/user.php - \phpbb\user::img()</li>
-	<li>/includes/functions_content.php - smiley_text()</li>
-</ul>
-
-<p>Path locations for the following template variables are affected by this too:</p>
-
-<ul>
-	<li>{T_ASSETS_PATH} - assets (non-style specific, static resources)</li>
-	<li>{T_THEME_PATH} - styles/xxx/theme</li>
-	<li>{T_TEMPLATE_PATH} - styles/xxx/template</li>
-	<li>{T_SUPER_TEMPLATE_PATH} - styles/xxx/template</li>
-	<li>{T_IMAGES_PATH} - images/</li>
-	<li>{T_SMILIES_PATH} - $config['smilies_path']/</li>
-	<li>{T_AVATAR_PATH} - $config['avatar_path']/</li>
-	<li>{T_AVATAR_GALLERY_PATH} - $config['avatar_gallery_path']/</li>
-	<li>{T_ICONS_PATH} - $config['icons_path']/</li>
-	<li>{T_RANKS_PATH} - $config['ranks_path']/</li>
-	<li>{T_UPLOAD_PATH} - $config['upload_path']/</li>
-	<li>{T_STYLESHEET_LINK} - styles/xxx/theme/stylesheet.css</li>
-	<li>New template variable {BOARD_URL} for the board url + script path.</li>
-</ul>
-
+					<table>
+						<tbody>
+							<tr><td><code>{{ T_ASSETS_PATH}} </code></td><td>assets <em>(non-style specific, static resources)</em></td></tr>
+							<tr><td><code>{{ T_THEME_PATH}} </code></td><td><samp>styles/xxx/theme</samp></td></tr>
+							<tr><td><code>{{ T_TEMPLATE_PATH}} </code></td><td><samp>styles/xxx/template</samp></td></tr>
+							<tr><td><code>{{ T_SUPER_TEMPLATE_PATH}} </code></td><td><samp>styles/xxx/template</samp></td></tr>
+							<tr><td><code>{{ T_IMAGES_PATH}} </code></td><td><samp>images/</samp></td></tr>
+							<tr><td><code>{{ T_SMILIES_PATH}} </code></td><td><samp>$config['smilies_path']/</samp></td></tr>
+							<tr><td><code>{{ T_AVATAR_PATH}} </code></td><td><samp>$config['avatar_path']/</samp></td></tr>
+							<tr><td><code>{{ T_AVATAR_GALLERY_PATH}} </code></td><td><samp>$config['avatar_gallery_path']/</samp></td></tr>
+							<tr><td><code>{{ T_ICONS_PATH}} </code></td><td><samp>$config['icons_path']/</samp></td></tr>
+							<tr><td><code>{{ T_RANKS_PATH}} </code></td><td><samp>$config['ranks_path']/</samp></td></tr>
+							<tr><td><code>{{ T_UPLOAD_PATH}} </code></td><td><samp>$config['upload_path']/</samp></td></tr>
+							<tr><td><code>{{ T_STYLESHEET_LINK}} </code></td><td><samp>styles/xxx/theme/stylesheet.css</samp></td></tr>
+							<tr><td><code>{{ BOARD_URL}} </code></td><td>for the board url + script path</td></tr>
+						</tbody>
+					</table>
+				</div>
+			</div>
 		</div>
 
-		<div class="back2top"><a href="#wrap" class="top">Back to Top</a></div>
+		<hr>
 
-		</div>
-	</div>
+		<h2 id="standards">
+			<a href="#standards"></a>
+			<span>Standards</span>
+		</h2>
 
-	<hr />
+		<div class="paragraph">
+			<div class="inner">
+				<div class="content">
+					<h3 id="standards.routing">
+						<a href="#standards.routing"></a>
+						<span>Routing</span>
+						<a href="#wrap" class="top">Back to Top</a>
+					</h3>
 
-<a name="code"></a><h2>2. Code Layout/Guidelines</h2>
+					<div class="inner">
+						<div class="column1">
+							<h4 id="standards.routing.files">
+								<a href="#standards.routing.files"></a>
+								<span>Routing files</span>
+							</h4>
+							<ul>
+								<li>
+									Routes should be declared in a separate file and imported into <code>routing.yml</code>
+									<br>The separate file should be named after the namespace, eg. <code>routing_feed.yml</code>
+								</li>
+								<li>
+									If multiple files are required, they should go in a separate directory.
+									<br>The separate directory should be named after the namespace, eg. <code>routing/report/routing_*.yml</code>
+								</li>
+								<li>
+									The controller(s) for the routes should go in a in a separate directory in the namespace.
+									<br>The separate directory should be named <code>controller</code>, eg. <code>/phpbb/feed/controller/feed.php</code>
+								</li>
+							</ul>
 
-	<div class="paragraph">
-		<div class="inner">
+							<h4 id="standards.routing.names">
+								<a href="#standards.routing.names"></a>
+								<span>Route names</span>
+							</h4>
+							<ul>
+								<li>All route names should be lowercase.</li>
+								<li>All route names should be prefixed with <code>phpbb_</code>
+								<li>Stay as close as possible to the full class the route leads to.</li>
+								<li>All route resources should be suffixed with <code>_routing</code></li>
+							</ul>
 
-		<div class="content">
+							<h4 id="standards.routing.order">
+								<a href="#standards.routing.order"></a>
+								<span>Route order</span>
+							</h4>
+							<ul>
+								<li>Routes resources should be ordered alphabetically.</li>
+								<li>
+									Routes can not have a specific order sometimes, use your best judgement.
+									<br> For example top levels first. Or pagination after base route.
+								</li>
+							</ul>
 
-	<p>Please note that these guidelines apply to all php, html, javascript and css files.</p>
+							<h4 id="standards.routing.parameters">
+								<a href="#standards.routing.parameters"></a>
+								<span>Route parameters</span>
+							</h4>
+							<ul>
+								<li>Parameters should follow the provided order.</li>
+								<li>Parameters should not be indented, just a single space after the colon</li>
+								<li>Strings starting with <code>@</code>, <code>%</code>, <code>`</code>, <code>|</code> or <code>></code> should be single quoted.</li>
+								<li>Most top level arrays should each be on a new line <em>(except <code>methods</code>)</em>.</li>
+								<li>Inline associative arrays should have have surrounding spaces.</li>
+							</ul>
+						</div>
+						<div class="column2">
+							<div class="codebox">
+								<pre class="yaml">
+phpbb_feed_routing:
+    resource: routing_feed.yml
+    prefix: /feed
+</pre>
+							</div>
+							<div class="codebox">
+								<pre class="yaml">
+phpbb_feed_forums:
+    path: /forums	# Do not use pattern
+    defaults:
+        _controller: phpbb.feed.controller:forums
 
-	<a name="namingvars"></a><h3>2.i. Variable/Function/Class Naming</h3>
+phpbb_feed_topics:
+    path: /topics
+    defaults:
+        _controller: phpbb.feed.controller:topics
 
-	<p>We will not be using any form of hungarian notation in our naming conventions. Many of us believe that hungarian naming is one of the primary code obfuscation techniques currently in use.</p>
+phpbb_feed_example_order:
+	path: /example/{order}/{id}
+	methods: [GET, POST]
+	defaults:
+	    _controller: some.controller:function
+		order: 'parameters'
+		id: 0
+	requirements:
+		order: \w+
+	    id: \d+
+</pre>
+							</div>
+						</div>
+					</div>
 
-	<h4>Variable Names:</h4>
-	<p>In PHP, variable names should be in all lowercase, with words separated by an underscore, example:</p>
+					<h3 id="standards.services">
+						<a href="#standards.services"></a>
+						<span>Services</span>
+						<a href="#wrap" class="top">Back to Top</a>
+					</h3>
 
-	<div class="indent">
-		<p><code>$current_user</code> is right, but <code>$currentuser</code> and <code> $currentUser</code> are not.</p>
-	</div>
+					<div class="inner">
+						<div class="column1">
+							<h4 id="standards.services.files">
+								<a href="#standards.services.files"></a>
+								<span>Service files</span>
+							</h4>
+							<ul>
+								<li>Services should be declared in a separate file and imported into <code>services.yml</code>
+									<br>The separate file should be name after the namespace, eg. <code>services_template.yml</code></li>
+								<li>If multiple files are required, they should go in a separate directory.
+									<br>The separate directory should be named after the namespace, eg. <code>services/template/services_*.yml</code></li>
+							</ul>
 
-	<p>In JavaScript, variable names should use camel case:</p>
+							<h4 id="standards.services.names">
+								<a href="#standards.services.names"></a>
+								<span>Service names</span>
+							</h4>
+							<ul>
+								<li>All service names should be lowercase.</li>
+								<li>Use the full class, omit <code>\phpbb\</code> and use dots as separator.</li>
+								<li>When the class name is the same as the initial directory, omit the class.</li>
+								<li>Service collections should be suffixed with <code>_collection</code></li>
+							</ul>
 
-	<div class="indent">
-		<p><code>currentUser</code> is right, but <code>currentuser</code> and <code>current_user</code> are not.</p>
-	</div>
+							<h4 id="standards.services.order">
+								<a href="#standards.services.order"></a>
+								<span>Service order</span>
+							</h4>
+							<ul>
+								<li>Imports first, then parameters, then services, then service collections.</li>
+								<li>Imports, parameters and services should be ordered alphabetically.</li>
+							</ul>
 
-	<p>Names should be descriptive, but concise. We don't want huge sentences as our variable names, but typing an extra couple of characters is always better than wondering what exactly a certain variable is for. </p>
+							<h4 id="standards.services.parameters">
+								<a href="#standards.services.parameters"></a>
+								<span>Service parameters</span>
+							</h4>
+							<ul>
+								<li>Parameters should follow the provided order.</li>
+								<li>Parameters should not be indented, just a single space after the colon</li>
+								<li>Class value should not have a leading backslash</li>
+								<li>Strings starting with <code>@</code>, <code>%</code>, <code>`</code>, <code>|</code> or <code>></code> should be single quoted.</li>
+								<li>Top level arrays should each be on a new line.</li>
+								<li>Inline associative arrays should have have surrounding spaces.</li>
+								<li>Deprecated message should include version and alternative.</li>
+							</ul>
+						</div>
 
-	<h4>Loop Indices:</h4>
-	<p>The <em>only</em> situation where a one-character variable name is allowed is when it's the index for some looping construct. In this case, the index of the outer loop should always be $i. If there's a loop inside that loop, its index should be $j, followed by $k, and so on. If the loop is being indexed by some already-existing variable with a meaningful name, this guideline does not apply, example:</p>
+						<div class="column2">
+							<div class="codebox">
+								<pre class="yaml">
+services:
+    # Regular service name
+    avatar.manager:
+        class: \phpbb\avatar\manager
 
-	<div class="codebox"><pre>
-for ($i = 0; $i &lt; $outer_size; $i++)
+    # Regular service name with underscore_
+    console.exception_subscriber:
+        class: phpbb\console\exception_subscriber
+
+    # When the class name is the same as the initial directory (example 1)
+    config:
+        class: phpbb\config\config
+
+    # When the class name is the same as the initial directory (example 2)
+    cron.controller:
+        class: phpbb\cron\controller\cron
+
+    # Service collection following regular convention, suffixed with _collection
+    notification.type_collection:
+        class: phpbb\di\service_collection
+
+    # Order of service parameters
+    example_order:
+        # Deprecation message with 'since', 'removed' and 'use'
+        deprecated: 'The "%service_id%" is deprecated since 3.3.1 and will be removed in 4.0.0, use "parameter_order" instead.'
+        alias: sample.order
+        abstract: false
+        synthetic: false
+        class: example\order\class			# No leading backslash
+        shared: false						# Do not use 'scope: prototype'
+        public: true
+        parent:
+        configurator:
+        factory:
+        arguments:
+            - '@avatar.manager'				# Top level array on new line
+            - '@request'					# Single quote all strings starting with @, %, `, | or >
+        calls:
+            - ['set_config', ['@config']]	# Non-top level arrays may be inline
+        tags:
+            - { name: notification.type }	# Inline associative array with surrounding spaces
+</pre>
+							</div>
+						</div>
+					</div>
+
+					<h3 id="standards.classes">
+						<a href="#standards.classes"></a>
+						<span>Classes</span>
+						<a href="#wrap" class="top">Back to Top</a>
+					</h3>
+
+					<h4 id="standards.classes.location">
+						<a href="#standards.classes.location"></a>
+						<span>Location</span>
+					</h4>
+					<ul>
+						<li>Classes should be in a subdirectory of <code>phpbb/</code></li>
+						<li>Directories should not contain underscores: <code>_</code></li>
+						<li>Directories should typically be singular noun, eg. <code>type</code> and not <code>types</code></li>
+					</ul>
+
+					<div class="inner">
+						<div class="column1">
+							<h4 id="standards.classes.declaration">
+								<a href="#standards.classes.declaration"></a>
+								<span>Declaration</span>
+							</h4>
+							<ul>
+								<li>Class names should use <samp>snake_case</samp>.</li>
+								<li>Document the class before the declaration.</li>
+								<li>Declare only one class per file.</li>
+								<li>Declare inheritance and implemented interface on the same line as the class name.</li>
+								<li>
+									Import non-<samp>phpbb</samp> classes
+									<ul>
+										<li><code>use</code> statements come after the namespace and before the class.</li>
+										<li>Classes that are outside the <code>phpbb</code> namespace.</li>
+										<li>Classes should not have a leading backslash.</li>
+									</ul>
+								</li>
+							</ul>
+						</div>
+						<div class="column2">
+							<div class="codebox">
+								<pre class="php">
+namespace phpbb\guidelines;
+
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Class documentation.
+ */
+abstract class coding extends base implements guidelines_interface
 {
-   for ($j = 0; $j &lt; $inner_size; $j++)
-   {
-      foo($i, $j);
-   }
-}</pre>
-	</div>
-
-	<h4>Function Names:</h4>
-	<p>Functions should also be named descriptively. We're not programming in C here, we don't want to write functions called things like "stristr()". Again, all lower-case names with words separated by a single underscore character in PHP, and camel caps in JavaScript. Function names should be prefixed with "phpbb_" and preferably have a verb in them somewhere. Good function names are <code>phpbb_print_login_status()</code>, <code>phpbb_get_user_data()</code>, etc. Constructor functions in JavaScript should begin with a capital letter.</p>
-
-	<h4>Function Arguments:</h4>
-	<p>Arguments are subject to the same guidelines as variable names. We don't want a bunch of functions like: <code>do_stuff($a, $b, $c)</code>. In most cases, we'd like to be able to tell how to use a function by just looking at its declaration. </p>
-
-	<h4>Class Names:</h4>
-
-	<p>Apart from following the rules for function names, all classes should meet the following conditions:</p>
-	<ul>
-		<li>Every class must be defined in a separate file.</li>
-		<li>The classes have to be located in a subdirectory of <code>phpbb/</code>.</li>
-		<li>Classnames must be namespaced with <code>\phpbb\</code> to avoid name clashes.</li>
-		<li>Class names/namespaces have to reflect the location of the file they are defined in. The namespace must be the directory in which the file is located. So the directory names must not contain any underscores, but the filename may.</li>
-		<li>Directories should typically be a singular noun (e.g. <code>dir</code> in the example below, not <code>dirs</code>.</li>
-	</ul>
-
-	<p>So given the following example directory structure you would result in the below listed lookups</p>
-	<div class="codebox"><pre>
-phpbb/
-  class_name.php
-  dir/
-    class_name.php
-      subdir/
-        class_name.php</pre>
-	</div>
-
-	<div class="codebox"><pre>
-\phpbb\class_name            - phpbb/class_name.php
-\phpbb\dir\class_name        - phpbb/dir/class_name.php
-\phpbb\dir\subdir\class_name - phpbb/dir/subdir/class_name.php</pre>
-	</div>
-
-
-	<h4>Summary:</h4>
-	<p>The basic philosophy here is to not hurt code clarity for the sake of laziness. This has to be balanced by a little bit of common sense, though; <code>phpbb_print_login_status_for_a_given_user()</code> goes too far, for example -- that function would be better named <code>phpbb_print_user_login_status()</code>, or just <code>phpbb_print_login_status()</code>.</p>
-
-	<h4>Special Namings: </h4>
-	<p>For all emoticons use the term <code>smiley</code> in singular and <code>smilies</code> in plural. For emails we use the term <code>email</code> (without dash between “e” and “m”).</p>
-
-	<a name="codelayout"></a><h3>2.ii. Code Layout</h3>
-
-	<h4>Always include the braces:</h4>
-	<p>This is another case of being too lazy to type 2 extra characters causing problems with code clarity. Even if the body of some construct is only one line long, do <em>not</em> drop the braces. Just don't, examples:</p>
-
-	<p class="bad">// These are all wrong. </p>
-
-	<div class="codebox"><pre>
-if (condition) do_stuff();
-
-if (condition)
-	do_stuff();
-
-while (condition)
-	do_stuff();
-
-for ($i = 0; $i &lt; size; $i++)
-	do_stuff($i);</pre>
-	</div>
-
-	<p class="good">// These are all right. </p>
-	<div class="codebox"><pre>
-if (condition)
-{
-	do_stuff();
+	// ...
 }
 
-while (condition)
+</pre>
+							</div>
+						</div>
+					</div>
+
+					<div class="inner">
+						<div class="column1">
+							<h4 id="standards.classes.visibility">
+								<a href="#standards.classes.visibility"></a>
+								<span>Visibility</span>
+							</h4>
+							<ul>
+								<li>All properties and methods should have a visibility keyword.</li>
+								<li>
+									<strong>public:</strong>
+									<span>So it can be accessed by anyone.</span>
+								</li>
+								<li>
+									<strong>protected:</strong>
+									<span>So it can be accessed by this class and inheriting & parent classes.</span>
+								</li>
+								<li>
+									<strong>private:</strong>
+									<span>So it can be accessed by this class.</span>
+								</li>
+								<li>
+									<strong>var:</strong>
+									<span>Should not be used.</span>
+								</li>
+							</ul>
+
+							<h4 id="standards.classes.properties">
+								<a href="#standards.classes.properties"></a>
+								<span>Properties</span>
+							</h4>
+							<ul>
+								<li>Class properties should be declared before class methods.</li>
+								<li>Properties should have the same order as in the constructor.</li>
+								<li>Non-injected properties should come after injected properties.</li>
+								<li>
+									Properties should have a single line docblock.
+									<ul>
+										<li>It should only contain the type hint.</li>
+										<li>If it is not a class, it should have a short description.</li>
+									</ul>
+								</li>
+							</ul>
+
+							<h4 id="standards.classes.constructor">
+								<a href="#standards.classes.constructor"></a>
+								<span>Constructor</span>
+							</h4>
+							<ul>
+								<li>Either all arguments are on the same line.</li>
+								<li>
+									Or all arguments are on a separate line.
+									<ul>
+										<li>Opening <code>(</code> is right after <code>__construct</code></li>
+										<li>Closing <code>)</code> is on a separate line.</li>
+									</ul>
+								</li>
+								<li>Type hint all services and parameters when possible.</li>
+								<li>
+									Arguments should be ordered by the following:
+									<ul>
+										<li>Services should be ordered alphabetically.</li>
+										<li>Services come before parameters.</li>
+										<li>
+											Parameters should be grouped.
+											<ul>
+												<li>Path parameters (<code>$admin_path</code>, <code>$root_path</code>, <code>$php_ext</code>) should be together.</li>
+												<li>Table parameters (<code>$posts_table</code>, <code>$users_table</code>, etc..) should be together.</li>
+											</ul>
+										</li>
+										<li>Path parameters come before table parameters.</li>
+										<li>Path parameters should follow <code>$admin_path</code> &raquo; <code>$root_path</code> &raquo; <code>$web_path</code> &raquo; <code>$php_ext</code></li>
+										<li>Table parameters should be ordered alphabetically.</li>
+									</ul>
+								</li>
+							</ul>
+						</div>
+						<div class="column2">
+							<div class="codebox">
+								<pre class="php">
+/** @var \phpbb\language\language */
+protected $language;
+
+/** @var \phpbb\template\template */
+protected $template;
+
+/** @var string phpBB root path */
+protected $root_path;
+
+/** @var string php File extension */
+protected $php_ext;
+
+/** @var array phpBB tables */
+protected $tables;
+
+/** @var bool Non-injected property */
+protected $property;
+
+/**
+ * Constructor.
+ *
+ * @param \phpbb\language\language $language  Language object
+ * @param \phpbb\template\template $template  Template object
+ * @param string                   $root_path phpBB root path
+ * @param string                   $php_ext   php File extension
+ * @param array                    $tables    phpBB tables
+ */
+public function __construct(
+	\phpbb\language\language $language,
+	\phpbb\template\template $template,
+	string $root_path,
+	string $php_ext,
+	array $tables
+)
 {
-	do_stuff();
+	// ...
+}
+</pre>
+							</div>
+						</div>
+					</div>
+
+
+					<h3 id="standards.interfaces">
+						<a href="#standards.interfaces"></a>
+						<span>Interfaces</span>
+						<a href="#wrap" class="top">Back to Top</a>
+					</h3>
+					<ul>
+						<li>Names should be suffixed with <code>_interface</code></li>
+						<li>Class constants should be declared in the interface.</li>
+					</ul>
+
+					<h3 id="standards.exceptions">
+						<a href="#standards.exceptions"></a>
+						<span>Exceptions</span>
+						<a href="#wrap" class="top">Back to Top</a>
+					</h3>
+					<ul>
+						<li>Names should be suffixed with <code>_exception</code></li>
+						<li>
+							Exceptions should go in their own, separate directory.
+							<ul>
+								<li>Either as <code>/phpbb/exception/*_exception.php</code></li>
+								<li>Or as <code>/phpbb/namespace/exception/*_exception.php</code></li>
+							</ul>
+						</li>
+						<li>Exception directory names should take the singular form: <code>exception</code></li>
+					</ul>
+
+					<h3 id="standards.functions">
+						<a href="#standards.functions"></a>
+						<span>Functions</span>
+						<a href="#wrap" class="top">Back to Top</a>
+					</h3>
+					<div class="inner">
+						<div class="column1">
+							<h4 id="standards.functions.names">
+								<a href="#standards.functions.names"></a>
+								<span>Function names</span>
+							</h4>
+							<ul>
+								<li>Should be <samp>snake_case</samp>.</li>
+								<li>Should be short but concise.</li>
+								<li>
+									Commonly start with a verb followed by an object.
+									<ul>
+										<li><code>get_name</code></li>
+										<li><code>set_error_prefix</code></li>
+										<li><code>print_login_status</code></li>
+									</ul>
+								</li>
+							</ul>
+
+							<h4 id="standards.functions.order">
+								<a href="#standards.functions.order"></a>
+								<span>Function order</span>
+							</h4>
+							<ul>
+								<li>
+									<code>construct</code>
+									Must come before all other functions.
+								</li>
+								<li>
+									<code>abstract</code>
+									<span>Must be implemented by inheriting classes.</span>
+								</li>
+								<li>
+									<code>public</code>
+									<span>Can be accessed by any other classes.</span>
+								</li>
+								<li>
+									<code>protected</code>
+									<span>Can be accessed by inheriting or parent classes.</span>
+								</li>
+								<li>
+									<code>private</code>
+									<span>Can only be accessed by this class itself.</span>
+								</li>
+							</ul>
+
+							<h4 id="standards.functions.keyword_order">
+								<a href="#standards.functions.keyword_order"></a>
+								<span>Keyword order</span>
+							</h4>
+							<ul>
+								<li><code>abstract</code>, <code>final</code> and <code>static</code> come before the visibility.</li>
+								<li><code>abstract</code> comes before <code>static</code></li>
+							</ul>
+
+							<h4 id="standards.functions.return_type_hinting">
+								<a href="#standards.functions.return_type_hinting"></a>
+								<span>Return type hinting</span>
+							</h4>
+							<ul>
+								<li>Should be done as much as possible.</li>
+								<li>There should be no space before the colon.</li>
+								<li>There should be a space after the colon.</li>
+								<li>Only <a href="https://www.php.net/manual/en/functions.arguments.php#functions.arguments.type-declaration.types" target="_blank">PHP valid types</a> should be used.</li>
+								<li>Only one type should <em>(and can)</em> be hinted.</li>
+							</ul>
+						</div>
+						<div class="column2">
+							<div class="codebox">
+								<pre class="php">
+abstract static public function get_subsection_name(): string;
+
+static public function get_name(): string
+{
+	return 'coding';
 }
 
-for ($i = 0; $i &lt; size; $i++)
+public function get_subsections(string $section): array
 {
-	do_stuff();
-}</pre>
-	</div>
+	// ...
+}
 
-	<h4>Where to put the braces:</h4>
-	<p>In PHP code, braces always go on their own line. The closing brace should also always be at the same column as the corresponding opening brace, examples:</p>
-
-	<div class="codebox"><pre>
-if (condition)
+protected function generate_section(array $row): array
 {
-	while (condition2)
-	{
-		...
+	// ...
+}
+
+private function is_subsection_available(string $subsection): bool
+{
+	// ...
+}
+</pre>
+							</div>
+						</div>
+					</div>
+
+					<h3 id="standards.variables">
+						<a href="#standards.variables"></a>
+						<span>Variables</span>
+						<a href="#wrap" class="top">Back to Top</a>
+					</h3>
+					<div class="inner">
+						<div class="column1">
+							<h4 id="standards.variables.names">
+								<a href="#standards.variables.names"></a>
+								<span>Variable names</span>
+							</h4>
+							<ul>
+								<li>Should be <samp>snake_case</samp>.</li>
+								<li>Should be short but concise.</li>
+								<li>
+									Only allowed one-letter variable are loop indices.
+									<ul>
+										<li>Not-nested loops should use <code>$i</code></li>
+										<li>First nested loop should use <code>$j</code></li>
+										<li>Second nested loop should use <code>$k</code>, etc..</li>
+									</ul>
+								</li>
+							</ul>
+
+							<h4 id="standards.variables.array">
+								<a href="#standars.variables.array"></a>
+								<span>Array</span>
+							</h4>
+							<ul>
+								<li>Should use new array syntax: <code>['a', 'b']</code></li>
+								<li>Commas after every (also the last) array element if they are on separate lines.</li>
+								<li>Array keys should not be literal strings, quote the strings instead.</li>
+							</ul>
+
+							<h4 id="standards.variables.boolean">
+								<a href="#standards.variables.boolean"></a>
+								<span>Boolean</span>
+							</h4>
+							<ul>
+								<li>Lowercase booleans should be used: <code>true</code> and <code>false</code></li>
+							</ul>
+
+							<h4 id="standards.variables.null">
+								<a href="#standards.variables.null"></a>
+								<span>Null</span>
+							</h4>
+							<ul>
+								<li>Lowercase null should be used: <code>null</code></li>
+							</ul>
+
+							<h4 id="standards.variables.string">
+								<a href="#standards.variables.string"></a>
+								<span>String</span>
+							</h4>
+							<ul>
+								<li>Strings should be single quoted as much as possible.</li>
+								<li>Strings containing a single quote should be double quoted.</li>
+								<li>
+									Strings requiring variable substitution should be double quoted.
+									<ul>
+										<li>Use <code>{$variable}</code> at all times.</li>
+										<li>Do not use <code>${variable}</code></li>
+										<li>Do note use <code>$variable</code></li>
+									</ul>
+								</li>
+								<li>String concatenation is done with a dot surrounded by spaces: <code>'' . ''</code></li>
+								<li>String concatenation should not be used when joining 4 strings or more.</li>
+							</ul>
+						</div>
+						<div class="column2">
+							<div class="codebox">
+								<pre class="php">
+// Array examples
+$modes		= ['overview', 'settings', 'logs'];
+$variables	= [
+	'ERRORS'	=> $errors,
+	'ACTION'	=> $action,
+];
+
+// Boolean and null examples
+$object			= null;
+$is_authed		= true;
+$is_available	= false;
+
+// String examples
+$sql_select	= 'SELECT user_id, username FROM ' . $this->tables['users'];
+$sql_where	= "WHERE username_clean = '" . $db->sql_escape($username_clean) . "'";
+$sql		= $sql_select . ' ' . $sql_where;
+
+$warn_msg	= 'The user (' . $username . ') has been warned.';
+$warn_msg	= "The user ({$username}) has been warned.";
+</pre>
+							</div>
+						</div>
+					</div>
+
+					<h3 id="standards.comments">
+						<a href="#standards.comments"></a>
+						<span>Comments</span>
+						<a href="#wrap" class="top">Back to Top</a>
+					</h3>
+					<div class="inner">
+						<div class="column1">
+							<h4 id="standards.comments.docblock">
+								<a href="#standards.comments.docblock"></a>
+								<span>Docblock</span>
+							</h4>
+							<ul>
+								<li>First line should start with double asterisks: <code>/**</code></li>
+								<li>All other lines should be indented with an additional space.</li>
+								<li>Additional indentation and outlining should be done with spaces.</li>
+								<li>Tags (<code>@param</code>, <code>@return</code>, etc..) are followed by a single space.</li>
+								<li>Tags should follow the provided order.</li>
+								<li>Empty line before <code>@return</code> and <code>@throws</code> are optional.</li>
+								<li>Empty line before <code>@deprecated</code> is mandatory.</li>
+								<li>All <code>@param</code> tags should be in order of the arguments</li>
+								<li>When type hinting includes <code>null</code>, always place it at the end.</li>
+								<li>Only used <code>mixed</code> for type hinting, when three or more types are possible.</li>
+							</ul>
+
+							<h4 id="standards.comments.in-code">
+								<a href="#standards.comments.in-code"></a>
+								<span>In-code</span>
+							</h4>
+							<ul>
+								<li><code>//</code> should be used for 1 or 2 line comments.</li>
+								<li><code>/** ... *</code> should not be used for 1 or 2 line comments.</li>
+								<li>
+									<code>/** ... *</code> should be used when type hinting a variable.
+									<br>Use the canonical order: <code>@var type $variable</code>
+								</li>
+								<li>
+									<code>/** ... */</code> should be used for 3+ line block comments.
+									<br>In-code block comments should follow the guidelines for <a href="#standards.comments.docblock">docblocks</a>.
+								</li>
+							</ul>
+						</div>
+						<div class="column2">
+							<div class="codebox">
+								<pre class="php">
+/**
+ * One-line introduction followed by a full-stop.
+ *
+ * An optional paragraph giving a more details explanation.
+ * An optional paragraph giving a more details explanation.
+ * @see is part of the paragraph
+ * @example is part of the paragraph
+ *
+ * @param array  $data    The data array
+ * @param string $name    The name string
+ *
+ * @throws http_exception When something goes wrong
+ *
+ * @return bool           Indicator of success
+ *
+ * @deprecated 3.2.1      Use this other function instead
+ */
+public function check_availability(array $data, string $name): bool
+{
+	/** @var \phpbb\notification\type\type_interface $type */
+	$type = $this->notification_manager->load_object($data['notification_type']);
+
+	// Set initial notification data
+	$type->set_initial_data($data);
+
+	return (bool) $type->is_available();
+}
+</pre>
+							</div>
+						</div>
+					</div>
+
+					<h3 id="standards.brackets">
+						<a href="#standards.brackets"></a>
+						<span>Brackets</span>
+						<a href="#wrap" class="top">Back to Top</a>
+					</h3>
+					<div class="inner">
+						<div class="column1">
+							<ul>
+								<li>Always include the brackets (braces <code>{}</code>, brackets <code>[]</code> and parentheses<code>()</code>).</li>
+								<li>Open and closing brackets should always have the same indentation.</li>
+								<li>Braces <code>{}</code> always go alone on a separate line</li>
+								<li>Either brackets <code>[]</code> and parentheses <code>()</code> open and close on the same line.</li>
+								<li>Or brackets <code>[]</code> and parentheses <code>()</code> open on the same line and close alone on a separate line.</li>
+							</ul>
+						</div>
+						<div class="column2">
+							<div class="codebox">
+								<pre class="php">
+if ($is_available === true)
+{
+	// opens and closes on the same line: if (...)
+	// Braces {} are alone on a separate line
+}
+
+if ($is_available === true
+	&& $method === 'notification.method.board'
+	&& ($name === 'notification.type.post' || $name === 'notification.type.topic')
+	&& ...
+)
+{
+	// opens on the same line: if (
+	// closes alone on a separate line: )
+}
+
+
+$array = ['a', 'b', 'c'];
+$array = [
+	// opens on the same line: [
+	// closes alone on a separate line: ];
+];
+</pre>
+							</div>
+						</div>
+					</div>
+
+					<h3 id="standards.javascript">
+						<a href="#standards.javascript"></a>
+						<span>JavaScript</span>
+						<a href="#wrap" class="top">Back to Top</a>
+					</h3>
+					<p>JavaScript should follow all the regular guidelines, with a few exceptions and additions:</p>
+					<div class="inner">
+						<div class="column1">
+							<ul>
+								<li>Functions and variables should use <samp>camelCase</samp>.</li>
+								<li>Opening and closing braces <code>{}</code> do not go alone on a separate line.</li>
+								<li>Use <code>typeof</code> to test if a variable is not <code>undefined</code></li>
+								<li>The <code>radix</code> should always be provided for <code>parseInt()</code>, defaults to 10.</li>
+								<li>Variable substitution in strings can use templating literals: <code>`${variable}`</code></li>
+								<li>
+									<code>var</code> should be used instead of <code>let</code>.
+									<br><em><code>let</code> currently makes <abbr title="Continuous Integration">CI</abbr> tests fail.</em>
+								</li>
+							</ul>
+						</div>
+						<div class="column2">
+							<div class="codebox">
+								<pre class="js">
+function showBertie() {
+	var size = 0,
+		name = 'Bertie';
+
+	if (typeof size !== 'undefined') {
+		size = parseInt(size, 10);
+	} else if (name !== 'Bertie') {
+		var text = `${name} is the only name possible!`;
+	} else {
+		// ...
 	}
 }
-else
-{
-	...
-}
+</pre>
+							</div>
+						</div>
+					</div>
+				</div>
+			</div>
+		</div>
 
-for ($i = 0; $i &lt; $size; $i++)
-{
-	...
-}
+		<hr>
 
-while (condition)
-{
-	...
-}
+		<h2 id="code">
+			<a href="#code"></a>
+			<span>Code</span>
+		</h2>
 
-function do_stuff()
-{
-	...
-}</pre>
-	</div>
+		<div class="paragraph">
+			<div class="inner">
+				<div class="content">
+					<h3 id="code.tokens">
+						<a href="#code.tokens"></a>
+						<span>Tokens</span>
+						<a href="#wrap" class="top">Back to Top</a>
+					</h3>
 
-	<p>In JavaScript code, braces always go on the same line:</p>
+					<div class="inner">
+						<div class="column1">
+							<h4 id="code.tokens.spaces">
+								<a href="#code.tokens.spaces"></a>
+								<span>Spaces between tokens</span>
+							</h4>
 
-	<div class="codebox"><pre>
-if (condition) {
-	while (condition2) {
-		...
-	}
-} else {
-	...
-}
-
-for (var i = 0; i &lt; size; i++) {
-	...
-}
-
-while (condition) {
-	...
-}
-
-function do_stuff() {
-	...
-}</pre>
-	</div>
-
-	<h4>Use spaces between tokens:</h4>
-	<p>This is another simple, easy step that helps keep code readable without much effort. Whenever you write an assignment, expression, etc.. Always leave <em>one</em> space between the tokens. Basically, write code as if it was English. Put spaces between variable names and operators. Don't put spaces just after an opening bracket or before a closing bracket. Don't put spaces just before a comma or a semicolon. This is best shown with a few examples, examples:</p>
-
-	<p>// Each pair shows the wrong way followed by the right way. </p>
-
-	<div class="codebox"><pre>
-$i=0;
+							<ul>
+								<li>Always leave one space between tokens.</li>
+								<li>Do not put a space after an opening bracket.</li>
+								<li>Do not put a space before a closing bracket.</li>
+								<li>Do not put a space before a comma.</li>
+								<li>Do not put a space before a semicolon.</li>
+							</ul>
+						</div>
+						<div class="column2">
+							<div class="codebox">
+								<pre class="php">
+$data = $this->get_data($i, $variable, 'mode');
+$path = $data['active'] ? $data['path'] : ['one', 'two', 'three'];
 $i = 0;
 
-if($i&lt;7) ...
-if ($i &lt; 7) ...
+if ($i < 7)
+else if ($i < 7 && $j > 8)
+for ($i = 0; $i < $size; $i++)
+</pre>
+							</div>
+						</div>
+					</div>
 
-if ( ($i &lt; 7)&amp;&amp;($j &gt; 8) ) ...
-if ($i &lt; 7 &amp;&amp; $j &gt; 8) ...
+					<div class="inner">
+						<div class="column1">
+							<div class="column1">
+								<h4 id="code.tokens.operator_precedence">
+									<a href="#code.tokens.operator_precedence"></a>
+									<span>Operator precedence</span>
+								</h4>
 
-do_stuff( $i, 'foo', $b );
-do_stuff($i, 'foo', $b);
+								<ul>
+									<li>Make precedence obvious by parentheses.</li>
+									<li>Do not enclose single expressions.</li>
+									<li>Do not over use parentheses.</li>
+								</ul>
+							</div>
+						</div>
+						<div class="column2">
+							<div class="codebox">
+								<pre class="php">
+$bool = ($i < 7 && $j > 8 || $k === 4);			// Wrong
+$bool = (($i < 7) && (($j < 8) || ($k === 4)));	// Wrong
+$bool = $i < 7 && ($j < 8 || $k === 4);			// Correct
+</pre>
+							</div>
+						</div>
+					</div>
 
-for($i=0; $i&lt;$size; $i++) ...
-for ($i = 0; $i &lt; $size; $i++) ...
+					<div class="inner">
+						<div class="column1">
+							<h4 id="code.tokens.shortcut_operators">
+								<a href="#code.tokens.shortcut_operators"></a>
+								<span>Shortcut operators</span>
+							</h4>
 
-$i=($j &lt; $size)?0:1;
-$i = ($j &lt; $size) ? 0 : 1;</pre>
-	</div>
+							<ul>
+								<li>Shortcut operators (<code>$i++</code> and <code>$i--</code>) should go alone on a separate line.</li>
+								<li>
+									Shortcut operators should not be part of an expression.
+									<br>It makes debugging unnecessarily more difficult.
+								</li>
+							</ul>
+						</div>
+						<div class="column2">
+							<div class="codebox">
+								<pre class="php">
+$array[++$i] = $j;	// Wrong
+$array[$i++] = $k;	// Wrong
 
-	<h4>Operator precedence:</h4>
-	<p>Do you know the exact precedence of all the operators in PHP? Neither do I. Don't guess. Always make it obvious by using brackets to force the precedence of an equation so you know what it does. Remember to not over-use this, as it may harden the readability. Basically, do not enclose single expressions. Examples:</p>
-
-	<p class="bad">// what's the result? who knows. </p>
-	<div class="codebox">
-		<pre>$bool = ($i &lt; 7 &amp;&amp; $j &gt; 8 || $k == 4);</pre>
-	</div>
-
-	<p class="bad">// now you can be certain what I'm doing here.</p>
-	<div class="codebox">
-		<pre>$bool = (($i &lt; 7) &amp;&amp; (($j &lt; 8) || ($k == 4)));</pre>
-	</div>
-
-	<p class="good">// But this one is even better, because it is easier on the eye but the intention is preserved</p>
-	<div class="codebox">
-		<pre>$bool = ($i &lt; 7 &amp;&amp; ($j &lt; 8 || $k == 4));</pre>
-	</div>
-
-	<h4>Quoting strings:</h4>
-	<p>There are two different ways to quote strings in PHP - either with single quotes or with double quotes. The main difference is that the parser does variable interpolation in double-quoted strings, but not in single quoted strings. Because of this, you should <em>always</em> use single quotes <em>unless</em> you specifically need variable interpolation to be done on that string. This way, we can save the parser the trouble of parsing a bunch of strings where no interpolation needs to be done.</p>
-	<p>Also, if you are using a string variable as part of a function call, you do not need to enclose that variable in quotes. Again, this will just make unnecessary work for the parser. Note, however, that nearly all of the escape sequences that exist for double-quoted strings will not work with single-quoted strings. Be careful, and feel free to break this guideline if it's making your code easier to read, examples:</p>
-
-	<p class="bad">// wrong </p>
-	<div class="codebox"><pre>
-$str = "This is a really long string with no variables for the parser to find.";
-
-do_stuff("$str");</pre>
-	</div>
-
-	<p class="good">// right</p>
-	<div class="codebox"><pre>
-$str = 'This is a really long string with no variables for the parser to find.';
-
-do_stuff($str);</pre>
-	</div>
-
-	<p class="bad">// Sometimes single quotes are just not right</p>
-	<div class="codebox"><pre>
-$post_url = $phpbb_root_path . 'posting.' . $phpEx . '?mode=' . $mode . '&amp;amp;start=' . $start;</pre>
-	</div>
-
-	<p class="good">// Double quotes are sometimes needed to not overcrowd the line with concatenations.</p>
-	<div class="codebox"><pre>
-$post_url = "{$phpbb_root_path}posting.$phpEx?mode=$mode&amp;amp;start=$start";</pre>
-	</div>
-
-	<p>In SQL statements mixing single and double quotes is partly allowed (following the guidelines listed here about SQL formatting), else one should try to only use one method - mostly single quotes.</p>
-
-	<h4>Commas after every array element:</h4>
-	<p>If an array is defined with each element on its own line, you still have to modify the previous line to add a comma when appending a new element. PHP allows for trailing (useless) commas in array definitions. These should always be used so each element including the comma can be appended with a single line. In JavaScript, do not use the trailing comma, as it causes browsers to throw errors.</p>
-
-	<p class="bad">// wrong</p>
-	<div class="codebox"><pre>
-$foo = array(
-	'bar' => 42,
-	'boo' => 23
-);</pre>
-	</div>
-
-	<p class="good">// right </p>
-	<div class="codebox"><pre>
-$foo = array(
-	'bar' => 42,
-	'boo' => 23,
-);</pre>
-	</div>
-
-
-	<h4>Associative array keys:</h4>
-	<p>In PHP, it's legal to use a literal string as a key to an associative array without quoting that string. We don't want to do this -- the string should always be quoted to avoid confusion. Note that this is only when we're using a literal, not when we're using a variable, examples:</p>
-
-	<p class="bad">// wrong</p>
-	<div class="codebox">
-		<pre>$foo = $assoc_array[blah];</pre>
-	</div>
-
-	<p class="good">// right </p>
-	<div class="codebox">
-		<pre>$foo = $assoc_array['blah'];</pre>
-	</div>
-
-	<p class="bad">// wrong</p>
-	<div class="codebox">
-		<pre>$foo = $assoc_array["$var"];</pre>
-	</div>
-
-	<p class="good">// right </p>
-	<div class="codebox">
-		<pre>$foo = $assoc_array[$var];</pre>
-	</div>
-
-	<h4>Comments:</h4>
-	<p>Each complex function should be preceded by a comment that tells a programmer everything they need to know to use that function. The meaning of every parameter, the expected input, and the output are required as a minimal comment. The function's behaviour in error conditions (and what those error conditions are) should also be present - but mostly included within the comment about the output.<br /><br />Especially important to document are any assumptions the code makes, or preconditions for its proper operation. Any one of the developers should be able to look at any part of the application and figure out what's going on in a reasonable amount of time.<br /><br />Avoid using <code>/* */</code> comment blocks for one-line comments, <code>//</code> should be used for one/two-liners.</p>
-
-	<h4>Magic numbers:</h4>
-	<p>Don't use them. Use named constants for any literal value other than obvious special cases. Basically, it's ok to check if an array has 0 elements by using the literal 0. It's not ok to assign some special meaning to a number and then use it everywhere as a literal. This hurts readability AND maintainability. The constants <code>true</code> and <code>false</code> should be used in place of the literals 1 and 0 -- even though they have the same values (but not type!), it's more obvious what the actual logic is when you use the named constants. Typecast variables where it is needed, do not rely on the correct variable type (PHP is currently very loose on typecasting which can lead to security problems if a developer does not keep a very close eye on it).</p>
-
-	<h4>Shortcut operators:</h4>
-	<p>The only shortcut operators that cause readability problems are the shortcut increment <code>$i++</code> and decrement <code>$j--</code> operators. These operators should not be used as part of an expression. They can, however, be used on their own line. Using them in expressions is just not worth the headaches when debugging, examples:</p>
-
-	<p class="bad">// wrong </p>
-	<div class="codebox"><pre>
-$array[++$i] = $j;
-$array[$i++] = $k;</pre>
-	</div>
-
-	<p class="good">// right </p>
-	<div class="codebox"><pre>
-$i++;
+$i++;				// Correct
 $array[$i] = $j;
 
-$array[$i] = $k;
-$i++;</pre>
-	</div>
+$array[$i] = $k;	// Correct
+$i++;
+</pre>
+							</div>
+						</div>
+					</div>
 
-	<h4>Inline conditionals:</h4>
-	<p>Inline conditionals should only be used to do very simple things. Preferably, they will only be used to do assignments, and not for function calls or anything complex at all. They can be harmful to readability if used incorrectly, so don't fall in love with saving typing by using them, examples:</p>
+					<div class="inner">
+						<div class="column1">
+							<h4 id="code.tokens.identical_comparison">
+								<a href="#code.tokens.identical_comparison"></a>
+								<span>Identical comparison</span>
+							</h4>
 
-	<p class="bad">// Bad place to use them</p>
-	<div class="codebox"><pre>
-($i &lt; $size &amp;&amp; $j &gt; $size) ? do_stuff($foo) : do_stuff($bar);</pre>
-	</div>
+							<ul>
+								<li>
+									Identical operators (<code>===</code> and <code>!==</code>) should be used as much as possible.
+									<br>This will prevent any variable types from being converted.
+									<br>Which in turn ensures there are no unexpected false positives.
+								</li>
+							</ul>
+						</div>
+						<div class="column2">
+							<div class="codebox">
+								<pre class="php">
+$mode = $this->request->variable('mode', '', true);
+$action = $this->request->variable('action', '', true);
 
-	<p class="good">// OK place to use them </p>
-	<div class="codebox"><pre>
-$min = ($i &lt; $j) ? $i : $j;</pre>
-	</div>
+if ($mode === 'settings')
+if ($action !== 'delete')
+</pre>
+							</div>
+						</div>
+					</div>
 
-	<h4>Don't use uninitialized variables.</h4>
-	<p>For phpBB3, we intend to use a higher level of run-time error reporting. This will mean that the use of an uninitialized variable will be reported as a warning. These warnings can be avoided by using the built-in isset() function to check whether a variable has been set - but preferably the variable is always existing. For checking if an array has a key set this can come in handy though, examples:</p>
+					<div class="inner">
+						<div class="column1">
+							<h4 id="code.tokens.inline_conditionals">
+								<a href="#code.tokens.inline_conditionals"></a>
+								<span>Inline conditionals</span>
+							</h4>
 
-	<p class="bad">// Wrong </p>
-	<div class="codebox">
-		<pre>if ($forum) ...</pre>
-	</div>
+							<ul>
+								<li>Should not be used for calling a function.</li>
+								<li>Should only be used for assignments.</li>
+								<li>Single conditionals should not be enclosed in parentheses.</li>
+								<li>Conditionals that should return a boolean, should be type casted.</li>
+							</ul>
+						</div>
+						<div class="column2">
+							<div class="codebox">
+								<pre class="php">
+($i < $size) ? do_stuff($foo) : do_stuff($bar);											// Wrong
+$min = $i < $j ? $i : $j;																// Correct
 
-	<p class="good">// Right </p>
-	<div class="codebox">
-		<pre>if (isset($forum)) ...</pre></div>
+$sig = $this->auth->acl_get('u_sig') ? true : false;									// Wrong
+$sig = (bool) $this->auth->acl_get('u_sig');											// Correct
+$emoji = (bool) ($this->auth->acl_get('u_emoji') && $this->config['allow_smilies']);	// Correct
+</pre>
+							</div>
+						</div>
+					</div>
 
-	<p class="good">// Also possible</p>
-	<div class="codebox">
-		<pre>if (isset($forum) &amp;&amp; $forum == 5)</pre>
-	</div>
+					<div class="inner">
+						<div class="column1">
+							<h4 id="code.tokens.initialised_variables">
+								<a href="#code.tokens.initialised_variables"></a>
+								<span>Initialised variables</span>
+							</h4>
 
-	<p>The <code>empty()</code> function is useful if you want to check if a variable is not set or being empty (an empty string, 0 as an integer or string, NULL, false, an empty array or a variable declared, but without a value in a class). Therefore empty should be used in favor of <code>isset($array) &amp;&amp; count($array) &gt; 0</code> - this can be written in a shorter way as <code>!empty($array)</code>.</p>
+							<ul>
+								<li>Either variables should be initialised with a default value.</li>
+								<li>
+									Or explicitly checked for existance when used <em>(every time!)</em>.
+									<br>Not the condition that it depends on, but the actual variable name.
+								</li>
+							</ul>
+						</div>
+						<div class="column2">
+							<div class="codebox">
+								<pre class="php">
+if ($this->request->is_set_post('submit'))
+{
+	$delete = true;
+}
 
-	<h4>Switch statements:</h4>
-	<p>Switch/case code blocks can get a bit long sometimes. To have some level of notice and being in-line with the opening/closing brace requirement (where they are on the same line for better readability), this also applies to switch/case code blocks and the breaks. An example:</p>
+$action = isset($delete) ? 'delete' : 'edit';
+</pre>
+							</div>
+						</div>
+					</div>
 
-	<p class="bad">// Wrong </p>
-	<div class="codebox"><pre>
+					<h4 id="code.tokens.magic_numbers">
+						<a href="#code.tokens.magic_numbers"></a>
+						<span>Magic numbers</span>
+					</h4>
+					<ul>
+						<li>Magic numbers should not be used.</li>
+						<li>Use named class constants instead.</li>
+					</ul>
+
+					<div class="inner">
+						<div class="column1">
+							<h4 id="code.tokens.switch_statements">
+								<a href="#code.tokens.switch_statements"></a>
+								<span>Switch statements</span>
+							</h4>
+
+							<ul>
+								<li>The <code>case</code> and <code>break</code> statements should have the same indentation.</li>
+								<li>There should be no empty line after the <code>case</code> statement.</li>
+								<li>There should be no empty line before the <code>break</code> statement.</li>
+								<li>There should be a <code>default</code> statement, always assume a case was not caught.</li>
+								<li>The <code>default</code> statement should also have a <code>break</code> statement.</li>
+								<li>When no <code>break</code> is intended, a <code>// no break;</code> comment should be provided.</li>
+								<li>There should be no <code>break</code> statement when the last line is a <code>return</code> or <code>throw</code></li>
+							</ul>
+						</div>
+						<div class="column2">
+							<div class="codebox">
+								<pre class="php">
 switch ($mode)
 {
-	case 'mode1':
-		// I am doing something here
-		break;
-	case 'mode2':
-		// I am doing something completely different here
-		break;
-}</pre>
-	</div>
+	case 'edit':
+		// Supply the no break statement
+	// no break;
 
-	<p class="good">// Good </p>
-	<div class="codebox"><pre>
-switch ($mode)
-{
-	case 'mode1':
-		// I am doing something here
+	case 'add':
+		// Same indentation for case and break
 	break;
 
-	case 'mode2':
-		// I am doing something completely different here
-	break;
+	case 'delete':
+		throw new \phpbb\exception\http_exception(403, 'NOT_AUTHORISED');
 
 	default:
-		// Always assume that a case was not caught
+		// Always assume a case was not caught
 	break;
-}</pre>
-	</div>
+}
+</pre>
+							</div>
+						</div>
+					</div>
 
-	<p class="good">// Also good, if you have more code between the case and the break </p>
-	<div class="codebox"><pre>
-switch ($mode)
+					<h3 id="code.optimisation">
+						<a href="#code.optimisation"></a>
+						<span>Optimisation</span>
+						<a href="#wrap" class="top">Back to Top</a>
+					</h3>
+
+					<h4 id="code.optimisation.in_array">
+						<a href="#code.optimisation.in_array"></a>
+						<span>in_array</span>
+					</h4>
+					<p>
+						Try to avoid <code>in_array()</code> on large arrays
+						and try to not place them inside loops if the array to check consists of more than 20 entries.
+						<br><code>in_array()</code> can be very time consuming and uses a lot of cpu processing time.
+						<br>For little checks it is not noticeable, but if checked against a large array within a loop
+						those checks alone can take several seconds.
+						<br>If you need this functionality, try using <code>isset()</code> on the arrays keys instead,
+						actually shifting the values into keys and vice versa.
+						<br>A call to <code>isset($array[$var])</code> is a lot faster than <code>in_array($var, array_keys($array))</code> for example.
+					</p>
+
+					<div class="inner">
+						<div class="column1">
+							<h4 id="code.optimisation.null_coalesce_operator">
+								<a href="#code.optimisation.null_coalesce_operator"></a>
+								<span>null coalesce operator</span>
+							</h4>
+							<p>
+								Try to use the <a href="https://www.php.net/manual/en/migration70.new-features.php#migration70.new-features.null-coalesce-op" target="_blank">null coalesce operator</a> (<code>??</code>) when possible,
+								when you are not sure if a variable or array index is set.
+								<br>This will prevent <code>undefined variable</code> and <code>undefined index</code> errors from occurring.
+								<br>It is also more efficient than <code>isset($var) ? $var : ''</code> as it will save an <code>isset()</code> call.
+								<br>Cause the "<code>true</code> statement" for that conditional, the plain <code>$var</code>, will be put through <code>isset()</code> again by PHP.
+								<br>In such cases you can and should use <code>$var ?? ''</code> instead.
+							</p>
+						</div>
+						<div class="column2">
+							<div class="codebox">
+								<pre class="php">
+if ($this->request->is_set_post('delete')
 {
-	case 'mode1':
+	$action = 'delete';
+	$delete = true;
+}
 
-		// I am doing something here
+$mode = $action ?? '';	// Correct: mode is now 'delete'
+$mode = $delete ?? '';	// Wrong: mode is now true
+</pre>
+							</div>
+						</div>
+					</div>
 
-	break;
+					<div class="inner">
+						<div class="column1">
+							<h4 id="code.optimisation.sql_queries_inside_loops">
+								<a href="#code.optimisation.sql_queries_inside_loops"></a>
+								<span>SQL queries inside loops</span>
+							</h4>
+							<p>
+								Database queries should not be executed inside loops (<code>for</code>, <code>foreach</code> and <code>while</code>)
+								as that can quickly result in a lot of SQL queries.
+								<br>Instead fetch all the data before the loop and index it to an associative array
+								with some sort of identifiers as keys.
+								<br>Then access the data inside the loop with the identifier.
+							</p>
+						</div>
+						<div class="column2">
+							<div class="codebox">
+								<pre class="php">
+$ids = [...];
+$data = $this->query_data($ids);
 
-	case 'mode2':
-
-		// I am doing something completely different here
-
-	break;
-
-	default:
-
-		// Always assume that a case was not caught
-
-	break;
-}</pre>
-	</div>
-
-	<p>Even if the break for the default case is not needed, it is sometimes better to include it just for readability and completeness.</p>
-
-	<p>If no break is intended, please add a comment instead. An example:</p>
-
-	<p class="good">// Example with no break </p>
-	<div class="codebox"><pre>
-switch ($mode)
+foreach ($ids as $id)
 {
-	case 'mode1':
-
-		// I am doing something here
-
-	// no break here
-
-	case 'mode2':
-
-		// I am doing something completely different here
-
-	break;
-
-	default:
-
-		// Always assume that a case was not caught
-
-	break;
-}</pre>
-	</div>
-
-	<h4>Class Members</h4>
-	<p>Use the explicit visibility qualifiers <code>public</code>, <code>private</code> and <code>protected</code> for all properties instead of <code>var</code>.
-
-	<p>Place the <code>static</code> qualifier before the visibility qualifiers.</p>
-
-	<p class="bad">//Wrong </p>
-	<div class="codebox"><pre>
-var $x;
-private static function f()</pre>
-	</div>
-
-	<p class="good">// Right </p>
-	<div class="codebox"><pre>
-public $x;
-static private function f()</pre>
-	</div>
-
-	<h4>Constants</h4>
-	<p>Prefer class constants over global constants created with <code>define()</code>.</p>
-
-	<a name="sql"></a><h3>2.iii. SQL/SQL Layout</h3>
-
-	<h4>Common SQL Guidelines: </h4>
-	<p>All SQL should be cross-DB compatible, if DB specific SQL is used alternatives must be provided which work on all supported DB's (MySQL4/5, MSSQL (7.0 and 2000), PostgreSQL (8.3+), SQLite, Oracle8, ODBC (generalised if possible)).</p>
-	<p>All SQL commands should utilise the DataBase Abstraction Layer (DBAL)</p>
-
-	<h4>SQL code layout:</h4>
-	<p>SQL Statements are often unreadable without some formatting, since they tend to be big at times. Though the formatting of sql statements adds a lot to the readability of code. SQL statements should be formatted in the following way, basically writing keywords: </p>
-
-	<div class="codebox"><pre>
-$sql = 'SELECT *
-&lt;-one tab-&gt;FROM ' . SOME_TABLE . '
-&lt;-one tab-&gt;WHERE a = 1
-&lt;-two tabs-&gt;AND (b = 2
-&lt;-three tabs-&gt;OR b = 3)
-&lt;-one tab-&gt;ORDER BY b';</pre>
-	</div>
-
-	<p>Here the example with the tabs applied:</p>
-
-	<div class="codebox"><pre>
-$sql = 'SELECT *
-	FROM ' . SOME_TABLE . '
-	WHERE a = 1
-		AND (b = 2
-			OR b = 3)
-	ORDER BY b';</pre>
-	</div>
-
-	<h4>SQL Quotes: </h4>
-	<p>Use double quotes where applicable. (The variables in these examples are typecasted to integers beforehand.) Examples: </p>
-
-	<p class="bad">// These are wrong.</p>
-	<div class="codebox"><pre>
-"UPDATE " . SOME_TABLE . " SET something = something_else WHERE a = $b";
-
-'UPDATE ' . SOME_TABLE . ' SET something = ' . $user_id . ' WHERE a = ' . $something;</pre>
-	</div>
-
-	<p class="good">// These are right. </p>
-
-	<div class="codebox"><pre>
-'UPDATE ' . SOME_TABLE . " SET something = something_else WHERE a = $b";
-
-'UPDATE ' . SOME_TABLE . " SET something = $user_id WHERE a = $something";</pre>
-	</div>
-
-	<p>In other words use single quotes where no variable substitution is required or where the variable involved shouldn't appear within double quotes. Otherwise use double quotes.</p>
-
-	<h4>Avoid DB specific SQL: </h4>
-	<p>The &quot;not equals operator&quot;, as defined by the SQL:2003 standard, is &quot;&lt;&gt;&quot;</p>
-
-	<p class="bad">// This is wrong.</p>
-	<div class="codebox"><pre>
-$sql = 'SELECT *
-	FROM ' . SOME_TABLE . '
-	WHERE a != 2';</pre>
-	</div>
-
-	<p class="good">// This is right. </p>
-	<div class="codebox"><pre>
-$sql = 'SELECT *
-	FROM ' . SOME_TABLE . '
-	WHERE a &lt;&gt; 2';</pre>
-	</div>
-
-	<h4>Common DBAL methods: </h4>
-
-	<h4>sql_escape():</h4>
-
-	<p>Always use <code>$db-&gt;sql_escape()</code> if you need to check for a string within an SQL statement (even if you are sure the variable cannot contain single quotes - never trust your input), for example:</p>
-
-	<div class="codebox"><pre>
-$sql = 'SELECT *
-	FROM ' . SOME_TABLE . "
-	WHERE username = '" . $db-&gt;sql_escape($username) . "'";</pre>
-	</div>
-
-	<h4>sql_query_limit():</h4>
-
-	<p>We do not add limit statements to the sql query, but instead use <code>$db-&gt;sql_query_limit()</code>. You basically pass the query, the total number of lines to retrieve and the offset.</p>
-
-	<p><strong>Note: </strong> Since Oracle handles limits differently and because of how we implemented this handling you need to take special care if you use <code>sql_query_limit</code> with an sql query retrieving data from more than one table.</p>
-
-	<p>Make sure when using something like "SELECT x.*, y.jars" that there is not a column named jars in x; make sure that there is no overlap between an implicit column and the explicit columns.</p>
-
-	<h4>sql_build_array():</h4>
-
-	<p>If you need to UPDATE or INSERT data, make use of the <code>$db-&gt;sql_build_array()</code> function. This function already escapes strings and checks other types, so there is no need to do this here. The data to be inserted should go into an array - <code>$sql_ary</code> - or directly within the statement if one or two variables needs to be inserted/updated. An example of an insert statement would be:</p>
-
-	<div class="codebox"><pre>
-$sql_ary = array(
-	'somedata'		=&gt; $my_string,
-	'otherdata'		=&gt; $an_int,
-	'moredata'		=&gt; $another_int,
-);
-
-$db-&gt;sql_query('INSERT INTO ' . SOME_TABLE . ' ' . $db-&gt;sql_build_array('INSERT', $sql_ary));</pre>
-	</div>
-
-	<p>To complete the example, this is how an update statement would look like:</p>
-
-	<div class="codebox"><pre>
-$sql_ary = array(
-	'somedata'		=&gt; $my_string,
-	'otherdata'		=&gt; $an_int,
-	'moredata'		=&gt; $another_int,
-);
-
-$sql = 'UPDATE ' . SOME_TABLE . '
-	SET ' . $db-&gt;sql_build_array('UPDATE', $sql_ary) . '
-	WHERE user_id = ' . (int) $user_id;
-$db-&gt;sql_query($sql);</pre>
-	</div>
-
-	<p>The <code>$db-&gt;sql_build_array()</code> function supports the following modes: <code>INSERT</code> (example above), <code>INSERT_SELECT</code> (building query for <code>INSERT INTO table (...) SELECT value, column ...</code> statements), <code>UPDATE</code> (example above) and <code>SELECT</code> (for building WHERE statement [AND logic]).</p>
-
-	<h4>sql_multi_insert():</h4>
-
-	<p>If you want to insert multiple statements at once, please use the separate <code>sql_multi_insert()</code> method. An example:</p>
-
-	<div class="codebox"><pre>
-$sql_ary = array();
-
-$sql_ary[] = array(
-	'somedata'		=&gt; $my_string_1,
-	'otherdata'		=&gt; $an_int_1,
-	'moredata'		=&gt; $another_int_1,
-);
-
-$sql_ary[] = array(
-	'somedata'		=&gt; $my_string_2,
-	'otherdata'		=&gt; $an_int_2,
-	'moredata'		=&gt; $another_int_2,
-);
-
-$db->sql_multi_insert(SOME_TABLE, $sql_ary);</pre>
-	</div>
-
-	<h4>sql_in_set():</h4>
-
-	<p>The <code>$db-&gt;sql_in_set()</code> function should be used for building <code>IN ()</code> and <code>NOT IN ()</code> constructs. Since (specifically) MySQL tend to be faster if for one value to be compared the <code>=</code> and <code>&lt;&gt;</code> operator is used, we let the DBAL decide what to do. A typical example of doing a positive match against a number of values would be:</p>
-
-	<div class="codebox"><pre>
-$sql = 'SELECT *
-	FROM ' . FORUMS_TABLE . '
-	WHERE ' . $db-&gt;sql_in_set('forum_id', $forum_ids);
-$db-&gt;sql_query($sql);</pre>
-	</div>
-
-	<p>Based on the number of values in $forum_ids, the query can look differently.</p>
-
-	<p class="good">// SQL Statement if $forum_ids = array(1, 2, 3);</p>
-
-	<div class="codebox"><pre>
-SELECT FROM phpbb_forums WHERE forum_id IN (1, 2, 3)</pre>
-	</div>
-
-	<p class="good">// SQL Statement if $forum_ids = array(1) or $forum_ids = 1</p>
-
-	<div class="codebox"><pre>
-SELECT FROM phpbb_forums WHERE forum_id = 1</pre>
-	</div>
-
-	<p>Of course the same is possible for doing a negative match against a number of values:</p>
-
-	<div class="codebox"><pre>
-$sql = 'SELECT *
-	FROM ' . FORUMS_TABLE . '
-	WHERE ' . $db-&gt;sql_in_set('forum_id', $forum_ids, <strong>true</strong>);
-$db-&gt;sql_query($sql);</pre>
-	</div>
-
-	<p>Based on the number of values in $forum_ids, the query can look differently here too.</p>
-
-	<p class="good">// SQL Statement if $forum_ids = array(1, 2, 3);</p>
-
-	<div class="codebox"><pre>
-SELECT FROM phpbb_forums WHERE forum_id <strong>NOT</strong> IN (1, 2, 3)</pre>
-	</div>
-
-	<p class="good">// SQL Statement if $forum_ids = array(1) or $forum_ids = 1</p>
-
-	<div class="codebox"><pre>
-SELECT FROM phpbb_forums WHERE forum_id <strong>&lt;&gt;</strong> 1</pre>
-	</div>
-
-	<p>If the given array is empty, an error will be produced.</p>
-
-	<h4>sql_build_query():</h4>
-
-	<p>The <code>$db-&gt;sql_build_query()</code> function is responsible for building sql statements for SELECT and SELECT DISTINCT queries if you need to JOIN on more than one table or retrieve data from more than one table while doing a JOIN. This needs to be used to make sure the resulting statement is working on all supported db's. Instead of explaining every possible combination, I will give a short example:</p>
-
-	<div class="codebox"><pre>
-$sql_array = array(
-	'SELECT'	=&gt; 'f.*, ft.mark_time',
-
-	'FROM'		=&gt; array(
-		FORUMS_WATCH_TABLE	=&gt; 'fw',
-		FORUMS_TABLE		=&gt; 'f',
-	),
-
-	'LEFT_JOIN'	=&gt; array(
-		array(
-			'FROM'	=&gt; array(FORUMS_TRACK_TABLE =&gt; 'ft'),
-			'ON'	=&gt; 'ft.user_id = ' . $user-&gt;data['user_id'] . ' AND ft.forum_id = f.forum_id',
-		),
-	),
-
-	'WHERE'		=&gt; 'fw.user_id = ' . $user-&gt;data['user_id'] . '
-		AND f.forum_id = fw.forum_id',
-
-	'ORDER_BY'	=&gt; 'left_id',
-);
-
-$sql = $db-&gt;sql_build_query('SELECT', $sql_array);</pre>
-	</div>
-
-	<p>The possible first parameter for sql_build_query() is SELECT or SELECT_DISTINCT. As you can see, the logic is pretty self-explaining. For the LEFT_JOIN key, just add another array if you want to join on to tables for example. The added benefit of using this construct is that you are able to easily build the query statement based on conditions - for example the above LEFT_JOIN is only necessary if server side topic tracking is enabled; a slight adjustement would be:</p>
-
-	<div class="codebox"><pre>
-$sql_array = array(
-	'SELECT'	=&gt; 'f.*',
-
-	'FROM'		=&gt; array(
-		FORUMS_WATCH_TABLE	=&gt; 'fw',
-		FORUMS_TABLE		=&gt; 'f',
-	),
-
-	'WHERE'		=&gt; 'fw.user_id = ' . $user-&gt;data['user_id'] . '
-		AND f.forum_id = fw.forum_id',
-
-	'ORDER_BY'	=&gt; 'left_id',
-);
-
-if ($config['load_db_lastread'])
+	$row = $data[$id];
+}
+</pre>
+							</div>
+						</div>
+					</div>
+
+					<div class="inner">
+						<div class="column1">
+							<h4 id="code.optimisation.operations_in_loop_definition">
+								<a href="#code.optimisation.operations_in_loop_definition"></a>
+								<span>Operations in loop definition</span>
+							</h4>
+
+							<p>
+								Always try to optimise your <code>for</code> loops if operations are going on in the comparing part.
+								<br>The comparing part is the second expression in statement and is executed on each iteration.
+								<br>Instead assign the variable in the first expression, which is only executed once at the beginning of the loop.
+								<br>Use short but concise names the assignments.
+							</p>
+						</div>
+						<div class="column2">
+							<div class="codebox">
+								<pre class="php">
+for ($i = 0; $i < count($post_data); $i++)
 {
-	$sql_array['LEFT_JOIN'] = array(
-		array(
-			'FROM'	=&gt; array(FORUMS_TRACK_TABLE =&gt; 'ft'),
-			'ON'	=&gt; 'ft.user_id = ' . $user-&gt;data['user_id'] . ' AND ft.forum_id = f.forum_id',
-		),
-	);
+	// Wrong: count() is executed on each iteration
+}
 
-	$sql_array['SELECT'] .= ', ft.mark_time ';
+for ($i = 0, $size = count($post_data); $i < $size; $i++)
+{
+	// Correct: count() is only executed once, at the beginning of the loop
+}
+</pre>
+							</div>
+						</div>
+					</div>
+
+					<h3 id="code.security">
+						<a href="#code.security"></a>
+						<span>Security</span>
+						<a href="#wrap" class="top">Back to Top</a>
+					</h3>
+					<p>
+						Any action or operation performed by a user needs to be checked and verified.
+						<br>For sensitive operations, the user should always have to confirm the action was intended.
+						<br>For any action or operation that alters the state of the database, some sort of security measure has to be implemented.
+						<br>Think of submitting a post (use a <em>form key</em>), deleting a post (use a <em>confirm box</em>) or marking the forums read (use a <em>link hash</em>).
+						<br>Any and all forms of <strong>user input</strong>, <strong>cookies</strong> and <strong>server variables</strong> should be checked, sanitized and escaped when necessary.
+					</p>
+
+					<div class="inner">
+						<div class="column1">
+							<h4 id="code.security.form_key">
+								<a href="#code.security.form_key"></a>
+								<span>Form key</span>
+							</h4>
+
+							<ul>
+								<li>Form names used in <code>*_form_key</code> functions should be assigned to <code>$form_key</code>.</li>
+								<li>The <code>add_form_key</code> function should follow this variable immediately.</li>
+								<li>The <code>check_form_key</code> function should be the first check upon submission.</li>
+								<li>The <em>(potential)</em> error should always be or include the <code>'FORM_INVALID'</code> language string.</li>
+								<li>The HTML <code>form</code> needs to have a <code>{{ S_FORM_TOKEN }}</code> variable, preferably right after the submit buttons.</li>
+							</ul>
+						</div>
+						<div class="column2">
+							<pre class="php">
+$form_key = 'my_forum_name';
+add_form_key($form_key);
+
+if ($this->request->is_set_post('submit'))
+{
+	if (!check_form_key($form_key))
+	{
+		$errors[] = $this->language->lang('FORM_INVALID');
+	}
+}
+</pre>
+						</div>
+					</div>
+
+					<div class="inner">
+						<div class="column1">
+							<h4 id="code.security.link_hash">
+								<a href="#code.security.link_hash"></a>
+								<span>Link hash</span>
+							</h4>
+
+							<ul>
+								<li>The <code>generate_link_hash</code> function should used for GET requests.</li>
+								<li>The <code>check_link_hash</code> function should be the first check upon submission.</li>
+								<li>The <em>(potential)</em> error should always be or include the <code>'FORM_INVALID'</code> language string.</li>
+								<li>Use <code>hash</code> as the parameter name when possible.</li>
+							</ul>
+						</div>
+						<div class="column2">
+							<pre class="php">
+if ($this->request->is_set('mark_something', \phpbb\request\request_interface::GET))
+{
+	$token = $this->request->variable('hash', '', true, \phpbb\request\request_interface::GET);
+
+	if (!check_link_hash($token, 'mark_something_important'))
+	{
+		$errors[] = $this->language->lang('FORM_INVALID');
+	}
+}
+
+$this->template->assign_var('U_MARK', $this->helper->route('...', ['hash' => generate_link_hash('mark_something_important')]));
+</pre>
+						</div>
+					</div>
+
+					<div class="inner">
+						<div class="column1">
+							<h4 id="code.security.confirm_box">
+								<a href="#code.security.confirm_box"></a>
+								<span>Confirm box</span>
+							</h4>
+
+							<ul>
+								<li>Should be used for all sensitive user operators.</li>
+								<li>When possible, the <code>true</code> statement should come before the <code>false</code> statement.</li>
+								<li>
+									Should provide a redirect after the <code>confirm_box(false, ...)</code> call.
+									<br>The user will be redirected to this page if they press <em>"No"</em>.
+								</li>
+							</ul>
+						</div>
+						<div class="column2">
+							<pre class="php">
+if (confirm_box(true))
+{
+	// The "true" statement
 }
 else
 {
-	// Here we read the cookie data
+	confirm_box(false, 'CONFIRM_OPERATION', build_hidden_fields([
+		'action' => 'delete',
+	]));
+
+	redirect($not_confirmed_url);
+}
+</pre>
+						</div>
+					</div>
+
+					<div class="inner">
+						<div class="column1">
+							<h4 id="code.security.login_box">
+								<a href="#code.security.login_box"></a>
+								<span>Login box</span>
+							</h4>
+
+							<ul>
+								<li>For all forms that allow a user to login, the <code>login_box</code> should be used.</li>
+								<li>Always provide an explanation as to why the user has to be logged in.</li>
+								<li>Only provide a redirect url when necessary, otherwise it will use the user's current location.</li>
+								<li>Do not provide or append the session id (<code>sid</code>) to the redirect url.</li>
+								<li>
+									For password protected forums, the <code>login_forum_box</code> should be used.
+									<ul>
+										<li>The <code>forum_id</code> should be provided.</li>
+										<li>The <code>forum_name</code> should be provided.</li>
+										<li>The <code>forum_password</code> should be provided.</li>
+									</ul>
+								</li>
+							</ul>
+						</div>
+						<div class="column2">
+							<pre class="php">
+if ($this->user->data['user_id'] == ANONYMOUS)
+{
+	login_box("index.{$this->php_ext}", $this->language->lang('LOGIN_EXPLAIN_UCP'));	// Redirects to the board index
+	login_box('', $this->language->lang('LOGIN_EXPLAIN_MCP'));							// Redirects to the current location
 }
 
-$sql = $db-&gt;sql_build_query('SELECT', $sql_array);</pre>
-	</div>
-
-	<a name="optimizing"></a><h3>2.iv. Optimizations</h3>
-
-	<h4>Operations in loop definition: </h4>
-	<p>Always try to optimize your loops if operations are going on at the comparing part, since this part is executed every time the loop is parsed through. For assignments a descriptive name should be chosen. Example:</p>
-
-	<p class="bad">// On every iteration the count function is called</p>
-	<div class="codebox"><pre>
-for ($i = 0; $i &lt; count($post_data); $i++)
+if (!empty($forum_data['forum_password']))
 {
-	do_something();
-}</pre>
-	</div>
+	login_forum_box($forum_data);
+}
+</pre>
+						</div>
+					</div>
 
-	<p class="good">// You are able to assign the (not changing) result within the loop itself</p>
-	<div class="codebox"><pre>
-for ($i = 0, $size = count($post_data); $i &lt; $size; $i++)
-{
-	do_something();
-}</pre>
-	</div>
+					<div class="inner">
+						<div class="column1">
+							<h4 id="code.security.request">
+								<a href="#code.security.request"></a>
+								<span>Request</span>
+							</h4>
 
-	<h4>Use of in_array(): </h4>
-	<p>Try to avoid using in_array() on huge arrays, and try to not place them into loops if the array to check consist of more than 20 entries. in_array() can be very time consuming and uses a lot of cpu processing time. For little checks it is not noticeable, but if checked against a huge array within a loop those checks alone can take several seconds. If you need this functionality, try using isset() on the arrays keys instead, actually shifting the values into keys and vice versa. A call to <code>isset($array[$var])</code> is a lot faster than <code>in_array($var, array_keys($array))</code> for example.</p>
+							<ul>
+								<li>Never trust <strong>user input</strong>, <strong>cookies</strong> and <strong>server variables</strong>.</li>
+								<li>Sanitize and verify all input and variables as much as possible.</li>
+								<li>Use the <code>\phpbb\request\request</code> class as much as possible.</li>
+								<li>Use <code>is_set</code> and <code>is_set_post</code> when checking existance.</li>
+								<li>Use <code>header</code> when requesting user headers.</li>
+								<li>Use <code>server</code> when requesting server variables.</li>
+								<li>Set the super global when only one is possible or allowed.</li>
+								<li>
+									Set the <code>multibyte</code> parameter to <code>true</code> when requesting strings.
+									<br>Especially if the string may contain <samp>UTF-8</samp> characters.
+									<br>Otherwise all bytes outside the <samp>ASCII</samp> range <em>(0-127)</em> will become question marks.
+								</li>
+							</ul>
+						</div>
+						<div class="column2">
+							<pre class="php">
+$search			= $this->request->is_set('search');
+$submit			= $this->request->is_set_post('submit');
 
+$int 			= $this->request->variable('integer', 0);
+$int_post		= $this->request->variable('int_post', 0, false, \phpbb\request\request_interface::POST);
+$int_array		= $this->request->variable('integers', [0]);
 
-	<a name="general"></a><h3>2.v. General Guidelines</h3>
+$string			= $this->request->variable('string', '', true);
+$string_array1	= $this->request->variable('strings', [''], true);
+$string_array2	= $this->request->variable('indexed', [0 => ['']], true);
 
-	<h4>General things:</h4>
-	<p>Never trust user input (this also applies to server variables as well as cookies).</p>
-	<p>Try to sanitize values returned from a function.</p>
-	<p>Try to sanitize given function variables within your function.</p>
-	<p>The auth class should be used for all authorisation checking.</p>
-	<p>No attempt should be made to remove any copyright information (either contained within the source or displayed interactively when the source is run/compiled), neither should the copyright information be altered in any way (it may be added to).</p>
+$cookie			= $this->request->variable($this->config['cookie_name'] . '_k', '', true, \phpbb\request\request_interface::COOKIE);
+$server			= $this->request->server('SERVER_NAME');
+$header			= $this->request->header('X-Forwarded-For');
+</pre>
+						</div>
+					</div>
 
-	<h4>Variables: </h4>
-	<p>Make use of the <code>\phpbb\request\request</code> class for everything.</p>
-	<p>The $request->variable() method determines the type to set from the second parameter (which determines the default value too). If you need to get a scalar variable type, you need to tell this the variable() method explicitly. Examples:</p>
+					<h4 id="code.security.php_restrictions">
+						<a href="#code.security.php_restrictions"></a>
+						<span>PHP restrictions</span>
+					</h4>
+					<ul>
+						<li>Use <code>strpos</code> instead of <code>strstr</code></li>
+						<li>Do not use <code>goto</code></li>
+						<li>
+							Do not execute dynamic code.
+							<ul>
+								<li>Do not use <code>eval</code></li>
+								<li>Do not use <code>create_function</code></li>
+								<li>
+									Do not use <code>preg_replace</code> with the <code>e</code> modifier.
+									<br>Use <code>preg_replace_callback</code> instead.
+								</li>
+							</ul>
+						</li>
+					</ul>
 
-	<p class="bad">// Old method, do not use it</p>
-	<div class="codebox"><pre>
-$start = (isset($HTTP_GET_VARS['start'])) ? intval($HTTP_GET_VARS['start']) : intval($HTTP_POST_VARS['start']);
-$submit = (isset($HTTP_POST_VARS['submit'])) ? true : false;</pre>
-	</div>
+					<h3 id="code.sql">
+						<a href="#code.sql"></a>
+						<span>SQL</span>
+						<a href="#wrap" class="top">Back to Top</a>
+					</h3>
 
-	<p class="good">// Use request var and define a default variable (use the correct type)</p>
-	<div class="codebox"><pre>
-$start = $request->variable('start', 0);
-$submit = $request->is_set_post('submit');</pre>
-	</div>
+					<div class="inner">
+						<div class="column1">
+							<h4 id="code.sql.compatibility">
+								<a href="#code.sql.compatibility"></a>
+								<span>Compatibility</span>
+							</h4>
 
-	<p class="bad">// $start is an int, the following use of $request->variable() therefore is not allowed</p>
-	<div class="codebox"><pre>
-$start = $request->variable('start', '0');</pre>
-	</div>
+							<ul>
+								<li>Always use <code>\phpbb\db\driver\driver_interface</code></li>
+								<li>Always use <code>sql_query_limit</code> for <code>LIMIT</code> and <code>OFFSET</code></li>
+								<li>Always use <code>sql_build_query</code> when joining tables.</li>
+								<li>Always use <code>sql_build_query</code> when using multiple, complex conditionals.</li>
+								<li>Always use <code>sql_multi_insert</code> when inserting multiple rows.</li>
+								<li>
+									Always use <code>sql_in_set</code> for building <code>IN</code> and <code>NOT IN</code> clauses.
+									<br>This will automatically check if the provided variable is an array or only contains one value.
+									<br>If it is in a single value, it will then automatically use <code>=</code> and <code><></code> instead.
+									<br>As those comparisons tend to be faster across most platforms.
+									<br>All values will be automatically escaped and quoted when necessary.
+								</li>
+								<li>Always use <code><></code> and not <code>!=</code> for "<em>not equal</em>"-comparison.</li>
+								<li>
+									No platform specific SQL should be used.
+									<br>Otherwise provide alternatives for all supported platforms.
+									<br>Use <code>switch ($this->db->get_sql_layer())</code> to provide the alternatives.
+								</li>
+							</ul>
 
-	<p class="good">// Getting an array, keys are integers, value defaults to 0</p>
-	<div class="codebox"><pre>
-$mark_array = $request->variable('mark', array(0));</pre>
-	</div>
+							<h4 id="code.sql.general">
+								<a href="#code.sql.general"></a>
+								<span>General</span>
+							</h4>
 
-	<p class="good">// Getting an array, keys are strings, value defaults to 0</p>
-	<div class="codebox"><pre>
-$action_ary = $request->variable('action', array('' =&gt; 0));</pre>
-	</div>
+							<ul>
+								<li>Always assign a SQL statement to a <code>$sql</code> variable before execution.</li>
+								<li>Always provide <code>as</code> statements for duplicate columns.</li>
+								<li>Always provide the direction (<code>ASC</code> or <code>DESC</code>) for the <code>ORDER BY</code> clause.</li>
+								<li>All selected columns should be present in the <code>GROUP BY</code> clause.</li>
+								<li>
+									All results from <code>SELECT</code> and <code>SELECT_DISTINCT</code> statements should be freed.
+									<br>This should be done with <code>sql_freeresult</code>
+								</li>
+								<li>
+									Database tables injection:
+									<ul>
+										<li>
+											Use <code>$tables</code> whenever possible.
+											<br>Even when it is just a single table.
+											<br>This will make future extending easier.
+										</li>
+										<li>Use <code>$table_prefix</code> when <code>$tables</code> is not possible.</li>
+										<li>Only use table constants (eg. <code>USERS_TABLE</code>) when service parameters are unavailable.</li>
+									</ul>
+								</li>
+							</ul>
+						</div>
+						<div class="column2">
+							<pre class="php">
+// These usernames are already available in the topics table, but as an example..
+$sql_array = [
+	'SELECT'	=> 't.*, u1.username, u2.username as second_name',
+	'FROM'		=> [
+		$this->tables['topics']	=> 't',
+		$this->tables['users']	=> 'u1',
+	],
+	'LEFT_JOIN'	=> [
+		[
+			'FROM'	=> [$this->tables['users'] => 'u2'],
+			'ON'	=> 't.topic_last_poster_id = u2.user_id',
+		],
+	],
+	'WHERE'		=> 't.topic_poster = u1.user_id
+		AND t.topic_reported <> 1
+		AND t.topic_id = ' . (int) $topic_id,
+	'ORDER_BY'	=> 't.topic_title ASC',
+];
 
-	<h4>Login checks/redirection: </h4>
-	<p>To show a forum login box use <code>login_forum_box($forum_data)</code>, else use the <code>login_box()</code> function.</p>
+$sql = $this->db->sql_build_query
+$result = $this->db->sql_query_limit($sql, $limit, $start);
+$rowset = $this->db->sql_fetchrowset($result);
+$this->db->sql_freeresult($result);
+</pre>
+						</div>
+					</div>
 
-	<p><code>$forum_data</code> should contain at least the <code>forum_id</code> and <code>forum_password</code> fields. If the field <code>forum_name</code> is available, then it is displayed on the forum login page.</p>
+					<div class="inner">
+						<div class="column1">
+							<h4 id="code.sql.indentation">
+								<a href="#code.sql.indentation"></a>
+								<span>Indentation</span>
+							</h4>
 
-	<p>The <code>login_box()</code> function can have a redirect as the first parameter. As a thumb of rule, specify an empty string if you want to redirect to the users current location, else do not add the <code>$SID</code> to the redirect string (for example within the ucp/login we redirect to the board index because else the user would be redirected to the login screen).</p>
+							<ul>
+								<li>All SQL clauses (<code>FROM</code>, <code>WHERE</code>, <code>ORDER BY</code>, etc..) should start on a new line.</li>
+								<li>All SQL clauses should be indented with one more tab than the <code>$sql</code> variable.</li>
+								<li>Wrapped lines inside SQL clauses should be indented with one additional tabs.</li>
+								<li>Each nested condition inside the SQL <code>WHERE</code> clause should have one additional tab.</li>
+							</ul>
+						</div>
+						<div class="column2">
+							<pre class="sql">
+$sql = 'SELECT forum_id, forum_name
+	FROM ' . $this->tables['forums'] . '
+	WHERE forum_id != 1
+		AND (parent_id = 2
+			OR parent_id = 3)
+	ORDER BY forum_name ASC';
+</pre>
+						</div>
+					</div>
 
-	<h4>Sensitive Operations: </h4>
-	<p>For sensitive operations always let the user confirm the action. For the confirmation screens, make use of the <code>confirm_box()</code> function.</p>
+					<div class="inner">
+						<div class="column1">
+							<h4 id="code.sql.quotes">
+								<a href="#code.sql.quotes"></a>
+								<span>Quotes</span>
+							</h4>
 
-	<h4>Altering Operations: </h4>
-	<p>For operations altering the state of the database, for instance posting, always verify the form token, unless you are already using <code>confirm_box()</code>. To do so, make use of the <code>add_form_key()</code> and <code>check_form_key()</code> functions. </p>
-	<div class="codebox"><pre>
-	add_form_key('my_form');
+							<ul>
+								<li>Single quotes <code>''</code> should almost always be used.</li>
+								<li>
+									Double quotes <code>""</code> should only be used when:
+									<ul>
+										<li>Using variable substitution, which are already type casted.</li>
+										<li>Single quotes are needed inside the statement for escaping.</li>
+									</ul>
+								</li>
+							</ul>
 
-	if ($submit)
-	{
-		if (!check_form_key('my_form'))
-		{
-			trigger_error('FORM_INVALID');
-		}
-	}</pre>
-	</div>
+							<h4 id="code.sql.variables">
+								<a href="#code.sql.variables"></a>
+								<span>Variables</span>
+							</h4>
 
-	<p>The string passed to <code>add_form_key()</code> needs to match the string passed to <code>check_form_key()</code>. Another requirement for this to work correctly is that all forms include the <code>{S_FORM_TOKEN}</code> template variable.</p>
+							<ul>
+								<li>All variables should be type casted.</li>
+								<li>All booleans should be casted to integers.</li>
+								<li>
+									All strings should be quoted and escaped.
+									<br>Single quotes <code>''</code> should be used.
+									<br><code>sql_escape</code> should be used.
+								</li>
+								<li>
+									This is done automatically when using <code>sql_build_array</code>
+									<br>You can can use various modes to achieve the correct statement:
+									<ul>
+										<li><code>INSERT</code> for use inside an <code>INSERT</code> statement.</li>
+										<li><code>UPDATE</code> for use inside an <code>UPDATE</code>'s <code>SET</code> clause</li>
+										<li><code>SELECT</code> for use inside a <code>WHERE</code> clause.</li>
+									</ul>
+								</li>
+							</ul>
+						</div>
+						<div class="column2">
+							<pre class="php">
+$group_id = $this->request->variable('group_id', 0);		// Already casted to an integer
+$username = $this->request->variable('username', '', true);	// Will need to be quoted and escaped
+$username = utf8_clean_string($username);					// Sanitise user input when necessary
+$user_new = false;											// Will need to be casted to an integer
 
+$sql = 'UPDATE ' . $this->tables['users'] . '
+	SET ' . $this->db->sql_build_array('UPDATE', $data) . '
+	WHERE user_new = ' . (int) $user_new . "
+		AND user_lang = 'en'
+		AND group_id = {$group_id}
+		AND username_clean = '" . $this->db->sql_escape($username) . "'";
+</pre>
+						</div>
+					</div>
 
-	<h4>Sessions: </h4>
-	<p>Sessions should be initiated on each page, as near the top as possible using the following code:</p>
+					<h4 id="code.sql.transactions">
+						<a href="#code.sql.transactions"></a>
+						<span>Transactions</span>
+					</h4>
+					<p>
+						A transaction should be used when multiple SQL queries need to succeed (not cause SQL errors) to consider the operation complete.
+						<br>Take for example creating a topic, both a topics table entry and a posts table entry have to be inserted.
+						<br>If either of them fails, we have a topic with no initial post or a post without a parent topic.
+						<br>When these two queries are inside a transaction, and one of them fails, the other one is automatically reverted.
+					</p>
 
-	<div class="codebox"><pre>
-$user-&gt;session_begin();
-$auth-&gt;acl($user-&gt;data);
-$user-&gt;setup();</pre>
-	</div>
-
-	<p>The <code>$user-&gt;setup()</code> call can be used to pass on additional language definition and a custom style (used in viewforum).</p>
-
-	<h4>Errors and messages: </h4>
-	<p>All messages/errors should be outputted by calling <code>trigger_error()</code> using the appropriate message type and language string. Example:</p>
-
-	<div class="codebox"><pre>
-trigger_error('NO_FORUM');</pre>
-	</div>
-
-	<div class="codebox"><pre>
-trigger_error($user-&gt;lang['NO_FORUM']);</pre>
-	</div>
-
-	<div class="codebox"><pre>
-trigger_error('NO_MODE', E_USER_ERROR);</pre>
-	</div>
-
-	<h4>Url formatting</h4>
-
-	<p>All urls pointing to internal files need to be prepended by the <code>$phpbb_root_path</code> variable. Within the administration control panel all urls pointing to internal files need to be prepended by the <code>$phpbb_admin_path</code> variable. This makes sure the path is always correct and users being able to just rename the admin folder and the acp still working as intended (though some links will fail and the code need to be slightly adjusted).</p>
-
-	<p>The <code>append_sid()</code> function from 2.0.x is available too, though it does not handle url alterations automatically. Please have a look at the code documentation if you want to get more details on how to use append_sid(). A sample call to append_sid() can look like this:</p>
-
-	<div class="codebox"><pre>
-append_sid(&quot;{$phpbb_root_path}memberlist.$phpEx&quot;, 'mode=group&amp;amp;g=' . $row['group_id'])</pre>
-	</div>
-
-	<h4>General function usage: </h4>
-
-	<p>Some of these functions are only chosen over others because of personal preference and have no benefit other than maintaining consistency throughout the code.</p>
-
-	<ul>
-		<li>
-			<p>Use <code>strpos</code> instead of <code>strstr</code></p>
-		</li>
-		<li>
-			<p>Use <code>else if</code> instead of <code>elseif</code></p>
-		</li>
-		<li>
-			<p>Use <code>false</code> (lowercase) instead of <code>FALSE</code></p>
-		</li>
-		<li>
-			<p>Use <code>true</code> (lowercase) instead of <code>TRUE</code></p>
-		</li>
-	</ul>
-
-	<h4>Exiting</h4>
-
-	<p>Your page should either call <code>page_footer()</code> in the end to trigger output through the template engine and terminate the script, or alternatively at least call the <code>exit_handler()</code>. That call is necessary because it provides a method for external applications embedding phpBB to be called at the end of the script.</p>
-
-	<a name="phprestrictions"></a><h3>2.vi. Restrictions on the Use of PHP</h3>
-
-	<h4>Dynamic code execution:</h4>
-
-	<p>Never execute dynamic PHP code (generated or in a constant string) using any of the following PHP functions:</p>
-
-	<ul>
-		<li><strong>eval</strong></li>
-		<li><strong>create_function</strong></li>
-		<li><strong>preg_replace</strong> with the <strong>e</strong> modifier in the pattern</li>
-	</ul>
-
-	<p>If absolutely necessary a file should be created, and a mechanism for creating this file prior to running phpBB should be provided as a setup process.</p>
-
-	<p>The <strong>e</strong> modifier in <strong>preg_replace</strong> can be replaced by <strong>preg_replace_callback</strong> and objects to encapsulate state that is needed in the callback code.</p>
-
-	<h4>Other functions, operators, statements and keywords:</h4>
-
-	<p>The following PHP statements should also not be used in phpBB:</p>
-
-	<ul>
-		<li><strong>goto</strong></li>
-	</ul>
-
+					<ul>
+						<li>Transactions create an "all or nothing" scenario.</li>
+						<li>Transactions automatically revert all changes on an error.</li>
+						<li>
+							The following transaction commands are available:
+							<ul>
+								<li><code>begin</code>: This will add all following SQL statements to the queue.</li>
+								<li><code>commit</code>: This will try to execute all queued SQL statements and automatically rollback on error.</li>
+								<li><code>rollback</code>: This can be used to empty the transaction queue and revert any changes done.</li>
+							</ul>
+						</li>
+					</ul>
+				</div>
+			</div>
 		</div>
 
-		<div class="back2top"><a href="#wrap" class="top">Back to Top</a></div>
+		<hr>
 
-		</div>
-	</div>
+		<h2 id="styling">
+			<a href="#styling"></a>
+			<span>Styling</span>
+		</h2>
 
-	<hr />
-
-<a name="styling"></a><h2>3. Styling</h2>
-	<div class="paragraph">
-		<div class="inner">
-
-		<div class="content">
-	<a name="cfgfiles"></a><h3>3.i. Style Config Files</h3>
-	<p>Style cfg files are simple name-value lists with the information necessary for installing a style. The important part of the style configuration file is assigning an unique name.</p>
-	<div class="codebox"><pre>
+		<div class="paragraph">
+			<div class="inner">
+				<div class="content">
+					<a name="cfgfiles"></a>
+					<h3 id="styling.config_files">
+						<a href="#styling.config_files"></a>
+						<span>Style config files</span>
+						<a href="#wrap" class="top">Back to Top</a>
+					</h3>
+					<p>
+						Style cfg files are simple name-value lists with the information necessary for installing a style.
+						The important part of the style configuration file is assigning an unique name.
+					</p>
+					<div class="codebox">
+						<pre>
 # General Information about this style
 name = prosilver_duplicate
 copyright = © phpBB Limited, 2007
@@ -1192,154 +1846,214 @@ phpbb_version = 3.3.0
 
 # Parent style
 # Set value to empty or to this style's name if this style does not have a parent style
-parent = prosilver</pre>
-	</div>
-	<a name="genstyling"></a><h3>3.2. General Styling Rules</h3>
-<p>Templates should be produced in a consistent manner. Where appropriate they should be based off an existing copy, e.g. index, viewforum or viewtopic (the combination of which implement a range of conditional and variable forms). Please also note that the indentation and coding guidelines also apply to templates where possible.</p>
+parent = prosilver
+</pre>
+					</div>
 
-<p>The outer table class <code>forumline</code> has gone and is replaced with <code>tablebg</code>.</p>
-<p>When writing <code>&lt;table&gt;</code> the order <code>&lt;table class="" cellspacing="" cellpadding="" border="" align=""&gt;</code> creates consistency and allows everyone to easily see which table produces which "look". The same applies to most other tags for which additional parameters can be set, consistency is the major aim here.</p>
-<p>Each block level element should be indented by one tab, same for tabular elements, e.g. <code>&lt;tr&gt;</code> <code>&lt;td&gt;</code> etc., whereby the intendiation of <code>&lt;table&gt;</code> and the following/ending <code>&lt;tr&gt;</code> should be on the same line. This applies not to div elements of course.</p>
-<p>Don't use <code>&lt;span&gt;</code> more than is essential ... the CSS is such that text sizes are dependent on the parent class. So writing <code>&lt;span class="gensmall"&gt;&lt;span class="gensmall"&gt;TEST&lt;/span&gt;&lt;/span&gt;</code> will result in very very small text. Similarly don't use span at all if another element can contain the class definition, e.g.</p>
+					<a name="genstyling"></a>
+					<h3 id="styling.general_rules">
+						<a href="#styling.general_rules"></a>
+						<span>General styling rules</span>
+						<a href="#wrap" class="top">Back to Top</a>
+					</h3>
+					<p>
+						Templates should be produced in a consistent manner.
+						Where appropriate they should be based off an existing copy, e.g. index, viewforum or viewtopic
+						(the combination of which implement a range of conditional and variable forms).
+						Please also note that the indentation and coding guidelines also apply to templates where possible.
+					</p>
 
-<div class="codebox"><pre>
+					<p>The outer table class <code>forumline</code> has gone and is replaced with <code>tablebg</code>.</p>
+					<p>
+						When writing <code>&lt;table&gt;</code> the order <code>&lt;table class="" cellspacing="" cellpadding="" border="" align=""&gt;</code>
+						creates consistency and allows everyone to easily see which table produces which "look".
+						The same applies to most other tags for which additional parameters can be set, consistency is the major aim here.
+					</p>
+					<p>
+						Each block level element should be indented by one tab, same for tabular elements,
+						e.g. <code>&lt;tr&gt;</code> <code>&lt;td&gt;</code> etc.,
+						whereby the indentation of <code>&lt;table&gt;</code> and the following/ending <code>&lt;tr&gt;</code> should be on the same line.
+						This applies not to div elements of course.
+					</p>
+					<p>
+						Don't use <code>&lt;span&gt;</code> more than is essential ...
+						the CSS is such that text sizes are dependent on the parent class.
+						So writing <code>&lt;span class="gensmall"&gt;&lt;span class="gensmall"&gt;TEST&lt;/span&gt;&lt;/span&gt;</code>
+						will result in very very small text. Similarly don't use span at all if another element can contain the class definition, e.g.
+					</p>
+
+					<div class="codebox">
+						<pre>
 &lt;td&gt;&lt;span class=&quot;gensmall&quot;&gt;TEST&lt;/span&gt;&lt;/td&gt;
-</pre></div>
+</pre>
+					</div>
 
-<p>can just as well become:</p>
-<div class="codebox"><pre>
+					<p>can just as well become:</p>
+
+					<div class="codebox">
+						<pre>
 &lt;td class=&quot;gensmall&quot;&gt;TEST&lt;/td&gt;
-</pre></div>
+</pre>
+					</div>
 
-<p>Try to match text class types with existing usage, e.g. don't use the nav class where viewtopic uses gensmall for example.</p>
+					<p>Try to match text class types with existing usage, e.g. don't use the nav class where viewtopic uses gensmall for example.</p>
+					<p>Row colours/classes are now defined by the template, use an <code>IF S_ROW_COUNT</code> switch, see viewtopic or viewforum for an example.</p>
+					<p>Remember block level ordering is important.</p>
+					<p>
+						Use a standard cellpadding of 2 and cellspacing of 0 on outer tables.
+						Inner tables can vary from 0 to 3 or even 4 depending on the need.
+					</p>
+					<p><strong>Use div container/css for styling and table for data representation.</strong></p>
+					<p>
+						The separate catXXXX and thXXX classes are gone.
+						When defining a header cell just use <code>&lt;th&gt;</code> rather than <code>&lt;th class="thHead"&gt;</code> etc.
+						Similarly for cat, don't use <code>&lt;td class="catLeft"&gt;</code> use <code>&lt;td class="cat"&gt;</code> etc.
+					</p>
+					<p>
+						Try to retain consistency of basic layout and class usage,
+						i.e. _EXPLAIN text should generally be placed below the title it explains,
+						e.g. <code>{L_POST_USERNAME}&lt;br /&gt;&lt;span class="gensmall"&gt;{L_POST_USERNAME_EXPLAIN}&lt;/span&gt;</code>
+						is the typical way of handling this ... there may be exceptions and this isn't a hard and fast rule.
+					</p>
+					<p>Try to keep template conditional and other statements tabbed in line with the block to which they refer.</p>
 
-<p>Row colours/classes are now defined by the template, use an <code>IF S_ROW_COUNT</code> switch, see viewtopic or viewforum for an example.</p>
-
-<p>Remember block level ordering is important.</p>
-
-<p>Use a standard cellpadding of 2 and cellspacing of 0 on outer tables. Inner tables can vary from 0 to 3 or even 4 depending on the need.</p>
-
-<p><strong>Use div container/css for styling and table for data representation.</strong></p>
-
-<p>The separate catXXXX and thXXX classes are gone. When defining a header cell just use <code>&lt;th&gt;</code> rather than <code>&lt;th class="thHead"&gt;</code> etc. Similarly for cat, don't use <code>&lt;td class="catLeft"&gt;</code> use <code>&lt;td class="cat"&gt;</code> etc.</p>
-
-<p>Try to retain consistency of basic layout and class usage, i.e. _EXPLAIN text should generally be placed below the title it explains, e.g. <code>{L_POST_USERNAME}&lt;br /&gt;&lt;span class="gensmall"&gt;{L_POST_USERNAME_EXPLAIN}&lt;/span&gt;</code> is the typical way of handling this ... there may be exceptions and this isn't a hard and fast rule.</p>
-
-<p>Try to keep template conditional and other statements tabbed in line with the block to which they refer.</p>
-
-<p class="good">this is correct</p>
-<div class="codebox"><pre>
+					<p class="good">This is correct</p>
+					<div class="codebox">
+						<pre>
 <span class="comment">&lt;!-- BEGIN test --&gt;</span>
 	&lt;tr&gt;
 		&lt;td&gt;&#123;test.TEXT&#125;&lt;/td&gt;
 	&lt;/tr&gt;
 <span class="comment">&lt;!-- END test --&gt;</span>
-</pre></div>
+</pre>
+					</div>
 
-<p class="good">this is also correct:</p>
-<div class="codebox"><pre>
+					<p class="good">This is also correct:</p>
+					<div class="codebox">
+						<pre>
 <span class="comment">&lt;!-- BEGIN test --&gt;</span>
 &lt;tr&gt;
 	&lt;td&gt;&#123;test.TEXT&#125;&lt;/td&gt;
 &lt;/tr&gt;
 <span class="comment">&lt;!-- END test --&gt;</span>
-</pre></div>
+</pre>
+					</div>
 
-<p>it gives immediate feedback on exactly what is looping - decide which way to use based on the readability.</p>
-
+					<p>It gives immediate feedback on exactly what is looping - decide which way to use based on the readability.</p>
+				</div>
+			</div>
 		</div>
 
-		<div class="back2top"><a href="#wrap" class="top">Back to Top</a></div>
+		<hr>
 
-		</div>
-	</div>
+		<h2 id="templating">
+			<a href="#templating"></a>
+			<span>Templating</span>
+		</h2>
 
-	<hr />
+		<div class="paragraph">
+			<div class="inner">
+				<div class="content">
+					<a name="templates"></a>
+					<h3 id="templating.general">
+						<a href="#templating.general"></a>
+						<span>General templating</span>
+						<a href="#wrap" class="top">Back to Top</a>
+					</h3>
 
-<a name="templating"></a><h2>4. Templating</h2>
-	<div class="paragraph">
-		<div class="inner">
+					<h4 id="templating.general.file_naming">
+						<a href="#templating.general.file_naming"></a>
+						<span>File naming</span>
+					</h4>
+					<p>Firstly templates now take the suffix &quot;.html&quot; rather than &quot;.tpl&quot;. This was done simply to make the lives of some people easier wrt syntax highlighting, etc.</p>
 
-		<div class="content">
-	<a name="templates"></a><h3>4.i. General Templating</h3>
+					<h4 id="templating.general.variables">
+						<a href="#templating.general.variables"></a>
+						<span>Variables</span>
+					</h4>
+					<p>All template variables should be named appropriately (using underscores for spaces), language entries should be prefixed with L_, system data with S_, urls with U_, javascript urls with UA_, language to be put in javascript statements with LA_, all other variables should be presented 'as is'.</p>
+					<p>L_* template variables are automatically mapped to the corresponding language entry if the code does not set (and therefore overwrite) this variable specifically and if the language entry exists. For example <code>{L_USERNAME}</code> maps to <code>$user-&gt;lang['USERNAME']</code>. The LA_* template variables are handled within the same way, but properly escaped so they can be put in javascript code. This should reduce the need to assign loads of new language variables in MODifications.</p>
 
-<h4>File naming</h4>
-<p>Firstly templates now take the suffix &quot;.html&quot; rather than &quot;.tpl&quot;. This was done simply to make the lives of some people easier wrt syntax highlighting, etc.</p>
-
-<h4>Variables</h4>
-<p>All template variables should be named appropriately (using underscores for spaces), language entries should be prefixed with L_, system data with S_, urls with U_, javascript urls with UA_, language to be put in javascript statements with LA_, all other variables should be presented 'as is'.</p>
-
-<p>L_* template variables are automatically mapped to the corresponding language entry if the code does not set (and therefore overwrite) this variable specifically and if the language entry exists. For example <code>{L_USERNAME}</code> maps to <code>$user-&gt;lang['USERNAME']</code>. The LA_* template variables are handled within the same way, but properly escaped so they can be put in javascript code. This should reduce the need to assign loads of new language variables in MODifications.
-</p>
-
-<h4>Blocks/Loops</h4>
-<p>The basic block level loop remains and takes the form:</p>
-<div class="codebox"><pre>
+					<h4 id="templating.general.blocks_loops">
+						<a href="#templating.general.blocks_loops"></a>
+						<span>Blocks / Loops</span>
+					</h4>
+					<p>The basic block level loop remains and takes the form:</p>
+					<div class="codebox"><pre>
 <span class="comment">&lt;!-- BEGIN loopname --&gt;</span>
 	markup, {loopname&#46;X_YYYYY}, etc&#46;
 <span class="comment">&lt;!-- END loopname --&gt;</span>
 </pre></div>
 
-<p>A bit later loops will be explained further. To not irritate you we will explain conditionals as well as other statements first.</p>
+					<p>A bit later loops will be explained further. To not irritate you we will explain conditionals as well as other statements first.</p>
 
-<h4>Including files</h4>
-<p>Something that existed in 2.0.x which no longer exists in 3.x is the ability to assign a template to a variable. This was used (for example) to output the jumpbox. Instead (perhaps better, perhaps not but certainly more flexible) we now have INCLUDE. This takes the simple form:</p>
+					<h4 id="templating.general.including_files">
+						<a href="#templating.general.including_files"></a>
+						<span>Including files</span>
+					</h4>
+					<p>Something that existed in 2.0.x which no longer exists in 3.x is the ability to assign a template to a variable. This was used (for example) to output the jumpbox. Instead (perhaps better, perhaps not but certainly more flexible) we now have INCLUDE. This takes the simple form:</p>
 
-<div class="codebox"><pre>
+					<div class="codebox"><pre>
 <span class="comment">&lt;!-- INCLUDE filename --&gt;</span>
 </pre></div>
 
-<p>You will note in the 3.x templates the major sources start with <code>&lt;!-- INCLUDE overall_header.html --&gt;</code> or <code>&lt;!-- INCLUDE simple_header.html --&gt;</code>, etc. In 2.0.x control of &quot;which&quot; header to use was defined entirely within the code. In 3.x the template designer can output what they like. Note that you can introduce new templates (i.e. other than those in the default set) using this system and include them as you wish ... perhaps useful for a common &quot;menu&quot; bar or some such. No need to modify loads of files as with 2.0.x.</p>
+					<p>You will note in the 3.x templates the major sources start with <code>&lt;!-- INCLUDE overall_header.html --&gt;</code> or <code>&lt;!-- INCLUDE simple_header.html --&gt;</code>, etc. In 2.0.x control of &quot;which&quot; header to use was defined entirely within the code. In 3.x the template designer can output what they like. Note that you can introduce new templates (i.e. other than those in the default set) using this system and include them as you wish ... perhaps useful for a common &quot;menu&quot; bar or some such. No need to modify loads of files as with 2.0.x.</p>
 
-<p>Added in <strong>3.0.6</strong> is the ability to include a file using a template variable to specify the file, this functionality only works for root variables (i.e. not block variables).</p>
-<div class="codebox"><pre>
+					<p>Added in <strong>3.0.6</strong> is the ability to include a file using a template variable to specify the file, this functionality only works for root variables (i.e. not block variables).</p>
+					<div class="codebox"><pre>
 <span class="comment">&lt;!-- INCLUDE {FILE_VAR} --&gt;</span>
 </pre></div>
 
-<p>Template defined variables can also be utilised.</p>
+					<p>Template defined variables can also be utilised.</p>
 
-<div class="codebox"><pre>
+					<div class="codebox"><pre>
 <span class="comment">&lt;!-- DEFINE $SOME_VAR = 'my_file.html' --&gt;</span>
 <span class="comment">&lt;!-- INCLUDE {$SOME_VAR} --&gt;</span>
 </pre></div>
 
-<h4>PHP</h4>
-<p>A contentious decision has seen the ability to include PHP within the template introduced. This is achieved by enclosing the PHP within relevant tags:</p>
+					<h4 id="templating.general.php">
+						<a href="#templating.general.php"></a>
+						<span>PHP</span>
+					</h4>
+					<p>A contentious decision has seen the ability to include PHP within the template introduced. This is achieved by enclosing the PHP within relevant tags:</p>
 
-<div class="codebox"><pre>
+					<div class="codebox"><pre>
 <span class="comment">&lt;!-- PHP --&gt;</span>
 	echo &quot;hello!&quot;;
 <span class="comment">&lt;!-- ENDPHP --&gt;</span>
 </pre></div>
 
-<p>You may also include PHP from an external file using:</p>
+					<p>You may also include PHP from an external file using:</p>
 
-<div class="codebox"><pre>
+					<div class="codebox"><pre>
 <span class="comment">&lt;!-- INCLUDEPHP somefile&#46;php --&gt;</span>
 </pre></div>
 
-<p>it will be included and executed inline.<br /><br />A note, it is very much encouraged that template designers do not include PHP. The ability to include raw PHP was introduced primarily to allow end users to include banner code, etc. without modifying multiple files (as with 2.0.x). It was not intended for general use ... hence <!-- w --><a href="https://www.phpbb.com">www.phpbb.com</a><!-- w --> will <strong>not</strong> make available template sets which include PHP. And by default templates will have PHP disabled (the admin will need to specifically activate PHP for a template).</p>
+					<p>it will be included and executed inline.<br /><br />A note, it is very much encouraged that template designers do not include PHP. The ability to include raw PHP was introduced primarily to allow end users to include banner code, etc. without modifying multiple files (as with 2.0.x). It was not intended for general use ... hence <!-- w --><a href="https://www.phpbb.com">www.phpbb.com</a><!-- w --> will <strong>not</strong> make available template sets which include PHP. And by default templates will have PHP disabled (the admin will need to specifically activate PHP for a template).</p>
 
-<h4>Conditionals/Control structures</h4>
-<p>The most significant addition to 3.x are conditions or control structures, &quot;if something then do this else do that&quot;. The system deployed is very similar to Smarty. This may confuse some people at first but it offers great potential and great flexibility with a little imagination. In their most simple form these constructs take the form:</p>
+					<h4 id="templating.general.conditionals">
+						<a href="#templating.general.conditionals"></a>
+						<span>Conditionals/Control structures</span>
+					</h4>
+					<p>The most significant addition to 3.x are conditions or control structures, &quot;if something then do this else do that&quot;. The system deployed is very similar to Smarty. This may confuse some people at first but it offers great potential and great flexibility with a little imagination. In their most simple form these constructs take the form:</p>
 
-<div class="codebox"><pre>
+					<div class="codebox"><pre>
 <span class="comment">&lt;!-- IF expr --&gt;</span>
 	markup
 <span class="comment">&lt;!-- ENDIF --&gt;</span>
 </pre></div>
 
-<p>expr can take many forms, for example:</p>
+					<p>expr can take many forms, for example:</p>
 
-<div class="codebox"><pre>
+					<div class="codebox"><pre>
 <span class="comment">&lt;!-- IF loop&#46;S_ROW_COUNT is even --&gt;</span>
 	markup
 <span class="comment">&lt;!-- ENDIF --&gt;</span>
 </pre></div>
 
-<p>This will output the markup if the S_ROW_COUNT variable in the current iteration of loop is an even value (i.e. the expr is TRUE). You can use various comparison methods (standard as well as equivalent textual versions noted in square brackets) including (<code>not, or, and, eq, neq, is</code> should be used if possible for better readability):</p>
+					<p>This will output the markup if the S_ROW_COUNT variable in the current iteration of loop is an even value (i.e. the expr is TRUE). You can use various comparison methods (standard as well as equivalent textual versions noted in square brackets) including (<code>not, or, and, eq, neq, is</code> should be used if possible for better readability):</p>
 
-<div class="codebox"><pre>
+					<div class="codebox"><pre>
 == [eq]
 != [neq, ne]
 &lt;&gt; (same as !=)
@@ -1367,17 +2081,17 @@ parent = prosilver</pre>
 is (can be used to join comparison operations)
 </pre></div>
 
-<p>Basic parenthesis can also be used to enforce good old BODMAS rules. Additionally some basic comparison types are defined:</p>
+					<p>Basic parenthesis can also be used to enforce good old BODMAS rules. Additionally some basic comparison types are defined:</p>
 
-<div class="codebox"><pre>
+					<div class="codebox"><pre>
 even
 odd
 div
 </pre></div>
 
-<p>Beyond the simple use of IF you can also do a sequence of comparisons using the following:</p>
+					<p>Beyond the simple use of IF you can also do a sequence of comparisons using the following:</p>
 
-<div class="codebox"><pre>
+					<div class="codebox"><pre>
 <span class="comment">&lt;!-- IF expr1 --&gt;</span>
 	markup
 <span class="comment">&lt;!-- ELSEIF expr2 --&gt;</span>
@@ -1392,9 +2106,9 @@ div
 <span class="comment">&lt;!-- ENDIF --&gt;</span>
 </pre></div>
 
-<p>Each statement will be tested in turn and the relevant output generated when a match (if a match) is found. It is not necessary to always use ELSEIF, ELSE can be used alone to match &quot;everything else&quot;.<br /><br />So what can you do with all this? Well take for example the colouration of rows in viewforum. In 2.0.x row colours were predefined within the source as either row color1, row color2 or row class1, row class2. In 3.x this is moved to the template, it may look a little daunting at first but remember control flows from top to bottom and it's not too difficult:</p>
+					<p>Each statement will be tested in turn and the relevant output generated when a match (if a match) is found. It is not necessary to always use ELSEIF, ELSE can be used alone to match &quot;everything else&quot;.<br /><br />So what can you do with all this? Well take for example the colouration of rows in viewforum. In 2.0.x row colours were predefined within the source as either row color1, row color2 or row class1, row class2. In 3.x this is moved to the template, it may look a little daunting at first but remember control flows from top to bottom and it's not too difficult:</p>
 
-<div class="codebox"><pre>
+					<div class="codebox"><pre>
 &lt;table&gt;
 	<span class="comment">&lt;!-- IF loop&#46;S_ROW_COUNT is even --&gt;</span>
 		&lt;tr class=&quot;row1&quot;&gt;
@@ -1406,9 +2120,9 @@ div
 &lt;/table&gt;
 </pre></div>
 
-<p>This will cause the row cell to be output using class row1 when the row count is even, and class row2 otherwise. The S_ROW_COUNT parameter gets assigned to loops by default. Another example would be the following: </p>
+					<p>This will cause the row cell to be output using class row1 when the row count is even, and class row2 otherwise. The S_ROW_COUNT parameter gets assigned to loops by default. Another example would be the following: </p>
 
-<div class="codebox"><pre>
+					<div class="codebox"><pre>
 &lt;table&gt;
 	<span class="comment">&lt;!-- IF loop&#46;S_ROW_COUNT &gt; 10 --&gt;</span>
 		&lt;tr bgcolor=&quot;#FF0000&quot;&gt;
@@ -1424,37 +2138,40 @@ div
 &lt;/table&gt;
 </pre></div>
 
-<p>This will output the row cell in purple for the first two rows, blue for rows 2 to 5, green for rows 5 to 10 and red for remainder. So, you could produce a &quot;nice&quot; gradient effect, for example.<br /><br />What else can you do? Well, you could use IF to do common checks on for example the login state of a user:</p>
+					<p>This will output the row cell in purple for the first two rows, blue for rows 2 to 5, green for rows 5 to 10 and red for remainder. So, you could produce a &quot;nice&quot; gradient effect, for example.<br /><br />What else can you do? Well, you could use IF to do common checks on for example the login state of a user:</p>
 
-<div class="codebox"><pre>
+					<div class="codebox"><pre>
 <span class="comment">&lt;!-- IF S_USER_LOGGED_IN --&gt;</span>
 	markup
 <span class="comment">&lt;!-- ENDIF --&gt;</span>
 </pre></div>
 
-<p>This replaces the existing (fudged) method in 2.0.x using a zero length array and BEGIN/END.</p>
+					<p>This replaces the existing (fudged) method in 2.0.x using a zero length array and BEGIN/END.</p>
 
-<h4>Extended syntax for Blocks/Loops</h4>
+					<h4 id="templating.general.extended_loops">
+						<a href="#templating.general.extended_loops"></a>
+						<span>Extended syntax for Blocks / Loops</span>
+					</h4>
 
-<p>Back to our loops - they had been extended with the following additions. Firstly you can set the start and end points of the loop. For example:</p>
+					<p>Back to our loops - they had been extended with the following additions. Firstly you can set the start and end points of the loop. For example:</p>
 
-<div class="codebox"><pre>
+					<div class="codebox"><pre>
 <span class="comment">&lt;!-- BEGIN loopname(2) --&gt;</span>
 	markup
 <span class="comment">&lt;!-- END loopname --&gt;</span>
 </pre></div>
 
-<p>Will start the loop on the third entry (note that indexes start at zero). Extensions of this are:
-<br /><br />
-<code>loopname(2)</code>: Will start the loop on the 3rd entry<br />
-<code>loopname(-2)</code>: Will start the loop two entries from the end<br />
-<code>loopname(3,4)</code>: Will start the loop on the fourth entry and end it on the fifth<br />
-<code>loopname(3,-4)</code>: Will start the loop on the fourth entry and end it four from last<br />
-</p>
+					<p>Will start the loop on the third entry (note that indexes start at zero). Extensions of this are:
+						<br /><br />
+						<code>loopname(2)</code>: Will start the loop on the 3rd entry<br />
+						<code>loopname(-2)</code>: Will start the loop two entries from the end<br />
+						<code>loopname(3,4)</code>: Will start the loop on the fourth entry and end it on the fifth<br />
+						<code>loopname(3,-4)</code>: Will start the loop on the fourth entry and end it four from last<br />
+					</p>
 
-<p>A further extension to begin is BEGINELSE:</p>
+					<p>A further extension to begin is BEGINELSE:</p>
 
-<div class="codebox"><pre>
+					<div class="codebox"><pre>
 <span class="comment">&lt;!-- BEGIN loop --&gt;</span>
 	markup
 <span class="comment">&lt;!-- BEGINELSE --&gt;</span>
@@ -1462,11 +2179,11 @@ div
 <span class="comment">&lt;!-- END loop --&gt;</span>
 </pre></div>
 
-<p>This will cause the markup between <code>BEGINELSE</code> and <code>END</code> to be output if the loop contains no values. This is useful for forums with no topics (for example) ... in some ways it replaces &quot;bits of&quot; the existing &quot;switch_&quot; type control (the rest being replaced by conditionals).</p>
+					<p>This will cause the markup between <code>BEGINELSE</code> and <code>END</code> to be output if the loop contains no values. This is useful for forums with no topics (for example) ... in some ways it replaces &quot;bits of&quot; the existing &quot;switch_&quot; type control (the rest being replaced by conditionals).</p>
 
-<p>Another way of checking if a loop contains values is by prefixing the loops name with a dot:</p>
+					<p>Another way of checking if a loop contains values is by prefixing the loops name with a dot:</p>
 
-<div class="codebox"><pre>
+					<div class="codebox"><pre>
 <span class="comment">&lt;!-- IF .loop --&gt;</span>
 	<span class="comment">&lt;!-- BEGIN loop --&gt;</span>
 		markup
@@ -1476,9 +2193,9 @@ div
 <span class="comment">&lt;!-- ENDIF --&gt;</span>
 </pre></div>
 
-<p>You are even able to check the number of items within a loop by comparing it with values within the IF condition:</p>
+					<p>You are even able to check the number of items within a loop by comparing it with values within the IF condition:</p>
 
-<div class="codebox"><pre>
+					<div class="codebox"><pre>
 <span class="comment">&lt;!-- IF .loop &gt; 2 --&gt;</span>
 	<span class="comment">&lt;!-- BEGIN loop --&gt;</span>
 		markup
@@ -1488,9 +2205,9 @@ div
 <span class="comment">&lt;!-- ENDIF --&gt;</span>
 </pre></div>
 
-<p>Nesting loops cause the conditionals needing prefixed with all loops from the outer one to the inner most. An illustration of this:</p>
+					<p>Nesting loops cause the conditionals needing prefixed with all loops from the outer one to the inner most. An illustration of this:</p>
 
-<div class="codebox"><pre>
+					<div class="codebox"><pre>
 <span class="comment">&lt;!-- BEGIN firstloop --&gt;</span>
 	{firstloop.MY_VARIABLE_FROM_FIRSTLOOP}
 
@@ -1500,9 +2217,9 @@ div
 <span class="comment">&lt;!-- END firstloop --&gt;</span>
 </pre></div>
 
-<p>Sometimes it is necessary to break out of nested loops to be able to call another loop within the current iteration. This sounds a little bit confusing and it is not used very often. The following (rather complex) example shows this quite good - it also shows how you test for the first and last row in a loop (i will explain the example in detail further down):</p>
+					<p>Sometimes it is necessary to break out of nested loops to be able to call another loop within the current iteration. This sounds a little bit confusing and it is not used very often. The following (rather complex) example shows this quite good - it also shows how you test for the first and last row in a loop (i will explain the example in detail further down):</p>
 
-<div class="codebox"><pre>
+					<div class="codebox"><pre>
 <span class="comment">&lt;!-- BEGIN l_block1 --&gt;</span>
 	<span class="comment">&lt;!-- IF l_block1.S_SELECTED --&gt;</span>
 		&lt;strong&gt;{l_block1.L_TITLE}&lt;/strong&gt;
@@ -1540,9 +2257,9 @@ div
 <span class="comment">&lt;!-- END l_block1 --&gt;</span>
 </pre></div>
 
-<p>Let us first concentrate on this part of the example:</p>
+					<p>Let us first concentrate on this part of the example:</p>
 
-<div class="codebox"><pre>
+					<div class="codebox"><pre>
 <span class="comment">&lt;!-- BEGIN l_block1 --&gt;</span>
 	<span class="comment">&lt;!-- IF l_block1.S_SELECTED --&gt;</span>
 		markup
@@ -1552,11 +2269,11 @@ div
 <span class="comment">&lt;!-- END l_block1 --&gt;</span>
 </pre></div>
 
-<p>Here we open the loop l_block1 and do some things if the value S_SELECTED within the current loop iteration is true, else we write the blocks link and title. Here, you see <code>{l_block1.L_TITLE}</code> referenced - you remember that L_* variables get automatically assigned the corresponding language entry? This is true, but not within loops. The L_TITLE variable within the loop l_block1 is assigned within the code itself.</p>
+					<p>Here we open the loop l_block1 and do some things if the value S_SELECTED within the current loop iteration is true, else we write the blocks link and title. Here, you see <code>{l_block1.L_TITLE}</code> referenced - you remember that L_* variables get automatically assigned the corresponding language entry? This is true, but not within loops. The L_TITLE variable within the loop l_block1 is assigned within the code itself.</p>
 
-<p>Let's have a closer look at the markup:</p>
+					<p>Let's have a closer look at the markup:</p>
 
-<div class="codebox"><pre>
+					<div class="codebox"><pre>
 <span class="comment">&lt;!-- BEGIN l_block1 --&gt;</span>
 .
 .
@@ -1580,9 +2297,9 @@ div
 <span class="comment">&lt;!-- END l_block1 --&gt;</span>
 </pre></div>
 
-<p>The <code>&lt;!-- IF S_PRIVMSGS --&gt;</code> statement clearly checks a global variable and not one within the loop, since the loop is not given here. So, if S_PRIVMSGS is true we execute the shown markup. Now, you see the <code>&lt;!-- BEGIN !folder --&gt;</code> statement. The exclamation mark is responsible for instructing the template engine to iterate through the main loop folder. So, we are now within the loop folder - with <code>&lt;!-- BEGIN folder --&gt;</code> we would have been within the loop <code>l_block1.folder</code> automatically as is the case with l_block2:</p>
+					<p>The <code>&lt;!-- IF S_PRIVMSGS --&gt;</code> statement clearly checks a global variable and not one within the loop, since the loop is not given here. So, if S_PRIVMSGS is true we execute the shown markup. Now, you see the <code>&lt;!-- BEGIN !folder --&gt;</code> statement. The exclamation mark is responsible for instructing the template engine to iterate through the main loop folder. So, we are now within the loop folder - with <code>&lt;!-- BEGIN folder --&gt;</code> we would have been within the loop <code>l_block1.folder</code> automatically as is the case with l_block2:</p>
 
-<div class="codebox"><pre>
+					<div class="codebox"><pre>
 <span class="comment">&lt;!-- BEGIN l_block1 --&gt;</span>
 .
 .
@@ -1602,11 +2319,11 @@ div
 <span class="comment">&lt;!-- END l_block1 --&gt;</span>
 </pre></div>
 
-<p>You see the difference? The loop l_block2 is a member of the loop l_block1 but the loop folder is a main loop.</p>
+					<p>You see the difference? The loop l_block2 is a member of the loop l_block1 but the loop folder is a main loop.</p>
 
-<p>Now back to our folder loop:</p>
+					<p>Now back to our folder loop:</p>
 
-<div class="codebox"><pre>
+					<div class="codebox"><pre>
 <span class="comment">&lt;!-- IF folder.S_FIRST_ROW --&gt;</span>
 	&lt;ul class=&quot;nav&quot;&gt;
 <span class="comment">&lt;!-- ENDIF --&gt;</span>
@@ -1618,9 +2335,9 @@ div
 <span class="comment">&lt;!-- ENDIF --&gt;</span>
 </pre></div>
 
-<p>You may have wondered what the comparison to S_FIRST_ROW and S_LAST_ROW is about. If you haven't guessed already - it is checking for the first iteration of the loop with <code>S_FIRST_ROW</code> and the last iteration with <code>S_LAST_ROW</code>. This can come in handy quite often if you want to open or close design elements, like the above list. Let us imagine a folder loop build with three iterations, it would go this way:</p>
+					<p>You may have wondered what the comparison to S_FIRST_ROW and S_LAST_ROW is about. If you haven't guessed already - it is checking for the first iteration of the loop with <code>S_FIRST_ROW</code> and the last iteration with <code>S_LAST_ROW</code>. This can come in handy quite often if you want to open or close design elements, like the above list. Let us imagine a folder loop build with three iterations, it would go this way:</p>
 
-<div class="codebox"><pre>
+					<div class="codebox"><pre>
 &lt;ul class=&quot;nav&quot;&gt; <span class="comment">&lt;!-- written on first iteration --&gt;</span>
 	&lt;li&gt;first element&lt;/li&gt; <span class="comment">&lt;!-- written on first iteration --&gt;</span>
 	&lt;li&gt;second element&lt;/li&gt; <span class="comment">&lt;!-- written on second iteration --&gt;</span>
@@ -1628,9 +2345,9 @@ div
 &lt;/ul&gt; <span class="comment">&lt;!-- written on third iteration --&gt;</span>
 </pre></div>
 
-<p>As you can see, all three elements are written down as well as the markup for the first iteration and the last one. Sometimes you want to omit writing the general markup - for example:</p>
+					<p>As you can see, all three elements are written down as well as the markup for the first iteration and the last one. Sometimes you want to omit writing the general markup - for example:</p>
 
-<div class="codebox"><pre>
+					<div class="codebox"><pre>
 <span class="comment">&lt;!-- IF folder.S_FIRST_ROW --&gt;</span>
 	&lt;ul class=&quot;nav&quot;&gt;
 <span class="comment">&lt;!-- ELSEIF folder.S_LAST_ROW --&gt;</span>
@@ -1640,19 +2357,22 @@ div
 <span class="comment">&lt;!-- ENDIF --&gt;</span>
 </pre></div>
 
-<p>would result in the following markup:</p>
+					<p>would result in the following markup:</p>
 
-<div class="codebox"><pre>
+					<div class="codebox"><pre>
 &lt;ul class=&quot;nav&quot;&gt; <span class="comment">&lt;!-- written on first iteration --&gt;</span>
 	&lt;li&gt;second element&lt;/li&gt; <span class="comment">&lt;!-- written on second iteration --&gt;</span>
 &lt;/ul&gt; <span class="comment">&lt;!-- written on third iteration --&gt;</span>
 </pre></div>
 
-<p>Just always remember that processing is taking place from top to bottom.</p>
+					<p>Just always remember that processing is taking place from top to bottom.</p>
 
-	<h4>Forms</h4>
-		<p>If a form is used for a non-trivial operation (i.e. more than a jumpbox), then it should include the <code>{S_FORM_TOKEN}</code> template variable.</p>
-		<div class="codebox"><pre>
+					<h4 id="templating.general.forms">
+						<a href="#templating.general.forms"></a>
+						<span>Forms</span>
+					</h4>
+					<p>If a form is used for a non-trivial operation (i.e. more than a jumpbox), then it should include the <code>{S_FORM_TOKEN}</code> template variable.</p>
+					<div class="codebox"><pre>
 &lt;form method=&quot;post&quot; id=&quot;mcp&quot; action=&quot;{U_POST_ACTION}&quot;&gt;
 
 	&lt;fieldset class="submit-buttons"&gt;
@@ -1663,14 +2383,19 @@ div
 &lt;/form&gt;
 		</pre></div><br />
 
-	<a name="stylestree"></a><h3>4.ii. Styles Tree</h3>
-		<p>When basing a new style on an existing one, it is not necessary to provide all the template files. By declaring the base style name in the <strong>parent</strong> field in the style configuration file, the style can be set to reuse template files from the parent style.</p>
+					<a name="stylestree"></a>
+					<h3 id="templating.styles_tree">
+						<a href="#templating.styles_tree"></a>
+						<span>Styles tree</span>
+						<a href="#wrap" class="top">Back to Top</a>
+					</h3>
+					<p>When basing a new style on an existing one, it is not necessary to provide all the template files. By declaring the base style name in the <strong>parent</strong> field in the style configuration file, the style can be set to reuse template files from the parent style.</p>
 
-		<p>The effect of doing so is that the template engine will use the template files in the new style where they exist, but fall back to files in the parent style otherwise.</p>
+					<p>The effect of doing so is that the template engine will use the template files in the new style where they exist, but fall back to files in the parent style otherwise.</p>
 
-		<p>We strongly encourage the use of parent styles for styles based on the bundled styles, as it will ease the update procedure.</p>
+					<p>We strongly encourage the use of parent styles for styles based on the bundled styles, as it will ease the update procedure.</p>
 
-		<div class="codebox"><pre>
+					<div class="codebox"><pre>
 # General Information about this style
 name = Custom Style
 copyright = © phpBB Limited, 2007
@@ -1685,38 +2410,49 @@ phpbb_version = 3.2.0-b1
 parent = prosilver
 		</pre></div>
 
-		<a name="template-events"></a><h3>4.iii. Template Events</h3>
-		<p>Template events must follow this format: <code>&lt;!-- EVENT event_name --&gt;</code></p>
-		<p>Using the above example, files named <code>event_name.html</code> located within extensions will be injected into the location of the event.</p>
+					<a name="template-events"></a>
+					<h3 id="templating.template_events">
+						<a href="#templating.template_events"></a>
+						<span>Template events</span>
+						<a href="#wrap" class="top">Back to Top</a>
+					</h3>
+					<p>Template events must follow this format: <code>&lt;!-- EVENT event_name --&gt;</code></p>
+					<p>Using the above example, files named <code>event_name.html</code> located within extensions will be injected into the location of the event.</p>
 
-		<h4>Template event naming guidelines:</h4>
-		<ul>
-			<li>An event name must be all lowercase, with each word separated by an underscore.</li>
-			<li>An event name must briefly describe the location and purpose of the event.</li>
-			<li>
-				An event name must end with one of the following suffixes:
-				<ul>
-					<li><code>_prepend</code> - This event adds an item to the beginning of a block of related items, or adds to the beginning of individual items in a block.</li>
-					<li><code>_append</code> - This event adds an item to the end of a block of related items, or adds to the end of individual items in a block.</li>
-					<li><code>_before</code> - This event adds content directly before the specified block</li>
-					<li><code>_after</code> - This event adds content directly after the specified block</li>
-				</ul>
-			</li>
-		</ul>
+					<h4 id="templating.template_events.naming_guidelines">
+						<a href="#templating.template_events.naming_guidelines"></a>
+						<span>Template event naming guidelines</span>
+					</h4>
+					<ul>
+						<li>An event name must be all lowercase, with each word separated by an underscore.</li>
+						<li>An event name must briefly describe the location and purpose of the event.</li>
+						<li>
+							An event name must end with one of the following suffixes:
+							<ul>
+								<li><code>_prepend</code> - This event adds an item to the beginning of a block of related items, or adds to the beginning of individual items in a block.</li>
+								<li><code>_append</code> - This event adds an item to the end of a block of related items, or adds to the end of individual items in a block.</li>
+								<li><code>_before</code> - This event adds content directly before the specified block</li>
+								<li><code>_after</code> - This event adds content directly after the specified block</li>
+							</ul>
+						</li>
+					</ul>
 
-		<h4>Template event documentation</h4>
-		<p>Events must be documented in <code>phpBB/docs/events.md</code> in alphabetical order based on the event name. The format is as follows:</p>
+					<h4 id="templating.template_events.documentation">
+						<a href="#templating.template_events.documentation"></a>
+						<span>Template event documentation</span>
+					</h4>
+					<p>Events must be documented in <code>phpBB/docs/events.md</code> in alphabetical order based on the event name. The format is as follows:</p>
 
-		<ul><li>An event found in only one template file:
-		<div class="codebox"><pre>event_name
+					<ul><li>An event found in only one template file:
+							<div class="codebox"><pre>event_name
 ===
 * Location: styles/&lt;style_name&gt;/template/filename.html
 * Purpose: A brief description of what this event should be used for.
 This may span multiple lines.
 * Since: Version since when the event was added
 </pre></div></li>
-		<li>An event found in multiple template files:
-		<div class="codebox"><pre>event_name
+						<li>An event found in multiple template files:
+							<div class="codebox"><pre>event_name
 ===
 * Locations:
     + first/file/path.html
@@ -1724,8 +2460,8 @@ This may span multiple lines.
 * Purpose: Same as above.
 * Since: 3.2.0-b1
 </pre></div>
-		<li>An event that is found multiple times in a file should have the number of instances in parenthesis next to the filename.
-		<div class="codebox"><pre>event_name
+						<li>An event that is found multiple times in a file should have the number of instances in parenthesis next to the filename.
+							<div class="codebox"><pre>event_name
 ===
 * Locations:
     + first/file/path.html (2)
@@ -1733,8 +2469,8 @@ This may span multiple lines.
 * Purpose: Same as above.
 * Since: 3.2.0-b1
 </pre></div></li>
-		<li>An actual example event documentation:
-		<div class="codebox"><pre>forumlist_body_last_post_title_prepend
+						<li>An actual example event documentation:
+							<div class="codebox"><pre>forumlist_body_last_post_title_prepend
 ====
 * Locations:
     + styles/prosilver/template/forumlist_body.html
@@ -1742,38 +2478,68 @@ This may span multiple lines.
 * Purpose: Add content before the post title of the latest post in a forum on the forum list.
 * Since: 3.2.0-a1
 </pre></div></ul><br />
-
+				</div>
+			</div>
 		</div>
 
-		<div class="back2top"><a href="#wrap" class="top">Back to Top</a></div>
+		<hr>
 
-		</div>
-	</div>
+		<h2 id="charsets">
+			<a href="#charsets"></a>
+			<span>Character sets and Encodings</span>
+		</h2>
 
-	<hr />
+		<div class="paragraph">
+			<div class="inner">
+				<div class="content">
 
+					<h4 id="charsets.what_are">
+						<a href="#charsets.what_are"></a>
+						<span>What are Unicode, UCS and UTF-8?</span>
+					</h4>
+					<p>
+						The <a href="http://en.wikipedia.org/wiki/Universal_Character_Set">Universal Character Set (UCS)</a>
+						described in ISO/IEC 10646 consists of a large amount of characters.
+						Each of them has a unique name and a code point which is an integer number.
+						<a href="http://en.wikipedia.org/wiki/Unicode">Unicode</a> - which is an industry standard -
+						complements the Universal Character Set with further information about the characters' properties and alternative character encodings.
+						More information on Unicode can be found on the <a href="http://www.unicode.org/">Unicode Consortium's website</a>.
+						One of the Unicode encodings is the <a href="http://en.wikipedia.org/wiki/UTF-8">8-bit Unicode Transformation Format (UTF-8)</a>.
+						It encodes characters with up to four bytes aiming for maximum compatibility with
+						the <a href="http://en.wikipedia.org/wiki/ASCII">American Standard Code for Information Interchange</a>
+						which is a 7-bit encoding of a relatively small subset of the UCS.
+					</p>
 
+					<h4 id="charsets.phpbb_use">
+						<a href="#charsets.phpbb_use"></a>
+						<span>phpBB's use of Unicode</span>
+					</h4>
+					<p>
+						Unfortunately PHP does not facilitate the use of Unicode prior to version 6.
+						Most functions simply treat strings as sequences of bytes assuming that each character takes up exactly one byte.
+						This behaviour still allows for storing UTF-8 encoded text in PHP strings but many operations on strings have unexpected results.
+						To circumvent this problem we have created some alternative functions to PHP's native string operations which use code points instead of bytes.
+						These functions can be found in <code>/includes/utf/utf_tools.php</code>.
+						They are also covered in the <a href="http://area51.phpbb.com/docs/code/">phpBB3 Sourcecode Documentation</a>.
+						A lot of native PHP functions still work with UTF-8 as long as you stick to certain restrictions.
+						For example <code>explode</code> still works as long as the first and the last character of the delimiter string are ASCII characters.
+					</p>
+					<p>
+						phpBB only uses the ASCII and the UTF-8 character encodings.
+						Still all Strings are UTF-8 encoded because ASCII is a subset of UTF-8.
+						The only exceptions to this rule are code sections which deal with external systems which use other encodings and character sets.
+						Such external data should be converted to UTF-8 using the <code>utf8_recode()</code> function supplied with phpBB.
+						It supports a variety of other character sets and encodings, a full list can be found below.
+					</p>
+					<p>
+						With <code>$request->variable()</code> you can either allow all UCS characters in user input or restrict user input to ASCII characters.
+						This feature is controlled by the method's third parameter called <code>$multibyte</code>.
+						You should allow multibyte characters in posts, PMs, topic titles, forum names, etc.
+						but it's not necessary for internal uses like a <code>$mode</code> variable which should only hold a predefined list of ASCII strings anyway.
+					</p>
 
-<a name="charsets"></a><h2>5. Character Sets and Encodings</h2>
-
-	<div class="paragraph">
-		<div class="inner">
-
-		<div class="content">
-
-
-
-<h4>What are Unicode, UCS and UTF-8?</h4>
-<p>The <a href="http://en.wikipedia.org/wiki/Universal_Character_Set">Universal Character Set (UCS)</a> described in ISO/IEC 10646 consists of a large amount of characters. Each of them has a unique name and a code point which is an integer number. <a href="http://en.wikipedia.org/wiki/Unicode">Unicode</a> - which is an industry standard - complements the Universal Character Set with further information about the characters' properties and alternative character encodings. More information on Unicode can be found on the <a href="http://www.unicode.org/">Unicode Consortium's website</a>. One of the Unicode encodings is the <a href="http://en.wikipedia.org/wiki/UTF-8">8-bit Unicode Transformation Format (UTF-8)</a>. It encodes characters with up to four bytes aiming for maximum compatibility with the <a href="http://en.wikipedia.org/wiki/ASCII">American Standard Code for Information Interchange</a> which is a 7-bit encoding of a relatively small subset of the UCS.</p>
-
-<h4>phpBB's use of Unicode</h4>
-<p>Unfortunately PHP does not facilitate the use of Unicode prior to version 6. Most functions simply treat strings as sequences of bytes assuming that each character takes up exactly one byte. This behaviour still allows for storing UTF-8 encoded text in PHP strings but many operations on strings have unexpected results. To circumvent this problem we have created some alternative functions to PHP's native string operations which use code points instead of bytes. These functions can be found in <code>/includes/utf/utf_tools.php</code>. They are also covered in the <a href="http://area51.phpbb.com/docs/code/">phpBB3 Sourcecode Documentation</a>. A lot of native PHP functions still work with UTF-8 as long as you stick to certain restrictions. For example <code>explode</code> still works as long as the first and the last character of the delimiter string are ASCII characters.</p>
-
-<p>phpBB only uses the ASCII and the UTF-8 character encodings. Still all Strings are UTF-8 encoded because ASCII is a subset of UTF-8. The only exceptions to this rule are code sections which deal with external systems which use other encodings and character sets. Such external data should be converted to UTF-8 using the <code>utf8_recode()</code> function supplied with phpBB. It supports a variety of other character sets and encodings, a full list can be found below.</p>
-
-<p>With <code>$request->variable()</code> you can either allow all UCS characters in user input or restrict user input to ASCII characters. This feature is controlled by the method's third parameter called <code>$multibyte</code>. You should allow multibyte characters in posts, PMs, topic titles, forum names, etc. but it's not necessary for internal uses like a <code>$mode</code> variable which should only hold a predefined list of ASCII strings anyway.</p>
-
-<div class="codebox"><pre>
+					<div class="codebox">
+						<pre class="php">
 // an input string containing a multibyte character
 $_REQUEST['multibyte_string'] = 'K&#228;se';
 
@@ -1781,625 +2547,723 @@ $_REQUEST['multibyte_string'] = 'K&#228;se';
 echo $request->variable('multibyte_string', '', true);
 // print request variable as ASCII string
 echo $request->variable('multibyte_string', '');
-</pre></div>
+</pre>
+					</div>
 
-<p>This code snippet will generate the following output:</p>
+					<p>This code snippet will generate the following output:</p>
 
-<div class="codebox"><pre>
+					<div class="codebox">
+						<pre class="plaintext">
 K&#228;se
 K??se
-</pre></div>
+</pre>
+					</div>
 
-<h4>Case Folding</h4>
+					<h4 id="charsets.case_folding">
+						<a href="#charsets.case_folding"></a>
+						<span>Case folding</span>
+					</h4>
+					<p>
+						Case insensitive comparison of strings is no longer possible with <code>strtolower</code> or <code>strtoupper</code>
+						as some characters have multiple lower case or multiple upper case forms depending on their position in a word.
+						The <code>utf8_strtolower</code> and the <code>utf8_strtoupper</code> functions suffer from the same problem
+						so they can only be used to display upper/lower case versions of a string but they cannot be used for case insensitive comparisons either.
+						So instead you should use case folding which gives you a case insensitive version of the string which can be used for case insensitive comparisons.
+						An NFC normalized string can be case folded using <code>utf8_case_fold_nfc()</code>.
+					</p>
 
-<p>Case insensitive comparison of strings is no longer possible with <code>strtolower</code> or <code>strtoupper</code> as some characters have multiple lower case or multiple upper case forms depending on their position in a word. The <code>utf8_strtolower</code> and the <code>utf8_strtoupper</code> functions suffer from the same problem so they can only be used to display upper/lower case versions of a string but they cannot be used for case insensitive comparisons either. So instead you should use case folding which gives you a case insensitive version of the string which can be used for case insensitive comparisons. An NFC normalized string can be case folded using <code>utf8_case_fold_nfc()</code>.</p>
-
-<p class="bad">// Bad - The strings might be the same even if strtolower differs</p>
-
-<div class="codebox"><pre>
+					<p class="bad">// Bad - The strings might be the same even if strtolower differs</p>
+					<div class="codebox">
+						<pre class="php">
 if (strtolower($string1) == strtolower($string2))
 {
 	echo '$string1 and $string2 are equal or differ in case';
 }
-</pre></div>
+</pre>
+					</div>
 
-<p class="good">// Good - Case folding is really case insensitive</p>
-
-<div class="codebox"><pre>
+					<p class="good">// Good - Case folding is really case insensitive</p>
+					<div class="codebox">
+						<pre class="php">
 if (utf8_case_fold_nfc($string1) == utf8_case_fold_nfc($string2))
 {
 	echo '$string1 and $string2 are equal or differ in case';
 }
 </pre></div>
 
-<h4>Confusables Detection</h4>
+					<h4 id="charsets.confusables_detection">
+						<a href="#charsets.confusables_detection"></a>
+						<span>Confusables detection</span>
+					</h4>
+					<p>
+						phpBB offers a special method <code>utf8_clean_string</code> which can be used to make sure string identifiers are unique.
+						This method uses Normalization Form Compatibility Composition (NFKC) instead of NFC and replaces similarly looking characters with a particular representative of the equivalence class.
+						This method is currently used for usernames and group names to avoid confusion with similarly looking names.
+					</p>
+				</div>
 
-<p>phpBB offers a special method <code>utf8_clean_string</code> which can be used to make sure string identifiers are unique. This method uses Normalization Form Compatibility Composition (NFKC) instead of NFC and replaces similarly looking characters with a particular representative of the equivalence class. This method is currently used for usernames and group names to avoid confusion with similarly looking names.</p>
-
+				<div class="back2top"><a href="#wrap" class="top">Back to Top</a></div>
+			</div>
 		</div>
 
-		<div class="back2top"><a href="#wrap" class="top">Back to Top</a></div>
+		<hr>
 
-		</div>
-	</div>
+		<h2 id="translation">
+			<a href="#translation"></a>
+			<span>Translation (<abbr title="Internationalisation">i18n</abbr>/<abbr title="Localisation">L10n</abbr>) Guidelines</span>
+		</h2>
 
-	<hr />
+		<div class="paragraph">
+			<div class="inner">
+				<div class="content">
 
-<a name="translation"></a><h2>6. Translation (<abbr title="Internationalisation">i18n</abbr>/<abbr title="Localisation">L10n</abbr>) Guidelines</h2>
+					<a name="standardisation"></a>
+					<h3 id="translation.standardisation">
+						<a href="#translation.standardisation"></a>
+						<span>Standardisation</span>
+						<a href="#wrap" class="top">Back to Top</a>
+					</h3>
 
-	<div class="paragraph">
-		<div class="inner">
+					<h4 id="translation.reason">
+						<a href="#translation.reason"></a>
+						<span>Reason</span>
+					</h4>
+					<p>
+						phpBB is one of the most translated open-source projects, with the current stable version being available in over 60 localisations.
+						Whilst the ad hoc approach to the naming of language packs has worked,
+						for phpBB3 and beyond we hope to make this process saner which will allow for better interoperation with current and future web browsers.
+					</p>
 
-		<div class="content">
+					<h4 id="translation.encoding">
+						<a href="#translation.encoding"></a>
+						<span>Encoding</span>
+					</h4>
+					<p>
+						With phpBB3, the output encoding for the forum in now UTF-8,
+						a Universal Character Encoding by the Unicode Consortium that is by design a superset to US-ASCII and ISO-8859-1.
+						By using one character set which simultaneously supports all scripts which previously would have required different encodings
+						(eg: ISO-8859-1 to ISO-8859-15 (Latin, Greek, Cyrillic, Thai, Hebrew, Arabic); GB2312 (Simplified Chinese); Big5 (Traditional Chinese), EUC-JP (Japanese), EUC-KR (Korean), VISCII (Vietnamese); et cetera),
+						we remove the need to convert between encodings and improves the accessibility of multilingual forums.
+					</p>
+					<p>
+						The impact is that the language files for phpBB must now also be encoded as UTF-8,
+						with a caveat that the files must <strong>not contain</strong> a <abbr title="Byte-Order-Mark">BOM</abbr>
+						for compatibility reasons with non-Unicode aware versions of PHP.
+						For those with forums using the Latin character set (ie: most European languages),
+						this change is transparent since UTF-8 is superset to US-ASCII and ISO-8859-1.
+					</p>
 
-	<a name="standardisation"></a><h3>6.i. Standardisation</h3>
+					<h4 id="translation.language_tag">
+						<a href="#translation.language_tag"></a>
+						<span>Language tag</span>
+					</h4>
+					<p>
+						The <abbr title="Internet Engineering Task Force">IETF</abbr> recently published <a href="http://tools.ietf.org/html/rfc4646">RFC 4646</a> for tags used to identify languages,
+						which in combination with <a href="http://tools.ietf.org/html/rfc4647">RFC 4647</a> obsoletes the older <a href="http://tools.ietf.org/html/rfc3066">RFC 3006</a> and older-still <a href="http://tools.ietf.org/html/rfc1766">RFC 1766</a>.
+						<a href="http://tools.ietf.org/html/rfc4646">RFC 4646</a> uses
+						<a href="http://www.loc.gov/standards/iso639-2/php/English_list.php">ISO 639-1/ISO 639-2</a>,
+						<a href="http://www.iso.ch/iso/en/prods-services/iso3166ma/02iso-3166-code-lists/list-en1.html">ISO 3166-1 alpha-2</a>,
+						<a href="http://www.unicode.org/iso15924/iso15924-codes.html">ISO 15924</a>
+						and <a href="http://unstats.un.org/unsd/methods/m49/m49.htm">UN M.49</a> to define a language tag.
+						Each complete tag is composed of subtags which are not case sensitive and can also be empty.
+					</p>
+					<p>
+						Ordering of the subtags in the case that they are all non-empty is:
+						<code>language</code>-<code>script</code>-<code>region</code>-<code>variant</code>-<code>extension</code>-<code>privateuse</code>.
+						Should any subtag be empty, its corresponding hyphen would also be omitted.
+						Thus, the language tag for English will be <code>en</code> <strong>and not</strong> <code>en-----</code>.
+					</p>
+					<p>
+						Most language tags consist of a two- or three-letter language subtag
+						(from <a href="http://www.loc.gov/standards/iso639-2/php/English_list.php">ISO 639-1/ISO 639-2</a>).
+						Sometimes, this is followed by a two-letter or three-digit region subtag
+						(from <a href="http://www.iso.ch/iso/en/prods-services/iso3166ma/02iso-3166-code-lists/list-en1.html">ISO 3166-1 alpha-2</a>
+						or <a href="http://unstats.un.org/unsd/methods/m49/m49.htm">UN M.49</a>).
+						Some examples are:
+					</p>
 
-	<h4>Reason:</h4>
+					<table>
+						<caption>Examples of various possible language tags as described by RFC 4646 and RFC 4647</caption>
+						<thead>
+							<tr>
+								<th scope="col">Language tag</th>
+								<th scope="col">Description</th>
+								<th scope="col">Component subtags</th>
+							</tr>
+						</thead>
+						<tbody>
+							<tr>
+								<td><code>en</code></td>
+								<td>English</td>
+								<td><code>language</code></td>
+							</tr>
+							<tr>
+								<td><code>mas</code></td>
+								<td>Masai</td>
+								<td><code>language</code></td>
+							</tr>
+							<tr>
+								<td><code>fr-CA</code></td>
+								<td>French as used in Canada</td>
+								<td><code>language</code>+<code>region</code></td>
+							</tr>
+							<tr>
+								<td><code>en-833</code></td>
+								<td>English as used in the Isle of Man</td>
+								<td><code>language</code>+<code>region</code></td>
+							</tr>
+							<tr>
+								<td><code>zh-Hans</code></td>
+								<td>Chinese written with Simplified script</td>
+								<td><code>language</code>+<code>script</code></td>
+							</tr>
+							<tr>
+								<td><code>zh-Hant-HK</code></td>
+								<td>Chinese written with Traditional script as used in Hong Kong</td>
+								<td><code>language</code>+<code>script</code>+<code>region</code></td>
+							</tr>
+							<tr>
+								<td><code>de-AT-1996</code></td>
+								<td>German as used in Austria with 1996 orthography</td>
+								<td><code>language</code>+<code>region</code>+<code>variant</code></td>
+							</tr>
+						</tbody>
+					</table>
 
-	<p>phpBB is one of the most translated open-source projects, with the current stable version being available in over 60 localisations. Whilst the ad hoc approach to the naming of language packs has worked, for phpBB3 and beyond we hope to make this process saner which will allow for better interoperation with current and future web browsers.</p>
+					<p>The ultimate aim of a language tag is to convey the needed <strong>useful distinguishing information</strong>, whilst keeping it as <strong>short as possible</strong>. So for example, use <code>en</code>, <code>fr</code> and <code>ja</code> as opposed to <code>en-GB</code>, <code>fr-FR</code> and <code>ja-JP</code>, since we know English, French and Japanese are the native language of Great Britain, France and Japan respectively.</p>
 
-	<h4>Encoding:</h4>
+					<p>Next is the <a href="http://www.unicode.org/iso15924/iso15924-codes.html">ISO 15924</a> language script code and when one should or shouldn't use it. For example, whilst <code>en-Latn</code> is syntactically correct for describing English written with Latin script, real world English writing is <strong>more-or-less exclusively in the Latin script</strong>. For such languages like English that are written in a single script, the <a href="http://www.iana.org/assignments/language-subtag-registry"><abbr title="Internet Assigned Numbers Authority">IANA</abbr> Language Subtag Registry</a> has a "Suppress-Script" field meaning the script code <strong>should be omitted</strong> unless a specific language tag requires a specific script code. Some languages are <strong>written in more than one script</strong> and in such cases, the script code <strong>is encouraged</strong> since an end-user may be able to read their language in one script, but not the other. Some examples are:</p>
 
-	<p>With phpBB3, the output encoding for the forum in now UTF-8, a Universal Character Encoding by the Unicode Consortium that is by design a superset to US-ASCII and ISO-8859-1. By using one character set which simultaenously supports all scripts which previously would have required different encodings (eg: ISO-8859-1 to ISO-8859-15 (Latin, Greek, Cyrillic, Thai, Hebrew, Arabic); GB2312 (Simplified Chinese); Big5 (Traditional Chinese), EUC-JP (Japanese), EUC-KR (Korean), VISCII (Vietnamese); et cetera), we remove the need to convert between encodings and improves the accessibility of multilingual forums.</p>
+					<table>
+						<caption>Examples of using a language subtag in combination with a script subtag</caption>
+						<thead>
+							<tr>
+								<th scope="col">Language tag</th>
+								<th scope="col">Description</th>
+								<th scope="col">Component subtags</th>
+							</tr>
+						</thead>
+						<tbody>
+							<tr>
+								<td><code>en-Brai</code></td>
+								<td>English written in Braille script</td>
+								<td><code>language</code>+<code>script</code></td>
+							</tr>
+							<tr>
+								<td><code>en-Dsrt</code></td>
+								<td>English written in Deseret (Mormon) script</td>
+								<td><code>language</code>+<code>script</code></td>
+							</tr>
+							<tr>
+								<td><code>sr-Latn</code></td>
+								<td>Serbian written in Latin script</td>
+								<td><code>language</code>+<code>script</code></td>
+							</tr>
+							<tr>
+								<td><code>sr-Cyrl</code></td>
+								<td>Serbian written in Cyrillic script</td>
+								<td><code>language</code>+<code>script</code></td>
+							</tr>
+							<tr>
+								<td><code>mn-Mong</code></td>
+								<td>Mongolian written in Mongolian script</td>
+								<td><code>language</code>+<code>script</code></td>
+							</tr>
+							<tr>
+								<td><code>mn-Cyrl</code></td>
+								<td>Mongolian written in Cyrillic script</td>
+								<td><code>language</code>+<code>script</code></td>
+							</tr>
+							<tr>
+								<td><code>mn-Phag</code></td>
+								<td>Mongolian written in Phags-pa script</td>
+								<td><code>language</code>+<code>script</code></td>
+							</tr>
+							<tr>
+								<td><code>az-Cyrl-AZ</code></td>
+								<td>Azerbaijani written in Cyrillic script as used in Azerbaijan</td>
+								<td><code>language</code>+<code>script</code>+<code>region</code></td>
+							</tr>
+							<tr>
+								<td><code>az-Latn-AZ</code></td>
+								<td>Azerbaijani written in Latin script as used in Azerbaijan</td>
+								<td><code>language</code>+<code>script</code>+<code>region</code></td>
+							</tr>
+							<tr>
+								<td><code>az-Arab-IR</code></td>
+								<td>Azerbaijani written in Arabic script as used in Iran</td>
+								<td><code>language</code>+<code>script</code>+<code>region</code></td>
+							</tr>
+						</tbody>
+					</table>
 
-	<p>The impact is that the language files for phpBB must now also be encoded as UTF-8, with a caveat that the files must <strong>not contain</strong> a <abbr title="Byte-Order-Mark">BOM</abbr> for compatibility reasons with non-Unicode aware versions of PHP. For those with forums using the Latin character set (ie: most European languages), this change is transparent since UTF-8 is superset to US-ASCII and ISO-8859-1.</p>
+					<p>Usage of the three-digit <a href="http://unstats.un.org/unsd/methods/m49/m49.htm">UN M.49</a> code over the two-letter <a href="http://www.iso.ch/iso/en/prods-services/iso3166ma/02iso-3166-code-lists/list-en1.html">ISO 3166-1 alpha-2</a> code should happen if a macro-geographical entity is required and/or the <a href="http://www.iso.ch/iso/en/prods-services/iso3166ma/02iso-3166-code-lists/list-en1.html">ISO 3166-1 alpha-2</a> is ambiguous.</p>
 
-	<h4>Language Tag:</h4>
+					<p>Examples of English using marco-geographical regions:</p>
 
-	<p>The <abbr title="Internet Engineering Task Force">IETF</abbr> recently published <a href="http://tools.ietf.org/html/rfc4646">RFC 4646</a> for tags used to identify languages, which in combination with <a href="http://tools.ietf.org/html/rfc4647">RFC 4647</a> obseletes the older <a href="http://tools.ietf.org/html/rfc3066">RFC 3006</a> and older-still <a href="http://tools.ietf.org/html/rfc1766">RFC 1766</a>. <a href="http://tools.ietf.org/html/rfc4646">RFC 4646</a> uses <a href="http://www.loc.gov/standards/iso639-2/php/English_list.php">ISO 639-1/ISO 639-2</a>, <a href="http://www.iso.ch/iso/en/prods-services/iso3166ma/02iso-3166-code-lists/list-en1.html">ISO 3166-1 alpha-2</a>, <a href="http://www.unicode.org/iso15924/iso15924-codes.html">ISO 15924</a> and <a href="http://unstats.un.org/unsd/methods/m49/m49.htm">UN M.49</a> to define a language tag. Each complete tag is composed of subtags which are not case sensitive and can also be empty.</p>
+					<table>
+						<caption>Coding for English using macro-geographical regions (examples for English of ISO 3166-1 alpha-2 vs. UN M.49 code)</caption>
+						<thead>
+							<tr>
+								<th scope="col">ISO 639-1/ISO 639-2 + ISO 3166-1 alpha-2</th>
+								<th scope="col" colspan="2">ISO 639-1/ISO 639-2 + UN M.49 (Example macro regions)</th>
+							</tr>
+						</thead>
+						<tbody>
+							<tr>
+								<td><dl><dt><code>en-AU</code></dt><dd>English as used in <strong>Australia</strong></dd></dl></td>
+								<td rowspan="2"><dl><dt><code>en-053</code></dt><dd>English as used in <strong>Australia &amp; New Zealand</strong></dd></dl></td>
+								<td rowspan="3"><dl><dt><code>en-009</code></dt><dd>English as used in <strong>Oceania</strong></dd></dl></td>
+							</tr>
+							<tr>
+								<td><dl><dt><code>en-NZ</code></dt><dd>English as used in <strong>New Zealand</strong></dd></dl></td>
+							</tr>
+							<tr>
+								<td><dl><dt><code>en-FJ</code></dt><dd>English as used in <strong>Fiji</strong></dd></dl></td>
+								<td><dl><dt><code>en-054 </code></dt><dd>English as used in <strong>Melanesia</strong></dd></dl></td>
+							</tr>
+						</tbody>
+					</table>
 
-	<p>Ordering of the subtags in the case that they are all non-empty is: <code>language</code>-<code>script</code>-<code>region</code>-<code>variant</code>-<code>extension</code>-<code>privateuse</code>. Should any subtag be empty, its corresponding hyphen would also be omitted. Thus, the language tag for English will be <code>en</code> <strong>and not</strong> <code>en-----</code>.</p>
+					<p>Examples of Spanish using marco-geographical regions:</p>
 
-	<p>Most language tags consist of a two- or three-letter language subtag (from <a href="http://www.loc.gov/standards/iso639-2/php/English_list.php">ISO 639-1/ISO 639-2</a>). Sometimes, this is followed by a two-letter or three-digit region subtag (from <a href="http://www.iso.ch/iso/en/prods-services/iso3166ma/02iso-3166-code-lists/list-en1.html">ISO 3166-1 alpha-2</a> or <a href="http://unstats.un.org/unsd/methods/m49/m49.htm">UN M.49</a>). Some examples are:</p>
+					<table>
+						<caption>Coding for Spanish macro-geographical regions (examples for Spanish of ISO 3166-1 alpha-2 vs. UN M.49 code)</caption>
+						<thead>
+							<tr>
+								<th scope="col">ISO 639-1/ISO 639-2 + ISO 3166-1 alpha-2</th>
+								<th scope="col" colspan="2">ISO 639-1/ISO 639-2 + UN M.49 (Example macro regions)</th>
+							</tr>
+						</thead>
+						<tbody>
+							<tr>
+								<td><dl><dt><code>es-PR</code></dt><dd>Spanish as used in <strong>Puerto Rico</strong></dd></dl></td>
+								<td rowspan="3"><dl><dt><code>es-419</code></dt><dd>Spanish as used in <strong>Latin America &amp; the Caribbean</strong></dd></dl></td>
+								<td rowspan="4"><dl><dt><code>es-019</code></dt><dd>Spanish as used in <strong>the Americas</strong></dd></dl></td>
+							</tr>
+							<tr>
+								<td><dl><dt><code>es-HN</code></dt><dd>Spanish as used in <strong>Honduras</strong></dd></dl></td>
+							</tr>
+							<tr>
+								<td><dl><dt><code>es-AR</code></dt><dd>Spanish as used in <strong>Argentina</strong></dd></dl></td>
+							</tr>
+							<tr>
+								<td><dl><dt><code>es-US</code></dt><dd>Spanish as used in <strong>United States of America</strong></dd></dl></td>
+								<td><dl><dt><code>es-021</code></dt><dd>Spanish as used in <strong>North America</strong></dd></dl></td>
+							</tr>
+						</tbody>
+					</table>
 
-	<table>
-	<caption>Examples of various possible language tags as described by RFC 4646 and RFC 4647</caption>
-	<thead>
-	<tr>
-		<th scope="col">Language tag</th>
-		<th scope="col">Description</th>
-		<th scope="col">Component subtags</th>
-	</tr>
-	</thead>
-	<tbody>
-	<tr>
-		<td><code>en</code></td>
-		<td>English</td>
-		<td><code>language</code></td>
-	</tr>
-	<tr>
-		<td><code>mas</code></td>
-		<td>Masai</td>
-		<td><code>language</code></td>
-	</tr>
-	<tr>
-		<td><code>fr-CA</code></td>
-		<td>French as used in Canada</td>
-		<td><code>language</code>+<code>region</code></td>
-	</tr>
-	<tr>
-		<td><code>en-833</code></td>
-		<td>English as used in the Isle of Man</td>
-		<td><code>language</code>+<code>region</code></td>
-	</tr>
-	<tr>
-		<td><code>zh-Hans</code></td>
-		<td>Chinese written with Simplified script</td>
-		<td><code>language</code>+<code>script</code></td>
-	</tr>
-	<tr>
-		<td><code>zh-Hant-HK</code></td>
-		<td>Chinese written with Traditional script as used in Hong Kong</td>
-		<td><code>language</code>+<code>script</code>+<code>region</code></td>
-	</tr>
-	<tr>
-		<td><code>de-AT-1996</code></td>
-		<td>German as used in Austria with 1996 orthography</td>
-		<td><code>language</code>+<code>region</code>+<code>variant</code></td>
-	</tr>
-	</tbody>
-	</table>
+					<p>Example of where the <a href="http://www.iso.ch/iso/en/prods-services/iso3166ma/02iso-3166-code-lists/list-en1.html">ISO 3166-1 alpha-2</a> is ambiguous and why <a href="http://unstats.un.org/unsd/methods/m49/m49.htm">UN M.49</a> might be preferred:</p>
 
-	<p>The ultimate aim of a language tag is to convey the needed <strong>useful distingushing information</strong>, whilst keeping it as <strong>short as possible</strong>. So for example, use <code>en</code>, <code>fr</code> and <code>ja</code> as opposed to <code>en-GB</code>, <code>fr-FR</code> and <code>ja-JP</code>, since we know English, French and Japanese are the native language of Great Britain, France and Japan respectively.</p>
+					<table>
+						<caption>Coding for ambiguous ISO 3166-1 alpha-2 regions</caption>
+						<thead>
+							<tr>
+								<th scope="col" colspan="2"><code>CS</code> assignment pre-1994</th>
+								<th scope="col" colspan="2"><code>CS</code> assignment post-1994</th>
+							</tr>
+						</thead>
+						<tbody>
+							<tr>
+								<td colspan="2">
+									<dl>
+										<dt><code>CS</code></dt><dd><strong>Czechoslovakia</strong> (ISO 3166-1)</dd>
+										<dt><code>200</code></dt><dd><strong>Czechoslovakia</strong> (UN M.49)</dd>
+									</dl>
+								</td>
+								<td colspan="2">
+									<dl>
+										<dt><code>CS</code></dt><dd><strong>Serbian &amp; Montenegro</strong> (ISO 3166-1)</dd>
+										<dt><code>891</code></dt><dd><strong>Serbian &amp; Montenegro</strong> (UN M.49)</dd>
+									</dl>
+								</td>
+							</tr>
+							<tr>
+								<td>
+									<dl>
+										<dt><code>CZ</code></dt><dd><strong>Czech Republic</strong> (ISO 3166-1)</dd>
+										<dt><code>203</code></dt><dd><strong>Czech Republic</strong> (UN M.49)</dd>
+									</dl>
+								</td>
+								<td>
+									<dl>
+										<dt><code>SK</code></dt><dd><strong>Slovakia</strong> (ISO 3166-1)</dd>
+										<dt><code>703</code></dt><dd><strong>Slovakia</strong> (UN M.49)</dd>
+									</dl>
+								</td>
+								<td>
+									<dl>
+										<dt><code>RS</code></dt><dd><strong>Serbia</strong> (ISO 3166-1)</dd>
+										<dt><code>688</code></dt><dd><strong>Serbia</strong> (UN M.49)</dd>
+									</dl>
+								</td>
+								<td>
+									<dl>
+										<dt><code>ME</code></dt><dd><strong>Montenegro</strong> (ISO 3166-1)</dd>
+										<dt><code>499</code></dt><dd><strong>Montenegro</strong> (UN M.49)</dd>
+									</dl>
+								</td>
+							</tr>
+						</tbody>
+					</table>
 
-	<p>Next is the <a href="http://www.unicode.org/iso15924/iso15924-codes.html">ISO 15924</a> language script code and when one should or shouldn't use it. For example, whilst <code>en-Latn</code> is syntaxically correct for describing English written with Latin script, real world English writing is <strong>more-or-less exclusively in the Latin script</strong>. For such languages like English that are written in a single script, the <a href="http://www.iana.org/assignments/language-subtag-registry"><abbr title="Internet Assigned Numbers Authority">IANA</abbr> Language Subtag Registry</a> has a "Suppress-Script" field meaning the script code <strong>should be omitted</strong> unless a specific language tag requires a specific script code. Some languages are <strong>written in more than one script</strong> and in such cases, the script code <strong>is encouraged</strong> since an end-user may be able to read their language in one script, but not the other. Some examples are:</p>
+					<h4 id="translation.macro_languages_and_topolects">
+						<a href="#translation.macro_languages_and_topolects"></a>
+						<span>Macro-languages & Topolects</span>
+					</h4>
+					<p>
+						<a href="http://tools.ietf.org/html/rfc4646">RFC 4646</a> anticipates features
+						which shall be available in (currently draft) <a href="http://www.sil.org/iso639-3/">ISO 639-3</a>
+						which aims to provide as complete enumeration of languages as possible,
+						including living, extinct, ancient and constructed languages, whether major, minor or unwritten.
+						A new feature of <a href="http://www.sil.org/iso639-3/">ISO 639-3</a> compared to the previous two revisions
+						is the concept of <a href="http://www.sil.org/iso639-3/macrolanguages.asp">macrolanguages</a>
+						where Arabic and Chinese are two such examples.
+						In such cases, their respective codes of <code>ar</code> and <code>zh</code> is very vague as to which dialect/topolect is used
+						or perhaps some terse classical variant which may be difficult for all but very educated users.
+						For such macrolanguages, it is recommended that the sub-language tag is used as a suffix to the macrolanguage tag, eg:
+					</p>
 
-	<table>
-	<caption>Examples of using a language subtag in combination with a script subtag</caption>
-	<thead>
-	<tr>
-		<th scope="col">Language tag</th>
-		<th scope="col">Description</th>
-		<th scope="col">Component subtags</th>
-	</tr>
-	</thead>
-	<tbody>
-	<tr>
-		<td><code>en-Brai</code></td>
-		<td>English written in Braille script</td>
-		<td><code>language</code>+<code>script</code></td>
-	</tr>
-	<tr>
-		<td><code>en-Dsrt</code></td>
-		<td>English written in Deseret (Mormon) script</td>
-		<td><code>language</code>+<code>script</code></td>
-	</tr>
-	<tr>
-		<td><code>sr-Latn</code></td>
-		<td>Serbian written in Latin script</td>
-		<td><code>language</code>+<code>script</code></td>
-	</tr>
-	<tr>
-		<td><code>sr-Cyrl</code></td>
-		<td>Serbian written in Cyrillic script</td>
-		<td><code>language</code>+<code>script</code></td>
-	</tr>
-	<tr>
-		<td><code>mn-Mong</code></td>
-		<td>Mongolian written in Mongolian script</td>
-		<td><code>language</code>+<code>script</code></td>
-	</tr>
-	<tr>
-		<td><code>mn-Cyrl</code></td>
-		<td>Mongolian written in Cyrillic script</td>
-		<td><code>language</code>+<code>script</code></td>
-	</tr>
-	<tr>
-		<td><code>mn-Phag</code></td>
-		<td>Mongolian written in Phags-pa script</td>
-		<td><code>language</code>+<code>script</code></td>
-	</tr>
-	<tr>
-		<td><code>az-Cyrl-AZ</code></td>
-		<td>Azerbaijani written in Cyrillic script as used in Azerbaijan</td>
-		<td><code>language</code>+<code>script</code>+<code>region</code></td>
-	</tr>
-	<tr>
-		<td><code>az-Latn-AZ</code></td>
-		<td>Azerbaijani written in Latin script as used in Azerbaijan</td>
-		<td><code>language</code>+<code>script</code>+<code>region</code></td>
-	</tr>
-	<tr>
-		<td><code>az-Arab-IR</code></td>
-		<td>Azerbaijani written in Arabic script as used in Iran</td>
-		<td><code>language</code>+<code>script</code>+<code>region</code></td>
-	</tr>
-	</tbody>
-	</table>
+					<table>
+						<caption>Macrolanguage subtag + sub-language subtag examples</caption>
+						<thead>
+							<tr>
+								<th scope="col">Language tag</th>
+								<th scope="col">Description</th>
+								<th scope="col">Component subtags</th>
+							</tr>
+						</thead>
+						<tbody>
+							<tr>
+								<td><code>zh-cmn</code></td>
+								<td>Mandarin (Putonghau/Guoyu) Chinese</td>
+								<td><code>macrolanguage</code>+<code>sublanguage</code></td>
+							</tr>
+							<tr>
+								<td><code>zh-yue</code></td>
+								<td>Yue (Cantonese) Chinese</td>
+								<td><code>macrolanguage</code>+<code>sublanguage</code></td>
+							</tr>
+							<tr>
+								<td><code>zh-cmn-Hans</code></td>
+								<td>Mandarin (Putonghau/Guoyu) Chinese written in Simplified script</td>
+								<td><code>macrolanguage</code>+<code>sublanguage</code>+<code>script</code></td>
+							</tr>
+							<tr>
+								<td><code>zh-cmn-Hant</code></td>
+								<td>Mandarin (Putonghau/Guoyu) Chinese written in Traditional script</td>
+								<td><code>macrolanguage</code>+<code>sublanguage</code>+<code>script</code></td>
+							</tr>
+							<tr>
+								<td><code>zh-nan-Latn-TW</code></td>
+								<td>Minnan (Hoklo) Chinese written in Latin script (POJ Romanisation) as used in Taiwan</td>
+								<td><code>macrolanguage</code>+<code>sublanguage</code>+<code>script</code>+<code>region</code></td>
+							</tr>
+						</tbody>
+					</table>
 
-	<p>Usage of the three-digit <a href="http://unstats.un.org/unsd/methods/m49/m49.htm">UN M.49</a> code over the two-letter <a href="http://www.iso.ch/iso/en/prods-services/iso3166ma/02iso-3166-code-lists/list-en1.html">ISO 3166-1 alpha-2</a> code should happen if a macro-geographical entity is required and/or the <a href="http://www.iso.ch/iso/en/prods-services/iso3166ma/02iso-3166-code-lists/list-en1.html">ISO 3166-1 alpha-2</a> is ambiguous.</p>
+					<a name="otherconsiderations"></a>
+					<h3 id="translation.considerations">
+						<a href="#translation.considerations"></a>
+						<span>Other considerations</span>
+						<a href="#wrap" class="top">Back to Top</a>
+					</h3>
 
-	<p>Examples of English using marco-geographical regions:</p>
+					<h4 id="translation.considerations.normalisation">
+						<a href="#translation.considerations.normalisation"></a>
+						<span>Normalisation of language tags for phpBB</span>
+					</h4>
+					<p>For phpBB, the language tags are <strong>not</strong> used in their raw form and instead converted to all lower-case and have the hyphen <code>-</code> replaced with an underscore <code>_</code> where appropriate, with some examples below:</p>
 
-	<table>
-	<caption>Coding for English using macro-geographical regions (examples for English of ISO 3166-1 alpha-2 vs. UN M.49 code)</caption>
-	<thead>
-	<tr>
-		<th scope="col">ISO 639-1/ISO 639-2 + ISO 3166-1 alpha-2</th>
-		<th scope="col" colspan="2">ISO 639-1/ISO 639-2 + UN M.49 (Example macro regions)</th>
-	</tr>
-	</thead>
-	<tbody>
-	<tr>
-		<td><dl><dt><code>en-AU</code></dt><dd>English as used in <strong>Australia</strong></dd></dl></td>
-		<td rowspan="2"><dl><dt><code>en-053</code></dt><dd>English as used in <strong>Australia &amp; New Zealand</strong></dd></dl></td>
-		<td rowspan="3"><dl><dt><code>en-009</code></dt><dd>English as used in <strong>Oceania</strong></dd></dl></td>
-	</tr>
-	<tr>
-		<td><dl><dt><code>en-NZ</code></dt><dd>English as used in <strong>New Zealand</strong></dd></dl></td>
-	</tr>
-	<tr>
-		<td><dl><dt><code>en-FJ</code></dt><dd>English as used in <strong>Fiji</strong></dd></dl></td>
-		<td><dl><dt><code>en-054 </code></dt><dd>English as used in <strong>Melanesia</strong></dd></dl></td>
-	</tr>
-	</tbody>
-	</table>
+					<table>
+						<caption>Language tag normalisation examples</caption>
+						<thead>
+							<tr>
+								<th scope="col">Raw language tag</th>
+								<th scope="col">Description</th>
+								<th scope="col">Value of <code>USER_LANG</code><br />in <code>./common.php</code></th>
+								<th scope="col">Language pack directory<br />name in <code>/language/</code></th>
+							</tr>
+						</thead>
+						<tbody>
+							<tr>
+								<td><code>en</code></td>
+								<td>British English</td>
+								<td><code>en</code></td>
+								<td><code>en</code></td>
+							</tr>
+							<tr>
+								<td><code>de-AT</code></td>
+								<td>German as used in Austria</td>
+								<td><code>de-at</code></td>
+								<td><code>de_at</code></td>
+							</tr>
+							<tr>
+								<td><code>es-419</code></td>
+								<td>Spanish as used in Latin America &amp; Caribbean</td>
+								<td><code>en-419</code></td>
+								<td><code>en_419</code></td>
+							</tr>
+							<tr>
+								<td><code>zh-yue-Hant-HK</code></td>
+								<td>Cantonese written in Traditional script as used in Hong Kong</td>
+								<td><code>zh-yue-hant-hk</code></td>
+								<td><code>zh_yue_hant_hk</code></td>
+							</tr>
+						</tbody>
+					</table>
 
-	<p>Examples of Spanish using marco-geographical regions:</p>
+					<h4 id="translation.considerations.iso">
+						<a href="#translation.considerations.iso"></a>
+						<span>How to use <code>iso.txt</code></span>
+					</h4>
+					<p>The <code>iso.txt</code> file is a small UTF-8 encoded plain-text file which consists of three lines:</p>
 
-	<table>
-	<caption>Coding for Spanish macro-geographical regions (examples for Spanish of ISO 3166-1 alpha-2 vs. UN M.49 code)</caption>
-	<thead>
-	<tr>
-		<th scope="col">ISO 639-1/ISO 639-2 + ISO 3166-1 alpha-2</th>
-		<th scope="col" colspan="2">ISO 639-1/ISO 639-2 + UN M.49 (Example macro regions)</th>
-	</tr>
-	</thead>
-	<tbody>
-	<tr>
-		<td><dl><dt><code>es-PR</code></dt><dd>Spanish as used in <strong>Puerto Rico</strong></dd></dl></td>
-		<td rowspan="3"><dl><dt><code>es-419</code></dt><dd>Spanish as used in <strong>Latin America &amp; the Caribbean</strong></dd></dl></td>
-		<td rowspan="4"><dl><dt><code>es-019</code></dt><dd>Spanish as used in <strong>the Americas</strong></dd></dl></td>
-	</tr>
-	<tr>
-		<td><dl><dt><code>es-HN</code></dt><dd>Spanish as used in <strong>Honduras</strong></dd></dl></td>
-	</tr>
-	<tr>
-		<td><dl><dt><code>es-AR</code></dt><dd>Spanish as used in <strong>Argentina</strong></dd></dl></td>
-	</tr>
-	<tr>
-		<td><dl><dt><code>es-US</code></dt><dd>Spanish as used in <strong>United States of America</strong></dd></dl></td>
-		<td><dl><dt><code>es-021</code></dt><dd>Spanish as used in <strong>North America</strong></dd></dl></td>
-	</tr>
-	</tbody>
-	</table>
+					<ol>
+						<li><code>Language's English name</code></li>
+						<li><code>Language's local name</code></li>
+						<li><code>Authors information</code></li>
+					</ol>
 
-	<p>Example of where the <a href="http://www.iso.ch/iso/en/prods-services/iso3166ma/02iso-3166-code-lists/list-en1.html">ISO 3166-1 alpha-2</a> is ambiguous and why <a href="http://unstats.un.org/unsd/methods/m49/m49.htm">UN M.49</a> might be preferred:</p>
+					<p><code>iso.txt</code> is automatically generated by the language pack submission system on phpBB.com. You don't have to create this file yourself if you plan on releasing your language pack on phpBB.com, but do keep in mind that phpBB itself does require this file to be present.</p>
 
-	<table>
-	<caption>Coding for ambiguous ISO 3166-1 alpha-2 regions</caption>
-	<thead>
-	<tr>
-		<th scope="col" colspan="2"><code>CS</code> assignment pre-1994</th>
-		<th scope="col" colspan="2"><code>CS</code> assignment post-1994</th>
-	</tr>
-	</thead>
-	<tbody>
-	<tr>
-		<td colspan="2">
-		<dl>
-		<dt><code>CS</code></dt><dd><strong>Czechoslovakia</strong> (ISO 3166-1)</dd>
-		<dt><code>200</code></dt><dd><strong>Czechoslovakia</strong> (UN M.49)</dd>
-		</dl>
-		</td>
-		<td colspan="2">
-		<dl>
-		<dt><code>CS</code></dt><dd><strong>Serbian &amp; Montenegro</strong> (ISO 3166-1)</dd>
-		<dt><code>891</code></dt><dd><strong>Serbian &amp; Montenegro</strong> (UN M.49)</dd>
-		</dl>
-		</td>
-	</tr>
-	<tr>
-		<td>
-		<dl>
-		<dt><code>CZ</code></dt><dd><strong>Czech Republic</strong> (ISO 3166-1)</dd>
-		<dt><code>203</code></dt><dd><strong>Czech Republic</strong> (UN M.49)</dd>
-		</dl>
-		</td>
-		<td>
-		<dl>
-		<dt><code>SK</code></dt><dd><strong>Slovakia</strong> (ISO 3166-1)</dd>
-		<dt><code>703</code></dt><dd><strong>Slovakia</strong> (UN M.49)</dd>
-		</dl>
-		</td>
-		<td>
-		<dl>
-		<dt><code>RS</code></dt><dd><strong>Serbia</strong> (ISO 3166-1)</dd>
-		<dt><code>688</code></dt><dd><strong>Serbia</strong> (UN M.49)</dd>
-		</dl>
-		</td>
-		<td>
-		<dl>
-		<dt><code>ME</code></dt><dd><strong>Montenegro</strong> (ISO 3166-1)</dd>
-		<dt><code>499</code></dt><dd><strong>Montenegro</strong> (UN M.49)</dd>
-		</dl>
-		</td>
-	</tr>
-	</tbody>
-	</table>
+					<p>Because language tags themselves are meant to be machine read, they can be rather obtuse to humans and why descriptive strings as provided by <code>iso.txt</code> are needed. Whilst <code>en-US</code> could be fairly easily deduced to be "English as used in the United States", <code>de-CH</code> is more difficult less one happens to know that <code>de</code> is from "<span lang="de">Deutsch</span>", German for "German" and <code>CH</code> is the abbreviation of the official Latin name for Switzerland, "<span lang="la">Confoederatio Helvetica</span>".</p>
 
-	<h4>Macro-languages &amp; Topolects:</h4>
+					<p>For the English language description, the language name is always first and any additional attributes required to describe the subtags within the language code are then listed in order separated with commas and enclosed within parentheses, eg:</p>
 
-	<p><a href="http://tools.ietf.org/html/rfc4646">RFC 4646</a> anticipates features which shall be available in (currently draft) <a href="http://www.sil.org/iso639-3/">ISO 639-3</a> which aims to provide as complete enumeration of languages as possible, including living, extinct, ancient and constructed languages, whether majour, minor or unwritten. A new feature of <a href="http://www.sil.org/iso639-3/">ISO 639-3</a> compared to the previous two revisions is the concept of <a href="http://www.sil.org/iso639-3/macrolanguages.asp">macrolanguages</a> where Arabic and Chinese are two such examples. In such cases, their respective codes of <code>ar</code> and <code>zh</code> is very vague as to which dialect/topolect is used or perhaps some terse classical variant which may be difficult for all but very educated users. For such macrolanguages, it is recommended that the sub-language tag is used as a suffix to the macrolanguage tag, eg:</p>
+					<table>
+						<caption>English language description examples for iso.txt</caption>
+						<thead>
+							<tr>
+								<th scope="col">Raw language tag</th>
+								<th scope="col">English description within <code>iso.txt</code></th>
+							</tr>
+						</thead>
+						<tbody>
+							<tr>
+								<td><code>en</code></td>
+								<td>British English</td>
+							</tr>
+							<tr>
+								<td><code>en-US</code></td>
+								<td>English (United States)</td>
+							</tr>
+							<tr>
+								<td><code>en-053</code></td>
+								<td>English (Australia &amp; New Zealand)</td>
+							</tr>
+							<tr>
+								<td><code>de</code></td>
+								<td>German</td>
+							</tr>
+							<tr>
+								<td><code>de-CH-1996</code></td>
+								<td>German (Switzerland, 1996 orthography)</td>
+							</tr>
+							<tr>
+								<td><code>gws-1996</code></td>
+								<td>Swiss German (1996 orthography)</td>
+							</tr>
+							<tr>
+								<td><code>zh-cmn-Hans-CN</code></td>
+								<td>Mandarin Chinese (Simplified, Mainland China)</td>
+							</tr>
+							<tr>
+								<td><code>zh-yue-Hant-HK</code></td>
+								<td>Cantonese Chinese (Traditional, Hong Kong)</td>
+							</tr>
+						</tbody>
+					</table>
 
-	<table>
-	<caption>Macrolanguage subtag + sub-language subtag examples</caption>
-	<thead>
-	<tr>
-		<th scope="col">Language tag</th>
-		<th scope="col">Description</th>
-		<th scope="col">Component subtags</th>
-	</tr>
-	</thead>
-	<tbody>
-	<tr>
-		<td><code>zh-cmn</code></td>
-		<td>Mandarin (Putonghau/Guoyu) Chinese</td>
-		<td><code>macrolanguage</code>+<code>sublanguage</code></td>
-	</tr>
-	<tr>
-		<td><code>zh-yue</code></td>
-		<td>Yue (Cantonese) Chinese</td>
-		<td><code>macrolanguage</code>+<code>sublanguage</code></td>
-	</tr>
-	<tr>
-		<td><code>zh-cmn-Hans</code></td>
-		<td>Mandarin (Putonghau/Guoyu) Chinese written in Simplified script</td>
-		<td><code>macrolanguage</code>+<code>sublanguage</code>+<code>script</code></td>
-	</tr>
-	<tr>
-		<td><code>zh-cmn-Hant</code></td>
-		<td>Mandarin (Putonghau/Guoyu) Chinese written in Traditional script</td>
-		<td><code>macrolanguage</code>+<code>sublanguage</code>+<code>script</code></td>
-	</tr>
-	<tr>
-		<td><code>zh-nan-Latn-TW</code></td>
-		<td>Minnan (Hoklo) Chinese written in Latin script (POJ Romanisation) as used in Taiwan</td>
-		<td><code>macrolanguage</code>+<code>sublanguage</code>+<code>script</code>+<code>region</code></td>
-	</tr>
-	</tbody>
-	</table>
+					<p>For the localised language description, just translate the English version though use whatever appropriate punctuation typical for your own locale, assuming the language uses punctuation at all.</p>
 
-	<a name="otherconsiderations"></a><h3>6.ii. Other considerations</h3>
+					<h4 id="translation.considerations.bidirectional">
+						<a href="#translation.considerations.bidirectional"></a>
+						<span>Unicode bi-directional considerations</span>
+					</h4>
+					<p>Because phpBB is now UTF-8, all translators must take into account that certain strings may be shown when the directionality of the document is either opposite to normal or is ambiguous.</p>
 
-	<h4>Normalisation of language tags for phpBB:</h4>
+					<p>The various Unicode control characters for bi-directional text and their HTML enquivalents where appropriate are as follows:</p>
 
-	<p>For phpBB, the language tags are <strong>not</strong> used in their raw form and instead converted to all lower-case and have the hyphen <code>-</code> replaced with an underscore <code>_</code> where appropriate, with some examples below:</p>
+					<table>
+						<caption>Unicode bidirectional control characters &amp; HTML elements/entities</caption>
+						<thead>
+							<tr>
+								<th scope="col">Unicode character<br />abbreviation</th>
+								<th scope="col">Unicode<br />code-point</th>
+								<th scope="col">Unicode character<br />name</th>
+								<th scope="col">Equivalent HTML<br />markup/entity</th>
+								<th scope="col">Raw character<br />(enclosed between '')</th>
+							</tr>
+						</thead>
+						<tbody>
+							<tr>
+								<td><code>LRM</code></td>
+								<td><code>U+200E</code></td>
+								<td>Left-to-Right Mark</td>
+								<td><code>&amp;lrm;</code></td>
+								<td>'&#x200E;'</td>
+							</tr>
+							<tr>
+								<td><code>RLM</code></td>
+								<td><code>U+200F</code></td>
+								<td>Right-to-Left Mark</td>
+								<td><code>&amp;rlm;</code></td>
+								<td>'&#x200F;'</td>
+							</tr>
+							<tr>
+								<td><code>LRE</code></td>
+								<td><code>U+202A</code></td>
+								<td>Left-to-Right Embedding</td>
+								<td><code>dir=&quot;ltr&quot;</code></td>
+								<td>'&#x202A;'</td>
+							</tr>
+							<tr>
+								<td><code>RLE</code></td>
+								<td><code>U+202B</code></td>
+								<td>Right-to-Left Embedding</td>
+								<td><code>dir=&quot;rtl&quot;</code></td>
+								<td>'&#x202B;'</td>
+							</tr>
+							<tr>
+								<td><code>PDF</code></td>
+								<td><code>U+202C</code></td>
+								<td>Pop Directional Formatting</td>
+								<td><code>&lt;/bdo&gt;</code></td>
+								<td>'&#x202C;'</td>
+							</tr>
+							<tr>
+								<td><code>LRO</code></td>
+								<td><code>U+202D</code></td>
+								<td>Left-to-Right Override</td>
+								<td><code>&lt;bdo dir=&quot;ltr&quot;&gt;</code></td>
+								<td>'&#x202D;'</td>
+							</tr>
+							<tr>
+								<td><code>RLO</code></td>
+								<td><code>U+202E</code></td>
+								<td>Right-to-Left Override</td>
+								<td><code>&lt;bdo dir=&quot;rtl&quot;&gt;</code></td>
+								<td>'&#x202E;'</td>
+							</tr>
+						</tbody>
+					</table>
 
-	<table>
-	<caption>Language tag normalisation examples</caption>
-	<thead>
-	<tr>
-		<th scope="col">Raw language tag</th>
-		<th scope="col">Description</th>
-		<th scope="col">Value of <code>USER_LANG</code><br />in <code>./common.php</code></th>
-		<th scope="col">Language pack directory<br />name in <code>/language/</code></th>
-	</tr>
-	</thead>
-	<tbody>
-	<tr>
-		<td><code>en</code></td>
-		<td>British English</td>
-		<td><code>en</code></td>
-		<td><code>en</code></td>
-	</tr>
-	<tr>
-		<td><code>de-AT</code></td>
-		<td>German as used in Austria</td>
-		<td><code>de-at</code></td>
-		<td><code>de_at</code></td>
-	</tr>
-	<tr>
-		<td><code>es-419</code></td>
-		<td>Spanish as used in Latin America &amp; Caribbean</td>
-		<td><code>en-419</code></td>
-		<td><code>en_419</code></td>
-	</tr>
-	<tr>
-		<td><code>zh-yue-Hant-HK</code></td>
-		<td>Cantonese written in Traditional script as used in Hong Kong</td>
-		<td><code>zh-yue-hant-hk</code></td>
-		<td><code>zh_yue_hant_hk</code></td>
-	</tr>
-	</tbody>
-	</table>
+					<p>For <code>iso.txt</code>, the directionality of the text can be explicitly set using special Unicode characters via any of the three methods provided by left-to-right/right-to-left markers/embeds/overrides, as without them, the ordering of characters will be incorrect, eg:</p>
 
-	<h4>How to use <code>iso.txt</code>:</h4>
+					<table>
+						<caption>Unicode bidirectional control characters iso.txt</caption>
+						<thead>
+							<tr>
+								<th scope="col">Directionality</th>
+								<th scope="col">Raw character view</th>
+								<th scope="col">Display of localised<br />description in <code>iso.txt</code></th>
+								<th scope="col">Ordering</th>
+							</tr>
+						</thead>
+						<tbody>
+							<tr>
+								<td><code>dir=&quot;ltr&quot;</code></td>
+								<td>English (Australia &amp; New Zealand)</td>
+								<td dir="ltr">English (Australia &amp; New Zealand)</td>
+								<td class="good">Correct</td>
+							</tr>
+							<tr>
+								<td><code>dir=&quot;rtl&quot;</code></td>
+								<td>English (Australia &amp; New Zealand)</td>
+								<td dir="rtl">English (Australia &amp; New Zealand)</td>
+								<td class="bad">Incorrect</td>
+							</tr>
+							<tr>
+								<td><code>dir=&quot;rtl&quot;</code> with <code>LRM</code></td>
+								<td>English (Australia &amp; New Zealand)<code>U+200E</code></td>
+								<td dir="rtl">English (Australia &amp; New Zealand)&#x200E;</td>
+								<td class="good">Correct</td>
+							</tr>
+							<tr>
+								<td><code>dir=&quot;rtl&quot;</code> with <code>LRE</code> &amp; <code>PDF</code></td>
+								<td><code>U+202A</code>English (Australia &amp; New Zealand)<code>U+202C</code></td>
+								<td dir="rtl">&#x202A;English (Australia &amp; New Zealand)&#x202C;</td>
+								<td class="good">Correct</td>
+							</tr>
+							<tr>
+								<td><code>dir=&quot;rtl&quot;</code> with <code>LRO</code> &amp; <code>PDF</code></td>
+								<td><code>U+202D</code>English (Australia &amp; New Zealand)<code>U+202C</code></td>
+								<td dir="rtl">&#x202D;English (Australia &amp; New Zealand)&#x202C;</td>
+								<td class="good">Correct</td>
+							</tr>
+						</tbody>
+					</table>
 
-	<p>The <code>iso.txt</code> file is a small UTF-8 encoded plain-text file which consists of three lines:</p>
+					<p>In choosing which of the three methods to use, in the majority of cases, the <code>LRM</code> or <code>RLM</code> to put a &quot;strong&quot; character to fully enclose an ambiguous punctuation character and thus make it inherit the correct directionality is sufficient.</p>
+					<p>Within some cases, there may be mixed scripts of a left-to-right and right-to-left direction, so using <code>LRE</code> &amp; <code>RLE</code> with <code>PDF</code> may be more appropriate. Lastly, in very rare instances where directionality must be forced, then use <code>LRO</code> &amp; <code>RLO</code> with <code>PDF</code>.</p>
+					<p>For further information on authoring techniques of bi-directional text, please see the W3C tutorial on <a href="http://www.w3.org/International/tutorials/bidi-xhtml/">authoring techniques for XHTML pages with bi-directional text</a>.</p>
 
-	<ol>
-		<li><code>Language's English name</code></li>
-		<li><code>Language's local name</code></li>
-		<li><code>Authors information</code></li>
-	</ol>
+					<a name="placeholders"></a>
+					<h3 id="translation.placeholders">
+						<a href="#translation.placeholders"></a>
+						<span>Working with placeholders</span>
+						<a href="#wrap" class="top">Back to Top</a>
+					</h3>
 
-	<p><code>iso.txt</code> is automatically generated by the language pack submission system on phpBB.com. You don't have to create this file yourself if you plan on releasing your language pack on phpBB.com, but do keep in mind that phpBB itself does require this file to be present.</p>
+					<p>As phpBB is translated into languages with different ordering rules to that of English, it is possible to show specific values in any order deemed appropriate. Take for example the extremely simple &quot;Page <em>X</em> of <em>Y</em>&quot;, whilst in English this could just be coded as:</p>
 
-	<p>Because language tags themselves are meant to be machine read, they can be rather obtuse to humans and why descriptive strings as provided by <code>iso.txt</code> are needed. Whilst <code>en-US</code> could be fairly easily deduced to be "English as used in the United States", <code>de-CH</code> is more difficult less one happens to know that <code>de</code> is from "<span lang="de">Deutsch</span>", German for "German" and <code>CH</code> is the abbreviation of the official Latin name for Switzerland, "<span lang="la">Confoederatio Helvetica</span>".</p>
-
-	<p>For the English language description, the language name is always first and any additional attributes required to describe the subtags within the language code are then listed in order separated with commas and enclosed within parentheses, eg:</p>
-
-	<table>
-	<caption>English language description examples for iso.txt</caption>
-	<thead>
-	<tr>
-		<th scope="col">Raw language tag</th>
-		<th scope="col">English description within <code>iso.txt</code></th>
-	</tr>
-	</thead>
-	<tbody>
-	<tr>
-		<td><code>en</code></td>
-		<td>British English</td>
-	</tr>
-	<tr>
-		<td><code>en-US</code></td>
-		<td>English (United States)</td>
-	</tr>
-	<tr>
-		<td><code>en-053</code></td>
-		<td>English (Australia &amp; New Zealand)</td>
-	</tr>
-	<tr>
-		<td><code>de</code></td>
-		<td>German</td>
-	</tr>
-	<tr>
-		<td><code>de-CH-1996</code></td>
-		<td>German (Switzerland, 1996 orthography)</td>
-	</tr>
-	<tr>
-		<td><code>gws-1996</code></td>
-		<td>Swiss German (1996 orthography)</td>
-	</tr>
-	<tr>
-		<td><code>zh-cmn-Hans-CN</code></td>
-		<td>Mandarin Chinese (Simplified, Mainland China)</td>
-	</tr>
-	<tr>
-		<td><code>zh-yue-Hant-HK</code></td>
-		<td>Cantonese Chinese (Traditional, Hong Kong)</td>
-	</tr>
-	</tbody>
-	</table>
-
-	<p>For the localised language description, just translate the English version though use whatever appropriate punctuation typical for your own locale, assuming the language uses punctuation at all.</p>
-
-	<h4>Unicode bi-directional considerations:</h4>
-
-	<p>Because phpBB is now UTF-8, all translators must take into account that certain strings may be shown when the directionality of the document is either opposite to normal or is ambiguous.</p>
-
-	<p>The various Unicode control characters for bi-directional text and their HTML enquivalents where appropriate are as follows:</p>
-
-	<table>
-	<caption>Unicode bidirectional control characters &amp; HTML elements/entities</caption>
-	<thead>
-	<tr>
-		<th scope="col">Unicode character<br />abbreviation</th>
-		<th scope="col">Unicode<br />code-point</th>
-		<th scope="col">Unicode character<br />name</th>
-		<th scope="col">Equivalent HTML<br />markup/entity</th>
-		<th scope="col">Raw character<br />(enclosed between '')</th>
-	</tr>
-	</thead>
-	<tbody>
-	<tr>
-		<td><code>LRM</code></td>
-		<td><code>U+200E</code></td>
-		<td>Left-to-Right Mark</td>
-		<td><code>&amp;lrm;</code></td>
-		<td>'&#x200E;'</td>
-	</tr>
-	<tr>
-		<td><code>RLM</code></td>
-		<td><code>U+200F</code></td>
-		<td>Right-to-Left Mark</td>
-		<td><code>&amp;rlm;</code></td>
-		<td>'&#x200F;'</td>
-	</tr>
-	<tr>
-		<td><code>LRE</code></td>
-		<td><code>U+202A</code></td>
-		<td>Left-to-Right Embedding</td>
-		<td><code>dir=&quot;ltr&quot;</code></td>
-		<td>'&#x202A;'</td>
-	</tr>
-	<tr>
-		<td><code>RLE</code></td>
-		<td><code>U+202B</code></td>
-		<td>Right-to-Left Embedding</td>
-		<td><code>dir=&quot;rtl&quot;</code></td>
-		<td>'&#x202B;'</td>
-	</tr>
-	<tr>
-		<td><code>PDF</code></td>
-		<td><code>U+202C</code></td>
-		<td>Pop Directional Formatting</td>
-		<td><code>&lt;/bdo&gt;</code></td>
-		<td>'&#x202C;'</td>
-	</tr>
-	<tr>
-		<td><code>LRO</code></td>
-		<td><code>U+202D</code></td>
-		<td>Left-to-Right Override</td>
-		<td><code>&lt;bdo dir=&quot;ltr&quot;&gt;</code></td>
-		<td>'&#x202D;'</td>
-	</tr>
-	<tr>
-		<td><code>RLO</code></td>
-		<td><code>U+202E</code></td>
-		<td>Right-to-Left Override</td>
-		<td><code>&lt;bdo dir=&quot;rtl&quot;&gt;</code></td>
-		<td>'&#x202E;'</td>
-	</tr>
-	</tbody>
-	</table>
-
-	<p>For <code>iso.txt</code>, the directionality of the text can be explicitly set using special Unicode characters via any of the three methods provided by left-to-right/right-to-left markers/embeds/overrides, as without them, the ordering of characters will be incorrect, eg:</p>
-
-	<table>
-	<caption>Unicode bidirectional control characters iso.txt</caption>
-	<thead>
-	<tr>
-		<th scope="col">Directionality</th>
-		<th scope="col">Raw character view</th>
-		<th scope="col">Display of localised<br />description in <code>iso.txt</code></th>
-		<th scope="col">Ordering</th>
-	</tr>
-	</thead>
-	<tbody>
-	<tr>
-		<td><code>dir=&quot;ltr&quot;</code></td>
-		<td>English (Australia &amp; New Zealand)</td>
-		<td dir="ltr">English (Australia &amp; New Zealand)</td>
-		<td class="good">Correct</td>
-	</tr>
-	<tr>
-		<td><code>dir=&quot;rtl&quot;</code></td>
-		<td>English (Australia &amp; New Zealand)</td>
-		<td dir="rtl">English (Australia &amp; New Zealand)</td>
-		<td class="bad">Incorrect</td>
-	</tr>
-	<tr>
-		<td><code>dir=&quot;rtl&quot;</code> with <code>LRM</code></td>
-		<td>English (Australia &amp; New Zealand)<code>U+200E</code></td>
-		<td dir="rtl">English (Australia &amp; New Zealand)&#x200E;</td>
-		<td class="good">Correct</td>
-	</tr>
-	<tr>
-		<td><code>dir=&quot;rtl&quot;</code> with <code>LRE</code> &amp; <code>PDF</code></td>
-		<td><code>U+202A</code>English (Australia &amp; New Zealand)<code>U+202C</code></td>
-		<td dir="rtl">&#x202A;English (Australia &amp; New Zealand)&#x202C;</td>
-		<td class="good">Correct</td>
-	</tr>
-	<tr>
-		<td><code>dir=&quot;rtl&quot;</code> with <code>LRO</code> &amp; <code>PDF</code></td>
-		<td><code>U+202D</code>English (Australia &amp; New Zealand)<code>U+202C</code></td>
-		<td dir="rtl">&#x202D;English (Australia &amp; New Zealand)&#x202C;</td>
-		<td class="good">Correct</td>
-	</tr>
-	</tbody>
-	</table>
-
-	<p>In choosing which of the three methods to use, in the majority of cases, the <code>LRM</code> or <code>RLM</code> to put a &quot;strong&quot; character to fully enclose an ambiguous punctuation character and thus make it inherit the correct directionality is sufficient.</p>
-	<p>Within some cases, there may be mixed scripts of a left-to-right and right-to-left direction, so using <code>LRE</code> &amp; <code>RLE</code> with <code>PDF</code> may be more appropriate. Lastly, in very rare instances where directionality must be forced, then use <code>LRO</code> &amp; <code>RLO</code> with <code>PDF</code>.</p>
-	<p>For further information on authoring techniques of bi-directional text, please see the W3C tutorial on <a href="http://www.w3.org/International/tutorials/bidi-xhtml/">authoring techniques for XHTML pages with bi-directional text</a>.</p>
-
-	<a name="placeholders"></a><h3>6.iii. Working with placeholders</h3>
-
-	<p>As phpBB is translated into languages with different ordering rules to that of English, it is possible to show specific values in any order deemed appropriate. Take for example the extremely simple &quot;Page <em>X</em> of <em>Y</em>&quot;, whilst in English this could just be coded as:</p>
-
-	<div class="codebox"><pre>
+					<div class="codebox"><pre>
 	...
 'PAGE_OF'	=&gt;	'Page %s of %s',
 		/* Just grabbing the replacements as they
 		come and hope they are in the right order */
 	...</pre>
-	</div>
+					</div>
 
-	<p>&hellip; a clearer way to show explicit replacement ordering is to do:</p>
+					<p>&hellip; a clearer way to show explicit replacement ordering is to do:</p>
 
-	<div class="codebox"><pre>
+					<div class="codebox"><pre>
 	...
 'PAGE_OF'	=&gt;	'Page %1$s of %2$s',
 		/* Explicit ordering of the replacements,
 		even if they are the same order as English */
 	...</pre>
-	</div>
+					</div>
 
-	<p>Why bother at all? Because some languages, the string transliterated back to English might read something like:</p>
+					<p>Why bother at all? Because some languages, the string transliterated back to English might read something like:</p>
 
-	<div class="codebox"><pre>
+					<div class="codebox"><pre>
 	...
 'PAGE_OF'	=&gt;	'Total of %2$s pages, currently on page %1$s',
 		/* Explicit ordering of the replacements,
 		reversed compared to English as the total comes first */
 	...</pre>
-	</div>
+					</div>
 
-	<a name="usingplurals"></a><h3>6.iv. Using plurals</h3>
+					<a name="usingplurals"></a>
+					<h3 id="translation.plurals">
+						<a href="#translation.plurals"></a>
+						<span>Using plurals</span>
+						<a href="#wrap" class="top">Back to Top</a>
+					</h3>
 
-	<p>
-		The english language is very simple when it comes to plurals.<br />
-		You have <code>0 elephants</code>, <code>1 elephant</code>, or <code>2+ elephants</code>. So basically you have 2 different forms: one singular and one plural.<br />
-		But for some other languages this is quite more difficult. Let's take the Bosnian language as another example:<br />
-		You have <code>[1/21/31] slon</code>, <code>[2/3/4] slona</code>, <code>[0/5/6] slonova</code> and <code>[7/8/9/11] ...</code> and some more difficult rules.
-	</p>
+					<p>
+						The english language is very simple when it comes to plurals.<br />
+						You have <code>0 elephants</code>, <code>1 elephant</code>, or <code>2+ elephants</code>. So basically you have 2 different forms: one singular and one plural.<br />
+						But for some other languages this is quite more difficult. Let's take the Bosnian language as another example:<br />
+						You have <code>[1/21/31] slon</code>, <code>[2/3/4] slona</code>, <code>[0/5/6] slonova</code> and <code>[7/8/9/11] ...</code> and some more difficult rules.
+					</p>
 
-	<p>The <a href="https://area51.phpbb.com/docs/dev/32x/language/plurals.html">plural system</a> takes care of this and can be used as follows:</p>
+					<p>The <a href="https://area51.phpbb.com/docs/dev/32x/language/plurals.html">plural system</a> takes care of this and can be used as follows:</p>
 
-	<p>The PHP code will basically look like this:</p>
+					<p>The PHP code will basically look like this:</p>
 
-	<div class="codebox"><pre>
+					<div class="codebox"><pre>
 	...
 	$user->lang('NUMBER_OF_ELEPHANTS', $number_of_elephants);
 	...</pre>
-	</div>
+					</div>
 
-	<p>And the English translation would be:</p>
+					<p>And the English translation would be:</p>
 
-	<div class="codebox"><pre>
+					<div class="codebox"><pre>
 	...
 	'NUMBER_OF_ELEPHANTS'	=> array(
 		0	=> 'You have no elephants', // Optional special case for 0
@@ -2407,11 +3271,11 @@ if (utf8_case_fold_nfc($string1) == utf8_case_fold_nfc($string2))
 		2	=> 'You have %d elephants', // Plural
 	),
 	...</pre>
-	</div>
+					</div>
 
-	<p>While the Bosnian translation can have more cases:</p>
+					<p>While the Bosnian translation can have more cases:</p>
 
-	<div class="codebox"><pre>
+					<div class="codebox"><pre>
 	...
 	'NUMBER_OF_ELEPHANTS'	=> array(
 		0	=> 'You have no slonova', // Optional special case for 0
@@ -2420,150 +3284,163 @@ if (utf8_case_fold_nfc($string1) == utf8_case_fold_nfc($string2))
 		3	=> ...
 	),
 	...</pre>
-	</div>
+					</div>
 
-	<p><strong>NOTE:</strong> It is okay to use plurals for an unknown number compared to a single item, when the number is not known and displayed:</p>
-	<div class="codebox"><pre>
+					<p><strong>NOTE:</strong> It is okay to use plurals for an unknown number compared to a single item, when the number is not known and displayed:</p>
+					<div class="codebox"><pre>
 	...
 	'MODERATOR'	=> 'Moderator',  // Your board has 1 moderator
 	'MODERATORS'	=> 'Moderators', // Your board has multiple moderators
 	...</pre>
-	</div>
+					</div>
 
-	<a name="writingstyle"></a><h3>6.v. Writing Style</h3>
+					<a name="writingstyle"></a>
+					<h3 id="translation.writing_style">
+						<a href="#translation.writing_style"></a>
+						<span>Writing style</span>
+						<a href="#wrap" class="top">Back to Top</a>
+					</h3>
 
-	<h4>Miscellaneous tips &amp; hints:</h4>
+					<h4 id="translation.writing_style.misc">
+						<a href="#translation.writing_style.misc"></a>
+						<span>Miscellaneous tips & hints</span>
+					</h4>
+					<p>As the language files are PHP files, where the various strings for phpBB are stored within an array which in turn are used for display within an HTML page, rules of syntax for both must be considered. Potentially problematic characters are: <code>'</code> (straight quote/apostrophe), <code>&quot;</code> (straight double quote), <code>&lt;</code> (less-than sign), <code>&gt;</code> (greater-than sign) and <code>&amp;</code> (ampersand).</p>
 
-	<p>As the language files are PHP files, where the various strings for phpBB are stored within an array which in turn are used for display within an HTML page, rules of syntax for both must be considered. Potentially problematic characters are: <code>'</code> (straight quote/apostrophe), <code>&quot;</code> (straight double quote), <code>&lt;</code> (less-than sign), <code>&gt;</code> (greater-than sign) and <code>&amp;</code> (ampersand).</p>
+					<p class="bad">// Bad - The un-escaped straight-quote/apostrophe will throw a PHP parse error</p>
 
-	<p class="bad">// Bad - The un-escapsed straight-quote/apostrophe will throw a PHP parse error</p>
-
-	<div class="codebox"><pre>
+					<div class="codebox"><pre>
 	...
 'CONV_ERROR_NO_AVATAR_PATH'
 	=&gt;	'Note to developer: you must specify $convertor['avatar_path'] to use %s.',
 	...</pre>
-	</div>
+					</div>
 
-	<p class="good">// Good - Literal straight quotes should be escaped with a backslash, ie: \</p>
+					<p class="good">// Good - Literal straight quotes should be escaped with a backslash, ie: \</p>
 
-	<div class="codebox"><pre>
+					<div class="codebox"><pre>
 	...
 'CONV_ERROR_NO_AVATAR_PATH'
 	=&gt;	'Note to developer: you must specify $convertor[\'avatar_path\'] to use %s.',
 	...</pre>
-	</div>
+					</div>
 
-	<p>However, because phpBB3 now uses UTF-8 as its sole encoding, we can actually use this to our advantage and not have to remember to escape a straight quote when we don't have to:</p>
+					<p>However, because phpBB3 now uses UTF-8 as its sole encoding, we can actually use this to our advantage and not have to remember to escape a straight quote when we don't have to:</p>
 
-	<p class="bad">// Bad - The un-escapsed straight-quote/apostrophe will throw a PHP parse error</p>
+					<p class="bad">// Bad - The un-escaped straight-quote/apostrophe will throw a PHP parse error</p>
 
-	<div class="codebox"><pre>
+					<div class="codebox"><pre>
 	...
 'USE_PERMISSIONS'	=&gt;	'Test out user's permissions',
 	...</pre>
-	</div>
+					</div>
 
-	<p class="good">// Okay - However, non-programmers wouldn't type "user\'s" automatically</p>
+					<p class="good">// Okay - However, non-programmers wouldn't type "user\'s" automatically</p>
 
-	<div class="codebox"><pre>
+					<div class="codebox"><pre>
 	...
 'USE_PERMISSIONS'	=&gt;	'Test out user\'s permissions',
 	...</pre>
-	</div>
+					</div>
 
-	<p class="good">// Best - Use the Unicode Right-Single-Quotation-Mark character</p>
+					<p class="good">// Best - Use the Unicode Right-Single-Quotation-Mark character</p>
 
-	<div class="codebox"><pre>
+					<div class="codebox"><pre>
 	...
 'USE_PERMISSIONS'	=&gt;	'Test out user&rsquo;s permissions',
 	...</pre>
-	</div>
+					</div>
 
-	<p>The <code>&quot;</code> (straight double quote), <code>&lt;</code> (less-than sign) and <code>&gt;</code> (greater-than sign) characters can all be used as displayed glyphs or as part of HTML markup, for example:</p>
+					<p>The <code>&quot;</code> (straight double quote), <code>&lt;</code> (less-than sign) and <code>&gt;</code> (greater-than sign) characters can all be used as displayed glyphs or as part of HTML markup, for example:</p>
 
-	<p class="bad">// Bad - Invalid HTML, as segments not part of elements are not entitised</p>
+					<p class="bad">// Bad - Invalid HTML, as segments not part of elements are not entitised</p>
 
-	<div class="codebox"><pre>
+					<div class="codebox"><pre>
 	...
 'FOO_BAR'	=&gt;	'PHP version &lt; 5.3.3.&lt;br /&gt;
 	Visit &quot;Downloads&quot; at &lt;a href=&quot;http://www.php.net/&quot;&gt;www.php.net&lt;/a&gt;.',
 	...</pre>
-	</div>
+					</div>
 
-	<p class="good">// Okay - No more invalid HTML, but &quot;&amp;quot;&quot; is rather clumsy</p>
+					<p class="good">// Okay - No more invalid HTML, but &quot;&amp;quot;&quot; is rather clumsy</p>
 
-	<div class="codebox"><pre>
+					<div class="codebox"><pre>
 	...
 'FOO_BAR'	=&gt;	'PHP version &amp;lt; 5.3.3.&lt;br /&gt;
 	Visit &amp;quot;Downloads&amp;quot; at &lt;a href=&quot;http://www.php.net/&quot;&gt;www.php.net&lt;/a&gt;.',
 	...</pre>
-	</div>
+					</div>
 
-	<p class="good">// Best - No more invalid HTML, and usage of correct typographical quotation marks</p>
+					<p class="good">// Best - No more invalid HTML, and usage of correct typographical quotation marks</p>
 
-	<div class="codebox"><pre>
+					<div class="codebox"><pre>
 	...
 'FOO_BAR'	=&gt;	'PHP version &amp;lt; 5.3.3.&lt;br /&gt;
 	Visit &ldquo;Downloads&rdquo; at &lt;a href=&quot;http://www.php.net/&quot;&gt;www.php.net&lt;/a&gt;.',
 	...</pre>
-	</div>
+					</div>
 
-	<p>Lastly, the <code>&amp;</code> (ampersand) must always be entitised regardless of where it is used:</p>
+					<p>Lastly, the <code>&amp;</code> (ampersand) must always be entitised regardless of where it is used:</p>
 
-	<p class="bad">// Bad - Invalid HTML, none of the ampersands are entitised</p>
+					<p class="bad">// Bad - Invalid HTML, none of the ampersands are entitised</p>
 
-	<div class="codebox"><pre>
+					<div class="codebox"><pre>
 	...
 'FOO_BAR'	=&gt;	'&lt;a href=&quot;http://somedomain.tld/?foo=1&amp;bar=2&quot;&gt;Foo &amp; Bar&lt;/a&gt;.',
 	...</pre>
-	</div>
+					</div>
 
-	<p class="good">// Good - Valid HTML, amperands are correctly entitised in all cases</p>
+					<p class="good">// Good - Valid HTML, ampersands are correctly entitised in all cases</p>
 
-	<div class="codebox"><pre>
+					<div class="codebox"><pre>
 	...
 'FOO_BAR'	=&gt;	'&lt;a href=&quot;http://somedomain.tld/?foo=1&amp;amp;bar=2&quot;&gt;Foo &amp;amp; Bar&lt;/a&gt;.',
 	...</pre>
-	</div>
+					</div>
 
-	<p>As for how these charcters are entered depends very much on choice of Operating System, current language locale/keyboard configuration and native abilities of the text editor used to edit phpBB language files. Please see <a href="http://en.wikipedia.org/wiki/Unicode#Input_methods">http://en.wikipedia.org/wiki/Unicode#Input_methods</a> for more information.</p>
+					<p>As for how these characters are entered depends very much on choice of Operating System, current language locale/keyboard configuration and native abilities of the text editor used to edit phpBB language files. Please see <a href="http://en.wikipedia.org/wiki/Unicode#Input_methods">http://en.wikipedia.org/wiki/Unicode#Input_methods</a> for more information.</p>
 
-	<h4>Spelling, punctuation, grammar, et cetera:</h4>
+					<h4 id="translation.writing_style.grammar">
+						<a href="#translation.writing_style.grammar"></a>
+						<span>Spelling, punctuation, grammar, et cetera</span>
+					</h4>
+					<p>The default language pack bundled with phpBB is <strong>British English</strong> using <a href="http://www.cambridge.org/">Cambridge University Press</a> spelling and is assigned the language code <code>en</code>. The style and tone of writing tends towards formal and translations <strong>should</strong> emulate this style, at least for the variant using the most compact language code. Less formal translations or those with colloquialisms <strong>must</strong> be denoted as such via either an <code>extension</code> or <code>privateuse</code> tag within its language code.</p>
 
-	<p>The default language pack bundled with phpBB is <strong>British English</strong> using <a href="http://www.cambridge.org/">Cambridge University Press</a> spelling and is assigned the language code <code>en</code>. The style and tone of writing tends towards formal and translations <strong>should</strong> emulate this style, at least for the variant using the most compact language code. Less formal translations or those with colloquialisms <strong>must</strong> be denoted as such via either an <code>extension</code> or <code>privateuse</code> tag within its language code.</p>
+				</div>
 
+				<div class="back2top"><a href="#wrap" class="top">Back to Top</a></div>
+
+			</div>
 		</div>
 
-		<div class="back2top"><a href="#wrap" class="top">Back to Top</a></div>
+		<hr>
 
+		<h2 id="disclaimer">
+			<a href="#disclaimer"></a>
+			<span>Copyright and Disclaimer</span>
+		</h2>
+
+		<div class="paragraph">
+			<div class="inner">
+				<div class="content">
+					<p>
+						phpBB is free software, released under the terms of the <a href="http://opensource.org/licenses/gpl-2.0.php">GNU General Public License, version 2 (GPL-2.0)</a>.
+						Copyright © <a href="https://www.phpbb.com">phpBB Limited</a>.
+						For full copyright and license information, please see the docs/CREDITS.txt file.
+					</p>
+				</div>
+
+				<div class="back2top"><a href="#wrap" class="top">Back to Top</a></div>
+			</div>
+		</div>
+
+		<!-- END DOCUMENT -->
+
+		<div id="page-footer">
+			<div class="version">&nbsp;</div>
 		</div>
 	</div>
-
-	<hr />
-
-<a name="disclaimer"></a><h2>7. Copyright and disclaimer</h2>
-
-	<div class="paragraph">
-		<div class="inner">
-
-		<div class="content">
-
-	<p>phpBB is free software, released under the terms of the <a href="http://opensource.org/licenses/gpl-2.0.php">GNU General Public License, version 2 (GPL-2.0)</a>. Copyright © <a href="https://www.phpbb.com">phpBB Limited</a>. For full copyright and license information, please see the docs/CREDITS.txt file.</p>
-
-		</div>
-
-		<div class="back2top"><a href="#wrap" class="top">Back to Top</a></div>
-
-		</div>
-	</div>
-
-<!-- END DOCUMENT -->
-
-	<div id="page-footer">
-		<div class="version">&nbsp;</div>
-	</div>
-</div></div>
+</div>
 
 <div>
 	<a id="bottom" accesskey="z"></a>


### PR DESCRIPTION
PHPBB-16389

Checklist:

- [ ] Correct branch: master for new features; 3.3.x & 3.2.x for fixes
- [ ] Tests pass
- [ ] Code follows coding guidelines: [master](https://area51.phpbb.com/docs/dev/master/development/coding_guidelines.html), [3.3.x](https://area51.phpbb.com/docs/dev/3.3.x/development/coding_guidelines.html) and [3.2.x](https://area51.phpbb.com/docs/dev/3.2.x/development/coding_guidelines.html)
- [ ] Commit follows commit message [format](https://area51.phpbb.com/docs/dev/3.3.x/development/git.html)

Tracker ticket (set the ticket ID to **your ticket ID**):

https://tracker.phpbb.com/browse/PHPBB3-16389

---

The coding guidelines are due for an overhaul.
There are currently (atleast in my eyes) a few issues:
- The guidelines are difficult to read/follow.
- The guidelines sections are difficult to link to.
- The guidelines are severely outdated: 10-15 years old!
- There is no code highlighting at all.
Which _(in my opinion)_ is weird when talking about specific code examples,
and makes the points less obvious and more difficult to see and understand.

---

#### Actual file changes
- Only _really_ changed the coding guidelines (not **Translations**, **Encodings**, etc..)
- Fixed most of the indentation so it is properly outlined.
- Fixed some of the wrapping, so it can actually be maintained.
- Added automatic numbering for all sections and sub-sections.
- Added anchors to each section: `#chapter1.section2.sub_section3`
- Enhanced the section headers to better distinguish the sections.
- Created a two column layout _(which is responsive)_.

---

#### Guidelines changes
- Barely made any chances to the existing guidelines.
- Made the rules more concise, rather than paragraphs of text.
- Added a few guidelines which were already followed but not documented.
  - Think of service naming conventions and their file placements.
  - Or exception naming and file placements.
- Replaced a part of the `SQL` section, 
  - Removed a part which was more a documentation on how the functions worked.
Which there already is proper documentation for, and a new PR that enhances it.
  - Added actual, concise rules. Which were already present but hidden in paragraphs of text.
- Added code highlighting, so code fragments actually make more sense rather than green blurs.

[Preview the complete overhauled guidelines](https://nimbusweb.me/s/image/3926906/rrb6esc7sl6fwb5byooq/a7SSSwlMbbu9OM31/anQn3iwOm0L3NVOA/screenshot-localhost-2020.03.03-22_08_13.png)
Or use this link: https://nimb.ws/uIoRFc

---

#### Suggestions
I am open to suggestions, by all means, let me know what you think.
That being said, I do think we need to start somewhere, as currently the guidelines as they are, are rather unmaintainable and outdated. Even if some rules are up for debate, I think we have to start off somewhere. Atleast with this we have a solid avenue and up-to-date document to work with.

---

#### CDN
Only thing I am not completely sure about, is that currently the code highlighting script and style ([HighlightJS](https://highlightjs.org/), which is also used by the s9e TextFormatter) is included through a CDN. I do not know if that is okay, or if a local copy should be used? And if so, how that should be done correclty?