### PR TITLE
[ticket/16765] Check if ACP_CONTACT_SETTINGS module already installed

### DIFF
--- a/phpBB/phpbb/db/migration/data/v310/contact_admin_acp_module.php
+++ b/phpBB/phpbb/db/migration/data/v310/contact_admin_acp_module.php
@@ -15,6 +15,20 @@ namespace phpbb\db\migration\data\v310;
 
 class contact_admin_acp_module extends \phpbb\db\migration\migration
 {
+	public function effectively_installed()
+	{
+		$sql = 'SELECT module_id
+			FROM ' . MODULES_TABLE . "
+			WHERE module_class = 'acp'
+				AND module_basename = 'acp_contact'
+				AND module_langname = 'ACP_CONTACT_SETTINGS'";
+		$result = $this->db->sql_query($sql);
+		$module_id = $this->db->sql_fetchfield('module_id');
+		$this->db->sql_freeresult($result);
+
+		return $module_id != false;
+	}
+
 	public function update_data()
 	{
 		return array(


### PR DESCRIPTION
Checks to see if the ACP_CONTACT_SETTINGS module is already installed prior to running migration.

PHPBB3-16765

Checklist:

- [x] Correct branch: master for new features; 3.3.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master](https://area51.phpbb.com/docs/dev/master/development/coding_guidelines.html) and [3.3.x](https://area51.phpbb.com/docs/dev/3.3.x/development/coding_guidelines.html)
- [x] Commit follows commit message [format](https://area51.phpbb.com/docs/dev/3.3.x/development/git.html)

Tracker ticket:

https://tracker.phpbb.com/browse/PHPBB3-16765
