### PR TITLE
[ticket/15609] MCP Queue and Report forum and topic identifiers

### DIFF
--- a/phpBB/includes/mcp/mcp_queue.php
+++ b/phpBB/includes/mcp/mcp_queue.php
@@ -370,8 +370,9 @@ class mcp_queue
 				$topic_id = $request->variable('t', 0);
 				$forum_info = array();
 
-				/* @var $pagination \phpbb\pagination */
-				$pagination = $phpbb_container->get('pagination');
+				// If 'sort' is set, "Go" was pressed which is located behind the forums <select> box
+				// Then, unset the topic id so it does not override the forum id
+				$topic_id = $request->is_set_post('sort') ? 0 : $topic_id;
 
 				if ($topic_id)
 				{
@@ -650,6 +651,9 @@ class mcp_queue
 					$template->assign_block_vars('postrow', $post_row);
 				}
 				unset($rowset, $forum_names);
+
+				/* @var \phpbb\pagination $pagination */
+				$pagination = $phpbb_container->get('pagination');
 
 				$base_url = $this->u_action . "&amp;f=$forum_id&amp;st=$sort_days&amp;sk=$sort_key&amp;sd=$sort_dir";
 				$pagination->generate_template_pagination($base_url, 'pagination', 'start', $total, $config['topics_per_page'], $start);

--- a/phpBB/includes/mcp/mcp_reports.php
+++ b/phpBB/includes/mcp/mcp_reports.php
@@ -337,6 +337,11 @@ class mcp_reports
 			case 'reports_closed':
 				$topic_id = $request->variable('t', 0);
 
+				if ($request->is_set_post('t'))
+				{
+					$topic_id = $request->variable('t', 0, false, \phpbb\request\request_interface::POST);
+				}
+
 				$forum_info = array();
 				$forum_list_reports = get_forum_list('m_report', false, true);
 				$forum_list_read = array_flip(get_forum_list('f_read', true, true)); // Flipped so we can isset() the forum IDs
@@ -412,7 +417,7 @@ class mcp_reports
 				$forum_options = '<option value="0"' . (($forum_id == 0) ? ' selected="selected"' : '') . '>' . $user->lang['ALL_FORUMS'] . '</option>';
 				foreach ($forum_list_reports as $row)
 				{
-					$forum_options .= '<option value="' . $row['forum_id'] . '"' . (($forum_id == $row['forum_id']) ? ' selected="selected"' : '') . '>' . str_repeat('&nbsp; &nbsp;', $row['padding']) . $row['forum_name'] . '</option>';
+					$forum_options .= '<option value="' . $row['forum_id'] . '"' . (($forum_id == $row['forum_id']) ? ' selected="selected"' : '') . '>' . str_repeat('&nbsp; &nbsp;', $row['padding']) . truncate_string($row['forum_name'], 30, 255, false, $user->lang('ELLIPSIS')) . '</option>';
 					$forum_data[$row['forum_id']] = $row;
 				}
 				unset($forum_list_reports);

--- a/phpBB/styles/prosilver/template/mcp_reports.html
+++ b/phpBB/styles/prosilver/template/mcp_reports.html
@@ -81,7 +81,13 @@
 
 		<div class="action-bar bottom">
 			<!-- INCLUDE display_options.html -->
-			<!-- IF TOPIC_ID --><label><input type="checkbox" class="radio" name="t" value="{TOPIC_ID}" checked="checked" onClick="document.getElementById('mcp').submit()" /> <strong>{L_ONLY_TOPIC}</strong></label><!-- ENDIF -->
+			<!-- IF TOPIC_ID -->
+				<label>
+					<input type="hidden" name="t" value="0">
+					<input type="checkbox" class="radio" name="t" value="{TOPIC_ID}" checked="checked" onClick="document.getElementById('mcp').submit()" />
+					<strong>{L_ONLY_TOPIC}</strong>
+				</label>
+			<!-- ENDIF -->
 
 			<div class="pagination">
 				{TOTAL_REPORTS}


### PR DESCRIPTION
PHPBB3-15609

Checklist:

- [x] Correct branch: master for new features; 3.3.x & 3.2.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master](https://area51.phpbb.com/docs/dev/master/development/coding_guidelines.html), [3.3.x](https://area51.phpbb.com/docs/dev/3.3.x/development/coding_guidelines.html) and [3.2.x](https://area51.phpbb.com/docs/dev/3.2.x/development/coding_guidelines.html)
- [x] Commit follows commit message [format](https://area51.phpbb.com/docs/dev/3.3.x/development/git.html)

Tracker ticket (set the ticket ID to **your ticket ID**):

https://tracker.phpbb.com/browse/PHPBB3-15609

---

- This truncates the forum names in the select dropdown in MCP reports (like in MCP queue)
- This allows actually unchecking the "Only this topic" in MCP reports
  - added a default input value, which is overriden by the checkbox
  - added a check if `t` was set in `POST`, so it can override the `GET` `t` parameter
- This makes the forum select box in MCP queue work properly
  - If "Go" was pressed (and thus `sort` is set in `POST`), then the topic id should not determine the forum id
