### PR TITLE
[ticket/16913] Add Search Index Progress Bar with Stats [3.3.x]

### DIFF
--- a/phpBB/adm/style/acp_search.html
+++ b/phpBB/adm/style/acp_search.html
@@ -78,24 +78,11 @@
 
 <!-- ELSEIF S_INDEX -->
 
-	<script>
-	// <![CDATA[
-		/**
-		* Popup search progress bar
-		*/
-		function popup_progress_bar(progress_type)
-		{
-			close_waitscreen = 0;
-			// no scrollbars
-			popup('{UA_PROGRESS_BAR}&amp;type=' + progress_type, 400, 240, '_index');
-		}
-	// ]]>
-	</script>
-
 	<h1>{L_ACP_SEARCH_INDEX}</h1>
 
 	<!-- IF S_CONTINUE_INDEXING -->
 		<p>{L_CONTINUE_EXPLAIN}</p>
+		{% if L_CONTINUE_PROGRESS %}<div class="centered-text" style="display: inline-block;">{{ L_CONTINUE_PROGRESS }}</div>{% endif %}
 
 		<form id="acp_search_continue" method="post" action="{U_CONTINUE_INDEXING}">
 			<fieldset>
@@ -151,10 +138,10 @@
 			<p class="quick">
 			<!-- IF backend.S_INDEXED -->
 				<input type="hidden" name="action" value="delete" />
-				<input class="button2" type="submit" value="{L_DELETE_INDEX}" onclick="popup_progress_bar('delete');" />
+				<input class="button2" type="submit" name="submit" value="{L_DELETE_INDEX}" />
 			<!-- ELSE -->
 				<input type="hidden" name="action" value="create" />
-				<input class="button2" type="submit" value="{L_CREATE_INDEX}" onclick="popup_progress_bar('create');" />
+				<input class="button2" type="submit" name="submit" value="{L_CREATE_INDEX}" />
 			<!-- ENDIF -->
 			</p>
 			{S_FORM_TOKEN}

--- a/phpBB/adm/style/acp_search.html
+++ b/phpBB/adm/style/acp_search.html
@@ -81,12 +81,28 @@
 	<h1>{L_ACP_SEARCH_INDEX}</h1>
 
 	<!-- IF S_CONTINUE_INDEXING -->
-		<p>{L_CONTINUE_EXPLAIN}</p>
-		{% if L_CONTINUE_PROGRESS %}<div class="centered-text" style="display: inline-block;">{{ L_CONTINUE_PROGRESS }}</div>{% endif %}
+		<p>
+			{% if S_CONTINUE_INDEXING == 'create' %}
+				{{ lang('CONTINUE_INDEXING_EXPLAIN') }}
+			{% else %}
+				{{ lang('CONTINUE_DELETING_INDEX_EXPLAIN') }}
+			{% endif %}
+		</p>
 
 		<form id="acp_search_continue" method="post" action="{U_CONTINUE_INDEXING}">
 			<fieldset>
-				<legend>{L_ACP_SUBMIT_CHANGES}</legend>
+				<legend>{{ lang('CONTINUE_INDEXING') }}</legend>
+				{% if CONTINUE_PROGRESS %}
+					<div class="centered-text">
+						<br>
+						<progress
+							value="{{ CONTINUE_PROGRESS.VALUE }}"
+							max="{{ CONTINUE_PROGRESS.TOTAL }}"
+							style="height: 2em; width: 20em;"></progress><br>
+						{{ CONTINUE_PROGRESS.PERCENTAGE|number_format(2) ~ ' %' }}<br>
+						{{ lang('SEARCH_INDEX_PROGRESS', CONTINUE_PROGRESS.VALUE, CONTINUE_PROGRESS.REMAINING, CONTINUE_PROGRESS.TOTAL) }}
+					</div>
+				{% endif %}
 				<p class="submit-buttons">
 					<input class="button1" type="submit" id="submit" name="submit" value="{L_SUBMIT}" />&nbsp;
 					<input class="button2" type="submit" id="cancel" name="cancel" value="{L_CANCEL}" />
@@ -138,10 +154,10 @@
 			<p class="quick">
 			<!-- IF backend.S_INDEXED -->
 				<input type="hidden" name="action" value="delete" />
