### PR TITLE
[ticket/17056] Fix PHP 8.2 deprecation warning about ${var} syntax

### DIFF
--- a/phpBB/phpbb/db/tools/mssql.php
+++ b/phpBB/phpbb/db/tools/mssql.php
@@ -182,7 +182,7 @@ class mssql extends tools
 
 			if (isset($prepared_column['auto_increment']) && $prepared_column['auto_increment'] && strlen($column_name) > 26) // "${column_name}_gen"
 			{
-				trigger_error("Index name '${column_name}_gen' on table '$table_name' is too long. The maximum auto increment column length is 26 characters.", E_USER_ERROR);
+				trigger_error("Index name '{$column_name}_gen' on table '$table_name' is too long. The maximum auto increment column length is 26 characters.", E_USER_ERROR);
 			}
 
 			// here we add the definition of the new column to the list of columns

--- a/phpBB/phpbb/db/tools/postgres.php
+++ b/phpBB/phpbb/db/tools/postgres.php
@@ -147,7 +147,7 @@ class postgres extends tools
 
 			if (isset($prepared_column['auto_increment']) && $prepared_column['auto_increment'] && strlen($column_name) > 26) // "${column_name}_gen"
 			{
-				trigger_error("Index name '${column_name}_gen' on table '$table_name' is too long. The maximum auto increment column length is 26 characters.", E_USER_ERROR);
+				trigger_error("Index name '{$column_name}_gen' on table '$table_name' is too long. The maximum auto increment column length is 26 characters.", E_USER_ERROR);
 			}
 
 			// here we add the definition of the new column to the list of columns

--- a/phpBB/phpbb/db/tools/tools.php
+++ b/phpBB/phpbb/db/tools/tools.php
@@ -275,7 +275,7 @@ class tools implements tools_interface
 
 			if (isset($prepared_column['auto_increment']) && $prepared_column['auto_increment'] && strlen($column_name) > 26) // "${column_name}_gen"
 			{
-				trigger_error("Index name '${column_name}_gen' on table '$table_name' is too long. The maximum auto increment column length is 26 characters.", E_USER_ERROR);
+				trigger_error("Index name '{$column_name}_gen' on table '$table_name' is too long. The maximum auto increment column length is 26 characters.", E_USER_ERROR);
 			}
 
 			// here we add the definition of the new column to the list of columns

--- a/tests/functional/acp_permissions_test.php
+++ b/tests/functional/acp_permissions_test.php
@@ -92,7 +92,7 @@ class phpbb_functional_acp_permissions_test extends phpbb_functional_test_case
 	public function test_change_permission($description, $permission_type, $permission, $mode, $object_name, $object_id)
 	{
 		// Get the form
-		$crawler = self::request('GET', "adm/index.php?i=acp_permissions&icat=16&mode=$mode&${object_name}[0]=$object_id&type=$permission_type&sid=" . $this->sid);
+		$crawler = self::request('GET', "adm/index.php?i=acp_permissions&icat=16&mode=$mode&{$object_name}[0]=$object_id&type=$permission_type&sid=" . $this->sid);
 		$this->assertStringContainsString($this->lang('ACL_SET'), $crawler->filter('h1')->eq(1)->text());
 
 		// XXX globals for \phpbb\auth\auth, refactor it later


### PR DESCRIPTION
The "${var}" style of string interpolation is deprecated in PHP 8.2, using "{$var}" syntax instead.

PHPBB3-17056

Checklist:

- [x] Correct branch: master for new features; 3.3.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master](https://area51.phpbb.com/docs/master/coding-guidelines.html) and [3.3.x](https://area51.phpbb.com/docs/dev/3.3.x/development/coding_guidelines.html)
- [x] Commit follows commit message [format](https://area51.phpbb.com/docs/dev/3.3.x/development/git.html)

Tracker ticket (set the ticket ID to **your ticket ID**):

https://tracker.phpbb.com/browse/PHPBB3-17056
