### PR TITLE
Change {L_MARK_READ} to {L_MARK} n prosilver template

### DIFF
--- a/phpBB/styles/prosilver/template/ucp_notifications.html
+++ b/phpBB/styles/prosilver/template/ucp_notifications.html
@@ -57,7 +57,7 @@
 					<li class="header">
 						<dl>
 							<dt><div class="list-inner">{L_NOTIFICATIONS}</div></dt>
-							<dd class="mark">{L_MARK_READ}</dd>
+							<dd class="mark">{L_MARK}</dd>
 						</dl>
 					</li>
 				</ul>


### PR DESCRIPTION
To solve the problem of translating the variable "mark read" in the user control panel => notifications list

Checklist:

- [ ] Correct branch: master for new features; 3.3.x for fixes
- [ ] Tests pass
- [ ] Code follows coding guidelines: [master](https://area51.phpbb.com/docs/dev/master/development/coding_guidelines.html) and [3.3.x](https://area51.phpbb.com/docs/dev/3.3.x/development/coding_guidelines.html)
- [ ] Commit follows commit message [format](https://area51.phpbb.com/docs/dev/3.3.x/development/git.html)

Tracker ticket (set the ticket ID to **your ticket ID**):

https://tracker.phpbb.com/browse/PHPBB3-12345
