### PR TITLE
[ticket/16660] Remove not needed RESET button from MCP and UCP

### DIFF
--- a/phpBB/styles/prosilver/template/mcp_ban.html
+++ b/phpBB/styles/prosilver/template/mcp_ban.html
@@ -81,7 +81,7 @@
 </div>
 
 <fieldset class="submit-buttons">
-	{S_HIDDEN_FIELDS}<input type="reset" value="{L_RESET}" name="reset" class="button2" />&nbsp;
+	{S_HIDDEN_FIELDS}
 	<input type="submit" name="bansubmit" value="{L_SUBMIT}" class="button1" />
 	{S_FORM_TOKEN}
 </fieldset>
@@ -118,7 +118,7 @@
 	</div>
 
 	<fieldset class="submit-buttons">
-		{S_HIDDEN_FIELDS}<input type="reset" value="{L_RESET}" name="reset" class="button2" />&nbsp;
+		{S_HIDDEN_FIELDS}
 		<input type="submit" name="unbansubmit" value="{L_SUBMIT}" class="button1" />
 	</fieldset>
 

--- a/phpBB/styles/prosilver/template/mcp_notes_front.html
+++ b/phpBB/styles/prosilver/template/mcp_notes_front.html
@@ -19,7 +19,6 @@
 </div>
 
 <fieldset class="submit-buttons">
-	<input type="reset" value="{L_RESET}" name="reset" class="button2" />&nbsp;
 	<input type="submit" name="submituser" value="{L_SUBMIT}" class="button1" />
 	{S_FORM_TOKEN}
 </fieldset>

--- a/phpBB/styles/prosilver/template/mcp_notes_user.html
+++ b/phpBB/styles/prosilver/template/mcp_notes_user.html
@@ -42,7 +42,7 @@
 </div>
 
 <fieldset class="submit-buttons">
-	{S_HIDDEN_FIELDS}<input type="reset" value="{L_RESET}" name="reset" class="button2" />&nbsp;
+	{S_HIDDEN_FIELDS}
 	<input type="submit" name="action[add_feedback]" value="{L_SUBMIT}" class="button1" />
 	{S_FORM_TOKEN}
 </fieldset>

--- a/phpBB/styles/prosilver/template/mcp_warn_front.html
+++ b/phpBB/styles/prosilver/template/mcp_warn_front.html
@@ -21,7 +21,6 @@
 </div>
 
 <fieldset class="submit-buttons">
-	<input type="reset" value="{L_RESET}" name="reset" class="button2" />&nbsp;
 	<input type="submit" name="submituser" value="{L_SUBMIT}" class="button1" />
 	{S_FORM_TOKEN}
 </fieldset>

--- a/phpBB/styles/prosilver/template/mcp_warn_post.html
+++ b/phpBB/styles/prosilver/template/mcp_warn_post.html
@@ -69,7 +69,6 @@
 <!-- EVENT mcp_warn_post_add_warning_field_after -->
 
 <fieldset class="submit-buttons">
-	<input type="reset" value="{L_RESET}" name="reset" class="button2" />&nbsp;
 	<input type="submit" name="action[add_warning]" value="{L_SUBMIT}" class="button1" />
 	{S_FORM_TOKEN}
 </fieldset>

--- a/phpBB/styles/prosilver/template/mcp_warn_user.html
+++ b/phpBB/styles/prosilver/template/mcp_warn_user.html
@@ -53,7 +53,6 @@
 <!-- EVENT mcp_warn_user_add_warning_field_after -->
 
 <fieldset class="submit-buttons">
-	<input type="reset" value="{L_RESET}" name="reset" class="button2" />&nbsp;
 	<input type="submit" name="action[add_warning]" value="{L_SUBMIT}" class="button1" />
 	{S_FORM_TOKEN}
 </fieldset>

--- a/phpBB/styles/prosilver/template/memberlist_search.html
+++ b/phpBB/styles/prosilver/template/memberlist_search.html
@@ -76,7 +76,6 @@
 	<hr />
 
 	<fieldset class="submit-buttons">
-		<input type="reset" value="{L_RESET}" name="reset" class="button2" />&nbsp;
 		<input type="submit" name="submit" value="{L_SEARCH}" class="button1" />
 		{S_FORM_TOKEN}
 	</fieldset>

--- a/phpBB/styles/prosilver/template/search_body.html
+++ b/phpBB/styles/prosilver/template/search_body.html
@@ -96,7 +96,7 @@
 	<div class="inner">
 
 	<fieldset class="submit-buttons">
-		{S_HIDDEN_FIELDS}<input type="reset" value="{L_RESET}" name="reset" class="button2" />&nbsp;
+		{S_HIDDEN_FIELDS}
 		<input type="submit" name="submit" value="{L_SEARCH}" class="button1" />
 	</fieldset>
 

