### PR TITLE
[ticket/16697] Remove $CP$ prefix when updating hashes and support phpBB2 check

### DIFF
--- a/phpBB/phpbb/console/command/fixup/update_hashes.php
+++ b/phpBB/phpbb/console/command/fixup/update_hashes.php
@@ -99,7 +99,8 @@ class update_hashes extends \phpbb\console\command\command
 
 		while ($row = $this->db->sql_fetchrow($result))
 		{
-			$new_hash = $this->passwords_manager->hash($row['user_password'], array($this->default_type));
+			$old_hash = preg_replace('/^\$CP\$/', '', $row['user_password']);
+			$new_hash = $this->passwords_manager->hash($old_hash, array($this->default_type));
 
 			$sql = 'UPDATE ' . USERS_TABLE . "
 					SET user_password = '" . $this->db->sql_escape($new_hash) . "'

--- a/phpBB/phpbb/cron/task/core/update_hashes.php
+++ b/phpBB/phpbb/cron/task/core/update_hashes.php
@@ -106,7 +106,8 @@ class update_hashes extends \phpbb\cron\task\base
 
 			while ($row = $this->db->sql_fetchrow($result))
 			{
-				$new_hash = $this->passwords_manager->hash($row['user_password'], array($this->default_type));
+				$old_hash = preg_replace('/^\$CP\$/', '', $row['user_password']);
+				$new_hash = $this->passwords_manager->hash($old_hash, array($this->default_type));
 
 				// Increase number so we know that users were selected from the database
 				$affected_rows++;


### PR DESCRIPTION
The $CP$ prefix is not part of the actual password hash.
phpBB2 passwords converted do currently include a phpass hash of the md5 of
the password. Make sure these are correctly checked.

PHPBB3-16697

Checklist:

- [x] Correct branch: master for new features; 3.3.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master](https://area51.phpbb.com/docs/dev/master/development/coding_guidelines.html) and [3.3.x](https://area51.phpbb.com/docs/dev/3.3.x/development/coding_guidelines.html)
- [x] Commit follows commit message [format](https://area51.phpbb.com/docs/dev/3.3.x/development/git.html)

Tracker ticket (set the ticket ID to **your ticket ID**):

https://tracker.phpbb.com/browse/PHPBB3-16697
