### PR TITLE
[ticket/19969] Hide flash status when post settings disallow [FLASH] …

### DIFF
--- a/phpBB/styles/prosilver/template/posting_editor.html
+++ b/phpBB/styles/prosilver/template/posting_editor.html
@@ -65,7 +65,9 @@
 			{BBCODE_STATUS}<br />
 			<!-- IF S_BBCODE_ALLOWED -->
 				{IMG_STATUS}<br />
+				<!-- IF S_BBCODE_FLASH -->
 				{FLASH_STATUS}<br />
+				<!-- ENDIF -->
 				{URL_STATUS}<br />
 			<!-- ENDIF -->
 			{SMILIES_STATUS}


### PR DESCRIPTION
[ticket/19969] Hide flash status when post settings disallow FLASH BBCode

Add check for S_BBCODE_FLASH around FLASH_STATUS

PHPBB3-16969

Checklist:

- [x] Correct branch: master for new features; 3.3.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master](https://area51.phpbb.com/docs/master/coding-guidelines.html) and [3.3.x](https://area51.phpbb.com/docs/dev/3.3.x/development/coding_guidelines.html)
- [x] Commit follows commit message [format](https://area51.phpbb.com/docs/dev/3.3.x/development/git.html)

Tracker ticket (set the ticket ID to **your ticket ID**):

https://tracker.phpbb.com/browse/PHPBB3-16969
