### PR TITLE
[ticket/17128] Fix outdated link to php.net date format page

### DIFF
--- a/phpBB/language/en/acp/board.php
+++ b/phpBB/language/en/acp/board.php
@@ -44,7 +44,7 @@ $lang = array_merge($lang, array(
 	'BOARD_STYLE'					=> 'Board style',
 	'CUSTOM_DATEFORMAT'				=> 'Custom…',
 	'DEFAULT_DATE_FORMAT'			=> 'Date format',
-	'DEFAULT_DATE_FORMAT_EXPLAIN'	=> 'The date format is the same as the PHP <code><a href="https://secure.php.net/manual/function.date.php">date()</a></code> function.',
+	'DEFAULT_DATE_FORMAT_EXPLAIN'	=> 'The syntax uses the same format as the PHP <a href="https://www.php.net/manual/datetime.format.php">date functions</a>.',
 	'DEFAULT_LANGUAGE'				=> 'Default language',
 	'DEFAULT_STYLE'					=> 'Default style',
 	'DEFAULT_STYLE_EXPLAIN'			=> 'The default style for new users.',

--- a/phpBB/language/en/ucp.php
+++ b/phpBB/language/en/ucp.php
@@ -116,7 +116,7 @@ $lang = array_merge($lang, array(
 	'BIRTHDAY'					=> 'Birthday',
 	'BIRTHDAY_EXPLAIN'			=> 'Setting a year will list your age when it is your birthday.',
 	'BOARD_DATE_FORMAT'			=> 'My date format',
-	'BOARD_DATE_FORMAT_EXPLAIN'	=> 'The syntax used is identical to the PHP <a href="https://secure.php.net/manual/function.date.php">date()</a> function.',
+	'BOARD_DATE_FORMAT_EXPLAIN'	=> 'The syntax uses the same format as the PHP <a href="https://www.php.net/manual/datetime.format.php">date functions</a>.',
 	'BOARD_LANGUAGE'			=> 'My language',
 	'BOARD_STYLE'				=> 'My board style',
 	'BOARD_TIMEZONE'			=> 'My timezone',


### PR DESCRIPTION
This fixes the outdated links we had to the date format page on php.net. PHP moved the date format syntax definition from the date() page to one of their DateTime pages.

Unrelated, but funnily after we spoke earlier @marc1706 I restarted the Codespace and it started acting normally again. Must have been a glitch with the container 🤣 

PHPBB3-17128

Checklist:

- [x] Correct branch: master for new features; 3.3.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master](https://area51.phpbb.com/docs/master/coding-guidelines.html) and [3.3.x](https://area51.phpbb.com/docs/dev/3.3.x/development/coding_guidelines.html)
- [x] Commit follows commit message [format](https://area51.phpbb.com/docs/dev/3.3.x/development/git.html)

Tracker ticket:
https://tracker.phpbb.com/browse/PHPBB3-17128

Screenshots:

ACP

<img width="575" alt="Screenshot 2023-09-24 at 9 49 41 pm" src="https://github.com/phpbb/phpbb/assets/2110222/82529ad9-a07d-4f64-ad07-3cd33c1f6cef">

UCP

<img width="418" alt="Screenshot 2023-09-24 at 9 49 25 pm" src="https://github.com/phpbb/phpbb/assets/2110222/c9bebb44-42b0-48d8-83c4-d85b33bc0591">



