### PR TITLE
[ticket/16606] add message author events to ucp_pm_viewmessage

### DIFF
--- a/phpBB/styles/prosilver/template/ucp_pm_viewmessage.html
+++ b/phpBB/styles/prosilver/template/ucp_pm_viewmessage.html
@@ -32,7 +32,9 @@
 				<!-- IF AUTHOR_AVATAR --><a href="{U_MESSAGE_AUTHOR}" class="avatar">{AUTHOR_AVATAR}</a><!-- ENDIF -->
 				<!-- EVENT ucp_pm_viewmessage_avatar_after -->
 			</div>
-			<!-- EVENT ucp_pm_viewmessage_post_author_before -->{MESSAGE_AUTHOR_FULL}<!-- EVENT ucp_pm_viewmessage_author_after -->
+			<!-- EVENT ucp_pm_viewmessage_post_author_before -->
+			{MESSAGE_AUTHOR_FULL}
+			<!-- EVENT ucp_pm_viewmessage_author_after -->
 		</dt>
 
 		<!-- EVENT ucp_pm_viewmessage_rank_before -->

--- a/phpBB/styles/prosilver/template/ucp_pm_viewmessage.html
+++ b/phpBB/styles/prosilver/template/ucp_pm_viewmessage.html
@@ -32,7 +32,7 @@
 				<!-- IF AUTHOR_AVATAR --><a href="{U_MESSAGE_AUTHOR}" class="avatar">{AUTHOR_AVATAR}</a><!-- ENDIF -->
 				<!-- EVENT ucp_pm_viewmessage_avatar_after -->
 			</div>
-			{MESSAGE_AUTHOR_FULL}
+			<!-- EVENT ucp_pm_viewmessage_post_author_before -->{MESSAGE_AUTHOR_FULL}<!-- EVENT ucp_pm_viewmessage_author_after -->
 		</dt>
 
 		<!-- EVENT ucp_pm_viewmessage_rank_before -->


### PR DESCRIPTION
I would like to request 2 new events in the ucp_pm_viewmessage.html template file.

The view topic and view member profile pages have an event before and after the posters username so it would make sense to have events like this also displayed on the view pm page.

PHPBB3-16606

Checklist:

- [ ] Correct branch: master for new features; 3.3.x & 3.2.x for fixes
- [ ] Tests pass
- [ ] Code follows coding guidelines: [master](https://area51.phpbb.com/docs/dev/master/development/coding_guidelines.html), [3.3.x](https://area51.phpbb.com/docs/dev/3.3.x/development/coding_guidelines.html) and [3.2.x](https://area51.phpbb.com/docs/dev/3.2.x/development/coding_guidelines.html)
- [ ] Commit follows commit message [format](https://area51.phpbb.com/docs/dev/3.3.x/development/git.html)

Tracker ticket (set the ticket ID to **your ticket ID**):

https://tracker.phpbb.com/browse/PHPBB3-16606
