### PR TITLE
[ticket/13859] Allow up-to-date format for Youtube profile field URLs

### DIFF
--- a/phpBB/phpbb/db/migration/data/v33x/profilefield_youtube_update.php
+++ b/phpBB/phpbb/db/migration/data/v33x/profilefield_youtube_update.php
@@ -1,0 +1,82 @@
+<?php
+/**
+*
+* This file is part of the phpBB Forum Software package.
+*
+* @copyright (c) phpBB Limited <https://www.phpbb.com>
+* @license GNU General Public License, version 2 (GPL-2.0)
+*
+* For full copyright and license information, please see
+* the docs/CREDITS.txt file.
+*
+*/
+
+namespace phpbb\db\migration\data\v33x;
+
+class profilefield_youtube_update extends \phpbb\db\migration\migration
+{
+	protected $youtube_url_matcher = 'https:\\/\\/(www\\.)?youtube\\.com\\/.+';
+
+	public function effectively_installed()
+	{
+		$profile_fields = $this->table_prefix . 'profile_fields';
+
+		$result = $this->db->sql_query(
+			"SELECT field_validation
+				FROM $profile_fields
+				WHERE field_name = 'phpbb_youtube'"
+		);
+
+		$row = $this->db->sql_fetchrow($result);
+		$this->db->sql_freeresult($result);
+
+		return $row['field_validation'] === $this->youtube_url_matcher;
+	}
+
+	static public function depends_on()
+	{
+		return ['\phpbb\db\migration\data\v33x\v337'];
+	}
+
+	public function update_data()
+	{
+		return [['custom', [[$this, 'update_youtube_profile_field']]]];
+	}
+
+	public function update_youtube_profile_field()
+	{
+		$profile_fields = $this->table_prefix . 'profile_fields';
+		$profile_fields_data = $this->table_prefix . 'profile_fields_data';
+
+		$field_validation = $this->db->sql_escape($this->youtube_url_matcher);
+
+		$min_length = strlen('https://youtube.com/c/') + 1;
+
+		$this->db->sql_query(
+			"UPDATE $profile_fields SET
+				field_length = '40',
+				field_minlen = '$min_length',
+				field_maxlen = '255',
+				field_validation = '$field_validation',
+				field_contact_url = '%s'
+				WHERE field_name = 'phpbb_youtube'"
+		);
+
+		$yt_profile_field = 'pf_phpbb_youtube';
+		$prepend_legacy_youtube_url = $this->db->sql_concatenate(
+			"'https://youtube.com/user/'", $yt_profile_field
+		);
+		$is_not_already_youtube_url = $this->db->sql_not_like_expression(
+			$this->db->get_any_char()
+				. 'youtube.com/'
+				. $this->db->get_any_char()
+		);
+
+		$this->db->sql_query(
+			"UPDATE $profile_fields_data SET
+				$yt_profile_field = $prepend_legacy_youtube_url
+				WHERE $yt_profile_field <> ''
+				AND $yt_profile_field $is_not_already_youtube_url"
+		);
+	}
+}

--- a/phpBB/phpbb/db/migration/data/v33x/profilefield_youtube_update.php
+++ b/phpBB/phpbb/db/migration/data/v33x/profilefield_youtube_update.php
@@ -33,7 +33,7 @@ class profilefield_youtube_update extends \phpbb\db\migration\migration
 		return $row['field_validation'] === $this->youtube_url_matcher;
 	}
 
-	static public function depends_on()
+	public static function depends_on()
 	{
 		return ['\phpbb\db\migration\data\v33x\v337'];
 	}


### PR DESCRIPTION
Per [the tracker issue](https://tracker.phpbb.com/browse/PHPBB3-13859) from May 2015:

> In 3.1 a youtube profilefield was added in which we can insert our youtube username to link to it.... There is just one major problem though...
>
> New youtube members no longer get an username. So I think we should decide on providing different ways to access their profile.

This PR will allow users to use any valid YouTube-domain URL, which allows for
all 3 formats (`/channel/...`, `/c/...`, and the now-legacy `/user/...`).

Per [YouTube's docs](https://support.google.com/youtube/answer/6180214?hl=en):

> ## Channel URL (ID-based)
> Example: youtube.com/channel/UCUZHFZ9jIKrLroW8LcyJEQQ
>
> This is the standard URL that YouTube channels use.
>
> ## Custom URL
> Example: youtube.com/c/YouTubeCreators
>
> A custom URL is a shorter, easy-to-remember URL that you can share with your
> audience.
>
> ## Legacy username URL
> Example: youtube.com/user/YouTube
>
> Depending on when your channel was created, it may have a username. Usernames are no longer required for channels today, but you can still use this URL to direct to your channel — even if your channel name has changed since you chose your username. Existing usernames can't be changed.

PHPBB3-13859

Checklist:

- [x] Correct branch: master for new features; 3.3.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master](https://area51.phpbb.com/docs/master/coding-guidelines.html) and [3.3.x](https://area51.phpbb.com/docs/dev/3.3.x/development/coding_guidelines.html)
- [x] Commit follows commit message [format](https://area51.phpbb.com/docs/dev/3.3.x/development/git.html)

Tracker ticket (set the ticket ID to **your ticket ID**):

https://tracker.phpbb.com/browse/PHPBB3-13859
