### PR TITLE
[ticket/16474] Hide vertical scrollbar for attachbox

### DIFF
--- a/phpBB/styles/prosilver/theme/content.css
+++ b/phpBB/styles/prosilver/theme/content.css
@@ -553,6 +553,7 @@ blockquote .codebox {
 	clear: left;
 	border-top: 1px solid transparent;
 	overflow-x: auto;
+	overflow-y: hidden;
 }
 
 .attachbox dd dd {


### PR DESCRIPTION
Checklist:

- [x] Correct branch: master for new features; 3.3.x & 3.2.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master](https://area51.phpbb.com/docs/dev/master/development/coding_guidelines.html), [3.3.x](https://area51.phpbb.com/docs/dev/3.3.x/development/coding_guidelines.html) and [3.2.x](https://area51.phpbb.com/docs/dev/3.2.x/development/coding_guidelines.html)
- [x] Commit follows commit message [format](https://area51.phpbb.com/docs/dev/3.3.x/development/git.html)

<a href="https://tracker.phpbb.com/browse/PHPBB3-16474">PHPBB3-16474</a>.

<table>
<tr>
<td>Before</td><td>After</td>
</tr>
<tr>
<td>
<img src="https://user-images.githubusercontent.com/212322/81692124-1bbc2680-9488-11ea-94fb-b96ed4fba105.png" />
</td>
<td>
<img src="https://user-images.githubusercontent.com/212322/81692071-0ba44700-9488-11ea-9888-fd959ce23152.png"
</td>
</tr>
</table>