### PR TITLE
[ticket/16828] Add hook event before find_users_for_notification() ex…

### DIFF
--- a/phpBB/phpbb/notification/manager.php
+++ b/phpBB/phpbb/notification/manager.php
@@ -255,34 +255,36 @@ class manager
 			'ignore_users'		=> array(),
 		), $options);
 
-		$break = false;
+		$notified_users = [];
+		$add_notifications_override = false;
 
 		/**
 		* Get notification data before find_users_for_notification() execute
 		*
 		* @event core.notification_manager_add_notifications_before
-		* @var	bool	break					Flag indicating if the function return after hook
-		* @var	array	notification_type_name	Type identifier or array of item types
-		* @var	string	data					Data specific for this type that will be inserted
-		* @var	string	options					Optional options to control what notifications are loaded
-		* @since 3.3.5-RC1
+		* @var	bool			add_notifications_override	Flag indicating whether function should return after event
+		* @var	array|string	notification_type_name		Type identifier or array of item types
+		* @var	string			data						Data specific for this notification type that will be inserted
+		* @var	array 			notified_users				Array of notified users
+		* @var	string			options						Optional options to control what notifications are loaded
+		* @since 3.3.6-RC1
 		*/
 		$vars = [
-			'break',
+			'add_notifications_override',
 			'notification_type_name',
 			'data',
+			'notified_users',
 			'options',
 		];
 		extract($this->phpbb_dispatcher->trigger_event('core.notification_manager_add_notifications_before', compact($vars)));
 
-		if ($break)
+		if ($add_notifications_override)
 		{
-			return [];
+			return $notified_users;
 		}
 
 		if (is_array($notification_type_name))
 		{
-			$notified_users = array();
 			$temp_options = $options;
 
 			foreach ($notification_type_name as $type)

--- a/phpBB/phpbb/notification/manager.php
+++ b/phpBB/phpbb/notification/manager.php
@@ -255,6 +255,31 @@ class manager
 			'ignore_users'		=> array(),
 		), $options);
 
+		$break = false;
+
+		/**
+		* Get notification data before find_users_for_notification() execute
+		*
+		* @event core.notification_manager_add_notifications_before
+		* @var	bool	break					Flag indicating if the function return after hook
+		* @var	array	notification_type_name	Type identifier or array of item types
+		* @var	string	data					Data specific for this type that will be inserted
+		* @var	string	options					Optional options to control what notifications are loaded
+		* @since 3.3.5-RC1
+		*/
+		$vars = [
+			'break',
+			'notification_type_name',
+			'data',
+			'options',
+		];
+		extract($this->phpbb_dispatcher->trigger_event('core.notification_manager_add_notifications_before', compact($vars)));
+
+		if ($break)
+		{
+			return [];
+		}
+
 		if (is_array($notification_type_name))
 		{
 			$notified_users = array();


### PR DESCRIPTION
Add hook event before find_users_for_notification() execute

Checklist:

- [x] Correct branch: master for new features; 3.3.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master](https://area51.phpbb.com/docs/dev/master/development/coding_guidelines.html) and [3.3.x](https://area51.phpbb.com/docs/dev/3.3.x/development/coding_guidelines.html)
- [ ] Commit follows commit message [format](https://area51.phpbb.com/docs/dev/3.3.x/development/git.html)

Tracker ticket
https://tracker.phpbb.com/browse/PHPBB3-16828
