### PR TITLE
[ticket/16605] Fix possible SQL error on user registration

### DIFF
--- a/phpBB/includes/ucp/ucp_register.php
+++ b/phpBB/includes/ucp/ucp_register.php
@@ -424,7 +424,7 @@ class ucp_register
 				$user_id = user_add($user_row, $cp_data);
 
 				// This should not happen, because the required variables are listed above...
-				if ($user_id === false)
+				if ((bool) $user_id === false)
 				{
 					trigger_error('NO_USER', E_USER_ERROR);
 				}


### PR DESCRIPTION
mysqli_insert_id() returns 0 if there was no previous query on the connection
or if the query did not update an AUTO_INCREMENT value for some reason.
https://www.php.net/manual/en/mysqli.insert-id.php#refsect1-mysqli.insert-id-returnvalues

Checklist:

- [x] Correct branch: master for new features; 3.3.x & 3.2.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master](https://area51.phpbb.com/docs/dev/master/development/coding_guidelines.html), [3.3.x](https://area51.phpbb.com/docs/dev/3.3.x/development/coding_guidelines.html) and [3.2.x](https://area51.phpbb.com/docs/dev/3.2.x/development/coding_guidelines.html)
- [x] Commit follows commit message [format](https://area51.phpbb.com/docs/dev/3.3.x/development/git.html)

<a href="https://tracker.phpbb.com/browse/PHPBB3-16605">PHPBB3-16605</a>.
