### PR TITLE
[ticket/16871] Do not allow negative forum and topic IDs in page_header

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,9 @@ phpBB's [Development Documentation](https://area51.phpbb.com/docs/dev/index.html
 
 ## 🔬 Automated Testing
 
-We have unit and functional tests in order to prevent regressions. You can view the bamboo continuous integration [here](https://bamboo.phpbb.com) or check our travis builds below:
+We have unit and functional tests in order to prevent regressions. You can view the bamboo continuous integration [here](https://bamboo.phpbb.com) or check our GitHub Actions below:
 
-Branch  | Description | Github Actions |
+Branch  | Description | GitHub Actions |
 ------- | ----------- | -------------- |
 **master** | Latest development version | ![Tests](https://github.com/phpbb/phpbb/workflows/Tests/badge.svg?branch=master) |
 **3.3.x** | Development of version 3.3.x | ![Tests](https://github.com/phpbb/phpbb/workflows/Tests/badge.svg?branch=3.3.x) |

--- a/phpBB/includes/functions.php
+++ b/phpBB/includes/functions.php
@@ -3874,8 +3874,9 @@ function page_header($page_title = '', $display_online_list = false, $item_id = 
 		}
 	}
 
-	$forum_id = $request->variable('f', 0);
-	$topic_id = $request->variable('t', 0);
+	// Negative forum and topic IDs are not allowed
+	$forum_id = max(0, $request->variable('f', 0));
+	$topic_id = max(0, $request->variable('t', 0));
 
 	$s_feed_news = false;
 


### PR DESCRIPTION
PHPBB3-16871

Checklist:

- [x] Correct branch: master for new features; 3.3.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master](https://area51.phpbb.com/docs/master/coding-guidelines.html) and [3.3.x](https://area51.phpbb.com/docs/dev/3.3.x/development/coding_guidelines.html)
- [x] Commit follows commit message [format](https://area51.phpbb.com/docs/dev/3.3.x/development/git.html)

Tracker ticket (PHPBB3-16871):

https://tracker.phpbb.com/browse/PHPBB3-16871

**Brief description:**

I can replicate the issue that Snover described on the bug tracker. If forum feeds are enabled, and you try going to the URL of a _valid_ post or topic whilst also supplying another argument for an _invalid_ (negative integer) forum or topic, then it will throw a few exception errors.

**Example URLs:**

    http://localhost:8001/phpBB3/phpBB/viewtopic.php?t=1&f=-1
    http://localhost:8001/phpBB3/phpBB/viewtopic.php?p=1&f=-1
    http://localhost:8001/phpBB3/phpBB/viewtopic.php?p=1&t=-1

**Returns:**

    Fatal error: Uncaught Symfony\Component\Routing\Exception\InvalidParameterException: 
    Parameter "forum_id" for route "phpbb_feed_forum" must match "\d+" ("-1" given) to generate a corresponding 
    URL. in...

**Fix:**

In `page_header()`, make sure that if an invalid forum or topic id is specified then the value defaults to `0` so that the feed link isn't generated.