### PR TITLE
Minor fix: Array [] syntax standardization

### DIFF
--- a/phpBB/language/en/acp/styles.php
+++ b/phpBB/language/en/acp/styles.php
@@ -21,7 +21,7 @@ if (!defined('IN_PHPBB'))
 
 if (empty($lang) || !is_array($lang))
 {
-	$lang = [];
+	$lang = array();
 }
 
 // DEVELOPERS PLEASE NOTE
@@ -36,7 +36,7 @@ if (empty($lang) || !is_array($lang))
 // equally where a string contains only two placeholders which are used to wrap text
 // in a url you again do not need to specify an order e.g., 'Click %sHERE%s' is fine
 
-$lang = array_merge($lang, [
+$lang = array_merge($lang, array(
 	'ACP_STYLES_EXPLAIN'						=> 'Here you can manage the styles available on your board.<br>Please note you cannot uninstall the “<strong>prosilver</strong>” style as it is phpBB’s default and primary parent style.',
 
 	'CANNOT_BE_INSTALLED'						=> 'Cannot be installed',
@@ -88,4 +88,4 @@ $lang = array_merge($lang, [
 	'UNINSTALL_DEFAULT'							=> 'You cannot uninstall the default style.',
 
 	'BROWSE_STYLES_DATABASE'					=> 'Browse styles database',
-]);
+));


### PR DESCRIPTION
Change array syntax from [] TO array() etc. as in other lang files.
As in https://area51.phpbb.com/docs/dev/master/language/usage.html#using-the-language-system-in-php

Checklist:

- [x] Correct branch: master for new features; 3.3.x & 3.2.x for fixes
- [ ] Tests pass
- [x] Code follows coding guidelines: [master](https://area51.phpbb.com/docs/dev/master/development/coding_guidelines.html), [3.3.x](https://area51.phpbb.com/docs/dev/3.3.x/development/coding_guidelines.html) and [3.2.x](https://area51.phpbb.com/docs/dev/3.2.x/development/coding_guidelines.html)
- [x] Commit follows commit message [format](https://area51.phpbb.com/docs/dev/3.3.x/development/git.html)

Tracker ticket (set the ticket ID to **your ticket ID**): **PHPBB3-16410**

https://tracker.phpbb.com/browse/PHPBB3-16410
