### PR TITLE
[ticket/16292] Propagate more errors to the installer UI

### DIFF
--- a/phpBB/install/startup.php
+++ b/phpBB/install/startup.php
@@ -93,18 +93,22 @@ function installer_msg_handler($errno, $msg_text, $errfile, $errline)
 		case E_USER_ERROR:
 			$msg = '<b>General Error:</b><br>' . $msg_text . '<br> in file ' . $errfile . ' on line ' . $errline . '<br><br>';
 
-			try
+			if (!empty($phpbb_installer_container))
 			{
-				/** @var \phpbb\install\helper\iohandler\iohandler_interface $iohandler */
-				$iohandler = $phpbb_installer_container->get('installer.helper.iohandler');
-				$iohandler->add_error_message($msg);
-				$iohandler->send_response(true);
-				exit();
+				try
+				{
+					/** @var \phpbb\install\helper\iohandler\iohandler_interface $iohandler */
+					$iohandler = $phpbb_installer_container->get('installer.helper.iohandler');
+					$iohandler->add_error_message($msg);
+					$iohandler->send_response(true);
+					exit();
+				}
+				catch (\phpbb\install\helper\iohandler\exception\iohandler_not_implemented_exception $e)
+				{
+					throw new \phpbb\exception\runtime_exception($msg);
+				}
 			}
-			catch (\phpbb\install\helper\iohandler\exception\iohandler_not_implemented_exception $e)
-			{
-				throw new \phpbb\exception\runtime_exception($msg);
-			}
+			throw new \phpbb\exception\runtime_exception($msg);
 		break;
 		case E_DEPRECATED:
 			return true;

--- a/phpBB/install/startup.php
+++ b/phpBB/install/startup.php
@@ -93,7 +93,18 @@ function installer_msg_handler($errno, $msg_text, $errfile, $errline)
 		case E_USER_ERROR:
 			$msg = '<b>General Error:</b><br>' . $msg_text . '<br> in file ' . $errfile . ' on line ' . $errline . '<br><br>';
 
-			throw new \phpbb\exception\runtime_exception($msg);
+			try
+			{
+				/** @var \phpbb\install\helper\iohandler\iohandler_interface $iohandler */
+				$iohandler = $phpbb_installer_container->get('installer.helper.iohandler');
+				$iohandler->add_error_message($msg);
+				$iohandler->send_response(true);
+				exit();
+			}
+			catch (\phpbb\install\helper\iohandler\exception\iohandler_not_implemented_exception $e)
+			{
+				throw new \phpbb\exception\runtime_exception($msg);
+			}
 		break;
 		case E_DEPRECATED:
 			return true;


### PR DESCRIPTION
Tries to pass near-fatal errors to the frontend before throwing a probably unhandled runtime exception. Should cause "Timeout detected" to more commonly be replaced with an actual error message.

Checklist:

- [x] Correct branch: master for new features; 3.3.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master](https://area51.phpbb.com/docs/dev/master/development/coding_guidelines.html) and [3.3.x](https://area51.phpbb.com/docs/dev/3.3.x/development/coding_guidelines.html)
- [x] Commit follows commit message [format](https://area51.phpbb.com/docs/dev/3.3.x/development/git.html)

Tracker ticket: https://tracker.phpbb.com/browse/PHPBB3-16292