-				<input class="button2" type="submit" name="submit" value="{L_DELETE_INDEX}" />
+				<input class="button2" type="submit" name="submit" value="{{ lang('DELETE_INDEX') }}" />
 			<!-- ELSE -->
 				<input type="hidden" name="action" value="create" />
-				<input class="button2" type="submit" name="submit" value="{L_CREATE_INDEX}" />
+				<input class="button2" type="submit" name="submit" value="{{ lang('CREATE_INDEX') }}" />
 			<!-- ENDIF -->
 			</p>
 			{S_FORM_TOKEN}
@@ -152,6 +168,24 @@
 
 	<!-- ENDIF -->
 
+<!-- ELSEIF S_INDEX_PROGRESS -->
+	<div class="successbox">
+		<h3>{{ INDEXING_TITLE }}</h3>
+		<p>
+			{{ INDEXING_EXPLAIN }}
+			{% if INDEXING_PROGRESS %}<br>{{ INDEXING_PROGRESS }}{% endif %}
+			{% if INDEXING_RATE %}<br>{{ INDEXING_RATE }}{% endif %}
+			{% if INDEXING_PROGRESS_BAR %}
+				<br>
+				<progress
+					value="{{ INDEXING_PROGRESS_BAR.VALUE }}"
+					max="{{ INDEXING_PROGRESS_BAR.TOTAL }}"
+					style="height: 2em; width: 20em;"></progress><br>
+				{{ INDEXING_PROGRESS_BAR.PERCENTAGE|number_format(2) ~ ' %' }}<br>
+				{{ lang('SEARCH_INDEX_PROGRESS', INDEXING_PROGRESS_BAR.VALUE, INDEXING_PROGRESS_BAR.REMAINING, INDEXING_PROGRESS_BAR.TOTAL) }}
+			{% endif %}
+		</p>
+	</div>
 <!-- ENDIF -->
 
 <!-- INCLUDE overall_footer.html -->

--- a/phpBB/includes/acp/acp_search.php
+++ b/phpBB/includes/acp/acp_search.php
@@ -239,7 +239,7 @@ class acp_search
 
 	function index($id, $mode)
 	{
-		global $db, $user, $template, $phpbb_log, $request;
+		global $db, $language, $user, $template, $phpbb_log, $request;
 		global $config, $phpbb_admin_path, $phpEx;
 
 		$action = $request->variable('action', '');
@@ -312,12 +312,17 @@ class acp_search
 					else if ($submit)
 					{
 						meta_refresh(1, append_sid($this->u_action . '&amp;action=delete&amp;skip_rows=' . $post_counter . '&amp;hash=' . generate_link_hash('acp_search')));
-						$lang_str_ary = [
-							$user->lang('DELETING_INDEX_IN_PROGRESS'),
-							$user->lang('DELETING_INDEX_IN_PROGRESS_EXPLAIN'),
-							$this->get_post_index_progress($post_counter)
-						];
-						trigger_error(implode('<br>', $lang_str_ary));
+						$template->assign_vars([
+							'S_INDEX_PROGRESS'		=> true,
+							'INDEXING_TITLE'		=> $language->lang('DELETING_INDEX_IN_PROGRESS'),
+							'INDEXING_EXPLAIN'		=> $language->lang('DELETING_INDEX_IN_PROGRESS_EXPLAIN'),
+							'INDEXING_PROGRESS_BAR'	=> $this->get_post_index_progress($post_counter),
+						]);
+
+						$this->tpl_name = 'acp_search';
+						$this->page_title = 'ACP_SEARCH_INDEX';
+
+						return;
 					}
 					else
 					{
@@ -355,14 +360,20 @@ class acp_search
 							$totaltime = microtime(true) - $starttime;
 							$rows_per_second = $row_count / $totaltime;
 							meta_refresh(1, append_sid($this->u_action . '&amp;action=delete&amp;skip_rows=' . $post_counter . '&amp;hash=' . generate_link_hash('acp_search')));
-							$lang_str_ary = [
-								$user->lang('DELETING_INDEX_IN_PROGRESS'),
-								$user->lang('DELETING_INDEX_IN_PROGRESS_EXPLAIN'),
-								$user->lang('SEARCH_INDEX_DELETE_REDIRECT', (int) $row_count, $post_counter),
-								$user->lang('SEARCH_INDEX_DELETE_REDIRECT_RATE', $rows_per_second),
-								$this->get_post_index_progress($post_counter)
-							];
-							trigger_error(implode('<br>', $lang_str_ary));
+
+							$template->assign_vars([
+								'S_INDEX_PROGRESS'		=> true,
+								'INDEXING_TITLE'		=> $language->lang('DELETING_INDEX_IN_PROGRESS'),
+								'INDEXING_EXPLAIN'		=> $language->lang('DELETING_INDEX_IN_PROGRESS_EXPLAIN'),
+								'INDEXING_PROGRESS'		=> $language->lang('SEARCH_INDEX_DELETE_REDIRECT', $row_count, $post_counter),
+								'INDEXING_RATE'			=> $language->lang('SEARCH_INDEX_DELETE_REDIRECT_RATE', $rows_per_second),
+								'INDEXING_PROGRESS_BAR'	=> $this->get_post_index_progress($post_counter),
+							]);
+
+							$this->tpl_name = 'acp_search';
+							$this->page_title = 'ACP_SEARCH_INDEX';
+
+							return;
 						}
 					}
 
