### PR TITLE
[ticket/16617] Trigger two events (posting.php, ucp_pm_compose.php) to allow overwrite status variables 

### DIFF
--- a/phpBB/includes/ucp/ucp_pm_compose.php
+++ b/phpBB/includes/ucp/ucp_pm_compose.php
@@ -687,6 +687,26 @@ function compose_pm($id, $mode, $action, $user_folders = array())
 	$flash_status	= ($config['auth_flash_pm'] && $auth->acl_get('u_pm_flash')) ? true : false;
 	$url_status		= ($config['allow_post_links']) ? true : false;
 
+	/**
+	 * Adds an opportunity to rewrite in private messages content statuses with extensions
+	 *
+	 * @event core.pm_content_statuses_settings
+	 *
+	 * @var bool bbcode_status
+	 * @var bool smilies_status
+	 * @var bool img_status
+	 * @var bool url_status
+	 * @var bool flash_status
+	 */
+	$vars = [
+		'bbcode_status',
+		'smilies_status',
+		'img_status',
+		'url_status',
+		'flash_status',
+	];
+	extract($phpbb_dispatcher->trigger_event('core.pm_content_statuses_settings', compact($vars)));
+
 	// Save Draft
 	if ($save && $auth->acl_get('u_savedrafts'))
 	{

--- a/phpBB/posting.php
+++ b/phpBB/posting.php
@@ -729,6 +729,28 @@ $url_status		= ($config['allow_post_links']) ? true : false;
 $flash_status	= ($bbcode_status && $auth->acl_get('f_flash', $forum_id) && $config['allow_post_flash']) ? true : false;
 $quote_status	= true;
 
+/**
+ * Adds an opportunity to rewrite in posting content statuses with extensions
+ *
+ * @event core.posting_content_statuses_settings
+ *
+ * @var bool bbcode_status
+ * @var bool smilies_status
+ * @var bool img_status
+ * @var bool url_status
+ * @var bool flash_status
+ * @var bool quote_status
+ */
+$vars = [
+	'bbcode_status',
+	'smilies_status',
+	'img_status',
+	'url_status',
+	'flash_status',
+	'quote_status',
+];
+extract($phpbb_dispatcher->trigger_event('core.posting_content_statuses_settings', compact($vars)));
+
 // Save Draft
 if ($save && $user->data['is_registered'] && $auth->acl_get('u_savedrafts') && ($mode == 'reply' || $mode == 'post' || $mode == 'quote'))
 {


### PR DESCRIPTION
Checklist:

- [x] Correct branch: master for new features; 3.3.x & 3.2.x for fixes
- [ ] Tests pass
- [x] Code follows coding guidelines: [master](https://area51.phpbb.com/docs/dev/master/development/coding_guidelines.html), [3.3.x](https://area51.phpbb.com/docs/dev/3.3.x/development/coding_guidelines.html) and [3.2.x](https://area51.phpbb.com/docs/dev/3.2.x/development/coding_guidelines.html)
- [x] Commit follows commit message [format](https://area51.phpbb.com/docs/dev/3.3.x/development/git.html)

Tracker ticket PHPBB3-16617

https://tracker.phpbb.com/browse/PHPBB3-16617

This events allow user to overwrite content statuses:
`$bbcode_status, $smilies_status, $img_status, $url_status, $flash_status, $quote_status`
