### PR TITLE
[ticket/16476] Eliminate links to deleted background images in tweaks.css

### DIFF
--- a/phpBB/styles/prosilver/theme/tweaks.css
+++ b/phpBB/styles/prosilver/theme/tweaks.css
@@ -28,14 +28,6 @@ dd label input { vertical-align: text-bottom\9; }
 	border-radius: 0;
 }
 
-.headerbar, .forumbg {
-	background-image: url("./images/bg_header.gif");
-}
-
-.forabg {
-	background-image: url("./images/bg_list.gif");
-}
-
 .tabs .tab > a {
 	border-radius: 0;
 }


### PR DESCRIPTION
**For 3.3.x only**.

Images were deleted with #5769.

Checklist:

- [x] Correct branch: master for new features; 3.3.x & 3.2.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master](https://area51.phpbb.com/docs/dev/master/development/coding_guidelines.html), [3.3.x](https://area51.phpbb.com/docs/dev/3.3.x/development/coding_guidelines.html) and [3.2.x](https://area51.phpbb.com/docs/dev/3.2.x/development/coding_guidelines.html)
- [x] Commit follows commit message [format](https://area51.phpbb.com/docs/dev/3.3.x/development/git.html)


<a href="https://tracker.phpbb.com/browse/PHPBB3-16476">PHPBB3-16476</a>.
