### PR TITLE
[ticket/16800] Fix 'No Posts' bug when no date format supplied

### DIFF
--- a/phpBB/includes/ucp/ucp_main.php
+++ b/phpBB/includes/ucp/ucp_main.php
@@ -396,23 +396,25 @@ class ucp_main
 						if ($row['forum_last_post_id'])
 						{
 							$last_post_time = $user->format_date($row['forum_last_post_time']);
+							$last_post_time_rfc3339 = gmdate(DATE_RFC3339, $row['forum_last_post_time']);
 							$last_post_url = append_sid("{$phpbb_root_path}viewtopic.$phpEx", "p=" . $row['forum_last_post_id']) . '#p' . $row['forum_last_post_id'];
 						}
 						else
 						{
-							$last_post_time = $last_post_url = '';
+							$last_post_time = $last_post_time_rfc3339 = $last_post_url = '';
 						}
 
 						$template_vars = array(
-							'FORUM_ID'				=> $forum_id,
-							'FORUM_IMG_STYLE'		=> $folder_image,
-							'FORUM_FOLDER_IMG'		=> $user->img($folder_image, $folder_alt),
-							'FORUM_IMAGE'			=> ($row['forum_image']) ? '<img src="' . $phpbb_root_path . $row['forum_image'] . '" alt="' . $user->lang[$folder_alt] . '" />' : '',
-							'FORUM_IMAGE_SRC'		=> ($row['forum_image']) ? $phpbb_root_path . $row['forum_image'] : '',
-							'FORUM_NAME'			=> $row['forum_name'],
-							'FORUM_DESC'			=> generate_text_for_display($row['forum_desc'], $row['forum_desc_uid'], $row['forum_desc_bitfield'], $row['forum_desc_options']),
-							'LAST_POST_SUBJECT'		=> $row['forum_last_post_subject'],
-							'LAST_POST_TIME'		=> $last_post_time,
+							'FORUM_ID'					=> $forum_id,
+							'FORUM_IMG_STYLE'			=> $folder_image,
+							'FORUM_FOLDER_IMG'			=> $user->img($folder_image, $folder_alt),
+							'FORUM_IMAGE'				=> ($row['forum_image']) ? '<img src="' . $phpbb_root_path . $row['forum_image'] . '" alt="' . $user->lang[$folder_alt] . '" />' : '',
+							'FORUM_IMAGE_SRC'			=> ($row['forum_image']) ? $phpbb_root_path . $row['forum_image'] : '',
+							'FORUM_NAME'				=> $row['forum_name'],
+							'FORUM_DESC'				=> generate_text_for_display($row['forum_desc'], $row['forum_desc_uid'], $row['forum_desc_bitfield'], $row['forum_desc_options']),
+							'LAST_POST_SUBJECT'			=> $row['forum_last_post_subject'],
+							'LAST_POST_TIME'			=> $last_post_time,
+							'LAST_POST_TIME_RFC3339'	=> $last_post_time_rfc3339,
 
 							'LAST_POST_AUTHOR'			=> get_username_string('username', $row['forum_last_poster_id'], $row['forum_last_poster_name'], $row['forum_last_poster_colour']),
 							'LAST_POST_AUTHOR_COLOUR'	=> get_username_string('colour', $row['forum_last_poster_id'], $row['forum_last_poster_name'], $row['forum_last_poster_colour']),

--- a/phpBB/styles/prosilver/template/forumlist_body.html
+++ b/phpBB/styles/prosilver/template/forumlist_body.html
@@ -89,7 +89,7 @@
 									<i class="icon fa-question fa-fw icon-blue" aria-hidden="true"></i><span class="sr-only">{L_POSTS_UNAPPROVED_FORUM}</span>
 								</a>
 							<!-- ENDIF -->
-							<!-- IF forumrow.LAST_POST_TIME -->
+							<!-- IF forumrow.LAST_POST_TIME_RFC3339 -->
 								<dfn>{L_LAST_POST}</dfn>
 								<!-- IF forumrow.S_DISPLAY_SUBJECT -->
 									<!-- EVENT forumlist_body_last_post_title_prepend -->

--- a/phpBB/styles/prosilver/template/ucp_main_subscribed.html
+++ b/phpBB/styles/prosilver/template/ucp_main_subscribed.html
@@ -36,12 +36,12 @@
 					</div>
 				</dt>
 				<dd class="lastpost">
-					<!-- IF forumrow.LAST_POST_TIME -->
+					<!-- IF forumrow.LAST_POST_TIME_RFC3339 -->
 						<span><dfn>{L_LAST_POST} </dfn>{L_POST_BY_AUTHOR} {forumrow.LAST_POST_AUTHOR_FULL}
 							<a href="{forumrow.U_LAST_POST}">
 								<i class="icon fa-external-link-square fa-fw icon-lightgray icon-md" aria-hidden="true"></i><span class="sr-only">{VIEW_LATEST_POST}</span>
 							</a>
-							<br />{forumrow.LAST_POST_TIME}</span>
+							<br /><time datetime="{forumrow.LAST_POST_TIME_RFC3339}">{forumrow.LAST_POST_TIME}</time></span>
 					<!-- ELSE -->
 						{L_NO_POSTS}<br />&nbsp;
 					<!-- ENDIF -->


### PR DESCRIPTION
PHPBB3-16800

Checklist:

- [x] Correct branch: master for new features; 3.3.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master](https://area51.phpbb.com/docs/master/coding-guidelines.html) and [3.3.x](https://area51.phpbb.com/docs/dev/3.3.x/development/coding_guidelines.html)
- [x] Commit follows commit message [format](https://area51.phpbb.com/docs/dev/3.3.x/development/git.html)

Tracker ticket:

https://tracker.phpbb.com/browse/PHPBB3-16800

I was able to reproduce the bug that stevemaury discovered in the ticket by setting the custom date format to `0` (which would fail the conditional in the template, causing the "No posts" message to appear in the forum list / subscription list even when there are topics and posts in the forum).

It's an extreme edge case, because it makes no sense for a user to pick a custom date format like this, but nonetheless it is a bug because it shouldn't say there are "No posts" when there are posts.

The fix is to use the RFC3339 date format as the conditional in the template file because that can't be influenced by any user input.

<img width="559" alt="image" src="https://user-images.githubusercontent.com/2110222/163710357-0b7df6d6-32f0-4ed0-9436-3186aa95dd3e.png">

