### PR TITLE
[ticket/16990] Fix for the style template code in the post editor

### DIFF
--- a/phpBB/styles/prosilver/template/posting_editor.html
+++ b/phpBB/styles/prosilver/template/posting_editor.html
@@ -184,14 +184,14 @@
 			<!-- ENDIF -->
 
 			{% if S_SOFTDELETE_ALLOWED || S_DELETE_ALLOWED %}
-				<hr class="dashed" />
+				<hr class="dashed">
 				<dl>
 					<dt><label for="delete">{{ lang('DELETE_POST') ~ lang('COLON') }}</label></dt>
 					{% if S_SOFTDELETE_ALLOWED %}
-						<dd><label for="delete"><input type="checkbox" name="delete" id="delete" {{ S_SOFTDELETE_CHECKED }} /> {{ lang('DELETE_POST_WARN') }}</label></dd>
+						<dd><label for="delete"><input type="checkbox" name="delete" id="delete" {{ S_SOFTDELETE_CHECKED }}> {{ lang('DELETE_POST_WARN') }}</label></dd>
 					{% endif %}
 					{% if S_DELETE_ALLOWED %}
-						<dd><label for="delete_permanent"><input type="checkbox" name="delete_permanent" id="delete_permanent" /> {{ lang('DELETE_POST_PERMANENTLY') }}</label></dd>
+						<dd><label for="delete_permanent"><input type="checkbox" name="delete_permanent" id="delete_permanent"> {{ lang('DELETE_POST_PERMANENTLY') }}</label></dd>
 					{% endif %}
 				</dl>
 			{% endif %}

--- a/phpBB/styles/prosilver/template/posting_editor.html
+++ b/phpBB/styles/prosilver/template/posting_editor.html
@@ -183,16 +183,18 @@
 			</dl>
 			<!-- ENDIF -->
 
-			<!-- IF S_SOFTDELETE_ALLOWED or S_DELETE_ALLOWED -->
+			{% if S_SOFTDELETE_ALLOWED || S_DELETE_ALLOWED %}
 				<hr class="dashed" />
 				<dl>
-					<dt><label for="delete">{L_DELETE_POST}{L_COLON}</label></dt>
-					<dd><label for="delete"><input type="checkbox" name="delete" id="delete" {S_SOFTDELETE_CHECKED} /> {L_DELETE_POST_WARN}</label></dd>
-					<!-- IF S_DELETE_ALLOWED and S_SOFTDELETE_ALLOWED -->
-						<dd><label for="delete_permanent"><input type="checkbox" name="delete_permanent" id="delete_permanent" /> {L_DELETE_POST_PERMANENTLY}</label></dd>
-					<!-- ENDIF -->
+					<dt><label for="delete">{{ lang('DELETE_POST') ~ lang('COLON') }}</label></dt>
+					{% if S_SOFTDELETE_ALLOWED %}
+						<dd><label for="delete"><input type="checkbox" name="delete" id="delete" {{ S_SOFTDELETE_CHECKED }} /> {{ lang('DELETE_POST_WARN') }}</label></dd>
+					{% endif %}
+					{% if S_DELETE_ALLOWED %}
+						<dd><label for="delete_permanent"><input type="checkbox" name="delete_permanent" id="delete_permanent" /> {{ lang('DELETE_POST_PERMANENTLY') }}</label></dd>
+					{% endif %}
 				</dl>
-			<!-- ENDIF -->
+			{% endif %}
 
 			<!-- IF S_EDIT_REASON -->
 			<dl>


### PR DESCRIPTION
The code present in the prosilver style template causes the wrong checkbox to be displayed in the post editor if the combination `f_delete`:true and `f_softdelete`:false is active in the user context. With this combination, this effectively prevents a forum post from being deleted via the editor options.

Corrected the relevant section and switched to Twig syntax

PHPBB3-16990

Checklist:

- [x] Correct branch: master for new features; 3.3.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master](https://area51.phpbb.com/docs/master/coding-guidelines.html) and [3.3.x](https://area51.phpbb.com/docs/dev/3.3.x/development/coding_guidelines.html)
- [x] Commit follows commit message [format](https://area51.phpbb.com/docs/dev/3.3.x/development/git.html)

Tracker ticket (set the ticket ID to **your ticket ID**):

https://tracker.phpbb.com/browse/PHPBB3-16990
