### PR TITLE
[ticket/13700] Add method for initializing config after cache purge

### DIFF
--- a/phpBB/phpbb/config/db.php
+++ b/phpBB/phpbb/config/db.php
@@ -13,20 +13,23 @@
 
 namespace phpbb\config;
 
+use phpbb\cache\driver\driver_interface as cache_interface;
+use phpbb\db\driver\driver_interface as db_interface;
+
 /**
 * Configuration container class
 */
-class db extends \phpbb\config\config
+class db extends config
 {
 	/**
 	* Cache instance
-	* @var \phpbb\cache\driver\driver_interface
+	* @var cache_interface
 	*/
 	protected $cache;
 
 	/**
 	* Database connection
-	* @var \phpbb\db\driver\driver_interface
+	* @var db_interface
 	*/
 	protected $db;
 
@@ -39,11 +42,11 @@ class db extends \phpbb\config\config
 	/**
 	* Creates a configuration container with a default set of values
 	*
-	* @param \phpbb\db\driver\driver_interface    $db    Database connection
-	* @param \phpbb\cache\driver\driver_interface $cache Cache instance
+	* @param db_interface    $db    Database connection
+	* @param cache_interface $cache Cache instance
 	* @param string                       $table Configuration table name
 	*/
-	public function __construct(\phpbb\db\driver\driver_interface $db, \phpbb\cache\driver\driver_interface $cache, $table)
+	public function __construct(db_interface $db, cache_interface $cache, $table)
 	{
 		$this->db = $db;
 		$this->cache = $cache;
@@ -54,7 +57,12 @@ class db extends \phpbb\config\config
 		parent::__construct($this->config);
 	}
 
-	public function initialise(\phpbb\cache\driver\driver_interface $cache)
+	/**
+	 * Initialise config with database and/or cached entries
+	 *
+	 * @param cache_interface $cache
+	 */
+	public function initialise(cache_interface $cache)
 	{
 		if (($config = $cache->get('config')) !== false)
 		{
@@ -100,7 +108,7 @@ class db extends \phpbb\config\config
 	* @param  String $key       The configuration option's name
 	* @param  bool   $use_cache Whether this variable should be cached or if it
 	*                           changes too frequently to be efficiently cached
-	* @return null
+	* @return void
 	*/
 	public function delete($key, $use_cache = true)
 	{

--- a/phpBB/phpbb/config/db.php
+++ b/phpBB/phpbb/config/db.php
@@ -49,6 +49,13 @@ class db extends \phpbb\config\config
 		$this->cache = $cache;
 		$this->table = $table;
 
+		$this->initialise($cache);
+
+		parent::__construct($this->config);
+	}
+
+	public function initialise(\phpbb\cache\driver\driver_interface $cache)
+	{
 		if (($config = $cache->get('config')) !== false)
 		{
 			$sql = 'SELECT config_name, config_value
@@ -84,7 +91,7 @@ class db extends \phpbb\config\config
 			$cache->put('config', $cached_config);
 		}
 
-		parent::__construct($config);
+		$this->config = $config;
 	}
 
 	/**

--- a/phpBB/phpbb/console/command/db/migrate.php
+++ b/phpBB/phpbb/console/command/db/migrate.php
@@ -58,6 +58,10 @@ class migrate extends \phpbb\console\command\db\migration_command
 		$this->migrator->create_migrations_table();
 
 		$this->cache->purge();
+		if ($this->config instanceof \phpbb\config\db)
+		{
+			$this->config->initialise($this->cache->get_driver());
+		}
 
 		$this->load_migrations();
 		$orig_version = $this->config['version'];


### PR DESCRIPTION
PHPBB3-13700

The goal of this is to be able to re-initialize the config entries after a cache purge, e.g. when running db migrations via CLI.

Checklist:

- [x] Correct branch: master for new features; 3.3.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master](https://area51.phpbb.com/docs/dev/master/development/coding_guidelines.html) and [3.3.x](https://area51.phpbb.com/docs/dev/3.3.x/development/coding_guidelines.html)
- [x] Commit follows commit message [format](https://area51.phpbb.com/docs/dev/3.3.x/development/git.html)

Tracker ticket (set the ticket ID to **your ticket ID**):

https://tracker.phpbb.com/browse/PHPBB3-13700
