### PR TITLE
[ticket/8071] Add sql_last_inserted_id alias for sql_nextid

### DIFF
--- a/phpBB/phpbb/db/driver/driver.php
+++ b/phpBB/phpbb/db/driver/driver.php
@@ -635,6 +635,14 @@ abstract class driver implements driver_interface
 	}
 
 	/**
+	 * {@inheritDoc}
+	 */
+	public function sql_nextid()
+	{
+		return $this->sql_last_inserted_id();
+	}
+
+	/**
 	* {@inheritDoc}
 	*/
 	function cast_expr_to_string($expression)

--- a/phpBB/phpbb/db/driver/driver_interface.php
+++ b/phpBB/phpbb/db/driver/driver_interface.php
@@ -299,8 +299,9 @@ interface driver_interface
 	 * The returned value can be used for selecting the item that has just been
 	 * inserted or for updating another table with an ID pointing to that item.
 	 *
-	 * Will be deprecated in a future version of phpBB in favor of
-	 * `sql_last_inserted_id`.
+	 * Alias of `sql_last_inserted_id`.
+	 *
+	 * @deprecated 3.3.11-RC1 Replaced by sql_last_inserted_id(), to be removed in 4.1.0-a1
 	 *
 	 * @return	string|false	Auto-incremented value of the last inserted row
 	 */
@@ -312,11 +313,7 @@ interface driver_interface
 	 * just been inserted or for updating another table with an ID pointing to
 	 * that item.
 	 *
-	 * Alias of `sql_nextid`.
-	 *
 	 * @return	string|false	Auto-incremented value of the last inserted row
-	 *
-	 * @since 3.3.8-RC1
 	 */
 	public function sql_last_inserted_id();
 

--- a/phpBB/phpbb/db/driver/driver_interface.php
+++ b/phpBB/phpbb/db/driver/driver_interface.php
@@ -289,11 +289,36 @@ interface driver_interface
 	public function cast_expr_to_bigint($expression);
 
 	/**
-	* Get last inserted id after insert statement
-	*
-	* @return	string		Autoincrement value of the last inserted row
-	*/
+	 * Gets the ID of the **last** inserted row immediately after an INSERT
+	 * statement.
+	 *
+	 * **Note**: Despite the name, the returned ID refers to the row that has
+	 * just been inserted, rather than the hypothetical ID of the next row if a
+	 * new one was to be inserted.
+	 *
+	 * The returned value can be used for selecting the item that has just been
+	 * inserted or for updating another table with an ID pointing to that item.
+	 *
+	 * Will be deprecated in a future version of phpBB in favor of
+	 * `sql_last_inserted_id`.
+	 *
+	 * @return	string|false	Auto-incremented value of the last inserted row
+	 */
 	public function sql_nextid();
+
+	/**
+	 * Gets the ID of the last inserted row immediately after an INSERT
+	 * statement. The returned value can be used for selecting the item that has
+	 * just been inserted or for updating another table with an ID pointing to
+	 * that item.
+	 *
+	 * Alias of `sql_nextid`.
+	 *
+	 * @return	string|false	Auto-incremented value of the last inserted row
+	 *
+	 * @since 3.3.8-RC1
+	 */
+	public function sql_last_inserted_id();
 
 	/**
 	* Add to query count

--- a/phpBB/phpbb/db/driver/factory.php
+++ b/phpBB/phpbb/db/driver/factory.php
@@ -314,9 +314,17 @@ class factory implements driver_interface
 	}
 
 	/**
-	* {@inheritdoc}
-	*/
+	 * {@inheritdoc}
+	 */
 	public function sql_nextid()
