### PR TITLE
[ticket/16940] Optimize phpBB Native Search [master]

### DIFF
--- a/phpBB/phpbb/search/backend/base.php
+++ b/phpBB/phpbb/search/backend/base.php
@@ -399,7 +399,7 @@ abstract class base implements search_backend_interface
 				$this->index_remove($ids, $posters, $forum_ids);
 			}
 
-			$post_counter = end($ids);
+			$post_counter = $ids[count($ids) - 1];
 		}
 
 		if ($post_counter <= $max_post_id)

--- a/phpBB/phpbb/search/backend/base.php
+++ b/phpBB/phpbb/search/backend/base.php
@@ -397,9 +397,8 @@ abstract class base implements search_backend_interface
 			if (count($ids))
 			{
 				$this->index_remove($ids, $posters, $forum_ids);
+				$post_counter = $ids[count($ids) - 1];
 			}
-
-			$post_counter = $ids[count($ids) - 1];
 		}
 
 		if ($post_counter < $max_post_id)

--- a/phpBB/phpbb/search/backend/base.php
+++ b/phpBB/phpbb/search/backend/base.php
@@ -452,8 +452,9 @@ abstract class base implements search_backend_interface
 	protected function get_posts_batch_after(int $post_id): \Generator
 	{
 		$sql = 'SELECT post_id, post_subject, post_text, poster_id, forum_id
-			FROM ' . POSTS_TABLE . '
-			WHERE post_id > ' . $post_id;
+				FROM ' . POSTS_TABLE . '
+				WHERE post_id > ' . (int) $post_id . '
+				ORDER BY post_id ASC';
 		$result = $this->db->sql_query_limit($sql, self::BATCH_SIZE);
 
 		while ($row = $this->db->sql_fetchrow($result))

--- a/phpBB/phpbb/search/backend/base.php
+++ b/phpBB/phpbb/search/backend/base.php
@@ -357,7 +357,7 @@ abstract class base implements search_backend_interface
 		$this->tidy();
 		$this->config['num_posts'] = $num_posts;
 
-		if ($post_counter <= $max_post_id)
+		if ($post_counter < $max_post_id)
 		{
 			$totaltime = microtime(true) - $starttime;
 			$rows_per_second = $row_count / $totaltime;
@@ -402,7 +402,7 @@ abstract class base implements search_backend_interface
 			$post_counter = $ids[count($ids) - 1];
 		}
 
-		if ($post_counter <= $max_post_id)
+		if ($post_counter < $max_post_id)
 		{
 			$totaltime = microtime(true) - $starttime;
 			$rows_per_second = $row_count / $totaltime;


### PR DESCRIPTION
- Use `sql_query_limit` instead of `sql_query`
- Update SQL query to reflect the above change
- Assign proper last `post_id` to `$post_counter`

> As-per previous code, between 2 post_ids there may or may not be 100/100 posts,
> sometimes or most of the times some posts might be deleted
> and hence no of post can be less than 100, eg. 80/100.
> 
> I optimized such that there will be always be 100/100 posts to index it in one `while(...)` loop.

> Example (Approx, since it's system depended):
>  
> Step is no of refresh, inside each step there are no of `while(...)` loops.
>  
> In Previous code:
> Step 1: 80 | 60 | 100 = 240 - (1 min)
> Step 2: 40 | 90 | 70 = 200 - (1 min)
> Step 3: 50 | 70 | 90 = 210 - (1 min)
>  
> PR code:
> Step 1: 100 | 100 | 100 = 300 - (1 min)
> Step 2: 100 | 100 | 100 = 300 - (1 min)
> Step 3: 50 = 50 - (few secs)
>  
> also on larger board, even no of Steps will reduce and hence also the time.
> 
> I hope you understand what I mean, this is the best explanation I can come with.

Checklist:

- [x] Correct branch: master for new features; 3.3.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master](https://area51.phpbb.com/docs/master/coding-guidelines.html) and [3.3.x](https://area51.phpbb.com/docs/dev/3.3.x/development/coding_guidelines.html)
- [x] Commit follows commit message [format](https://area51.phpbb.com/docs/dev/3.3.x/development/git.html)

Tracker ticket (set the ticket ID to **your ticket ID**):

https://tracker.phpbb.com/browse/PHPBB3-16940
