### PR TITLE
[ticket/16391] Add extensions info_acp_ lang file to MCP logs

### DIFF
--- a/phpBB/includes/mcp/mcp_logs.php
+++ b/phpBB/includes/mcp/mcp_logs.php
@@ -39,6 +39,7 @@ class mcp_logs
 		global $config, $phpbb_container, $phpbb_log;
 
 		$user->add_lang('acp/common');
+		$this->p_master->add_mod_info('acp');
 
 		$action = $request->variable('action', array('' => ''));
 


### PR DESCRIPTION
PHPBB3-16391

Checklist:

- [x] Correct branch: master for new features; 3.3.x & 3.2.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master](https://area51.phpbb.com/docs/dev/master/development/coding_guidelines.html), [3.3.x](https://area51.phpbb.com/docs/dev/3.3.x/development/coding_guidelines.html) and [3.2.x](https://area51.phpbb.com/docs/dev/3.2.x/development/coding_guidelines.html)
- [x] Commit follows commit message [format](https://area51.phpbb.com/docs/dev/3.3.x/development/git.html)

Tracker ticket (set the ticket ID to **your ticket ID**):

https://tracker.phpbb.com/browse/PHPBB3-16391

---

The ticket suggested including the `info_mcp_` into the ACP.
However, the core includes the `acp/common` into the MCP.
So I opted to stick with that approach, where `$p_master` is also already available.
