### PR TITLE
Patched Fix decode-uri-component vulnerable to Denial of Service (DoS)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1694,9 +1694,9 @@
 			}
 		},
 		"node_modules/decode-uri-component": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-			"integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.2.tgz",
+			"integrity": "sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==",
 			"dev": true,
 			"engines": {
 				"node": ">=0.10"
@@ -9490,9 +9490,9 @@
 			}
 		},
 		"decode-uri-component": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.0.tgz",
-			"integrity": "sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=",
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.2.tgz",
+			"integrity": "sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==",
 			"dev": true
 		},
 		"deep-is": {


### PR DESCRIPTION
decode-uri-component 0.2.0 is vulnerable to Improper Input Validation resulting in DoS. Affected versions of this project are vulnerable to Denial of Service (DoS) due to improper input validation, when the hash string # kun%ea%ba%5a%ba is being parsed by decodeUriComponent.

**PoC:**
```js
const decodeUriComponent = require('decode-uri-component'); var x = decodeUriComponent('%ea%ba%5a%ba'); console.log(x);
```
CVE-2022-38900
CWE-20
`CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H`

Checklist:

- [x] Correct branch: master for new features; 3.3.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master](https://area51.phpbb.com/docs/master/coding-guidelines.html) and [3.3.x](https://area51.phpbb.com/docs/dev/3.3.x/development/coding_guidelines.html)
- [x] Commit follows commit message [format](https://area51.phpbb.com/docs/dev/3.3.x/development/git.html)

Tracker ticket:

https://tracker.phpbb.com/browse/PHPBB3-12345
