### PR TITLE
[ticket/16178] Make container_builder use same cache directory as Container

### DIFF
--- a/phpBB/phpbb/di/container_builder.php
+++ b/phpBB/phpbb/di/container_builder.php
@@ -117,6 +117,11 @@ class container_builder
 	private $build_exception;
 
 	/**
+	 * @var array
+	 */
+	private $env_parameters = [];
+
+	/**
 	 * Constructor
 	 *
 	 * @param string $phpbb_root_path Path to the phpbb includes directory.
@@ -124,8 +129,14 @@ class container_builder
 	 */
 	public function __construct($phpbb_root_path, $php_ext)
 	{
-		$this->phpbb_root_path = $phpbb_root_path;
-		$this->php_ext = $php_ext;
+		$this->phpbb_root_path	= $phpbb_root_path;
+		$this->php_ext			= $php_ext;
+		$this->env_parameters	= $this->get_env_parameters();
+
+		if (isset($this->env_parameters['core.cache_dir']))
+		{
+			$this->with_cache_dir($this->env_parameters['core.cache_dir']);
+		}
 	}
 
 	/**
@@ -581,14 +592,14 @@ class container_builder
 	protected function get_core_parameters()
 	{
 		return array_merge(
-			array(
+			[
 				'core.root_path'     => $this->phpbb_root_path,
 				'core.php_ext'       => $this->php_ext,
 				'core.environment'   => $this->get_environment(),
 				'core.debug'         => defined('DEBUG') ? DEBUG : false,
 				'core.cache_dir'     => $this->get_cache_dir(),
-			),
-			$this->get_env_parameters()
+			],
+			$this->env_parameters
 		);
 	}
 

--- a/tests/di/container_cache_directory_test.php
+++ b/tests/di/container_cache_directory_test.php
@@ -1,0 +1,125 @@
+<?php
+/**
+*
+* This file is part of the phpBB Forum Software package.
+*
+* @copyright (c) phpBB Limited <https://www.phpbb.com>
+* @license GNU General Public License, version 2 (GPL-2.0)
+*
+* For full copyright and license information, please see
+* the docs/CREDITS.txt file.
+*
+*/
+
+namespace
+{
+	class container_cache_directory_test extends \phpbb_test_case //phpbb_di_container_test
+	{
+		protected $config_php;
+
+		/**
+		* @var \phpbb\di\container_builder
+		*/
+		protected $builder;
+		protected $phpbb_root_path;
+		protected $filename;
+
+		public function setUp(): void
+		{
+			$this->phpbb_root_path = dirname(__FILE__) . '/';
+			$this->config_php = new \phpbb\config_php_file($this->phpbb_root_path . 'fixtures/', 'php');
+			$this->builder = new phpbb_mock_phpbb_di_container_builder($this->phpbb_root_path . 'fixtures/', 'php');
+			$this->builder->with_config($this->config_php);
+
+			$this->filename = $this->phpbb_root_path . '../tmp/container.php';
+			if (is_file($this->filename))
+			{
+				unlink($this->filename);
+			}
+
+			parent::setUp();
+		}
+
+		public function test_cache_directory_can_be_overridden()
+		{
+			$new_cache_directory = $this->phpbb_root_path . 'fixtures/overwrite-cache-directory/test/';
+
+			// This is how one overrides the cache directory.
+			// The file cache driver will now write to a new directory.
+			$_SERVER['PHPBB____core__cache_dir'] = $new_cache_directory;
+
+			$container = $this->builder->get_container();
+
+			$this->assertEquals($container->getParameter('core.cache_dir'), $new_cache_directory);
+		}
+
+		/**
+		 * By default autoload_xxx.php and container_xxx.php files
+		 * will also be written to the default cache directory.
+		 * This test demonstrates the default behavior.
+		 */
+		public function test_container_and_autoload_cache()
+		{
+			$default_cache_directory = $this->phpbb_root_path . 'fixtures/cache/test';
+
+			// Make sure our test directory will be empty.
+			if (is_dir($default_cache_directory))
+			{
+				array_map('unlink', glob($default_cache_directory . '/*'));
+			}
+			else
+			{
+				mkdir($default_cache_directory, 0777, true);
+			}
+
+			// Use the normal container_builder
+			$builder = new \phpbb\di\container_builder($this->phpbb_root_path . 'fixtures/', 'php');
+			$builder->with_config($this->config_php);
+
+			$container = $builder->get_container();
+
+			$files_written_to_cache = array_map('basename', glob($default_cache_directory . '/*'));
+
+			$this->assertNotEmpty(preg_grep('/autoload_.+.php/', $files_written_to_cache), 'There should be an autoload file in the cache directory.');
+			$this->assertNotEmpty(preg_grep('/container_.+.php/', $files_written_to_cache), 'There should be an container file in the cache directory.');
+
+			// Cleanup the cache directory to prevent class redeclaration errors.
+			array_map('unlink', glob($default_cache_directory . '/*'));
+		}
+
+		/**
+		 * The desired behavior: When we have a custom cache directory
+		 * the autoload and container cache files are also written to the custom cache directory.
+		 */
+		public function test_autoload_and_container_cache_are_written_to_overriden_cache_directory()
+		{
+			$new_cache_directory = $this->phpbb_root_path . 'fixtures/overwrite-cache-directory/test/';
+
+			$_SERVER['PHPBB____core__cache_dir'] = $new_cache_directory;
+
+			// Make sure our test directory will be empty.
+			if (is_dir($new_cache_directory))
+			{
+				array_map('unlink', glob($new_cache_directory . '/*'));
+			}
+			else
+			{
+				mkdir($new_cache_directory, 0777, true);
+			}
+
+			// Use the normal container_builder
+			$builder = new \phpbb\di\container_builder($this->phpbb_root_path . 'fixtures/', 'php');
+			$builder->with_config($this->config_php);
+
+			$container = $builder->get_container();
+
+			$files_written_to_cache = array_map('basename', glob($new_cache_directory."/*"));
+
+			$this->assertNotEmpty(preg_grep('/autoload_.+.php/', $files_written_to_cache), 'There should be an autoload file in the cache directory.');
+			$this->assertNotEmpty(preg_grep('/container_.+.php/', $files_written_to_cache), 'There should be an container file in the cache directory.');
+
+			array_map('unlink', glob($new_cache_directory . '/*'));
+
+		}
+	}
+}

