### PR TITLE
[ticket/16913] Add Search Index Progress Bar with Stats [master]

### DIFF
--- a/phpBB/adm/style/acp_search_index.html
+++ b/phpBB/adm/style/acp_search_index.html
@@ -2,19 +2,6 @@
 
 <a id="maincontent"></a>
 
-<script>
-// <![CDATA[
-	/**
-	* Popup search progress bar
-	*/
-	function popup_progress_bar(progress_type)
-	{
-		close_waitscreen = 0;
-		// no scrollbars
-		popup('{{ UA_PROGRESS_BAR }}&amp;type=' + progress_type, 400, 240, '_index');
-	}
-// ]]>
-</script>
 
 <h1>{{ lang('ACP_SEARCH_INDEX') }}</h1>
 
@@ -65,10 +52,10 @@
 	<p class="quick">
 	{% if backend.S_INDEXED %}
 		<input type="hidden" name="action" value="delete" />
-		<input class="button2" type="submit" value="{{ lang('DELETE_INDEX') }}" onclick="popup_progress_bar('delete');" />
+		<input class="button2" type="submit" name="submit" value="{{ lang('DELETE_INDEX') }}" />
 	{% else %}
 		<input type="hidden" name="action" value="create" />
-		<input class="button2" type="submit" value="{{ lang('CREATE_INDEX') }}" onclick="popup_progress_bar('create');" />
+		<input class="button2" type="submit" name="submit" value="{{ lang('CREATE_INDEX') }}" />
 	{% endif %}
 	</p>
 	{{ S_FORM_TOKEN }}

--- a/phpBB/adm/style/acp_search_index_inprogress.html
+++ b/phpBB/adm/style/acp_search_index_inprogress.html
@@ -2,23 +2,11 @@
 
 <a id="maincontent"></a>
 
-<script>
-    // <![CDATA[
-    /**
-     * Popup search progress bar
-     */
-    function popup_progress_bar(progress_type)
-    {
-        close_waitscreen = 0;
-        // no scrollbars
-        popup('{{ UA_PROGRESS_BAR }}&amp;type=' + progress_type, 400, 240, '_index');
-    }
-    // ]]>
-</script>
 
 <h1>{{ lang('CONTINUE') }}</h1>
 
 <p>{{ lang('CONTINUE_EXPLAIN') }}</p>
+{% if CONTINUE_PROGRESS %}<div class="centered-text" style="display: inline-block;">{{ CONTINUE_PROGRESS }}</div>{% endif %}
 
 <form id="acp_search_continue" method="post" action="{{ U_ACTION }}">
 	<fieldset>

--- a/phpBB/includes/acp/acp_search.php
+++ b/phpBB/includes/acp/acp_search.php
@@ -23,6 +23,7 @@ use phpbb\request\request;
 use phpbb\search\search_backend_factory;
 use phpbb\template\template;
 use phpbb\user;
