### PR TITLE
[ticket/16782] Use alternative template for mention BBCode

### DIFF
--- a/phpBB/assets/javascript/mentions.js
+++ b/phpBB/assets/javascript/mentions.js
@@ -293,7 +293,7 @@
 				itemClass: 'mention-item',
 				menuItemTemplate,
 				selectTemplate(item) {
-					return '[mention=' + item.type + ':' + item.id + ']' + item.name + '[/mention]';
+					return '[mention ' + (item.type === 'g' ? 'group_id=' : 'user_id=') + item.id + ']' + item.name + '[/mention]';
 				},
 				menuItemLimit: mentionNamesLimit,
 				values(text, cb) {


### PR DESCRIPTION
PHPBB3-16782

Checklist:

- [x] Correct branch: master for new features; 3.3.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master](https://area51.phpbb.com/docs/dev/master/development/coding_guidelines.html) and [3.3.x](https://area51.phpbb.com/docs/dev/3.3.x/development/coding_guidelines.html)
- [x] Commit follows commit message [format](https://area51.phpbb.com/docs/dev/3.3.x/development/git.html)

Tracker ticket (set the ticket ID to **your ticket ID**):

https://tracker.phpbb.com/browse/PHPBB3-16782

This will change the BBCode from:
```
[mention=u:2]test[/mention]
[mention=g:5]testGroup[/mention]
```
to:
```
[mention user_id=2]test[/mention]
[mention group_id=5]testGroup[/mention]
```
Both types are supported by the current BBCode implementation and will continue to work.