### PR TITLE
[ticket/17092] Check for Spamhaus error codes

### DIFF
--- a/phpBB/language/en/acp/common.php
+++ b/phpBB/language/en/acp/common.php
@@ -738,6 +738,10 @@ $lang = array_merge($lang, array(
 	'LOG_SEARCH_INDEX_CREATED'	=> '<strong>Created search index for</strong><br />» %s',
 	'LOG_SEARCH_INDEX_REMOVED'	=> '<strong>Removed search index for</strong><br />» %s',
 	'LOG_SPHINX_ERROR'			=> '<strong>Sphinx Error</strong><br />» %s',
+
+	'LOG_SPAMHAUS_OPEN_RESOLVER'		=> 'Spamhaus does not allow queries using an open resolver. Blacklist checking has been disabled. For more information, see https://www.spamhaus.com/product/help-for-spamhaus-public-mirror-users/.',
+	'LOG_SPAMHAUS_VOLUME_LIMIT'			=> 'Spamhaus query volume limit has been exceeded. Blacklist checking has been disabled. For more information, see https://www.spamhaus.com/product/help-for-spamhaus-public-mirror-users/.',
+
 	'LOG_STYLE_ADD'				=> '<strong>Added new style</strong><br />» %s',
 	'LOG_STYLE_DELETE'			=> '<strong>Deleted style</strong><br />» %s',
 	'LOG_STYLE_EDIT_DETAILS'	=> '<strong>Edited style</strong><br />» %s',

--- a/phpBB/phpbb/session.php
+++ b/phpBB/phpbb/session.php
@@ -1355,7 +1355,7 @@ class session
 	* @param string 		$dnsbl	the blacklist to check against
 	* @param string|false	$ip		the IPv4 address to check
 	*
-	* @return true if listed in spamhaus database
+	* @return bool true if listed in spamhaus database, false if not
 	*/
 	function check_dnsbl_spamhaus($dnsbl, $ip = false)
 	{
@@ -1378,7 +1378,7 @@ class session
 			$reverse_ip = $quads[3] . '.' . $quads[2] . '.' . $quads[1] . '.' . $quads[0];
 
 			$records = dns_get_record($reverse_ip . '.' . $dnsbl . '.', DNS_A);
-			if ($records === false || empty($records))
+			if (empty($records))
 			{
 				return false;
 			}
@@ -1423,7 +1423,7 @@ class session
 	* @param string 		$dnsbl	the blacklist to check against
 	* @param string|false	$ip		the IPv4 address to check
 	*
-	* @return true if record is returned
+	* @return bool true if record is returned, false if not
 	*/
 	function check_dnsbl_ipv4_generic($dnsbl, $ip = false)
 	{

--- a/phpBB/phpbb/session.php
+++ b/phpBB/phpbb/session.php
@@ -1354,7 +1354,7 @@ class session
 	*
 	* @param string 		$dnsbl	the blacklist to check against
 	* @param string|false	$ip		the IPv4 address to check
-    *
+	*
 	* @return true if listed in spamhaus database
 	*/
 	function check_dnsbl_spamhaus($dnsbl, $ip = false)
@@ -1422,7 +1422,7 @@ class session
 	*
 	* @param string 		$dnsbl	the blacklist to check against
 	* @param string|false	$ip		the IPv4 address to check
-    *
+	*
 	* @return true if record is returned
 	*/
 	function check_dnsbl_ipv4_generic($dnsbl, $ip = false)

--- a/phpBB/phpbb/session.php
+++ b/phpBB/phpbb/session.php
@@ -1401,7 +1401,6 @@ class session
 
 				if ($error !== false)
 				{
-					echo 'Error encountered<br>';
 					$config->set('check_dnsbl', 0);
 					$phpbb_log->add('critical', $this->data['user_id'], $ip, $error);
 				}


### PR DESCRIPTION
Switches to using callbacks for each DNSBL so that special cases can be handled when needed. Adds support for Spamhaus error codes and disables DNSBL checking if errors are encountered since they probably won't be resolved in a timely manner by the owner or host. An error log entry is generated as well to inform the owner of why DNSBL checking was disabled.

To test, set your resolver to 1.1.1.1 or 9.9.9.9, enable DNSBL checking under Security Settings, and attempt to post. Without the changes, you should get a message stating that you're on the Spamhaus blacklist. With the changes, it should go through, but disables DNSBL checking and generates a log in the Error log of the ACP.


Checklist:

- [x] Correct branch: master for new features; 3.3.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master](https://area51.phpbb.com/docs/master/coding-guidelines.html) and [3.3.x](https://area51.phpbb.com/docs/dev/3.3.x/development/coding_guidelines.html)
- [x] Commit follows commit message [format](https://area51.phpbb.com/docs/dev/3.3.x/development/git.html)

Tracker ticket (set the ticket ID to **your ticket ID**):

https://tracker.phpbb.com/browse/PHPBB3-17092
