### PR TITLE
[ticket/16796] Fixing misalignment of header items in category on index

### DIFF
--- a/phpBB/styles/prosilver/theme/content.css
+++ b/phpBB/styles/prosilver/theme/content.css
@@ -98,7 +98,7 @@ li.row strong {
 }
 
 li.header dt, li.header dd {
-	line-height: 1em;
+	line-height: 1.6em;
 	border-left-width: 0;
 	margin: 2px 0 4px 0;
 	padding-top: 2px;


### PR DESCRIPTION
This is a fix for the Posts and Views alignment on index page in the header of category/forum.

Replaces https://github.com/phpbb/phpbb/pull/6235

PHPBB3-16796

Checklist:

- [x] Correct branch: master for new features; 3.3.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master](https://area51.phpbb.com/docs/master/coding-guidelines.html) and [3.3.x](https://area51.phpbb.com/docs/dev/3.3.x/development/coding_guidelines.html)
- [x] Commit follows commit message [format](https://area51.phpbb.com/docs/dev/3.3.x/development/git.html)

Tracker ticket (set the ticket ID to **your ticket ID**):

https://tracker.phpbb.com/browse/PHPBB3-16796