@@ -389,12 +400,18 @@ class acp_search
 					else if ($submit)
 					{
 						meta_refresh(1, append_sid($this->u_action . '&amp;action=create&amp;skip_rows=' . $post_counter . '&amp;hash=' . generate_link_hash('acp_search')));
-						$lang_str_ary = [
-							$user->lang('INDEXING_IN_PROGRESS'),
-							$user->lang('INDEXING_IN_PROGRESS_EXPLAIN'),
-							$this->get_post_index_progress($post_counter)
-						];
-						trigger_error(implode('<br>', $lang_str_ary));
+
+						$template->assign_vars([
+							'S_INDEX_PROGRESS'		=> true,
+							'INDEXING_TITLE'		=> $language->lang('INDEXING_IN_PROGRESS'),
+							'INDEXING_EXPLAIN'		=> $language->lang('INDEXING_IN_PROGRESS_EXPLAIN'),
+							'INDEXING_PROGRESS_BAR'	=> $this->get_post_index_progress($post_counter),
+						]);
+
+						$this->tpl_name = 'acp_search';
+						$this->page_title = 'ACP_SEARCH_INDEX';
+
+						return;
 					}
 					else
 					{
@@ -459,14 +476,19 @@ class acp_search
 							$totaltime = microtime(true) - $starttime;
 							$rows_per_second = $row_count / $totaltime;
 							meta_refresh(1, append_sid($this->u_action . '&amp;action=create&amp;skip_rows=' . $post_counter . '&amp;hash=' . generate_link_hash('acp_search')));
-							$lang_str_ary = [
-								$user->lang('INDEXING_IN_PROGRESS'),
-								$user->lang('INDEXING_IN_PROGRESS_EXPLAIN'),
-								$user->lang('SEARCH_INDEX_CREATE_REDIRECT', (int) $row_count, $post_counter),
-								$user->lang('SEARCH_INDEX_CREATE_REDIRECT_RATE', $rows_per_second),
-								$this->get_post_index_progress($post_counter)
-							];
-							trigger_error(implode('<br>', $lang_str_ary));
+							$template->assign_vars([
+								'S_INDEX_PROGRESS'		=> true,
+								'INDEXING_TITLE'		=> $language->lang('INDEXING_IN_PROGRESS'),
+								'INDEXING_EXPLAIN'		=> $language->lang('INDEXING_IN_PROGRESS_EXPLAIN'),
+								'INDEXING_PROGRESS'		=> $language->lang('SEARCH_INDEX_CREATE_REDIRECT', $row_count, $post_counter),
+								'INDEXING_RATE'			=> $language->lang('SEARCH_INDEX_CREATE_REDIRECT_RATE', $rows_per_second),
+								'INDEXING_PROGRESS_BAR'	=> $this->get_post_index_progress($post_counter),
+							]);
+
+							$this->tpl_name = 'acp_search';
+							$this->page_title = 'ACP_SEARCH_INDEX';
+
+							return;
 						}
 					}
 
