### PR TITLE
[ticket/16630] Restore clean_formatting()'s behaviour

### DIFF
--- a/phpBB/includes/functions_content.php
+++ b/phpBB/includes/functions_content.php
@@ -532,7 +532,7 @@ function strip_bbcode(&$text, $uid = '')
 
 	if (preg_match('#^<[rt][ >]#', $text))
 	{
-		$text = $phpbb_container->get('text_formatter.utils')->clean_formatting($text);
+		$text = utf8_htmlspecialchars($phpbb_container->get('text_formatter.utils')->clean_formatting($text));
 	}
 	else
 	{

--- a/phpBB/phpbb/textformatter/s9e/utils.php
+++ b/phpBB/phpbb/textformatter/s9e/utils.php
@@ -15,6 +15,9 @@ namespace phpbb\textformatter\s9e;
 
 /**
 * Text manipulation utilities
+*
+* In this implementation, "plain text" refers to regular text as it would be inputted by a user.
+* "Parsed text" is XML suitable to be reinserted into the database.
 */
 class utils implements \phpbb\textformatter\utils_interface
 {
@@ -31,7 +34,7 @@ class utils implements \phpbb\textformatter\utils_interface
 		// Insert a space before <s> and <e> then remove formatting
 		$xml = preg_replace('#<[es]>#', ' $0', $xml);
 
-		return utf8_htmlspecialchars(\s9e\TextFormatter\Utils::removeFormatting($xml));
+		return \s9e\TextFormatter\Utils::removeFormatting($xml);
 	}
 
 	/**

--- a/phpBB/phpbb/textformatter/utils_interface.php
+++ b/phpBB/phpbb/textformatter/utils_interface.php
@@ -15,6 +15,10 @@ namespace phpbb\textformatter;
 
 /**
 * Used to manipulate a parsed text
+*
+* In this interface, "plain text" refers to regular text as it would be inputted by a user.
+* "Parsed text" refers to whichever form is returned by the implementation after parsing, which
+* should be suitable to be reinserted into the database.
 */
 interface utils_interface
 {
@@ -73,7 +77,7 @@ interface utils_interface
 	 * Return whether or not a parsed text represent an empty text.
 	 *
 	 * @param  string $text Parsed text
-	 * @return bool         Tue if the original text is empty
+	 * @return bool         True if the original text is empty
 	 */
 	public function is_empty($text);
 }

--- a/tests/text_formatter/s9e/utils_test.php
+++ b/tests/text_formatter/s9e/utils_test.php
@@ -61,12 +61,16 @@ class phpbb_textformatter_s9e_utils_test extends phpbb_test_case
 				'Plain text'
 			),
 			array(
+				'<t>Plain &amp; boring</t>',
+				'Plain & boring'
+			),
+			array(
 				"<t>Multi<br/>\nline</t>",
 				"Multi\nline"
 			),
 			array(
-				'<r><B><s>[b]</s>bold<e>[/b]</e></B></r>',
-				' bold '
+				'<r><B><s>[b]</s>bold<e>[/b]</e></B> &amp; <I><s>[i]</s>italic<e>[/i]</e></I></r>',
+				' bold  &  italic '
 			)
 		);
 	}


### PR DESCRIPTION
PHPBB3-16630

Checklist:

- [x] Correct branch: master for new features; 3.3.x & 3.2.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master](https://area51.phpbb.com/docs/dev/master/development/coding_guidelines.html), [3.3.x](https://area51.phpbb.com/docs/dev/3.3.x/development/coding_guidelines.html) and [3.2.x](https://area51.phpbb.com/docs/dev/3.2.x/development/coding_guidelines.html)
- [x] Commit follows commit message [format](https://area51.phpbb.com/docs/dev/3.3.x/development/git.html)

Tracker ticket (set the ticket ID to **your ticket ID**):

https://tracker.phpbb.com/browse/PHPBB3-16630
