### PR TITLE
[ticket/16985] Fix MYSQLi bug - Incorrect string value for non-BMP chars

### DIFF
--- a/phpBB/phpbb/db/driver/mysqli.php
+++ b/phpBB/phpbb/db/driver/mysqli.php
@@ -331,7 +331,10 @@ class mysqli extends \phpbb\db\driver\mysql_base
 	*/
 	function sql_escape($msg)
 	{
-		return @mysqli_real_escape_string($this->db_connect_id, $msg);
+		return @mysqli_real_escape_string(
+			$this->db_connect_id,
+			utf8_encode_ucr($msg)
+		);
 	}
 
 	/**


### PR DESCRIPTION
Fixes [PHPBB3-16985](https://tracker.phpbb.com/browse/PHPBB3-16985) and will likely also fix a class of various related bugs, such as [CUSTDB-826](https://tracker.phpbb.com/projects/CUSTDB/issues/CUSTDB-826).

 `utf8_encode_ucr` is idempotent for any string that doesn't contain unencoded non-BMP characters, so double-encoding won't be an issue for any strings already encoded using it.

Checklist:

- [x] Correct branch: master for new features; 3.3.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master](https://area51.phpbb.com/docs/master/coding-guidelines.html) and [3.3.x](https://area51.phpbb.com/docs/dev/3.3.x/development/coding_guidelines.html)
- [x] Commit follows commit message [format](https://area51.phpbb.com/docs/dev/3.3.x/development/git.html)

Tracker ticket (set the ticket ID to **your ticket ID**):

https://tracker.phpbb.com/browse/PHPBB3-16985