@@ -552,9 +574,7 @@ class acp_search
 			$template->assign_vars(array(
 				'S_CONTINUE_INDEXING'	=> $this->state[1],
 				'U_CONTINUE_INDEXING'	=> $this->u_action . '&amp;action=' . $this->state[1] . '&amp;hash=' . generate_link_hash('acp_search'),
-				'L_CONTINUE'			=> ($this->state[1] == 'create') ? $user->lang['CONTINUE_INDEXING'] : $user->lang['CONTINUE_DELETING_INDEX'],
-				'L_CONTINUE_EXPLAIN'	=> ($this->state[1] == 'create') ? $user->lang['CONTINUE_INDEXING_EXPLAIN'] : $user->lang['CONTINUE_DELETING_INDEX_EXPLAIN'],
-				'L_CONTINUE_PROGRESS'	=> (isset($this->state[2]) && $this->state[2] > 0) ? $this->get_post_index_progress($this->state[2]) : $this->get_post_index_progress(0)
+				'CONTINUE_PROGRESS'	=> (isset($this->state[2]) && $this->state[2] > 0) ? $this->get_post_index_progress($this->state[2]) : $this->get_post_index_progress(0)
 			));
 		}
 	}
@@ -589,7 +609,7 @@ class acp_search
 	 * Get progress stats of search index with HTML progress bar.
 	 *
 	 * @param int		$post_counter	Post ID of last post indexed.
-	 * @return string	Returns string with HTML progress bar and stats.
+	 * @return array	Returns array with progress bar data.
 	 */
 	function get_post_index_progress(int $post_counter)
 	{
@@ -612,10 +632,12 @@ class acp_search
 		$total_count = $done_count + $remain_count;
 		$percent = ($done_count / $total_count) * 100;
 
-		$progress = sprintf('<progress value="%1$d" max="%2$d" style="height: 2em; width: 20em;"></progress><br> %3$.2f %% <br>', $done_count, $total_count, $percent);
-		$progress .= $language->lang('SEARCH_INDEX_PROGRESS', $done_count, $remain_count, $total_count);
-
-		return $progress;
+		return [
+			'VALUE'			=> $done_count,
+			'TOTAL'			=> $total_count,
+			'PERCENTAGE'	=> $percent,
+			'REMAINING'		=> $remain_count,
+		];
 	}
 
 	function save_state($state = false)

