### PR TITLE
[ticket/17148] Fix sql_table_exists() error for PostgreSQL 9.3 and earlier - 3.3.x

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -234,6 +234,8 @@ jobs:
             matrix:
                 include:
                     - php: '7.1'
+                      db: "postgres:9.3"
+                    - php: '7.1'
                       db: "postgres:9.5"
                     - php: '7.1'
                       db: "postgres:9.6"
@@ -264,7 +266,7 @@ jobs:
 
         services:
             postgres:
-                image: ${{ matrix.db != 'postgres:9.5' && matrix.db != 'postgres:9.6' && matrix.db != 'postgres:10' && matrix.db != 'postgres:11' && matrix.db != 'postgres:12' && matrix.db != 'postgres:13' && 'postgres:10' || matrix.db }}
+                image: ${{ matrix.db != 'postgres:9.3' && matrix.db != 'postgres:9.5' && matrix.db != 'postgres:9.6' && matrix.db != 'postgres:10' && matrix.db != 'postgres:11' && matrix.db != 'postgres:12' && matrix.db != 'postgres:13' && 'postgres:10' || matrix.db }}
                 env:
                     POSTGRES_HOST: localhost
                     POSTGRES_USER: postgres

--- a/phpBB/phpbb/db/tools/postgres.php
+++ b/phpBB/phpbb/db/tools/postgres.php
@@ -102,7 +102,7 @@ class postgres extends tools
 	function sql_table_exists($table_name)
 	{
 		$sql = "SELECT CAST(EXISTS(
-			SELECT FROM information_schema.tables
+			SELECT * FROM information_schema.tables
 				WHERE table_schema = 'public'
 					AND table_name   = '" . $this->db->sql_escape($table_name) . "'
 			) AS INTEGER)";


### PR DESCRIPTION
Fix `3.3.x` only as `master` doesn't have this code.

Checklist:

- [x] Correct branch: master for new features; 3.3.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master](https://area51.phpbb.com/docs/master/coding-guidelines.html) and [3.3.x](https://area51.phpbb.com/docs/dev/3.3.x/development/coding_guidelines.html)
- [x] Commit follows commit message [format](https://area51.phpbb.com/docs/dev/3.3.x/development/git.html)

<a href="https://tracker.phpbb.com/browse/PHPBB3-17148">PHPBB3-17148</a>.
