### PR TITLE
[ticket/16917] Update phpbbcli.php's permissions in release archive

### DIFF
--- a/build/build.xml
+++ b/build/build.xml
@@ -362,6 +362,8 @@
 		<chmod mode="0777" file="${dir}/store" />
 		<chmod mode="0777" file="${dir}/files" />
 		<chmod mode="0777" file="${dir}/images/avatars/upload" />
+		<!-- set permissions of executable scripts to 755 -->
+		<chmod mode="0755" file="${dir}/bin/phpbbcli.php" />
 	</target>
 
 	<target name="clean-vendor-dir">


### PR DESCRIPTION
Changes default permissions of `bin/phpbbcli.php` in the release archive so those that want to use a system level cron on *nix can save a step.

Checklist:

- [x] Correct branch: master for new features; 3.3.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master](https://area51.phpbb.com/docs/master/coding-guidelines.html) and [3.3.x](https://area51.phpbb.com/docs/dev/3.3.x/development/coding_guidelines.html)
- [x] Commit follows commit message [format](https://area51.phpbb.com/docs/dev/3.3.x/development/git.html)

Tracker ticket (set the ticket ID to **your ticket ID**):

https://tracker.phpbb.com/browse/PHPBB3-16917