+use phpbb\db\driver\driver_interface;
 
 if (!defined('IN_PHPBB'))
 {
@@ -63,6 +64,9 @@ class acp_search
 	/** @var user */
 	protected $user;
 
+	/** @var driver_interface DBAL driver */
+	protected $db;
+
 	/** @var string */
 	protected $phpbb_admin_path;
 
@@ -71,7 +75,7 @@ class acp_search
 
 	public function __construct($p_master)
 	{
-		global $config, $phpbb_container, $language, $phpbb_log, $request, $template, $user, $phpbb_admin_path, $phpEx;
+		global $config, $phpbb_container, $language, $phpbb_log, $request, $template, $user, $db, $phpbb_admin_path, $phpEx;
 
 		$this->config = $config;
 		$this->language = $language;
@@ -81,6 +85,7 @@ class acp_search
 		$this->search_backend_factory = $phpbb_container->get('search.backend_factory');
 		$this->template = $template;
 		$this->user = $user;
+		$this->db = $db;
 		$this->phpbb_admin_path = $phpbb_admin_path;
 		$this->php_ex = $phpEx;
 	}
@@ -278,10 +283,6 @@ class acp_search
 		{
 			switch ($action)
 			{
-				case 'progress_bar':
-					$this->display_progress_bar();
-				break;
-
 				case 'create':
 				case 'delete':
 					$this->index_action($id, $mode, $action, $state);
@@ -302,7 +303,7 @@ class acp_search
 
 			if (!empty($state))
 			{
-				$this->index_inprogress($id, $mode, $state[self::STATE_ACTION]);
+				$this->index_inprogress($id, $mode, $state);
 			}
 			else
 			{
@@ -337,7 +338,6 @@ class acp_search
 
 		$this->template->assign_vars([
 			'U_ACTION'				=> $this->u_action . '&amp;hash=' . generate_link_hash('acp_search'),
-			'UA_PROGRESS_BAR'		=> addslashes($this->u_action . '&amp;action=progress_bar'),
 		]);
 	}
 
@@ -346,18 +346,21 @@ class acp_search
 	 *
 	 * @param string $id
 	 * @param string $mode
-	 * @param string $action Action in progress: 'create' or 'delete'
+	 * @param array $state
 	 */
-	private function index_inprogress(string $id, string $mode, string $action): void
+	private function index_inprogress(string $id, string $mode, array $state): void
 	{
 		$this->tpl_name = 'acp_search_index_inprogress';
 		$this->page_title = 'ACP_SEARCH_INDEX';
 
+		$action = $state[self::STATE_ACTION];
+		$post_counter = (isset($state[self::STATE_POST_COUNTER]) && $state[self::STATE_POST_COUNTER] > 0) ? $state[self::STATE_POST_COUNTER] : 0;
+
 		$this->template->assign_vars([
 			'U_ACTION'				=> $this->u_action . '&amp;action=' . $action . '&amp;hash=' . generate_link_hash('acp_search'),
-			'UA_PROGRESS_BAR'		=> addslashes($this->u_action . '&amp;action=progress_bar'),
 			'L_CONTINUE'			=> ($action === 'create') ? $this->language->lang('CONTINUE_INDEXING') : $this->language->lang('CONTINUE_DELETING_INDEX'),
 			'L_CONTINUE_EXPLAIN'	=> ($action === 'create') ? $this->language->lang('CONTINUE_INDEXING_EXPLAIN') : $this->language->lang('CONTINUE_DELETING_INDEX_EXPLAIN'),
+			'CONTINUE_PROGRESS'		=> $this->get_post_index_progress($post_counter),
 			'S_ACTION'				=> $action,
 		]);
 	}
@@ -403,6 +406,22 @@ class acp_search
 		$action = $state[self::STATE_ACTION];
 		$post_counter = &$state[self::STATE_POST_COUNTER];
 
+		$message_progress = $this->language->lang(($action == 'create') ? 'INDEXING_IN_PROGRESS' : 'DELETING_INDEX_IN_PROGRESS');
+		$message_progress_explain = $this->language->lang(($action == 'create') ? 'INDEXING_IN_PROGRESS_EXPLAIN' : 'DELETING_INDEX_IN_PROGRESS_EXPLAIN');
+
+		if ($this->request->is_set_post('submit'))
+		{
+			$u_action = append_sid($this->phpbb_admin_path . "index." . $this->php_ex, "i=$id&mode=$mode&action=$action&hash=" . generate_link_hash('acp_search'), false);
+			meta_refresh(1, $u_action);
+
+			$lang_str_ary = [
+				$message_progress,
+				$message_progress_explain,
+				$this->get_post_index_progress($post_counter)
+			];
+			trigger_error(implode('<br>', $lang_str_ary));
+		}
+
 		// Execute create/delete
 		$search = $this->search_backend_factory->get($type);
 
@@ -418,13 +437,21 @@ class acp_search
 
 				$message_redirect = $this->language->lang(($action == 'create') ? 'SEARCH_INDEX_CREATE_REDIRECT' : 'SEARCH_INDEX_DELETE_REDIRECT', (int) $status['row_count'], $status['post_counter']);
 				$message_rate = $this->language->lang(($action == 'create') ? 'SEARCH_INDEX_CREATE_REDIRECT_RATE' : 'SEARCH_INDEX_DELETE_REDIRECT_RATE', $status['rows_per_second']);
-				trigger_error($message_redirect . $message_rate);
+
+				$lang_str_ary = [
+					$message_progress,
+					$message_progress_explain,
+					$message_redirect,
+					$message_rate,
+					$this->get_post_index_progress($status['post_counter'])
+				];
+				trigger_error(implode('<br>', $lang_str_ary));
 			}
 		}
 		catch (Exception $e)
 		{
 			$this->save_state([]); // Unexpected error, cancel action
-			trigger_error($e->getMessage() . adm_back_link($this->u_action) . $this->close_popup_js(), E_USER_WARNING);
+			trigger_error($e->getMessage() . adm_back_link($this->u_action), E_USER_WARNING);
 		}
 
 		$search->tidy();
@@ -435,43 +462,38 @@ class acp_search
 		$this->log->add('admin', $this->user->data['user_id'], $this->user->ip, $log_operation, false, [$search->get_name()]);
 
 		$message = $this->language->lang(($action == 'create') ? 'SEARCH_INDEX_CREATED' : 'SEARCH_INDEX_REMOVED');
-		trigger_error($message . adm_back_link($this->u_action) . $this->close_popup_js());
+		trigger_error($message . adm_back_link($this->u_action));
 	}
 
 	/**
-	 * Popup window
-	 */
-	private function display_progress_bar(): void
-	{
-		$type = $this->request->variable('type', '');
-		$l_type = ($type === 'create') ? 'INDEXING_IN_PROGRESS' : 'DELETING_INDEX_IN_PROGRESS';
-
-		adm_page_header($this->language->lang($l_type));
-
-		$this->template->set_filenames([
-			'body'	=> 'progress_bar.html'
-		]);
-
-		$this->template->assign_vars([
-			'L_PROGRESS'			=> $this->language->lang($l_type),
-			'L_PROGRESS_EXPLAIN'	=> $this->language->lang($l_type . '_EXPLAIN'),
-		]);
-
-		adm_page_footer();
-	}
-
-	/**
-	 * Javascript code for closing the waiting screen (is attached to the trigger_errors)
+	 * Get progress stats of search index with HTML progress bar.
 	 *
-	 * @return string
+	 * @param int		$post_counter	Post ID of last post indexed.
+	 * @return string	Returns string with HTML progress bar and stats.
 	 */
