### PR TITLE
[ticket/16914] Added missing id to language select element

### DIFF
--- a/phpBB/styles/prosilver/template/memberlist_email.html
+++ b/phpBB/styles/prosilver/template/memberlist_email.html
@@ -71,7 +71,7 @@
 			<dl>
 				<dt><label for="lang">{L_DEST_LANG}{L_COLON}</label><br />
 					<span>{L_DEST_LANG_EXPLAIN}</span></dt>
-				<dd><select name="lang">{S_LANG_OPTIONS}</select></dd>
+				<dd><select name="lang" id="lang">{S_LANG_OPTIONS}</select></dd>
 			</dl>
 		<!-- ENDIF -->
 		<dl>


### PR DESCRIPTION
The id of the language select element referenced by it's label was missing.

PHPBB3-16914

Checklist:

- [x] Correct branch: master for new features; 3.3.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master](https://area51.phpbb.com/docs/master/coding-guidelines.html) and [3.3.x](https://area51.phpbb.com/docs/dev/3.3.x/development/coding_guidelines.html)
- [x] Commit follows commit message [format](https://area51.phpbb.com/docs/dev/3.3.x/development/git.html)

Tracker ticket (set the ticket ID to **your ticket ID**):

https://tracker.phpbb.com/browse/PHPBB3-16914
