### PR TITLE
[ticket/16645] Simplified text_reparser.poll_option

### DIFF
--- a/phpBB/config/default/container/services_text_reparser.yml
+++ b/phpBB/config/default/container/services_text_reparser.yml
@@ -73,6 +73,7 @@ services:
         class: phpbb\textreparser\plugins\poll_option
         arguments:
             - '@dbal.conn'
+            - '%tables.poll_options%'
         calls:
             - [set_name, [poll_option]]
         tags:

--- a/phpBB/phpbb/textreparser/plugins/poll_option.php
+++ b/phpBB/phpbb/textreparser/plugins/poll_option.php
@@ -13,51 +13,31 @@
 
 namespace phpbb\textreparser\plugins;
 
-class poll_option extends \phpbb\textreparser\base
+class poll_option extends \phpbb\textreparser\row_based_plugin
 {
 	/**
-	* @var \phpbb\db\driver\driver_interface
+	* {@inheritdoc}
 	*/
-	protected $db;
-
-	/**
-	* Constructor
-	*
-	* @param \phpbb\db\driver\driver_interface $db Database connection
-	*/
-	public function __construct(\phpbb\db\driver\driver_interface $db)
+	public function get_columns()
 	{
-		$this->db = $db;
+		return [
+			'id'   => 'topic_id',
+			'text' => 'poll_option_text',
+		];
 	}
 
 	/**
 	* {@inheritdoc}
 	*/
-	public function get_max_id()
-	{
-		$sql = 'SELECT MAX(topic_id) AS max_id FROM ' . POLL_OPTIONS_TABLE;
-		$result = $this->db->sql_query($sql);
-		$max_id = (int) $this->db->sql_fetchfield('max_id');
-		$this->db->sql_freeresult($result);
-
-		return $max_id;
-	}
-
-	/**
-	* {@inheritdoc}
-	*/
-	protected function get_records_by_range($min_id, $max_id)
+	protected function get_records_by_range_query($min_id, $max_id)
 	{
 		$sql = 'SELECT o.topic_id, o.poll_option_id, o.poll_option_text AS text, p.enable_bbcode, p.enable_smilies, p.enable_magic_url, p.bbcode_uid
 			FROM ' . POLL_OPTIONS_TABLE . ' o, ' . TOPICS_TABLE . ' t, ' . POSTS_TABLE . ' p
 			WHERE o.topic_id BETWEEN ' . $min_id . ' AND ' . $max_id .'
 				AND t.topic_id = o.topic_id
 				AND p.post_id = t.topic_first_post_id';
-		$result = $this->db->sql_query($sql);
-		$records = $this->db->sql_fetchrowset($result);
-		$this->db->sql_freeresult($result);
 
-		return $records;
+		return $sql;
 	}
 
 	/**

--- a/tests/text_reparser/plugins/poll_option_test.php
+++ b/tests/text_reparser/plugins/poll_option_test.php
@@ -24,7 +24,7 @@ class phpbb_textreparser_poll_option_test extends phpbb_database_test_case
 
 	protected function get_reparser()
 	{
-		return new \phpbb\textreparser\plugins\poll_option($this->db);
+		return new \phpbb\textreparser\plugins\poll_option($this->db, POLL_OPTIONS_TABLE);
 	}
 
 	protected function get_rows()


### PR DESCRIPTION
It's a minor change that could be merged into 3.3.x but it changes the constructor's signature, that's why it's against master.

PHPBB3-16645

Checklist:

- [x] Correct branch: master for new features; 3.3.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master](https://area51.phpbb.com/docs/dev/master/development/coding_guidelines.html) and [3.3.x](https://area51.phpbb.com/docs/dev/3.3.x/development/coding_guidelines.html)
- [x] Commit follows commit message [format](https://area51.phpbb.com/docs/dev/3.3.x/development/git.html)

Tracker ticket (set the ticket ID to **your ticket ID**):

https://tracker.phpbb.com/browse/PHPBB3-16645