-	private function close_popup_js(): string
+	function get_post_index_progress(int $post_counter)
 	{
-		return "<script type=\"text/javascript\">\n" .
-			"// <![CDATA[\n" .
-			"	close_waitscreen = 1;\n" .
-			"// ]]>\n" .
-			"</script>\n";
+		$sql = 'SELECT COUNT(post_id) as done_count
+			FROM ' . POSTS_TABLE . '
+			WHERE post_id <= ' . (int) $post_counter;
+		$result = $this->db->sql_query($sql);
+		$done_count = (int) $this->db->sql_fetchfield('done_count');
+		$this->db->sql_freeresult($result);
+
+		$sql = 'SELECT COUNT(post_id) as remain_count
+			FROM ' . POSTS_TABLE . '
+			WHERE post_id > ' . (int) $post_counter;
+		$result = $this->db->sql_query($sql);
+		$remain_count = (int) $this->db->sql_fetchfield('remain_count');
+		$this->db->sql_freeresult($result);
+
+		$total_count = $done_count + $remain_count;
+		$percent = ($done_count / $total_count) * 100;
+
+		$progress = sprintf('<progress value="%1$d" max="%2$d" style="height: 2em; width: 20em;"></progress><br> %3$.2f %% <br>', $done_count, $total_count, $percent);
+		$progress .= $this->language->lang('SEARCH_INDEX_PROGRESS', $done_count, $remain_count, $total_count);
+
+		return $progress;
 	}
 
 	/**

--- a/phpBB/language/en/acp/search.php
+++ b/phpBB/language/en/acp/search.php
@@ -52,7 +52,7 @@ $lang = array_merge($lang, array(
 	'DEFAULT_SEARCH_RETURN_CHARS'			=> 'Default number of returned characters',
 	'DEFAULT_SEARCH_RETURN_CHARS_EXPLAIN'	=> 'The default number of characters that will be returned while searching. A value of 0 will return the entire post.',
 	'DELETE_INDEX'							=> 'Delete index',
-	'DELETING_INDEX_IN_PROGRESS'			=> 'Deleting the index in progress',
+	'DELETING_INDEX_IN_PROGRESS'			=> 'Deletion of index is in progress…',
 	'DELETING_INDEX_IN_PROGRESS_EXPLAIN'	=> 'The search backend is currently cleaning its index. This can take a few minutes.',
 
 	'FULLTEXT_MYSQL_INCOMPATIBLE_DATABASE'	=> 'The MySQL fulltext backend can only be used with MySQL4 and above.',
@@ -92,7 +92,7 @@ $lang = array_merge($lang, array(
 	'GO_TO_SEARCH_INDEX'					=> 'Go to search index page',
 
 	'INDEX_STATS'							=> 'Index statistics',
-	'INDEXING_IN_PROGRESS'					=> 'Indexing in progress',
+	'INDEXING_IN_PROGRESS'					=> 'Indexing in progress…',
 	'INDEXING_IN_PROGRESS_EXPLAIN'			=> 'The search backend is currently indexing all posts on the board. This can take from a few minutes to a few hours depending on your board’s size.',
 
 	'LIMIT_SEARCH_LOAD'						=> 'Search page system load limit',
@@ -112,18 +112,19 @@ $lang = array_merge($lang, array(
 	'SEARCH_GUEST_INTERVAL'					=> 'Guest search flood interval',
 	'SEARCH_GUEST_INTERVAL_EXPLAIN'			=> 'Number of seconds guests must wait between searches. If one guest searches all others have to wait until the time interval passed.',
 	'SEARCH_INDEX_CREATE_REDIRECT'			=> array(
-		2	=> 'All posts up to post id %2$d have now been indexed, of which %1$d posts were within this step.<br />',
+		2	=> 'All posts up to post id %2$d have now been indexed, of which %1$d posts were within this step.',
 	),
 	'SEARCH_INDEX_CREATE_REDIRECT_RATE'		=> array(
-		2	=> 'The current rate of indexing is approximately %1$.1f posts per second.<br />Indexing in progress…',
+		2	=> 'The current rate of indexing is approximately %1$.1f posts per second.',
 	),
 	'SEARCH_INDEX_DELETE_REDIRECT'			=> array(
-		2	=> 'All posts up to post id %2$d have been removed from the search index, of which %1$d posts were within this step.<br />',
+		2	=> 'All posts up to post id %2$d have been removed from the search index, of which %1$d posts were within this step.',
 	),
 	'SEARCH_INDEX_DELETE_REDIRECT_RATE'		=> array(
-		2	=> 'The current rate of deleting is approximately %1$.1f posts per second.<br />Deleting in progress…',
+		2	=> 'The current rate of deleting is approximately %1$.1f posts per second.',
 	),
 	'SEARCH_INDEX_CREATED'					=> 'Successfully indexed all posts in the board database.',
+	'SEARCH_INDEX_PROGRESS'					=> 'Done: %1$d | Pending: %2$d | Total: %3$d',
 	'SEARCH_INDEX_REMOVED'					=> 'Successfully deleted the search index for this backend.',
 	'SEARCH_INTERVAL'						=> 'User search flood interval',
 	'SEARCH_INTERVAL_EXPLAIN'				=> 'Number of seconds users must wait between searches. This interval is checked independently for each user.',

--- a/tests/functional/search/base.php
+++ b/tests/functional/search/base.php
@@ -210,6 +210,21 @@ abstract class phpbb_functional_search_base extends phpbb_functional_test_case
 		);
 		$form->setValues($form_values);
 		$crawler = self::submit($form);
+
+		$meta_refresh = $crawler->filter('meta[http-equiv="refresh"]');
+
+		if ($meta_refresh->count() > 0)
+		{
+			// Wait for posts to be fully indexed
+			while ($meta_refresh->count() > 0)
+			{
+				preg_match('#url=.+/(adm+.+)#', $meta_refresh->attr('content'), $match);
+				$url = $match[1];
+				$crawler = self::request('POST', $url);
+				$meta_refresh = $crawler->filter('meta[http-equiv="refresh"]');
+			}
+		}
+
 		$this->assertContainsLang('SEARCH_INDEX_CREATED', $crawler->text());
 
 		// Ensure search index has been actually created
@@ -232,6 +247,21 @@ abstract class phpbb_functional_search_base extends phpbb_functional_test_case
 		);
 		$form->setValues($form_values);
 		$crawler = self::submit($form);
+
+		$meta_refresh = $crawler->filter('meta[http-equiv="refresh"]');
+
+		if ($meta_refresh->count() > 0)
+		{
+			// Wait for index to be fully deleted
+			while ($meta_refresh->count() > 0)
+			{
+				preg_match('#url=.+/(adm+.+)#', $meta_refresh->attr('content'), $match);
+				$url = $match[1];
+				$crawler = self::request('POST', $url);
+				$meta_refresh = $crawler->filter('meta[http-equiv="refresh"]');
+			}
+		}
+
 		$this->assertContainsLang('SEARCH_INDEX_REMOVED', $crawler->text());
 
 		// Ensure search index has been actually removed


### PR DESCRIPTION
ScreenShot:
.
1st run (On Submit) : 
![search_1st_run](https://user-images.githubusercontent.com/25451052/181301126-6fffd78a-4a39-4a63-ae53-8949033aaad8.png)
.
2nd & consecutive run (On each Refresh) : 
![search_nth_run](https://user-images.githubusercontent.com/25451052/181301174-86a581cf-2f61-4856-beea-08010c246a9b.png)
.
Continue to run (In-case the Indexing was Interrupted) : 
![search_cont_run](https://user-images.githubusercontent.com/25451052/181301410-2dc7b5dc-67a2-48ea-a5ae-848c9853f16a.png)
.
Changes :
- Update SQL for count of posts
- Update search index test
- Removed "Pop-up Progress Bar".
- For first run display the "Success Message".
- Display the Info from "Pop-up Progress Bar" to "Success Message".
- Only display "Redirect" & "Rate" of post refreshed "Success Message".
- Minor Language Fix.
- Use `ORDER BY post_id ASC` for progress stats.
- Removed HTML from Lang String.
- Moved HTML to PHP file.
- Increased the size of Progress-Bar by 2x.

Checklist:

- [x] Correct branch: master for new features; 3.3.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master](https://area51.phpbb.com/docs/master/coding-guidelines.html) and [3.3.x](https://area51.phpbb.com/docs/dev/3.3.x/development/coding_guidelines.html)
- [x] Commit follows commit message [format](https://area51.phpbb.com/docs/dev/3.3.x/development/git.html)

Tracker ticket (set the ticket ID to **your ticket ID**):

https://tracker.phpbb.com/browse/PHPBB3-16913
