### PR TITLE
[ticket/16718] Make sure phpBB's autoloader is used before extensions

### DIFF
--- a/phpBB/phpbb/di/container_builder.php
+++ b/phpBB/phpbb/di/container_builder.php
@@ -478,6 +478,12 @@ class container_builder
 				}
 			}
 
+			// Make sure phpBB's autoloader is used before the extension autoloaders
+			if (count($extensions))
+			{
+				$autoloaders .= "require('" . $this->phpbb_root_path . "vendor/autoload.php');";
+			}
+
 			$configCache = new ConfigCache($this->get_autoload_filename(), false);
 			$configCache->write($autoloaders);
 

--- a/tests/di/fixtures/vendor/autoload.php
+++ b/tests/di/fixtures/vendor/autoload.php
@@ -1,0 +1,2 @@
+<?php
+// this is just a dummy file to have an autoload file for container builder in place


### PR DESCRIPTION
This resolves compatibility issues with extensions that use composer v2.

PHPBB3-16718

Checklist:

- [x] Correct branch: master for new features; 3.3.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master](https://area51.phpbb.com/docs/dev/master/development/coding_guidelines.html) and [3.3.x](https://area51.phpbb.com/docs/dev/3.3.x/development/coding_guidelines.html)
- [x] Commit follows commit message [format](https://area51.phpbb.com/docs/dev/3.3.x/development/git.html)

Tracker ticket (set the ticket ID to **your ticket ID**):

https://tracker.phpbb.com/browse/PHPBB3-16718
