### PR TITLE
[ticket/16891] Do not change an extension status in the midle of a request

### DIFF
--- a/phpBB/config/default/container/services.yml
+++ b/phpBB/config/default/container/services.yml
@@ -116,6 +116,7 @@ services:
             - '@dbal.conn'
             - '@config'
             - '@filesystem'
+            - '@router'
             - '%tables.ext%'
             - '%core.root_path%'
             - '%core.php_ext%'

--- a/phpBB/phpbb/routing/router.php
+++ b/phpBB/phpbb/routing/router.php
@@ -81,6 +81,11 @@ class router implements RouterInterface
 	protected $cache_dir;
 
 	/**
+	 * @var bool
+	 */
+	protected $use_cache;
+
+	/**
 	 * Construct method
 	 *
 	 * @param ContainerInterface			$container			DI container
@@ -97,6 +102,7 @@ class router implements RouterInterface
 		$this->php_ext				= $php_ext;
 		$this->context				= new RequestContext();
 		$this->cache_dir			= $cache_dir;
+		$this->use_cache			= true;
 	}
 
 	/**
@@ -177,6 +183,22 @@ class router implements RouterInterface
 	}
 
 	/**
+	 * Enables the use of a cached URL generator and matcher
+	 */
+	public function with_cache()
+	{
+		$this->use_cache = true;
+	}
+
+	/**
+	 * Disables the use of a cached URL generator and matcher
+	 */
+	public function without_cache()
+	{
+		$this->use_cache = false;
+	}
+
+	/**
 	 * Gets the UrlMatcher instance associated with this Router.
 	 *
 	 * @return \Symfony\Component\Routing\Matcher\UrlMatcherInterface A UrlMatcherInterface instance
@@ -198,6 +220,12 @@ class router implements RouterInterface
 	 */
 	protected function create_dumped_url_matcher()
 	{
+		if (!$this->use_cache)
+		{
+			$this->create_new_url_matcher();
+			return;
+		}
+
 		try
 		{
 			$cache = new ConfigCache("{$this->cache_dir}url_matcher.{$this->php_ext}", defined('DEBUG'));
@@ -253,6 +281,12 @@ class router implements RouterInterface
 	 */
 	protected function create_dumped_url_generator()
 	{
+		if (!$this->use_cache)
+		{
+			$this->create_new_url_generator();
+			return;
+		}
+
 		try
 		{
 			$cache = new ConfigCache("{$this->cache_dir}url_generator.{$this->php_ext}", defined('DEBUG'));

--- a/tests/dbal/migrator_test.php
+++ b/tests/dbal/migrator_test.php
@@ -80,6 +80,7 @@ class phpbb_dbal_migrator_test extends phpbb_database_test_case
 			$this->db,
 			$this->config,
 			new phpbb\filesystem\filesystem(),
+			new phpbb_mock_dummy_router(),
 			'phpbb_ext',
 			__DIR__ . '/../../phpBB/',
 			'php',

--- a/tests/extension/manager_test.php
+++ b/tests/extension/manager_test.php
@@ -30,6 +30,7 @@ class phpbb_extension_manager_test extends phpbb_database_test_case
 	{
 		parent::setUp();
 
+		$this->db = null;
 		$this->extension_manager = $this->create_extension_manager();
 	}
 
@@ -95,7 +96,12 @@ class phpbb_extension_manager_test extends phpbb_database_test_case
 
 		$this->assertEquals(array('vendor2/foo'), array_keys($this->extension_manager->all_enabled()));
 		$this->extension_manager->enable('vendor2/bar');
-		$this->assertEquals(array('vendor2/bar', 'vendor2/foo'), array_keys($this->extension_manager->all_enabled()));
+
+		// We should not display the extension as being enabled in the same request
+		$this->assertEquals(array('vendor2/foo'), array_keys($this->extension_manager->all_enabled()));
+		// With a different request we should see the extension as being disabled
+		$this->assertEquals(array('vendor2/bar', 'vendor2/foo'), array_keys($this->create_extension_manager()->all_enabled()));
+
 		$this->assertEquals(array('vendor/moo', 'vendor2/bar', 'vendor2/foo'), array_keys($this->extension_manager->all_configured()));
 
 		$this->assertEquals(4, vendor2\bar\ext::$state);
@@ -119,7 +125,12 @@ class phpbb_extension_manager_test extends phpbb_database_test_case
 
 		$this->assertEquals(array('vendor2/foo'), array_keys($this->extension_manager->all_enabled()));
 		$this->extension_manager->disable('vendor2/foo');
-		$this->assertEquals(array(), array_keys($this->extension_manager->all_enabled()));
+
+		// We should still display the extension as being enabled in the current request
+		$this->assertEquals(array('vendor2/foo'), array_keys($this->extension_manager->all_enabled()));
+		// With a different request we should see the extension as being disabled
+		$this->assertEquals(array(), array_keys($this->create_extension_manager()->all_enabled()));
+
 		$this->assertEquals(array('vendor/moo', 'vendor2/foo'), array_keys($this->extension_manager->all_configured()));
 
 		$this->assertTrue(vendor2\foo\ext::$disabled);
@@ -147,7 +158,6 @@ class phpbb_extension_manager_test extends phpbb_database_test_case
 
 	protected function create_extension_manager($with_cache = true)
 	{
-
 		$config = new \phpbb\config\config(array('version' => PHPBB_VERSION));
 		$db = $this->new_dbal();
 		$factory = new \phpbb\db\tools\factory();
@@ -177,6 +187,7 @@ class phpbb_extension_manager_test extends phpbb_database_test_case
 			$db,
 			$config,
 			new \phpbb\filesystem\filesystem(),
+			new phpbb_mock_dummy_router(),
 			'phpbb_ext',
 			__DIR__ . '/',
 			$php_ext,

--- a/tests/extension/metadata_manager_test.php
+++ b/tests/extension/metadata_manager_test.php
@@ -98,6 +98,7 @@ class phpbb_extension_metadata_manager_test extends phpbb_database_test_case
 			$this->db,
 			$this->config,
 			new \phpbb\filesystem\filesystem(),
+			new phpbb_mock_dummy_router(),
 			'phpbb_ext',
 			$this->phpbb_root_path,
 			$this->phpEx,

--- a/tests/mock/dummy_router.php
+++ b/tests/mock/dummy_router.php
@@ -1,0 +1,31 @@
+<?php
+/**
+*
+* This file is part of the phpBB Forum Software package.
+*
+* @copyright (c) phpBB Limited <https://www.phpbb.com>
+* @license GNU General Public License, version 2 (GPL-2.0)
+*
+* For full copyright and license information, please see
+* the docs/CREDITS.txt file.
+*
+*/
+
+class phpbb_mock_dummy_router extends phpbb_mock_router
+{
+	public function __construct()
+	{
+	}
+
+	public function get_matcher()
+	{
+		$this->create_new_url_matcher();
+		return parent::get_matcher();
+	}
+
+	public function get_generator()
+	{
+		$this->create_new_url_generator();
+		return parent::get_generator();
+	}
+}

--- a/tests/mock/extension_manager.php
+++ b/tests/mock/extension_manager.php
@@ -11,6 +11,7 @@
 *
 */
 
+
 class phpbb_mock_extension_manager extends \phpbb\extension\manager
 {
 	public function __construct($phpbb_root_path, $extensions = array(), $container = null)
@@ -25,5 +26,6 @@ class phpbb_mock_extension_manager extends \phpbb\extension\manager
 		$this->container = $container;
 		$this->config = new \phpbb\config\config(array());
 		$this->user = new \phpbb\user($lang,'\phpbb\datetime');
+		$this->router = new phpbb_mock_dummy_router();
 	}
 }

--- a/tests/test_framework/phpbb_functional_test_case.php
+++ b/tests/test_framework/phpbb_functional_test_case.php
@@ -261,6 +261,7 @@ class phpbb_functional_test_case extends phpbb_test_case
 			$db,
 			$config,
 			new phpbb\filesystem\filesystem(),
+			new phpbb_mock_dummy_router(),
 			self::$config['table_prefix'] . 'ext',
 			__DIR__ . '/',
 			$phpEx,


### PR DESCRIPTION
When enabling an extension, it should be considered as not being enabled for the entire request as if the "enabled" flag is switch furing the request, the extension will stay not loaded (same when disabling an extension).

Example when it can be an issue today : if the router is called for the first time after enabling the extension and if the extension uses a custom route loader (like phpbb/pages) then the router will fail because the custom route will be found but the custom loader will not be loaded and available.

PHPBB3-16891

Checklist:

- [x] Correct branch: master for new features; 3.3.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master](https://area51.phpbb.com/docs/master/coding-guidelines.html) and [3.3.x](https://area51.phpbb.com/docs/dev/3.3.x/development/coding_guidelines.html)
- [x] Commit follows commit message [format](https://area51.phpbb.com/docs/dev/3.3.x/development/git.html)

Tracker ticket (set the ticket ID to **your ticket ID**):

https://tracker.phpbb.com/browse/PHPBB3-16891
