### PR TITLE
[ticket/17148] Fix sql_table_exists() error for PostgreSQL 9.3 and earlier - master

### DIFF
--- a/phpBB/docs/INSTALL.html
+++ b/phpBB/docs/INSTALL.html
@@ -141,13 +141,13 @@
 		<ul>
 			<li>MySQL 4.1.3 or above (MySQLi required)</li>
 			<li>MariaDB 5.1 or above</li>
-			<li>PostgreSQL 8.3+</li>
+			<li>PostgreSQL 9.4+</li>
 			<li>SQLite 3.6.15+</li>
 			<li>MS SQL Server 2000 or above (via ODBC or the native adapter)</li>
 			<li>Oracle</li>
 		</ul>
 		</li>
-		<li><strong>PHP 7.3.0+</strong> up to and including <strong>PHP 8.1</strong> with support for the database you intend to use.</li>
+		<li><strong>PHP 7.3.0+</strong> up to and including <strong>PHP 8.2</strong> with support for the database you intend to use.</li>
 		<li>The following PHP modules are required:
 		<ul>
 			<li>json</li>


### PR DESCRIPTION
`master` version of #6493.

Checklist:

- [x] Correct branch: master for new features; 3.3.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master](https://area51.phpbb.com/docs/master/coding-guidelines.html) and [3.3.x](https://area51.phpbb.com/docs/dev/3.3.x/development/coding_guidelines.html)
- [x] Commit follows commit message [format](https://area51.phpbb.com/docs/dev/3.3.x/development/git.html)

<a href="https://tracker.phpbb.com/browse/PHPBB3-17148">PHPBB3-17148</a>.
