### PR TITLE
[ticket/17068] ALLOW_CDN_EXPLAIN: Refines and expands the description

### DIFF
--- a/phpBB/language/en/acp/board.php
+++ b/phpBB/language/en/acp/board.php
@@ -386,7 +386,7 @@ $lang = array_merge($lang, array(
 	'ACP_LOAD_SETTINGS_EXPLAIN'	=> 'Here you can enable and disable certain board functions to reduce the amount of processing required. On most servers there is no need to disable any functions. However on certain systems or in shared hosting environments it may be beneficial to disable capabilities you do not really need. You can also specify limits for system load and active sessions beyond which the board will go offline.',
 
 	'ALLOW_CDN'						=> 'Allow usage of third party content delivery networks',
-	'ALLOW_CDN_EXPLAIN'				=> 'If this setting is enabled, some files will be served from external third party servers instead of your server. This reduces the network bandwidth required by your server, but may present a privacy issue for some board administrators. In a default phpBB installation, this includes loading “jQuery” and the font “Open Sans” from Google’s content delivery network.',
+	'ALLOW_CDN_EXPLAIN'				=> 'If this setting is enabled, some files will be served from external third party servers instead of your server. This reduces the network bandwidth used by your server but may cause a privacy issue in some countries. In a default phpBB installation, this includes loading “jQuery” and the font “Open Sans” from Google’s content delivery network. This also applies to the “Font Awesome” font, which phpBB and some extensions use to render icons.',
 	'ALLOW_LIVE_SEARCHES'			=> 'Allow live searches',
 	'ALLOW_LIVE_SEARCHES_EXPLAIN'	=> 'If this setting is enabled, users are provided with keyword suggestions as they type in certain fields throughout the board.',
 	'CUSTOM_PROFILE_FIELDS'			=> 'Custom profile fields',

--- a/phpBB/language/en/acp/board.php
+++ b/phpBB/language/en/acp/board.php
@@ -386,7 +386,7 @@ $lang = array_merge($lang, array(
 	'ACP_LOAD_SETTINGS_EXPLAIN'	=> 'Here you can enable and disable certain board functions to reduce the amount of processing required. On most servers there is no need to disable any functions. However on certain systems or in shared hosting environments it may be beneficial to disable capabilities you do not really need. You can also specify limits for system load and active sessions beyond which the board will go offline.',
 
 	'ALLOW_CDN'						=> 'Allow usage of third party content delivery networks',
-	'ALLOW_CDN_EXPLAIN'				=> 'If this setting is enabled, some files will be served from external third party servers instead of your server. This reduces the network bandwidth used by your server but may cause a privacy issue in some countries. In a default phpBB installation, this includes loading “jQuery” and the font “Open Sans” from Google’s content delivery network. This also applies to the “Font Awesome” font, which phpBB and some extensions use to render icons.',
+	'ALLOW_CDN_EXPLAIN'				=> 'If this setting is enabled, some files will be served from external third party servers instead of your server. This reduces the network bandwidth used by your server, but may present a privacy issue in some countries. In a default phpBB installation, this includes loading “jQuery” and the font “Open Sans” from Google’s content delivery network. This also applies to the “Font Awesome” font, which phpBB and some extensions use to render icons.',
 	'ALLOW_LIVE_SEARCHES'			=> 'Allow live searches',
 	'ALLOW_LIVE_SEARCHES_EXPLAIN'	=> 'If this setting is enabled, users are provided with keyword suggestions as they type in certain fields throughout the board.',
 	'CUSTOM_PROFILE_FIELDS'			=> 'Custom profile fields',


### PR DESCRIPTION
Concerns the description of the switch "APC > GENERAL > Load settings > Allow usage of third party content delivery networks:".

* The text gives the impression that the choice of the switch state is a personal preference of individual administrators. In fact, this is a matter of local privacy laws.
* Missing mention that the switch also controls the integration of Font Awesome, part of phpBB's GUI and extensions.

PHPBB3-17068

Checklist:

- [x] Correct branch: master for new features; 3.3.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master](https://area51.phpbb.com/docs/master/coding-guidelines.html) and [3.3.x](https://area51.phpbb.com/docs/dev/3.3.x/development/coding_guidelines.html)
- [x] Commit follows commit message [format](https://area51.phpbb.com/docs/dev/3.3.x/development/git.html)

Tracker ticket (set the ticket ID to **your ticket ID**):

https://tracker.phpbb.com/browse/PHPBB3-17068
