### PR TITLE
[ticket/17188] Allow request variable to check multiline unicode

### DIFF
--- a/phpBB/phpbb/request/type_cast_helper.php
+++ b/phpBB/phpbb/request/type_cast_helper.php
@@ -55,7 +55,7 @@ class type_cast_helper implements \phpbb\request\type_cast_helper_interface
 				// Make sure multibyte characters are wellformed
 				if ($multibyte)
 				{
-					if (!preg_match('/^./u', $result))
+					if (!preg_match('/^./um', $result))
 					{
 						$result = '';
 					}

--- a/phpBB/phpbb/request/type_cast_helper.php
+++ b/phpBB/phpbb/request/type_cast_helper.php
@@ -55,7 +55,7 @@ class type_cast_helper implements \phpbb\request\type_cast_helper_interface
 				// Make sure multibyte characters are wellformed
 				if ($multibyte)
 				{
-					if (!preg_match('/^./um', $result))
+					if (!preg_match('//u', $result))
 					{
 						$result = '';
 					}

--- a/tests/request/type_cast_helper_test.php
+++ b/tests/request/type_cast_helper_test.php
@@ -20,43 +20,86 @@ class phpbb_type_cast_helper_test extends phpbb_test_case
 		$this->type_cast_helper = new \phpbb\request\type_cast_helper();
 	}
 
-	public function test_simple_recursive_set_var()
+	public function type_cast_helper_test_data()
 	{
-		$data = 'eviL<3';
-		$expected = 'eviL&lt;3';
+		return [
+			[
+				'eviL<3',
+				'eviL&lt;3',
+				'',
+				true,
+			],
+			[
+				['eviL<3'],
+				['eviL&lt;3'],
+				[0 => ''],
+				true,
+			],
+			[
+				" eviL<3\t\t",
+				" eviL&lt;3\t\t",
+				'',
+				true,
+				false,
+			],
+			[
+				[" eviL<3\t\t"],
+				[" eviL&lt;3\t\t"],
+				[0 => ''],
+				true,
+				false,
+			],
+			// Test multiline unicode vars
+			[
+				"  
 
-		$this->type_cast_helper->recursive_set_var($data, '', true);
+Тест ",
+				"  
 
-		$this->assertEquals($expected, $data);
+Тест ",
+				'',
+				true,
+				false,
+			],
+			[
+				"  
+
+Тест ",
+				"Тест",
+				'',
+				true,
+				true,
+			],
+			[
+				["  
+
+Тест "],
+				["  
+
+Тест "],
+				[0 => ''],
+				true,
+				false,
+			],
+			[
+				["  
+
+Тест "],
+				["Тест"],
+				[0 => ''],
+				true,
+				true,
+			],
+		];
 	}
 
-	public function test_nested_recursive_set_var()
+	/**
+	 * @dataProvider type_cast_helper_test_data
+	 */
+	public function test_recursive_set_var($var, $expected, $default, $multibyte, $trim = true)
 	{
-		$data = array('eviL<3');
-		$expected = array('eviL&lt;3');
+		$this->type_cast_helper->recursive_set_var($var, $default, $multibyte, $trim);
 
-		$this->type_cast_helper->recursive_set_var($data, array(0 => ''), true);
-
-		$this->assertEquals($expected, $data);
-	}
-
-	public function test_simple_untrimmed_recursive_set_var()
-	{
-		$data = " eviL<3\t\t";
-		$expected = " eviL&lt;3\t\t";
-
-		$this->type_cast_helper->recursive_set_var($data, '', true, false);
-
-		$this->assertEquals($expected, $data);
-	}
-
-	public function test_nested_untrimmed_recursive_set_var()
-	{
-		$data = array(" eviL<3\t\t");
-		$expected = array(" eviL&lt;3\t\t");
-
-		$this->type_cast_helper->recursive_set_var($data, array(0 => ''), true, false);
-
-		$this->assertEquals($expected, $data);
+		$this->assertEquals($expected, $var);
 	}
 }


### PR DESCRIPTION
Change set_var to check for multiline strings if multibyte

PHPBB3-17188

Checklist:

- [x] Correct branch: master for new features; 3.3.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master](https://area51.phpbb.com/docs/master/coding-guidelines.html) and [3.3.x](https://area51.phpbb.com/docs/dev/3.3.x/development/coding_guidelines.html)
- [x] Commit follows commit message [format](https://area51.phpbb.com/docs/dev/3.3.x/development/git.html)

Tracker ticket:

https://tracker.phpbb.com/browse/PHPBB3-17188