--- a/phpBB/includes/acp/acp_search.php
+++ b/phpBB/includes/acp/acp_search.php
@@ -262,11 +262,6 @@ class acp_search
 		{
 			switch ($action)
 			{
-				case 'progress_bar':
-					$type = $request->variable('type', '');
-					$this->display_progress_bar($type);
-				break;
-
 				case 'delete':
 					$this->state[1] = 'delete';
 				break;
@@ -311,14 +306,24 @@ class acp_search
 						{
 							$this->state = array('');
 							$this->save_state();
-							trigger_error($error . adm_back_link($this->u_action) . $this->close_popup_js(), E_USER_WARNING);
+							trigger_error($error . adm_back_link($this->u_action), E_USER_WARNING);
 						}
+					}
+					else if ($submit)
+					{
+						meta_refresh(1, append_sid($this->u_action . '&amp;action=delete&amp;skip_rows=' . $post_counter . '&amp;hash=' . generate_link_hash('acp_search')));
+						$lang_str_ary = [
+							$user->lang('DELETING_INDEX_IN_PROGRESS'),
+							$user->lang('DELETING_INDEX_IN_PROGRESS_EXPLAIN'),
+							$this->get_post_index_progress($post_counter)
+						];
+						trigger_error(implode('<br>', $lang_str_ary));
 					}
 					else
 					{
 						$starttime = microtime(true);
 						$row_count = 0;
-						while (still_on_time() && $post_counter <= $this->max_post_id)
+						while (still_on_time() && $post_counter < $this->max_post_id)
 						{
 							$sql = 'SELECT post_id, poster_id, forum_id
 								FROM ' . POSTS_TABLE . '
@@ -350,7 +355,14 @@ class acp_search
 							$totaltime = microtime(true) - $starttime;
 							$rows_per_second = $row_count / $totaltime;
 							meta_refresh(1, append_sid($this->u_action . '&amp;action=delete&amp;skip_rows=' . $post_counter . '&amp;hash=' . generate_link_hash('acp_search')));
-							trigger_error($user->lang('SEARCH_INDEX_DELETE_REDIRECT', (int) $row_count, $post_counter) . $user->lang('SEARCH_INDEX_DELETE_REDIRECT_RATE', $rows_per_second));
+							$lang_str_ary = [
+								$user->lang('DELETING_INDEX_IN_PROGRESS'),
+								$user->lang('DELETING_INDEX_IN_PROGRESS_EXPLAIN'),
+								$user->lang('SEARCH_INDEX_DELETE_REDIRECT', (int) $row_count, $post_counter),
+								$user->lang('SEARCH_INDEX_DELETE_REDIRECT_RATE', $rows_per_second),
+								$this->get_post_index_progress($post_counter)
+							];
+							trigger_error(implode('<br>', $lang_str_ary));
 						}
 					}
 
@@ -360,7 +372,7 @@ class acp_search
 					$this->save_state();
 
 					$phpbb_log->add('admin', $user->data['user_id'], $user->ip, 'LOG_SEARCH_INDEX_REMOVED', false, array($name));
-					trigger_error($user->lang['SEARCH_INDEX_REMOVED'] . adm_back_link($this->u_action) . $this->close_popup_js());
+					trigger_error($user->lang['SEARCH_INDEX_REMOVED'] . adm_back_link($this->u_action));
 				break;
 
 				case 'create':
@@ -371,8 +383,18 @@ class acp_search
 						{
 							$this->state = array('');
 							$this->save_state();
-							trigger_error($error . adm_back_link($this->u_action) . $this->close_popup_js(), E_USER_WARNING);
+							trigger_error($error . adm_back_link($this->u_action), E_USER_WARNING);
 						}
+					}
+					else if ($submit)
+					{
+						meta_refresh(1, append_sid($this->u_action . '&amp;action=create&amp;skip_rows=' . $post_counter . '&amp;hash=' . generate_link_hash('acp_search')));
+						$lang_str_ary = [
+							$user->lang('INDEXING_IN_PROGRESS'),
+							$user->lang('INDEXING_IN_PROGRESS_EXPLAIN'),
+							$this->get_post_index_progress($post_counter)
+						];
+						trigger_error(implode('<br>', $lang_str_ary));
 					}
 					else
 					{
@@ -388,7 +410,7 @@ class acp_search
 
 						$starttime = microtime(true);
 						$row_count = 0;
-						while (still_on_time() && $post_counter <= $this->max_post_id)
+						while (still_on_time() && $post_counter < $this->max_post_id)
 						{
 							$sql = 'SELECT post_id, post_subject, post_text, poster_id, forum_id
 								FROM ' . POSTS_TABLE . '
@@ -437,7 +459,14 @@ class acp_search
 							$totaltime = microtime(true) - $starttime;
 							$rows_per_second = $row_count / $totaltime;
 							meta_refresh(1, append_sid($this->u_action . '&amp;action=create&amp;skip_rows=' . $post_counter . '&amp;hash=' . generate_link_hash('acp_search')));
-							trigger_error($user->lang('SEARCH_INDEX_CREATE_REDIRECT', (int) $row_count, $post_counter) . $user->lang('SEARCH_INDEX_CREATE_REDIRECT_RATE', $rows_per_second));
+							$lang_str_ary = [
+								$user->lang('INDEXING_IN_PROGRESS'),
+								$user->lang('INDEXING_IN_PROGRESS_EXPLAIN'),
+								$user->lang('SEARCH_INDEX_CREATE_REDIRECT', (int) $row_count, $post_counter),
+								$user->lang('SEARCH_INDEX_CREATE_REDIRECT_RATE', $rows_per_second),
+								$this->get_post_index_progress($post_counter)
+							];
+							trigger_error(implode('<br>', $lang_str_ary));
 						}
 					}
 