--- a/tests/di/container_cache_directory_test.php
+++ b/tests/di/container_cache_directory_test.php
@@ -28,8 +28,6 @@ namespace
 		{
 			$this->phpbb_root_path = dirname(__FILE__) . '/';
 			$this->config_php = new \phpbb\config_php_file($this->phpbb_root_path . 'fixtures/', 'php');
-			$this->builder = new phpbb_mock_phpbb_di_container_builder($this->phpbb_root_path . 'fixtures/', 'php');
-			$this->builder->with_config($this->config_php);
 
 			$this->filename = $this->phpbb_root_path . '../tmp/container.php';
 			if (is_file($this->filename))
@@ -48,6 +46,8 @@ namespace
 			// The file cache driver will now write to a new directory.
 			$_SERVER['PHPBB____core__cache_dir'] = $new_cache_directory;
 
+			$this->builder = new phpbb_mock_phpbb_di_container_builder($this->phpbb_root_path . 'fixtures/', 'php');
+			$this->builder->with_config($this->config_php);
 			$container = $this->builder->get_container();
 
 			$this->assertEquals($container->getParameter('core.cache_dir'), $new_cache_directory);
@@ -60,7 +60,7 @@ namespace
 		 */
 		public function test_container_and_autoload_cache()
 		{
-			$default_cache_directory = $this->phpbb_root_path . 'fixtures/cache/test';
+			$default_cache_directory = $this->phpbb_root_path . 'fixtures/cache/test/';
 
 			// Make sure our test directory will be empty.
 			if (is_dir($default_cache_directory))


### PR DESCRIPTION
Replacement for #5707.

Checklist:

- [x] Correct branch: master for new features; 3.3.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master](https://area51.phpbb.com/docs/dev/master/development/coding_guidelines.html) and [3.3.x](https://area51.phpbb.com/docs/dev/3.3.x/development/coding_guidelines.html)
- [x] Commit follows commit message [format](https://area51.phpbb.com/docs/dev/3.3.x/development/git.html)

<a href="https://tracker.phpbb.com/browse/PHPBB3-16178">PHPBB3-16178</a>.
