### PR TITLE
[ticket/16604] Remove checks for avatar upload path in avatar settings

### DIFF
--- a/phpBB/includes/acp/acp_board.php
+++ b/phpBB/includes/acp/acp_board.php
@@ -510,29 +510,6 @@ class acp_board
 			}
 		}
 
-		if ($mode == 'avatar' && $cfg_array['allow_avatar_upload'])
-		{
-			// If avatar uploading is enabled but the path setting is empty,
-			// config variable validation is bypassed. Catch the case here
-			if (!$cfg_array['avatar_path'])
-			{
-				$error[] = $language->lang('AVATAR_NO_UPLOAD_PATH');
-			}
-			else if (!$submit)
-			{
-				$filesystem = $phpbb_container->get('filesystem');
-				$avatar_path_exists = $filesystem->exists($phpbb_root_path . $cfg_array['avatar_path']);
-				$avatar_path_writable = $filesystem->is_writable($phpbb_root_path . $cfg_array['avatar_path']);
-
-				// Not existing or writable path will be caught on submit by validate_config_vars().
-				// Display the warning if the directory was changed on the server afterwards
-				if (!$avatar_path_exists || !$avatar_path_writable)
-				{
-					$error[] = $language->lang('AVATAR_NO_UPLOAD_DIR');
-				}
-			}
-		}
-
 		// We validate the complete config if wished
 		validate_config_vars($display_vars['vars'], $cfg_array, $error);
 

--- a/tests/functional/acp_avatar_settings_test.php
+++ b/tests/functional/acp_avatar_settings_test.php
@@ -41,43 +41,5 @@ class phpbb_functional_acp_avatar_settings_test extends phpbb_functional_test_ca
 		]);
 		$crawler = self::submit($form);
 		$this->assertContainsLang('CONFIG_UPDATED', $crawler->filter('div[class="successbox"] > p')->text());
-
-		$crawler = self::request('GET', 'adm/index.php?i=acp_board&mode=avatar&sid=' . $this->sid);
-
-		// Test empty avatar storage path while avatar uploading is enabled - invalid
-		$form = $crawler->selectButton($this->lang('SUBMIT'))->form([
-			'config[avatar_path]' => ''
-		]);
-		$crawler = self::submit($form);
-		$this->assertContainsLang('WARNING', $crawler->filter('div[class="errorbox"] > h3')->text());
-		$this->assertContainsLang('AVATAR_NO_UPLOAD_PATH', $crawler->filter('div[class="errorbox"] > p')->text());
-
-		// Test avatar upload path became not writable on the server afterwards
-		// Unix tests only
-		if (!defined('PHP_WINDOWS_VERSION_MAJOR'))
-		{
-			$crawler = self::request('GET', 'adm/index.php?i=acp_board&mode=avatar&sid=' . $this->sid);
-			$form = $crawler->selectButton($this->lang('SUBMIT'))->form();
-			$values = $form->getValues();
-			$avatar_upload_path = $values['config[avatar_path]'];
-			$filesystem = new \phpbb\filesystem\filesystem;
-			// Make the directory not writable
-			global $phpbb_root_path;
-			$filesystem->chmod($phpbb_root_path . $avatar_upload_path, 444);
-			$this->assertFalse($filesystem->is_writable($phpbb_root_path . $avatar_upload_path));
-
-			// Visit Avatar ACP settings again - warning should be displayed
-			$crawler = self::request('GET', 'adm/index.php?i=acp_board&mode=avatar&sid=' . $this->sid);
-			$this->assertContainsLang('WARNING', $crawler->filter('div[class="errorbox"] > h3')->text());
-			$this->assertContainsLang('AVATAR_NO_UPLOAD_DIR', $crawler->filter('div[class="errorbox"] > p')->text());
-			
-			// Restore default state
-			$filesystem->chmod($phpbb_root_path . $avatar_upload_path, 777);
-			$this->assertTrue($filesystem->is_writable($phpbb_root_path . $avatar_upload_path));
-
-			$crawler = self::request('GET', 'adm/index.php?i=acp_board&mode=avatar&sid=' . $this->sid);
-			$this->assertNotContainsLang('AVATAR_NO_UPLOAD_DIR', $this->get_content());
-			$this->assertNotContainsLang('AVATAR_NO_UPLOAD_PATH', $this->get_content());
-		}
 	}
 }


### PR DESCRIPTION
This is unfortunately no longer possible to do on master. See also #6049 

PHPBB3-16604

Checklist:

- [x] Correct branch: master for new features; 3.3.x & 3.2.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master](https://area51.phpbb.com/docs/dev/master/development/coding_guidelines.html), [3.3.x](https://area51.phpbb.com/docs/dev/3.3.x/development/coding_guidelines.html) and [3.2.x](https://area51.phpbb.com/docs/dev/3.2.x/development/coding_guidelines.html)
- [x] Commit follows commit message [format](https://area51.phpbb.com/docs/dev/3.3.x/development/git.html)

Tracker ticket (set the ticket ID to **your ticket ID**):

https://tracker.phpbb.com/browse/PHPBB3-16604