@@ -447,7 +476,7 @@ class acp_search
 					$this->save_state();
 
 					$phpbb_log->add('admin', $user->data['user_id'], $user->ip, 'LOG_SEARCH_INDEX_CREATED', false, array($name));
-					trigger_error($user->lang['SEARCH_INDEX_CREATED'] . adm_back_link($this->u_action) . $this->close_popup_js());
+					trigger_error($user->lang['SEARCH_INDEX_CREATED'] . adm_back_link($this->u_action));
 				break;
 			}
 		}
@@ -516,8 +545,6 @@ class acp_search
 		$template->assign_vars(array(
 			'S_INDEX'				=> true,
 			'U_ACTION'				=> $this->u_action . '&amp;hash=' . generate_link_hash('acp_search'),
-			'U_PROGRESS_BAR'		=> append_sid("{$phpbb_admin_path}index.$phpEx", "i=$id&amp;mode=$mode&amp;action=progress_bar"),
-			'UA_PROGRESS_BAR'		=> addslashes(append_sid("{$phpbb_admin_path}index.$phpEx", "i=$id&amp;mode=$mode&amp;action=progress_bar")),
 		));
 
 		if (isset($this->state[1]))
@@ -526,38 +553,10 @@ class acp_search
 				'S_CONTINUE_INDEXING'	=> $this->state[1],
 				'U_CONTINUE_INDEXING'	=> $this->u_action . '&amp;action=' . $this->state[1] . '&amp;hash=' . generate_link_hash('acp_search'),
 				'L_CONTINUE'			=> ($this->state[1] == 'create') ? $user->lang['CONTINUE_INDEXING'] : $user->lang['CONTINUE_DELETING_INDEX'],
-				'L_CONTINUE_EXPLAIN'	=> ($this->state[1] == 'create') ? $user->lang['CONTINUE_INDEXING_EXPLAIN'] : $user->lang['CONTINUE_DELETING_INDEX_EXPLAIN'])
-			);
+				'L_CONTINUE_EXPLAIN'	=> ($this->state[1] == 'create') ? $user->lang['CONTINUE_INDEXING_EXPLAIN'] : $user->lang['CONTINUE_DELETING_INDEX_EXPLAIN'],
+				'L_CONTINUE_PROGRESS'	=> (isset($this->state[2]) && $this->state[2] > 0) ? $this->get_post_index_progress($this->state[2]) : $this->get_post_index_progress(0)
+			));
 		}
-	}
-
-	function display_progress_bar($type)
-	{
-		global $template, $user;
-
-		$l_type = ($type == 'create') ? 'INDEXING_IN_PROGRESS' : 'DELETING_INDEX_IN_PROGRESS';
-
-		adm_page_header($user->lang[$l_type]);
-
-		$template->set_filenames(array(
-			'body'	=> 'progress_bar.html')
-		);
-
-		$template->assign_vars(array(
-			'L_PROGRESS'			=> $user->lang[$l_type],
-			'L_PROGRESS_EXPLAIN'	=> $user->lang[$l_type . '_EXPLAIN'])
-		);
-
-		adm_page_footer();
-	}
-
-	function close_popup_js()
-	{
-		return "<script type=\"text/javascript\">\n" .
-			"// <![CDATA[\n" .
-			"	close_waitscreen = 1;\n" .
-			"// ]]>\n" .
-			"</script>\n";
 	}
 
 	function get_search_types()
@@ -584,6 +583,39 @@ class acp_search
 		$db->sql_freeresult($result);
 
 		return $max_post_id;
