### PR TITLE
[ticket/16435] Restore calling page_footer() events in controllers

### DIFF
--- a/phpBB/develop/create_variable_overview.php
+++ b/phpBB/develop/create_variable_overview.php
@@ -464,7 +464,7 @@ $old_char = '';
 foreach ($lang_references as $lang_var => $filenames)
 {
 	$var = preg_replace('#^L_(.*?)#', '\1', $lang_var);
-	$char = $var{0};
+	$char = $var[0];
 	if ($old_char != $char)
 	{
 		$old_char = $char;
@@ -480,7 +480,7 @@ foreach ($lang_references as $lang_var => $filenames)
 	echo '.';
 	flush();
 	$var = preg_replace('#^L_(.*?)#', '\1', $lang_var);
-	$char = $var{0};
+	$char = $var[0];
 	if ($old_char != $char)
 	{
 		$old_char = $char;

--- a/tests/test_framework/phpbb_session_test_case.php
+++ b/tests/test_framework/phpbb_session_test_case.php
@@ -65,7 +65,7 @@ abstract class phpbb_session_test_case extends phpbb_database_test_case
 			FROM ' . SESSIONS_TABLE . '
 			WHERE session_time < ' . ($time_now - (int) $config['session_length']) . '
 				AND session_user_id <> ' . ANONYMOUS . '
-			GROUP BY session_user_id';
+			GROUP BY session_user_id ORDER BY session_user_id ASC';
 
 		$this->assertSqlResultEquals($expected_sessions, $sql, $message);
 	}


### PR DESCRIPTION
A variant of restoring BC broken in #5831.

Checklist:

- [x] Correct branch: master for new features; 3.3.x & 3.2.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master](https://area51.phpbb.com/docs/dev/master/development/coding_guidelines.html), [3.3.x](https://area51.phpbb.com/docs/dev/3.3.x/development/coding_guidelines.html) and [3.2.x](https://area51.phpbb.com/docs/dev/3.2.x/development/coding_guidelines.html)
- [x] Commit follows commit message [format](https://area51.phpbb.com/docs/dev/3.3.x/development/git.html)

Tracker ticket (set the ticket ID to **your ticket ID**):

<a href="https://tracker.phpbb.com/browse/PHPBB3-16435">PHPBB3-16435</a>.
