### PR TITLE
[ticket/16763] fix imageset mine pip alignment

### DIFF
--- a/phpBB/styles/prosilver/theme/icons.css
+++ b/phpBB/styles/prosilver/theme/icons.css
@@ -90,11 +90,13 @@ blockquote cite:before,
 	border-radius: 50%;
 	position: absolute;
 	z-index: 101;
+	top: 50%;
 	left: 32px;
 	display: block;
 	float: left;
 	width: 8px;
 	height: 8px;
+	margin-top: -17px;
 }
 
 .row-item-sub {


### PR DESCRIPTION
PHPBB3-16763

Checklist:

- [x] Correct branch: master for new features; 3.3.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master](https://area51.phpbb.com/docs/dev/master/development/coding_guidelines.html) and [3.3.x](https://area51.phpbb.com/docs/dev/3.3.x/development/coding_guidelines.html)
- [x] Commit follows commit message [format](https://area51.phpbb.com/docs/dev/3.3.x/development/git.html)

Tracker ticket (set the ticket ID to **your ticket ID**):

https://tracker.phpbb.com/browse/PHPBB3-16763

Before:
<img width="158" alt="115195447-7abbef80-a08a-11eb-8d73-f0ad93db8fa5" src="https://user-images.githubusercontent.com/73081/115481898-385cf480-a1e9-11eb-864d-dc02aa18d6d1.png">

After:
<img width="113" alt="115195498-89a2a200-a08a-11eb-9014-2977033a47b2" src="https://user-images.githubusercontent.com/73081/115481954-4ca0f180-a1e9-11eb-9afc-9440ae164777.png">