+	}
+
+	/**
+	 * Get progress stats of search index with HTML progress bar.
+	 *
+	 * @param int		$post_counter	Post ID of last post indexed.
+	 * @return string	Returns string with HTML progress bar and stats.
+	 */
+	function get_post_index_progress(int $post_counter)
+	{
+		global $db, $language;
+
+		$sql = 'SELECT COUNT(post_id) as done_count
+			FROM ' . POSTS_TABLE . '
+			WHERE post_id <= ' . (int) $post_counter;
+		$result = $db->sql_query($sql);
+		$done_count = (int) $db->sql_fetchfield('done_count');
+		$db->sql_freeresult($result);
+
+		$sql = 'SELECT COUNT(post_id) as remain_count
+			FROM ' . POSTS_TABLE . '
+			WHERE post_id > ' . (int) $post_counter;
+		$result = $db->sql_query($sql);
+		$remain_count = (int) $db->sql_fetchfield('remain_count');
+		$db->sql_freeresult($result);
+
+		$total_count = $done_count + $remain_count;
+		$percent = ($done_count / $total_count) * 100;
+
+		$progress = sprintf('<progress value="%1$d" max="%2$d" style="height: 2em; width: 20em;"></progress><br> %3$.2f %% <br>', $done_count, $total_count, $percent);
+		$progress .= $language->lang('SEARCH_INDEX_PROGRESS', $done_count, $remain_count, $total_count);
+
+		return $progress;
 	}
 
 	function save_state($state = false)

