### PR TITLE
[ticket/16767] Report missing migration instead of dependency

### DIFF
--- a/phpBB/phpbb/db/migrator.php
+++ b/phpBB/phpbb/db/migrator.php
@@ -339,9 +339,10 @@ class migrator
 			$depend = $this->get_valid_name($depend);
 
 			// Test all possible namings before throwing exception
-			if ($this->unfulfillable($depend) !== false)
+			$missing = $this->unfulfillable($depend);
+			if ($missing !== false)
 			{
-				throw new \phpbb\db\migration\exception('MIGRATION_NOT_FULFILLABLE', $name, $depend);
+				throw new \phpbb\db\migration\exception('MIGRATION_NOT_FULFILLABLE', $name, $missing);
 			}
 
 			if (!isset($this->migration_state[$depend]) ||


### PR DESCRIPTION
If a migration has an unfulfillable dependency, the migration causing the dependency to be unfulfillable is now shown in the error message instead of just the dependency.

Checklist:

- [x] Correct branch: master for new features; 3.3.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master](https://area51.phpbb.com/docs/dev/master/development/coding_guidelines.html) and [3.3.x](https://area51.phpbb.com/docs/dev/3.3.x/development/coding_guidelines.html)
- [x] Commit follows commit message [format](https://area51.phpbb.com/docs/dev/3.3.x/development/git.html)

Tracker ticket:

https://tracker.phpbb.com/browse/PHPBB3-16767
