### PR TITLE
[ticket/17026] Session viewonline not defined in Memberlist

### DIFF
--- a/phpBB/memberlist.php
+++ b/phpBB/memberlist.php
@@ -1634,17 +1634,20 @@ switch ($mode)
 		if (count($user_list))
 		{
 			// Session time?! Session time...
-			$sql = 'SELECT session_user_id, MAX(session_time) AS session_time
+			$sql = 'SELECT session_user_id, MAX(session_time) AS session_time, MIN(session_viewonline) AS session_viewonline
 				FROM ' . SESSIONS_TABLE . '
 				WHERE session_time >= ' . (time() - $config['session_length']) . '
 					AND ' . $db->sql_in_set('session_user_id', $user_list) . '
 				GROUP BY session_user_id';
 			$result = $db->sql_query($sql);
 
-			$session_times = array();
+			$session_ary = [];
 			while ($row = $db->sql_fetchrow($result))
 			{
-				$session_times[$row['session_user_id']] = $row['session_time'];
+				$session_ary[$row['session_user_id']] = [
+					'session_time' => $row['session_time'],
+					'session_viewonline' => $row['session_viewonline'],
+				];
 			}
 			$db->sql_freeresult($result);
 
@@ -1708,7 +1711,7 @@ switch ($mode)
 			$id_cache = array();
 			while ($row = $db->sql_fetchrow($result))
 			{
-				$row['session_time'] = (!empty($session_times[$row['user_id']])) ? $session_times[$row['user_id']] : 0;
+				$row = array_merge($row, !empty($session_ary[$row['user_id']]) ? $session_ary[$row['user_id']] : ['session_time' => 0, 'session_viewonline' => 0]);
 				$row['last_visit'] = (!empty($row['session_time'])) ? $row['session_time'] : $row['user_lastvisit'];
 
 				$id_cache[$row['user_id']] = $row;

--- a/phpBB/memberlist.php
+++ b/phpBB/memberlist.php
@@ -1711,7 +1711,8 @@ switch ($mode)
 			$id_cache = array();
 			while ($row = $db->sql_fetchrow($result))
 			{
-				$row = array_merge($row, !empty($session_ary[$row['user_id']]) ? $session_ary[$row['user_id']] : ['session_time' => 0, 'session_viewonline' => 0]);
+				$row['session_time'] = $session_ary[$row['user_id']]['session_time'] ?? 0;
+				$row['session_viewonline'] = $session_ary[$row['user_id']]['session_viewonline'] ?? 0;
 				$row['last_visit'] = (!empty($row['session_time'])) ? $row['session_time'] : $row['user_lastvisit'];
 
 				$id_cache[$row['user_id']] = $row;


### PR DESCRIPTION
In `memberlist.php` the `session_viewonline` is not defined,
hence the function `phpbb_show_profile(...)` does not have the required data to produce online status of user.
This is helpful for extensions and styles.

Checklist:

- [x] Correct branch: master for new features; 3.3.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master](https://area51.phpbb.com/docs/master/coding-guidelines.html) and [3.3.x](https://area51.phpbb.com/docs/dev/3.3.x/development/coding_guidelines.html)
- [x] Commit follows commit message [format](https://area51.phpbb.com/docs/dev/3.3.x/development/git.html)

Tracker ticket (set the ticket ID to **your ticket ID**):

https://tracker.phpbb.com/browse/PHPBB3-17026