+	{
+		return $this->get_driver()->sql_nextid();
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function sql_last_inserted_id()
 	{
 		return $this->get_driver()->sql_nextid();
 	}

--- a/phpBB/phpbb/db/driver/factory.php
+++ b/phpBB/phpbb/db/driver/factory.php
@@ -318,7 +318,7 @@ class factory implements driver_interface
 	 */
 	public function sql_nextid()
 	{
-		return $this->get_driver()->sql_nextid();
+		return $this->get_driver()->sql_last_inserted_id();
 	}
 
 	/**
@@ -326,7 +326,7 @@ class factory implements driver_interface
 	 */
 	public function sql_last_inserted_id()
 	{
-		return $this->get_driver()->sql_nextid();
+		return $this->get_driver()->sql_last_inserted_id();
 	}
 
 	/**

--- a/phpBB/phpbb/db/driver/mssql_odbc.php
+++ b/phpBB/phpbb/db/driver/mssql_odbc.php
@@ -269,8 +269,8 @@ class mssql_odbc extends \phpbb\db\driver\mssql_base
 	}
 
 	/**
-	* {@inheritDoc}
-	*/
+	 * {@inheritDoc}
+	 */
 	function sql_nextid()
 	{
 		$result_id = @odbc_exec($this->db_connect_id, 'SELECT @@IDENTITY');
@@ -287,6 +287,14 @@ class mssql_odbc extends \phpbb\db\driver\mssql_base
 		}
 
 		return false;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function sql_last_inserted_id()
+	{
+		return $this->sql_nextid();
 	}
 
 	/**

--- a/phpBB/phpbb/db/driver/mssql_odbc.php
+++ b/phpBB/phpbb/db/driver/mssql_odbc.php
@@ -269,9 +269,9 @@ class mssql_odbc extends \phpbb\db\driver\mssql_base
 	}
 
 	/**
-	 * {@inheritDoc}
+	 * {@inheritdoc}
 	 */
-	function sql_nextid()
+	public function sql_last_inserted_id()
 	{
 		$result_id = @odbc_exec($this->db_connect_id, 'SELECT @@IDENTITY');
 
@@ -287,14 +287,6 @@ class mssql_odbc extends \phpbb\db\driver\mssql_base
 		}
 
 		return false;
-	}
-
-	/**
-	 * {@inheritdoc}
-	 */
-	public function sql_last_inserted_id()
-	{
-		return $this->sql_nextid();
 	}
 
 	/**

--- a/phpBB/phpbb/db/driver/mssqlnative.php
+++ b/phpBB/phpbb/db/driver/mssqlnative.php
@@ -271,8 +271,8 @@ class mssqlnative extends \phpbb\db\driver\mssql_base
 	}
 
 	/**
-	* {@inheritDoc}
-	*/
+	 * {@inheritDoc}
+	 */
 	function sql_nextid()
 	{
 		$result_id = @sqlsrv_query($this->db_connect_id, 'SELECT @@IDENTITY');
@@ -288,6 +288,14 @@ class mssqlnative extends \phpbb\db\driver\mssql_base
 		{
 			return false;
 		}
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function sql_last_inserted_id()
+	{
+		return $this->sql_nextid();
 	}
 
 	/**

--- a/phpBB/phpbb/db/driver/mssqlnative.php
+++ b/phpBB/phpbb/db/driver/mssqlnative.php
@@ -271,9 +271,9 @@ class mssqlnative extends \phpbb\db\driver\mssql_base
 	}
 
 	/**
-	 * {@inheritDoc}
+	 * {@inheritdoc}
 	 */
-	function sql_nextid()
+	public function sql_last_inserted_id()
 	{
 		$result_id = @sqlsrv_query($this->db_connect_id, 'SELECT @@IDENTITY');
 
@@ -288,14 +288,6 @@ class mssqlnative extends \phpbb\db\driver\mssql_base
 		{
 			return false;
 		}
-	}
-
-	/**
-	 * {@inheritdoc}
-	 */
-	public function sql_last_inserted_id()
-	{
-		return $this->sql_nextid();
 	}
 
 	/**

--- a/phpBB/phpbb/db/driver/mysqli.php
+++ b/phpBB/phpbb/db/driver/mysqli.php
@@ -289,19 +289,11 @@ class mysqli extends \phpbb\db\driver\mysql_base
 	}
 
 	/**
-	 * {@inheritDoc}
-	 */
-	function sql_nextid()
-	{
-		return ($this->db_connect_id) ? @mysqli_insert_id($this->db_connect_id) : false;
-	}
-
-	/**
 	 * {@inheritdoc}
 	 */
 	public function sql_last_inserted_id()
 	{
-		return $this->sql_nextid();
+		return ($this->db_connect_id) ? @mysqli_insert_id($this->db_connect_id) : false;
 	}
 
 	/**

--- a/phpBB/phpbb/db/driver/mysqli.php
+++ b/phpBB/phpbb/db/driver/mysqli.php
@@ -289,11 +289,19 @@ class mysqli extends \phpbb\db\driver\mysql_base
 	}
 
 	/**
-	* {@inheritDoc}
-	*/
+	 * {@inheritDoc}
+	 */
 	function sql_nextid()
 	{
 		return ($this->db_connect_id) ? @mysqli_insert_id($this->db_connect_id) : false;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function sql_last_inserted_id()
+	{
+		return $this->sql_nextid();
 	}
 
 	/**

--- a/phpBB/phpbb/db/driver/oracle.php
+++ b/phpBB/phpbb/db/driver/oracle.php
@@ -570,9 +570,9 @@ class oracle extends \phpbb\db\driver\driver
 	}
 
 	/**
-	 * {@inheritDoc}
+	 * {@inheritdoc}
 	 */
-	function sql_nextid()
+	public function sql_last_inserted_id()
 	{
 		$query_id = $this->query_result;
 
@@ -605,14 +605,6 @@ class oracle extends \phpbb\db\driver\driver
 		}
 
 		return false;
-	}
-
-	/**
-	 * {@inheritdoc}
-	 */
-	public function sql_last_inserted_id()
-	{
-		return $this->sql_nextid();
 	}
 
 	/**

--- a/phpBB/phpbb/db/driver/oracle.php
+++ b/phpBB/phpbb/db/driver/oracle.php
@@ -570,8 +570,8 @@ class oracle extends \phpbb\db\driver\driver
 	}
 
 	/**
-	* {@inheritDoc}
-	*/
+	 * {@inheritDoc}
+	 */
 	function sql_nextid()
 	{
 		$query_id = $this->query_result;
@@ -605,6 +605,14 @@ class oracle extends \phpbb\db\driver\driver
 		}
 
 		return false;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function sql_last_inserted_id()
+	{
+		return $this->sql_nextid();
 	}
 
 	/**

--- a/phpBB/phpbb/db/driver/postgres.php
+++ b/phpBB/phpbb/db/driver/postgres.php
@@ -342,9 +342,9 @@ class postgres extends \phpbb\db\driver\driver
 	}
 
 	/**
-	 * {@inheritDoc}
+	 * {@inheritdoc}
 	 */
-	function sql_nextid()
+	public function sql_last_inserted_id()
 	{
 		$query_id = $this->query_result;
 
@@ -368,14 +368,6 @@ class postgres extends \phpbb\db\driver\driver
 		}
 
 		return false;
-	}
-
-	/**
-	 * {@inheritdoc}
-	 */
-	public function sql_last_inserted_id()
-	{
-		return $this->sql_nextid();
 	}
 
 	/**

--- a/phpBB/phpbb/db/driver/postgres.php
+++ b/phpBB/phpbb/db/driver/postgres.php
@@ -342,8 +342,8 @@ class postgres extends \phpbb\db\driver\driver
 	}
 
 	/**
-	* {@inheritDoc}
-	*/
+	 * {@inheritDoc}
+	 */
 	function sql_nextid()
 	{
 		$query_id = $this->query_result;
@@ -368,6 +368,14 @@ class postgres extends \phpbb\db\driver\driver
 		}
 
 		return false;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function sql_last_inserted_id()
