### PR TITLE
[ticket/15947] Fix X out of 0 messages stored bug

### DIFF
--- a/phpBB/language/en/common.php
+++ b/phpBB/language/en/common.php
@@ -432,6 +432,7 @@ $lang = array_merge($lang, array(
 	'MESSAGE'				=> 'Message',
 	'MESSAGES'				=> 'Messages',
 	'MESSAGES_COUNT'		=> array(
+		0	=> 'unlimited messages',
 		1	=> '%d message',
 		2	=> '%d messages',
 	),


### PR DESCRIPTION
PHPBB3-15947

Checklist:

- [x] Correct branch: master for new features; 3.3.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master](https://area51.phpbb.com/docs/master/coding-guidelines.html) and [3.3.x](https://area51.phpbb.com/docs/dev/3.3.x/development/coding_guidelines.html)
- [x] Commit follows commit message [format](https://area51.phpbb.com/docs/dev/3.3.x/development/git.html)

Tracker ticket:

https://tracker.phpbb.com/browse/PHPBB3-15947

A minor language issue reported by Kovi/Tuft in PHPBB3-15947. I've reproduced it and added a fix by covering an extra translation case for 0/unlimited.

<img width="709" alt="image" src="https://user-images.githubusercontent.com/2110222/163584104-c0067e42-b3d0-4774-8faf-1237853a0674.png">

