### PR TITLE
[ticket/16398] Disable AJAX for extension actions

### DIFF
--- a/phpBB/adm/style/acp_ext_actions.html
+++ b/phpBB/adm/style/acp_ext_actions.html
@@ -1,7 +1,7 @@
 {% for action in enabled.actions %}
-	<a href="{{ action.U_ACTION }}"{% if action.L_ACTION_EXPLAIN %} title="{{ action.L_ACTION_EXPLAIN }}"{% endif %}{% if action.COLOR %} style="color: {{ action.COLOR }};"{% endif %} data-ajax="{{ action.ACTION_AJAX }}" data-refresh="true">{{ action.L_ACTION }}</a>{% if not action.S_LAST_ROW %}&nbsp;|&nbsp;{% endif %}
+	<a href="{{ action.U_ACTION }}"{% if action.L_ACTION_EXPLAIN %} title="{{ action.L_ACTION_EXPLAIN }}"{% endif %}{% if action.COLOR %} style="color: {{ action.COLOR }};"{% endif %}{% if not S_AJAX_DISABLED %} data-ajax="{{ action.ACTION_AJAX }}" data-refresh="true"{% endif %}>{{ action.L_ACTION }}</a>{% if not action.S_LAST_ROW %}&nbsp;|&nbsp;{% endif %}
 {% endfor %}
 
 {% for action in disabled.actions %}
-	<a href="{{ action.U_ACTION }}"{% if action.L_ACTION_EXPLAIN %} title="{{ action.L_ACTION_EXPLAIN }}"{% endif %}{% if action.COLOR %} style="color: {{ action.COLOR }};"{% endif %} data-ajax="{{ action.ACTION_AJAX }}" data-refresh="true">{{ action.L_ACTION }}</a>{% if not action.S_LAST_ROW %}&nbsp;|&nbsp;{% endif %}
+	<a href="{{ action.U_ACTION }}"{% if action.L_ACTION_EXPLAIN %} title="{{ action.L_ACTION_EXPLAIN }}"{% endif %}{% if action.COLOR %} style="color: {{ action.COLOR }};"{% endif %}{% if not S_AJAX_DISABLED %} data-ajax="{{ action.ACTION_AJAX }}" data-refresh="true"{% endif %}>{{ action.L_ACTION }}</a>{% if not action.S_LAST_ROW %}&nbsp;|&nbsp;{% endif %}
 {% endfor %}

--- a/phpBB/adm/style/acp_ext_list.html
+++ b/phpBB/adm/style/acp_ext_list.html
@@ -7,7 +7,17 @@
 	<p>{L_EXTENSIONS_EXPLAIN}</p>
 
 	<fieldset class="quick">
-		<span class="small"><a href="https://www.phpbb.com/go/customise/extensions/3.3" target="_blank">{L_BROWSE_EXTENSIONS_DATABASE}</a> &bull; <a href="{U_VERSIONCHECK_FORCE}">{L_VERSIONCHECK_FORCE_UPDATE_ALL}</a> &bull; <a href="javascript:phpbb.toggleDisplay('version_check_settings');">{L_SETTINGS}</a></span>
+		<span class="small">
+			{% if not S_AJAX_DISABLED %}
+				<a href="{{ U_AJAX_DISABLE }}" class="uses-js">{{ lang('DISABLE_AJAX_ACTIONS') }}</a>
+				&bull;
+			{% endif %}
+			<a href="https://www.phpbb.com/go/customise/extensions/3.3" target="_blank">{L_BROWSE_EXTENSIONS_DATABASE}</a>
+			&bull;
+			<a href="{U_VERSIONCHECK_FORCE}">{L_VERSIONCHECK_FORCE_UPDATE_ALL}</a>
+			&bull;
+			<a href="javascript:phpbb.toggleDisplay('version_check_settings');">{L_SETTINGS}</a>
+		</span>
 	</fieldset>
 
 	<form id="version_check_settings" method="post" action="{U_ACTION}" style="display:none">

--- a/phpBB/adm/style/admin.css
+++ b/phpBB/adm/style/admin.css
@@ -129,6 +129,10 @@ hr {
 	display: none;
 }
 
+.nojs .uses-js {
+	display: none;
+}
+
 @media only screen and (max-width: 800px), only screen and (max-device-width: 800px)
 {
 	body {

--- a/phpBB/includes/acp/acp_extensions.php
+++ b/phpBB/includes/acp/acp_extensions.php
@@ -152,6 +152,8 @@ class acp_extensions
 				$this->list_available_exts();
 
 				$this->template->assign_vars(array(
+					'S_AJAX_DISABLED'		=> $this->request->variable('ajax', '', true) === 'off',
+					'U_AJAX_DISABLE'		=> $this->u_action . '&amp;action=list&amp;ajax=off',
 					'U_VERSIONCHECK_FORCE' 	=> $this->u_action . '&amp;action=list&amp;versioncheck_force=1',
 					'FORCE_UNSTABLE'		=> $this->config['extension_force_unstable'],
 					'U_ACTION' 				=> $this->u_action,

--- a/phpBB/language/en/acp/extensions.php
+++ b/phpBB/language/en/acp/extensions.php
@@ -116,6 +116,7 @@ $lang = array_merge($lang, array(
 	'AUTHOR_HOMEPAGE'		=> 'Homepage',
 	'AUTHOR_ROLE'			=> 'Role',
 
+	'DISABLE_AJAX_ACTIONS'	=> 'Disable AJAX actions',
 	'NOT_UP_TO_DATE'		=> '%s is not up to date',
 	'UP_TO_DATE'			=> '%s is up to date',
 	'ANNOUNCEMENT_TOPIC'	=> 'Release Announcement',


### PR DESCRIPTION
PHPBB3-16398

Checklist:

- [ ] Correct branch: master for new features; 3.3.x & 3.2.x for fixes
- [ ] Tests pass
- [ ] Code follows coding guidelines: [master](https://area51.phpbb.com/docs/dev/master/development/coding_guidelines.html), [3.3.x](https://area51.phpbb.com/docs/dev/3.3.x/development/coding_guidelines.html) and [3.2.x](https://area51.phpbb.com/docs/dev/3.2.x/development/coding_guidelines.html)
- [ ] Commit follows commit message [format](https://area51.phpbb.com/docs/dev/3.3.x/development/git.html)

Tracker ticket (set the ticket ID to **your ticket ID**):

https://tracker.phpbb.com/browse/PHPBB3-16398

---

This adds a 'disable AJAX actions' in the upper right corner when viewing the extensions list.
This will add a `&ajax=off` GET parameter to the module.
If it's set to `off`, the `data-ajax=""` attributes are not added on that page load, and the actions are 'regular' requests. 
This will affect one action, AJAX is automatically turned back on the next page load when viewing extensions. It is not persistent. 
