### PR TITLE
Improve handling of DDoS/brute force attacks on login form

### DIFF
--- a/phpBB/phpbb/captcha/plugins/captcha_abstract.php
+++ b/phpBB/phpbb/captcha/plugins/captcha_abstract.php
@@ -157,7 +157,8 @@ abstract class captcha_abstract
 			FROM ' . CONFIRM_TABLE . ' c
 			LEFT JOIN ' . SESSIONS_TABLE . ' s ON (c.session_id = s.session_id)
 			WHERE s.session_id IS NULL' .
-				((empty($type)) ? '' : ' AND c.confirm_type = ' . (int) $type);
+				((empty($type)) ? '' : ' AND c.confirm_type = ' . (int) $type)
+			. ' LIMIT 100000';
 		$result = $db->sql_query($sql);
 
 		if ($row = $db->sql_fetchrow($result))

--- a/phpBB/phpbb/session.php
+++ b/phpBB/phpbb/session.php
@@ -802,22 +802,25 @@ class session
 
 			unset($cookie_expire);
 
-			$sql = 'SELECT COUNT(session_id) AS sessions
-					FROM ' . SESSIONS_TABLE . '
-					WHERE session_user_id = ' . (int) $this->data['user_id'] . '
-					AND session_time >= ' . (int) ($this->time_now - (max((int) $config['session_length'], (int) $config['form_token_lifetime'])));
-			$result = $db->sql_query($sql);
-			$row = $db->sql_fetchrow($result);
-			$db->sql_freeresult($result);
-
-			if ((int) $row['sessions'] <= 1 || empty($this->data['user_form_salt']))
+			if ($this->data['user_id'] != ANONYMOUS)
 			{
-				$this->data['user_form_salt'] = unique_id();
-				// Update the form key
-				$sql = 'UPDATE ' . USERS_TABLE . '
-					SET user_form_salt = \'' . $db->sql_escape($this->data['user_form_salt']) . '\'
-					WHERE user_id = ' . (int) $this->data['user_id'];
-				$db->sql_query($sql);
+				$sql = 'SELECT COUNT(session_id) AS sessions
+						FROM ' . SESSIONS_TABLE . '
+						WHERE session_user_id = ' . (int) $this->data['user_id'] . '
+						AND session_time >= ' . (int) ($this->time_now - (max((int) $config['session_length'], (int) $config['form_token_lifetime'])));
+				$result = $db->sql_query($sql);
+				$row = $db->sql_fetchrow($result);
+				$db->sql_freeresult($result);
+
+				if ((int) $row['sessions'] <= 1 || empty($this->data['user_form_salt']))
+				{
+					$this->data['user_form_salt'] = unique_id();
+					// Update the form key
+					$sql = 'UPDATE ' . USERS_TABLE . '
+						SET user_form_salt = \'' . $db->sql_escape($this->data['user_form_salt']) . '\'
+						WHERE user_id = ' . (int) $this->data['user_id'];
+					$db->sql_query($sql);
+				}
 			}
 		}
 		else


### PR DESCRIPTION
Checklist:

- [x] Correct branch: master for new features; 3.3.x for fixes
- [ ] Tests pass
- [ ] Code follows coding guidelines: [master](https://area51.phpbb.com/docs/master/coding-guidelines.html) and [3.3.x](https://area51.phpbb.com/docs/dev/3.3.x/development/coding_guidelines.html)
- [ ] Commit follows commit message [format](https://area51.phpbb.com/docs/dev/3.3.x/development/git.html)

Tracker ticket (set the ticket ID to **your ticket ID**):

https://tracker.phpbb.com/browse/PHPBB3-

----

Background:

I had a DDoS attack on login form. It quickly filled the sessions table with tens of thousands of sessions for the anonymous user. A lot of sessions for this user dramatically decreased the performance of `SELECT COUNT(session_id) AS sessions FROM  SESSIONS_TABLE  ...` query, since the efficiency of `session_user_id` index was almost non-existent (99% of sessions was for anonymous user, so the query needed to count almost all rows in table). I excluded this query for the anonymous user, since it was not needed anyway. This significantly improved performance of forum, but...

...sessions were still created and the sessions table was growing. I ignored this, but after a few days I realized that cron does not work correctly. It turns out that task for clearing old sessions tried to load hundreds of thousands of sessions in one query, which exceeded the memory limit, and the whole process failed (and this was repeated over and over since old sessions were never removed). I added a limit to this query, so sessions could be cleaned up in smaller batches (I'm still not sure if this limit is optimal, but it worked for me).