### PR TITLE
[ticket/17076] Fix signature length calculation

### DIFF
--- a/phpBB/includes/message_parser.php
+++ b/phpBB/includes/message_parser.php
@@ -1154,7 +1154,7 @@ class parse_message extends bbcode_firstpass
 		}
 
 		// Store message length...
-		$message_length = ($mode == 'post') ? utf8_strlen($this->message) : utf8_strlen(preg_replace('#\[\/?[a-z\*\+\-]+(=[\S]+)?\]#ius', ' ', $this->message));
+		$message_length = ($mode == 'post') ? utf8_strlen($this->message) : utf8_strlen(preg_replace('#\[\/?[a-z\*\+\-]+(?:=\S+?)?\]#ius', '', $this->message));
 
 		// Maximum message length check. 0 disables this check completely.
 		if ((int) $config['max_' . $mode . '_chars'] > 0 && $message_length > (int) $config['max_' . $mode . '_chars'])


### PR DESCRIPTION
The error occurs when BBcode is used but there is no whitespace. In this case, a part of the RegEx that is designed to be greedy is responsible for selecting all BBcode tag containers and their content that do not contain whitespace. This, in combination with the replace string, effectively reduces the entire signature to a single space. This is the explanation for the reported behavior of phpBB.

In addition, the bug also generally prevents the correct removal of BBcode containers if their content does not contain whitespace. In such cases, the BBcode tags are removed along with the content, which also results in incorrect calculation of the text length.

* Changed the corresponding RegEx part from greedy to non-greedy.
* Removed an unnecessary class definition.
* Changed an unnecessary capturing group to a non-capturing group.
* Changed the replace string from a space to an empty string. <- Here, however, I'm not sure if the space was intentional or not!

PHPBB3-17076

Checklist:

- [x] Correct branch: master for new features; 3.3.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master](https://area51.phpbb.com/docs/master/coding-guidelines.html) and [3.3.x](https://area51.phpbb.com/docs/dev/3.3.x/development/coding_guidelines.html)
- [x] Commit follows commit message [format](https://area51.phpbb.com/docs/dev/3.3.x/development/git.html)

https://tracker.phpbb.com/browse/PHPBB3-17076
