### PR TITLE
[ticket/16617] Add events to override message/PM BBCode status indications

### DIFF
--- a/phpBB/includes/ucp/ucp_pm_compose.php
+++ b/phpBB/includes/ucp/ucp_pm_compose.php
@@ -687,6 +687,26 @@ function compose_pm($id, $mode, $action, $user_folders = array())
 	$flash_status	= ($config['auth_flash_pm'] && $auth->acl_get('u_pm_flash')) ? true : false;
 	$url_status		= ($config['allow_post_links']) ? true : false;
 
+	/**
+	 * Adds an opportunity to rewrite in private messages content statuses with extensions
+	 *
+	 * @event core.pm_content_statuses_settings
+	 *
+	 * @var bool bbcode_status
+	 * @var bool smilies_status
+	 * @var bool img_status
+	 * @var bool url_status
+	 * @var bool flash_status
+	 */
+	$vars = [
+		'bbcode_status',
+		'smilies_status',
+		'img_status',
+		'url_status',
+		'flash_status',
+	];
+	extract($phpbb_dispatcher->trigger_event('core.pm_content_statuses_settings', compact($vars)));
+
 	// Save Draft
 	if ($save && $auth->acl_get('u_savedrafts'))
 	{

--- a/phpBB/includes/ucp/ucp_pm_compose.php
+++ b/phpBB/includes/ucp/ucp_pm_compose.php
@@ -690,7 +690,7 @@ function compose_pm($id, $mode, $action, $user_folders = array())
 	/**
 	 * Event to override private message BBCode status indications
 	 *
-	 * @event core.ucp_pm_compose_modify_bbcode_status_indications
+	 * @event core.ucp_pm_compose_modify_bbcode_status
 	 *
 	 * @var bool	bbcode_status	BBCode status
 	 * @var bool	smilies_status	Smilies status
@@ -706,7 +706,7 @@ function compose_pm($id, $mode, $action, $user_folders = array())
 		'flash_status',
 		'url_status',
 	];
-	extract($phpbb_dispatcher->trigger_event('core.ucp_pm_compose_modify_bbcode_status_indications', compact($vars)));
+	extract($phpbb_dispatcher->trigger_event('core.ucp_pm_compose_modify_bbcode_status', compact($vars)));
 
 	// Save Draft
 	if ($save && $auth->acl_get('u_savedrafts'))

--- a/phpBB/includes/ucp/ucp_pm_compose.php
+++ b/phpBB/includes/ucp/ucp_pm_compose.php
@@ -688,24 +688,25 @@ function compose_pm($id, $mode, $action, $user_folders = array())
 	$url_status		= ($config['allow_post_links']) ? true : false;
 
 	/**
-	 * Adds an opportunity to rewrite in private messages content statuses with extensions
+	 * Event to override private message BBCode status indications
 	 *
-	 * @event core.pm_content_statuses_settings
+	 * @event core.ucp_pm_compose_modify_bbcode_status_indications
 	 *
-	 * @var bool bbcode_status
-	 * @var bool smilies_status
-	 * @var bool img_status
-	 * @var bool url_status
-	 * @var bool flash_status
+	 * @var bool	bbcode_status	BBCode status
+	 * @var bool	smilies_status	Smilies status
+	 * @var bool	img_status		Image BBCode status
+	 * @var bool	flash_status	Flash BBCode status
+	 * @var bool	url_status		URL BBCode status
+	 * @since 3.3.3-RC1
 	 */
 	$vars = [
 		'bbcode_status',
 		'smilies_status',
 		'img_status',
-		'url_status',
 		'flash_status',
+		'url_status',
 	];
-	extract($phpbb_dispatcher->trigger_event('core.pm_content_statuses_settings', compact($vars)));
+	extract($phpbb_dispatcher->trigger_event('core.ucp_pm_compose_modify_bbcode_status_indications', compact($vars)));
 
 	// Save Draft
 	if ($save && $auth->acl_get('u_savedrafts'))

--- a/phpBB/posting.php
+++ b/phpBB/posting.php
@@ -729,6 +729,28 @@ $url_status		= ($config['allow_post_links']) ? true : false;
 $flash_status	= ($bbcode_status && $auth->acl_get('f_flash', $forum_id) && $config['allow_post_flash']) ? true : false;
 $quote_status	= true;
 
+/**
+ * Adds an opportunity to rewrite in posting content statuses with extensions
+ *
+ * @event core.posting_content_statuses_settings
+ *
+ * @var bool bbcode_status
+ * @var bool smilies_status
+ * @var bool img_status
+ * @var bool url_status
+ * @var bool flash_status
+ * @var bool quote_status
+ */
+$vars = [
+	'bbcode_status',
+	'smilies_status',
+	'img_status',
+	'url_status',
+	'flash_status',
+	'quote_status',
+];
+extract($phpbb_dispatcher->trigger_event('core.posting_content_statuses_settings', compact($vars)));
+
 // Save Draft
 if ($save && $user->data['is_registered'] && $auth->acl_get('u_savedrafts') && ($mode == 'reply' || $mode == 'post' || $mode == 'quote'))
 {

--- a/phpBB/posting.php
+++ b/phpBB/posting.php
@@ -732,7 +732,7 @@ $quote_status	= true;
 /**
  * Event to override message BBCode status indications
  *
- * @event core.posting_modify_bbcode_status_indications
+ * @event core.posting_modify_bbcode_status
  *
  * @var bool	bbcode_status	BBCode status
  * @var bool	smilies_status	Smilies status
@@ -750,7 +750,7 @@ $vars = [
 	'flash_status',
 	'quote_status',
 ];
-extract($phpbb_dispatcher->trigger_event('core.posting_modify_bbcode_status_indications', compact($vars)));
+extract($phpbb_dispatcher->trigger_event('core.posting_modify_bbcode_status', compact($vars)));
 
 // Save Draft
 if ($save && $user->data['is_registered'] && $auth->acl_get('u_savedrafts') && ($mode == 'reply' || $mode == 'post' || $mode == 'quote'))

--- a/phpBB/posting.php
+++ b/phpBB/posting.php
@@ -730,16 +730,17 @@ $flash_status	= ($bbcode_status && $auth->acl_get('f_flash', $forum_id) && $conf
 $quote_status	= true;
 
 /**
- * Adds an opportunity to rewrite in posting content statuses with extensions
+ * Event to override message BBCode status indications
  *
- * @event core.posting_content_statuses_settings
+ * @event core.posting_modify_bbcode_status_indications
  *
- * @var bool bbcode_status
- * @var bool smilies_status
- * @var bool img_status
- * @var bool url_status
- * @var bool flash_status
- * @var bool quote_status
+ * @var bool	bbcode_status	BBCode status
+ * @var bool	smilies_status	Smilies status
+ * @var bool	img_status		Image BBCode status
+ * @var bool	url_status		URL BBCode status
+ * @var bool	flash_status	Flash BBCode status
+ * @var bool	quote_status	Quote BBCode status
+ * @since 3.3.3-RC1
  */
 $vars = [
 	'bbcode_status',
@@ -749,7 +750,7 @@ $vars = [
 	'flash_status',
 	'quote_status',
 ];
-extract($phpbb_dispatcher->trigger_event('core.posting_content_statuses_settings', compact($vars)));
+extract($phpbb_dispatcher->trigger_event('core.posting_modify_bbcode_status_indications', compact($vars)));
 
 // Save Draft
 if ($save && $user->data['is_registered'] && $auth->acl_get('u_savedrafts') && ($mode == 'reply' || $mode == 'post' || $mode == 'quote'))


### PR DESCRIPTION
Replacement for #6065.

Checklist:

- [x] Correct branch: master for new features; 3.3.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master](https://area51.phpbb.com/docs/dev/master/development/coding_guidelines.html) and [3.3.x](https://area51.phpbb.com/docs/dev/3.3.x/development/coding_guidelines.html)
- [x] Commit follows commit message [format](https://area51.phpbb.com/docs/dev/3.3.x/development/git.html)

<a href="https://tracker.phpbb.com/browse/PHPBB3-16617">PHPBB3-16617</a>.
