### PR TITLE
[ticket/16916] Include PHP version number in startup/install error

### DIFF
--- a/phpBB/includes/startup.php
+++ b/phpBB/includes/startup.php
@@ -27,7 +27,7 @@ error_reporting($level);
 */
 if (version_compare(PHP_VERSION, '7.1.3', '<'))
 {
-	die('You are running an unsupported PHP version. Please upgrade to PHP 7.1.3 or higher before trying to install or update to phpBB 3.3');
+	die('You are running an unsupported PHP version (' . PHP_VERSION . '). Please upgrade to PHP 7.1.3 or higher before trying to install or update to phpBB 3.3');
 }
 // Register globals and magic quotes have been dropped in PHP 5.4 so no need for extra checks
 

--- a/phpBB/install/app.php
+++ b/phpBB/install/app.php
@@ -22,7 +22,7 @@ $phpEx = substr(strrchr(__FILE__, '.'), 1);
 
 if (version_compare(PHP_VERSION, '7.1.3', '<'))
 {
-	die('You are running an unsupported PHP version. Please upgrade to PHP 7.1.3 or higher before trying to install or update to phpBB 3.3');
+	die('You are running an unsupported PHP version (' . PHP_VERSION . '). Please upgrade to PHP 7.1.3 or higher before trying to install or update to phpBB 3.3');
 }
 
 $startup_new_path = $phpbb_root_path . 'install/update/update/new/install/startup.' . $phpEx;


### PR DESCRIPTION
If the PHP version is too low, an error is displayed during installation and normal startup. This error does not include the current PHP version number, which often becomes a debate with users who believe they are running a supported version. It's usually a misconfiguration or custom php/user.ini somewhere that the user is unaware of. This at least removes one step of the support and debugging process.

Checklist:

- [x] Correct branch: master for new features; 3.3.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master](https://area51.phpbb.com/docs/master/coding-guidelines.html) and [3.3.x](https://area51.phpbb.com/docs/dev/3.3.x/development/coding_guidelines.html)
- [x] Commit follows commit message [format](https://area51.phpbb.com/docs/dev/3.3.x/development/git.html)

Tracker ticket (set the ticket ID to **your ticket ID**):

https://tracker.phpbb.com/browse/PHPBB3-16916
