### PR TITLE
[ticket/17045] Use NUM_ATTACHMENTS in UCP and right css classes

### DIFF
--- a/phpBB/styles/prosilver/template/ucp_attachments.html
+++ b/phpBB/styles/prosilver/template/ucp_attachments.html
@@ -10,7 +10,7 @@
 	<p>{L_ATTACHMENTS_EXPLAIN}</p>
 
 	<!-- IF .attachrow -->
-		<div class="action-bar top">
+		<div class="action-bar bar-top">
 			<div class="pagination">
 				{NUM_ATTACHMENTS}
 				<!-- IF .pagination -->
@@ -50,12 +50,12 @@
 		<!-- END attachrow -->
 		</ul>
 
-		<div class="action-bar bottom">
+		<div class="action-bar bar-bottom">
 			<!-- INCLUDE display_options.html -->
 			{S_FORM_TOKEN}
 
 			<div class="pagination">
-				{TOTAL_ATTACHMENTS} {L_TITLE}
+				{NUM_ATTACHMENTS}
 				<!-- IF .pagination -->
 					<!-- INCLUDE pagination.html -->
 				<!-- ELSE -->


### PR DESCRIPTION
PHPBB3-17045

Before:
![ticket-17045-before](https://user-images.githubusercontent.com/1311778/216140409-2085f8f9-3ecc-4b83-a173-cdd485dcc18c.PNG)

After this fix:
![ticket-17045-after](https://user-images.githubusercontent.com/1311778/216140447-cf0dbb10-8411-4270-8421-117a5e46b403.PNG)



Checklist:

- [x] Correct branch: master for new features; 3.3.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master](https://area51.phpbb.com/docs/master/coding-guidelines.html) and [3.3.x](https://area51.phpbb.com/docs/dev/3.3.x/development/coding_guidelines.html)
- [x] Commit follows commit message [format](https://area51.phpbb.com/docs/dev/3.3.x/development/git.html)

Tracker ticket (set the ticket ID to **your ticket ID**):

https://tracker.phpbb.com/browse/PHPBB3-17045