--- a/phpBB/styles/prosilver/template/ucp_avatar_options.html
+++ b/phpBB/styles/prosilver/template/ucp_avatar_options.html
@@ -39,7 +39,6 @@
 	</div>
 <!-- IF not S_GROUP_MANAGE -->
 	<fieldset class="submit-buttons">
-		<input type="reset" value="{L_RESET}" name="reset" class="button2" /> &nbsp;
 		<input type="submit" name="submit" value="{L_SUBMIT}" class="button1" />
 	</fieldset>
 <!-- ENDIF -->

--- a/phpBB/styles/prosilver/template/ucp_groups_manage.html
+++ b/phpBB/styles/prosilver/template/ucp_groups_manage.html
@@ -74,7 +74,6 @@
 
 <fieldset class="submit-buttons">
 	{S_HIDDEN_FIELDS}
-	<input type="reset" value="{L_RESET}" name="reset" class="button2" />&nbsp;
 	<input type="submit" name="update" value="{L_SUBMIT}" class="button1" />
 	{S_FORM_TOKEN}
 </fieldset>

--- a/phpBB/styles/prosilver/template/ucp_main_drafts.html
+++ b/phpBB/styles/prosilver/template/ucp_main_drafts.html
@@ -16,7 +16,7 @@
 	</div>
 
 			<fieldset class="submit-buttons">
-				{S_HIDDEN_FIELDS}<input type="reset" value="{L_RESET}" name="reset" class="button2" />&nbsp;
+				{S_HIDDEN_FIELDS}
 				<input type="submit" name="submit" value="{L_SAVE}" class="button1" />
 				{S_FORM_TOKEN}
 			</fieldset>

--- a/phpBB/styles/prosilver/template/ucp_prefs_personal.html
+++ b/phpBB/styles/prosilver/template/ucp_prefs_personal.html
@@ -79,7 +79,7 @@
 </div>
 
 <fieldset class="submit-buttons">
-	{S_HIDDEN_FIELDS}<input type="reset" value="{L_RESET}" name="reset" class="button2" />&nbsp;
+	{S_HIDDEN_FIELDS}
 	<input type="submit" name="submit" value="{L_SUBMIT}" class="button1" />
 	{S_FORM_TOKEN}
 </fieldset>

--- a/phpBB/styles/prosilver/template/ucp_prefs_post.html
+++ b/phpBB/styles/prosilver/template/ucp_prefs_post.html
@@ -44,7 +44,7 @@
 </div>
 
 <fieldset class="submit-buttons">
-	{S_HIDDEN_FIELDS}<input type="reset" value="{L_RESET}" name="reset" class="button2" />&nbsp;
+	{S_HIDDEN_FIELDS}
 	<input type="submit" name="submit" value="{L_SUBMIT}" class="button1" />
 	{S_FORM_TOKEN}
 </fieldset>

--- a/phpBB/styles/prosilver/template/ucp_prefs_view.html
+++ b/phpBB/styles/prosilver/template/ucp_prefs_view.html
@@ -89,7 +89,7 @@
 </div>
 
 <fieldset class="submit-buttons">
-	{S_HIDDEN_FIELDS}<input type="reset" value="{L_RESET}" name="reset" class="button2" />&nbsp;
+	{S_HIDDEN_FIELDS}
 	<input type="submit" name="submit" value="{L_SUBMIT}" class="button1" />
 	{S_FORM_TOKEN}
 </fieldset>

--- a/phpBB/styles/prosilver/template/ucp_profile_profile_info.html
+++ b/phpBB/styles/prosilver/template/ucp_profile_profile_info.html
@@ -42,7 +42,7 @@
 </div>
 
 <fieldset class="submit-buttons">
-	{S_HIDDEN_FIELDS}<input type="reset" value="{L_RESET}" name="reset" class="button2" />&nbsp;
+	{S_HIDDEN_FIELDS}
 	<input type="submit" name="submit" value="{L_SUBMIT}" class="button1" />
 	{S_FORM_TOKEN}
 </fieldset>

--- a/phpBB/styles/prosilver/template/ucp_profile_reg_details.html
+++ b/phpBB/styles/prosilver/template/ucp_profile_reg_details.html
@@ -50,7 +50,7 @@
 </div>
 
 <fieldset class="submit-buttons">
-	{S_HIDDEN_FIELDS}<input type="reset" value="{L_RESET}" name="reset" class="button2" />&nbsp;
+	{S_HIDDEN_FIELDS}
 	<input type="submit" name="submit" value="{L_SUBMIT}" class="button1" />
 	{S_FORM_TOKEN}
 </fieldset>

