### PR TITLE
[ticket/16694] Create exceptional case to Twemoji instances of U+2764

### DIFF
--- a/phpBB/phpbb/textformatter/s9e/factory.php
+++ b/phpBB/phpbb/textformatter/s9e/factory.php
@@ -364,6 +364,9 @@ class factory implements \phpbb\textformatter\cache_interface
 		</xsl:choose>';
 		$tag->template = '<xsl:choose><xsl:when test="$S_VIEWSMILIES">' . str_replace('class="emoji"', 'class="emoji smilies"', $tag->template) . '</xsl:when><xsl:otherwise><xsl:value-of select="."/></xsl:otherwise></xsl:choose>';
 
+		// Add an alias to ensure red heart will become Twemoji'd, even though Unicode says it doesn't have Emoji_Presentation attribute.
+		$configurator->Emoji->aliases["\u{2764}"] = "\u{2764}\u{FE0F}";
+
 		/**
 		* Modify the s9e\TextFormatter configurator after the default settings are set
 		*


### PR DESCRIPTION
Adding an alias to ensure phpBB will Twemoji U+2764 (red heart).  text-formatter is correctly following Unicode spec and omitting Twemoji treatment because this character doesn't have the Emoji_Presentation attribute.  But this leads to platform-dependent display differences that prevent all phpBB users from seeing the "red heart" that was entered.

Checklist:

- [x] Correct branch: master for new features; 3.3.x for fixes
- [ ] Tests pass
- [x] Code follows coding guidelines: [master](https://area51.phpbb.com/docs/dev/master/development/coding_guidelines.html) and [3.3.x](https://area51.phpbb.com/docs/dev/3.3.x/development/coding_guidelines.html)
- [x] Commit follows commit message [format](https://area51.phpbb.com/docs/dev/3.3.x/development/git.html)

https://tracker.phpbb.com/browse/PHPBB3-16694