--- a/phpBB/language/en/acp/search.php
+++ b/phpBB/language/en/acp/search.php
@@ -52,7 +52,7 @@ $lang = array_merge($lang, array(
 	'DEFAULT_SEARCH_RETURN_CHARS'			=> 'Default number of returned characters',
 	'DEFAULT_SEARCH_RETURN_CHARS_EXPLAIN'	=> 'The default number of characters that will be returned while searching. A value of 0 will return the entire post.',
 	'DELETE_INDEX'							=> 'Delete index',
-	'DELETING_INDEX_IN_PROGRESS'			=> 'Deleting the index in progress',
+	'DELETING_INDEX_IN_PROGRESS'			=> 'Deletion of index is in progress…',
 	'DELETING_INDEX_IN_PROGRESS_EXPLAIN'	=> 'The search backend is currently cleaning its index. This can take a few minutes.',
 
 	'FULLTEXT_MYSQL_INCOMPATIBLE_DATABASE'	=> 'The MySQL fulltext backend can only be used with MySQL4 and above.',
@@ -92,7 +92,7 @@ $lang = array_merge($lang, array(
 	'GO_TO_SEARCH_INDEX'					=> 'Go to search index page',
 
 	'INDEX_STATS'							=> 'Index statistics',
-	'INDEXING_IN_PROGRESS'					=> 'Indexing in progress',
+	'INDEXING_IN_PROGRESS'					=> 'Indexing in progress…',
 	'INDEXING_IN_PROGRESS_EXPLAIN'			=> 'The search backend is currently indexing all posts on the board. This can take from a few minutes to a few hours depending on your board’s size.',
 
 	'LIMIT_SEARCH_LOAD'						=> 'Search page system load limit',
@@ -112,18 +112,19 @@ $lang = array_merge($lang, array(
 	'SEARCH_GUEST_INTERVAL'					=> 'Guest search flood interval',
 	'SEARCH_GUEST_INTERVAL_EXPLAIN'			=> 'Number of seconds guests must wait between searches. If one guest searches all others have to wait until the time interval passed.',
 	'SEARCH_INDEX_CREATE_REDIRECT'			=> array(
-		2	=> 'All posts up to post id %2$d have now been indexed, of which %1$d posts were within this step.<br />',
+		2	=> 'All posts up to post id %2$d have now been indexed, of which %1$d posts were within this step.',
 	),
 	'SEARCH_INDEX_CREATE_REDIRECT_RATE'		=> array(
-		2	=> 'The current rate of indexing is approximately %1$.1f posts per second.<br />Indexing in progress…',
+		2	=> 'The current rate of indexing is approximately %1$.1f posts per second.',
 	),
 	'SEARCH_INDEX_DELETE_REDIRECT'			=> array(
-		2	=> 'All posts up to post id %2$d have been removed from the search index, of which %1$d posts were within this step.<br />',
+		2	=> 'All posts up to post id %2$d have been removed from the search index, of which %1$d posts were within this step.',
 	),
 	'SEARCH_INDEX_DELETE_REDIRECT_RATE'		=> array(
-		2	=> 'The current rate of deleting is approximately %1$.1f posts per second.<br />Deleting in progress…',
+		2	=> 'The current rate of deleting is approximately %1$.1f posts per second.',
 	),
 	'SEARCH_INDEX_CREATED'					=> 'Successfully indexed all posts in the board database.',
+	'SEARCH_INDEX_PROGRESS'					=> 'Done: %1$d | Pending: %2$d | Total: %3$d',
 	'SEARCH_INDEX_REMOVED'					=> 'Successfully deleted the search index for this backend.',
 	'SEARCH_INTERVAL'						=> 'User search flood interval',
 	'SEARCH_INTERVAL_EXPLAIN'				=> 'Number of seconds users must wait between searches. This interval is checked independently for each user.',

--- a/tests/functional/search/base.php
+++ b/tests/functional/search/base.php
@@ -191,6 +191,21 @@ abstract class phpbb_functional_search_base extends phpbb_functional_test_case
 		);
 		$form->setValues($form_values);
 		$crawler = self::submit($form);
+
+		$meta_refresh = $crawler->filter('meta[http-equiv="refresh"]');
+
+		if ($meta_refresh->count() > 0)
+		{
+			// Wait for posts to be fully indexed
+			while ($meta_refresh->count() > 0)
+			{
+				preg_match('#url=.+/(adm+.+)#', $meta_refresh->attr('content'), $match);
+				$url = $match[1];
+				$crawler = self::request('POST', $url);
+				$meta_refresh = $crawler->filter('meta[http-equiv="refresh"]');
+			}
+		}
+
 		$this->assertContainsLang('SEARCH_INDEX_CREATED', $crawler->text());
 
 		// Ensure search index has been actually created
@@ -213,6 +228,21 @@ abstract class phpbb_functional_search_base extends phpbb_functional_test_case
 		);
 		$form->setValues($form_values);
 		$crawler = self::submit($form);
+
+		$meta_refresh = $crawler->filter('meta[http-equiv="refresh"]');
+
+		if ($meta_refresh->count() > 0)
+		{
+			// Wait for index to be fully deleted
+			while ($meta_refresh->count() > 0)
+			{
+				preg_match('#url=.+/(adm+.+)#', $meta_refresh->attr('content'), $match);
+				$url = $match[1];
+				$crawler = self::request('POST', $url);
+				$meta_refresh = $crawler->filter('meta[http-equiv="refresh"]');
+			}
+		}
+
 		$this->assertContainsLang('SEARCH_INDEX_REMOVED', $crawler->text());
 
 		// Ensure search index has been actually removed


### PR DESCRIPTION
PR for **[phpbb:master](https://github.com/phpbb/phpbb/tree/master)** is at #6441 .

---

ScreenShot:
.
1st run (On Submit) : 
![search_1st_run](https://user-images.githubusercontent.com/25451052/181301126-6fffd78a-4a39-4a63-ae53-8949033aaad8.png)
.
2nd & consecutive run (On each Refresh) : 
![search_nth_run](https://user-images.githubusercontent.com/25451052/181301174-86a581cf-2f61-4856-beea-08010c246a9b.png)
.
Continue to run (In-case the Indexing was Interrupted) : 
![search_cont_run](https://user-images.githubusercontent.com/25451052/181301410-2dc7b5dc-67a2-48ea-a5ae-848c9853f16a.png)
.
Changes :
- Update SQL for count of posts
- Update search index test
- Removed "Pop-up Progress Bar".
- For first run display the "Success Message".
- Display the Info from "Pop-up Progress Bar" to "Success Message".
- Only display "Redirect" & "Rate" of post refreshed "Success Message".
- Minor Language Fix.
- Use `ORDER BY post_id ASC` for progress stats.
- Removed HTML from Lang String.
- Moved HTML to PHP file.
- Increased the size of Progress-Bar by 2x.

Checklist:

- [x] Correct branch: master for new features; 3.3.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master](https://area51.phpbb.com/docs/master/coding-guidelines.html) and [3.3.x](https://area51.phpbb.com/docs/dev/3.3.x/development/coding_guidelines.html)
- [x] Commit follows commit message [format](https://area51.phpbb.com/docs/dev/3.3.x/development/git.html)

Tracker ticket (set the ticket ID to **your ticket ID**):

https://tracker.phpbb.com/browse/PHPBB3-16913
