### PR TITLE
[ticket/16940] Optimize phpBB Native Search [3.3.x]

### DIFF
--- a/phpBB/includes/acp/acp_search.php
+++ b/phpBB/includes/acp/acp_search.php
@@ -322,7 +322,8 @@ class acp_search
 						{
 							$sql = 'SELECT post_id, poster_id, forum_id
 								FROM ' . POSTS_TABLE . '
-								WHERE post_id > ' . (int) $post_counter;
+								WHERE post_id > ' . (int) $post_counter . '
+								ORDER BY post_id ASC';
 							$result = $db->sql_query_limit($sql, $this->batch_size);
 
 							$ids = $posters = $forum_ids = array();
@@ -392,7 +393,8 @@ class acp_search
 						{
 							$sql = 'SELECT post_id, post_subject, post_text, poster_id, forum_id
 								FROM ' . POSTS_TABLE . '
-								WHERE post_id > ' . (int) $post_counter;
+								WHERE post_id > ' . (int) $post_counter . '
+								ORDER BY post_id ASC';
 							$result = $db->sql_query_limit($sql, $this->batch_size);
 
 							$buffer = $db->sql_buffer_nested_transactions();

--- a/phpBB/includes/acp/acp_search.php
+++ b/phpBB/includes/acp/acp_search.php
@@ -345,7 +345,7 @@ class acp_search
 						// save the current state
 						$this->save_state();
 
-						if ($post_counter <= $this->max_post_id)
+						if ($post_counter < $this->max_post_id)
 						{
 							$totaltime = microtime(true) - $starttime;
 							$rows_per_second = $row_count / $totaltime;
@@ -431,7 +431,7 @@ class acp_search
 						$this->search->tidy();
 						$config['num_posts'] = $num_posts;
 
-						if ($post_counter <= $this->max_post_id)
+						if ($post_counter < $this->max_post_id)
 						{
 							$totaltime = microtime(true) - $starttime;
 							$rows_per_second = $row_count / $totaltime;

--- a/phpBB/includes/acp/acp_search.php
+++ b/phpBB/includes/acp/acp_search.php
@@ -340,7 +340,7 @@ class acp_search
 								$this->search->index_remove($ids, $posters, $forum_ids);
 							}
 
-							$post_counter = end($ids);
+							$post_counter = $ids[count($ids) - 1];
 						}
 						// save the current state
 						$this->save_state();

--- a/phpBB/includes/acp/acp_search.php
+++ b/phpBB/includes/acp/acp_search.php
@@ -339,9 +339,8 @@ class acp_search
 							if (count($ids))
 							{
 								$this->search->index_remove($ids, $posters, $forum_ids);
+								$post_counter = $ids[count($ids) - 1];
 							}
-
-							$post_counter = $ids[count($ids) - 1];
 						}
 						// save the current state
 						$this->save_state();

--- a/phpBB/includes/acp/acp_search.php
+++ b/phpBB/includes/acp/acp_search.php
@@ -322,9 +322,8 @@ class acp_search
 						{
 							$sql = 'SELECT post_id, poster_id, forum_id
 								FROM ' . POSTS_TABLE . '
-								WHERE post_id >= ' . (int) ($post_counter + 1) . '
-									AND post_id <= ' . (int) ($post_counter + $this->batch_size);
-							$result = $db->sql_query($sql);
+								WHERE post_id > ' . (int) $post_counter;
+							$result = $db->sql_query_limit($sql, $this->batch_size);
 
 							$ids = $posters = $forum_ids = array();
 							while ($row = $db->sql_fetchrow($result))
@@ -341,7 +340,7 @@ class acp_search
 								$this->search->index_remove($ids, $posters, $forum_ids);
 							}
 
-							$post_counter += $this->batch_size;
+							$post_counter = end($ids);
 						}
 						// save the current state
 						$this->save_state();
@@ -393,9 +392,8 @@ class acp_search
 						{
 							$sql = 'SELECT post_id, post_subject, post_text, poster_id, forum_id
 								FROM ' . POSTS_TABLE . '
-								WHERE post_id >= ' . (int) ($post_counter + 1) . '
-									AND post_id <= ' . (int) ($post_counter + $this->batch_size);
-							$result = $db->sql_query($sql);
+								WHERE post_id > ' . (int) $post_counter;
+							$result = $db->sql_query_limit($sql, $this->batch_size);
 
 							$buffer = $db->sql_buffer_nested_transactions();
 
@@ -416,13 +414,12 @@ class acp_search
 									$this->search->index('post', $row['post_id'], $row['post_text'], $row['post_subject'], $row['poster_id'], $row['forum_id']);
 								}
 								$row_count++;
+								$post_counter = $row['post_id'];
 							}
 							if (!$buffer)
 							{
 								$db->sql_freeresult($result);
 							}
-
-							$post_counter += $this->batch_size;
 						}
 						// save the current state
 						$this->save_state();


### PR DESCRIPTION
- Use `sql_query_limit` instead of `sql_query`
- Update SQL query to reflect the above change
- Assign proper last `post_id` to `$post_counter`

> As-per previous code, between 2 post_ids there may or may not be 100/100 posts,
> sometimes or most of the times some posts might be deleted
> and hence no of post can be less than 100, eg. 80/100.
> 
> I optimized such that there will be always be 100/100 posts to index it in one `while(...)` loop.

> Example (Approx, since it's system depended):
>  
> Step is no of refresh, inside each step there are no of `while(...)` loops.
>  
> In Previous code:
> Step 1: 80 | 60 | 100 = 240 - (1 min)
> Step 2: 40 | 90 | 70 = 200 - (1 min)
> Step 3: 50 | 70 | 90 = 210 - (1 min)
>  
> PR code:
> Step 1: 100 | 100 | 100 = 300 - (1 min)
> Step 2: 100 | 100 | 100 = 300 - (1 min)
> Step 3: 50 = 50 - (few secs)
>  
> also on larger board, even no of Steps will reduce and hence also the time.
> 
> I hope you understand what I mean, this is the best explanation I can come with.

Checklist:

- [x] Correct branch: master for new features; 3.3.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master](https://area51.phpbb.com/docs/master/coding-guidelines.html) and [3.3.x](https://area51.phpbb.com/docs/dev/3.3.x/development/coding_guidelines.html)
- [x] Commit follows commit message [format](https://area51.phpbb.com/docs/dev/3.3.x/development/git.html)

Tracker ticket (set the ticket ID to **your ticket ID**):

https://tracker.phpbb.com/browse/PHPBB3-16940