--- a/phpBB/styles/prosilver/template/ucp_profile_signature.html
+++ b/phpBB/styles/prosilver/template/ucp_profile_signature.html
@@ -42,7 +42,6 @@
 
 <fieldset class="submit-buttons">
 	{S_HIDDEN_FIELDS}
-	<input type="reset" name="reset" value="{L_RESET}" class="button2" />&nbsp;
 	<input type="submit" name="preview" value="{L_PREVIEW}" class="button2" />&nbsp;
 	<input type="submit" name="submit" value="{L_SUBMIT}" class="button1" />
 	{S_FORM_TOKEN}

--- a/phpBB/styles/prosilver/template/ucp_register.html
+++ b/phpBB/styles/prosilver/template/ucp_register.html
@@ -105,7 +105,6 @@
 
 	<fieldset class="submit-buttons">
 		{S_HIDDEN_FIELDS}
-		<input type="reset" value="{L_RESET}" name="reset" class="button2" />&nbsp;
 		<input type="submit" tabindex="9" name="submit" id="submit" value="{L_SUBMIT}" class="button1 default-submit-action" />
 		{S_FORM_TOKEN}
 	</fieldset>

--- a/phpBB/styles/prosilver/template/ucp_resend.html
+++ b/phpBB/styles/prosilver/template/ucp_resend.html
@@ -20,7 +20,7 @@
 		</dl>
 		<dl>
 			<dt>&nbsp;</dt>
-			<dd>{S_HIDDEN_FIELDS}{S_FORM_TOKEN}<input type="submit" name="submit" id="submit" class="button1" value="{L_SUBMIT}" tabindex="2" />&nbsp; <input type="reset" value="{L_RESET}" name="reset" class="button2" /></dd>
+			<dd>{S_HIDDEN_FIELDS}{S_FORM_TOKEN}<input type="submit" name="submit" id="submit" class="button1" value="{L_SUBMIT}" tabindex="2" /></dd>
 		</dl>
 		</fieldset>
 	</div>

--- a/phpBB/styles/prosilver/template/ucp_reset_password.html
+++ b/phpBB/styles/prosilver/template/ucp_reset_password.html
@@ -36,7 +36,7 @@
 		{% endif %}
 		<dl>
 			<dt>&nbsp;</dt>
-			<dd>{{ S_HIDDEN_FIELDS }}<input type="submit" name="submit" id="submit" class="button1" value="{{ lang('SUBMIT') }}" tabindex="2" />&nbsp; <input type="reset" value="{{ lang('RESET') }}" name="reset" class="button2" /></dd>
+			<dd>{{ S_HIDDEN_FIELDS }}<input type="submit" name="submit" id="submit" class="button1" value="{{ lang('SUBMIT') }}" tabindex="2" /></dd>
 		</dl>
 		{{ S_FORM_TOKEN }}
 		</fieldset>

--- a/phpBB/styles/prosilver/template/ucp_zebra_foes.html
+++ b/phpBB/styles/prosilver/template/ucp_zebra_foes.html
@@ -32,7 +32,7 @@
 </div>
 
 <fieldset class="submit-buttons">
-	{S_HIDDEN_FIELDS}<input type="reset" value="{L_RESET}" name="reset" class="button2" />&nbsp;
+	{S_HIDDEN_FIELDS}
 	<input type="submit" name="submit" value="{L_SUBMIT}" class="button1" />
 	{S_FORM_TOKEN}
 </fieldset>

--- a/phpBB/styles/prosilver/template/ucp_zebra_friends.html
+++ b/phpBB/styles/prosilver/template/ucp_zebra_friends.html
@@ -34,7 +34,7 @@
 </div>
 
 <fieldset class="submit-buttons">
-	{S_HIDDEN_FIELDS}<input type="reset" value="{L_RESET}" name="reset" class="button2" />&nbsp;
+	{S_HIDDEN_FIELDS}
 	<input type="submit" name="submit" value="{L_SUBMIT}" class="button1" />
 	{S_FORM_TOKEN}
 </fieldset>


### PR DESCRIPTION
This will improved the UX and UI for the moderator and user of a phpBB, because they are no longer "tricked" into purge the whole input from the last seconds. 

PHPBB3-16660

Checklist:

- [x] Correct branch: master for new features; 3.3.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master](https://area51.phpbb.com/docs/dev/master/development/coding_guidelines.html) and [3.3.x](https://area51.phpbb.com/docs/dev/3.3.x/development/coding_guidelines.html)
- [x] Commit follows commit message [format](https://area51.phpbb.com/docs/dev/3.3.x/development/git.html)

Tracker ticket (set the ticket ID to **your ticket ID**):

https://tracker.phpbb.com/browse/PHPBB3-16660
