### PR TITLE
[ticket/17171] Remove unsupported CSS rules for placeholder

### DIFF
--- a/phpBB/styles/prosilver/theme/responsive.css
+++ b/phpBB/styles/prosilver/theme/responsive.css
@@ -23,18 +23,6 @@
 	.section-viewtopic .search-box .inputbox {
 		width: 57px;
 	}
-
-	.action-bar .search-box .inputbox ::-moz-placeholder {
-    	content: "Search...";
-  	}
-
-  	.action-bar .search-box .inputbox :-ms-input-placeholder {
-  		content: "Search...";
-  	}
-
-  	.action-bar .search-box .inputbox ::-webkit-input-placeholder {
-  		content: "Search...";
-  	}
 }
 
 @media (max-width: 500px) {


### PR DESCRIPTION
The content property is not supported by the placeholder pseudo-element and hence the rules do not have any effect and can be removed.

PHPBB3-17171

Checklist:

- [x] Correct branch: master for new features; 3.3.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master](https://area51.phpbb.com/docs/master/coding-guidelines.html) and [3.3.x](https://area51.phpbb.com/docs/dev/3.3.x/development/coding_guidelines.html)
- [x] Commit follows commit message [format](https://area51.phpbb.com/docs/dev/3.3.x/development/git.html)

Tracker ticket:

https://tracker.phpbb.com/browse/PHPBB3-17171