+	{
+		return $this->sql_nextid();
 	}
 
 	/**

--- a/phpBB/phpbb/db/driver/sqlite3.php
+++ b/phpBB/phpbb/db/driver/sqlite3.php
@@ -242,19 +242,11 @@ class sqlite3 extends \phpbb\db\driver\driver
 	}
 
 	/**
-	 * {@inheritDoc}
-	 */
-	function sql_nextid()
-	{
-		return ($this->db_connect_id) ? $this->dbo->lastInsertRowID() : false;
-	}
-
-	/**
 	 * {@inheritdoc}
 	 */
 	public function sql_last_inserted_id()
 	{
-		return $this->sql_nextid();
+		return ($this->db_connect_id) ? $this->dbo->lastInsertRowID() : false;
 	}
 
 	/**

--- a/phpBB/phpbb/db/driver/sqlite3.php
+++ b/phpBB/phpbb/db/driver/sqlite3.php
@@ -242,11 +242,19 @@ class sqlite3 extends \phpbb\db\driver\driver
 	}
 
 	/**
-	* {@inheritDoc}
-	*/
-	public function sql_nextid()
+	 * {@inheritDoc}
+	 */
+	function sql_nextid()
 	{
 		return ($this->db_connect_id) ? $this->dbo->lastInsertRowID() : false;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
+	public function sql_last_inserted_id()
+	{
+		return $this->sql_nextid();
 	}
 
 	/**


### PR DESCRIPTION
Fixes [DBAL function sql_nextid - name is misleading](https://tracker.phpbb.com/browse/PHPBB3-8071).

Per the tracker issue:
> This function gets the ID of the last inserted row, not the ID of the next row to be inserted (which is difficult due to different autoincrement steps and also lends itself nicely to race conditions).

@iwisdom replied that the naming is consistent with how PHP itself names this functionality, but the link they posted doesn't support that (I guess this is referring to a much older version of PHP? The comment is from 2009).

Checklist:

- [x] Correct branch: master for new features; 3.3.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master](https://area51.phpbb.com/docs/master/coding-guidelines.html) and [3.3.x](https://area51.phpbb.com/docs/dev/3.3.x/development/coding_guidelines.html)
- [x] Commit follows commit message [format](https://area51.phpbb.com/docs/dev/3.3.x/development/git.html)

Tracker ticket (set the ticket ID to **your ticket ID**):

https://tracker.phpbb.com/browse/PHPBB3-8071