### PR TITLE
[ticket/15214] Add event & functionality for assigning template event priority

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -543,10 +543,9 @@ jobs:
                   New-WebHandler -Name "PHP-FastCGI" -Path "*.php" -Modules FastCgiModule -ScriptProcessor "C:\tools\php\php-cgi.exe" -Verb '*' -ResourceType Either
                   iisreset
                   NET START W3SVC
-                  icacls "${env:GITHUB_WORKSPACE}\phpBB\cache" /grant "Users:(OI)(CI)F" /T
                   mkdir "${env:GITHUB_WORKSPACE}\phpBB\cache\test"
-                  mkdir "${env:GITHUB_WORKSPACE}\phpBB\cache\test\twig"
                   mkdir "${env:GITHUB_WORKSPACE}\phpBB\cache\installer"
+                  icacls "${env:GITHUB_WORKSPACE}\phpBB\cache" /grant Users:F /T
                   icacls "${env:GITHUB_WORKSPACE}\phpBB\files" /grant Users:F /T
                   icacls "${env:GITHUB_WORKSPACE}\phpBB\store" /grant Users:F /T
                   icacls "${env:GITHUB_WORKSPACE}\phpBB\images\avatars\upload" /grant Users:F /T

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -543,9 +543,7 @@ jobs:
                   New-WebHandler -Name "PHP-FastCGI" -Path "*.php" -Modules FastCgiModule -ScriptProcessor "C:\tools\php\php-cgi.exe" -Verb '*' -ResourceType Either
                   iisreset
                   NET START W3SVC
-                  mkdir "${env:GITHUB_WORKSPACE}\phpBB\cache\test"
-                  mkdir "${env:GITHUB_WORKSPACE}\phpBB\cache\installer"
-                  icacls "${env:GITHUB_WORKSPACE}\phpBB\cache" /grant Users:F /T
+                  icacls "${env:GITHUB_WORKSPACE}\phpBB\cache" /grant "Users:(OI)(CI)F" /T
                   icacls "${env:GITHUB_WORKSPACE}\phpBB\files" /grant Users:F /T
                   icacls "${env:GITHUB_WORKSPACE}\phpBB\store" /grant Users:F /T
                   icacls "${env:GITHUB_WORKSPACE}\phpBB\images\avatars\upload" /grant Users:F /T

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -544,6 +544,9 @@ jobs:
                   iisreset
                   NET START W3SVC
                   icacls "${env:GITHUB_WORKSPACE}\phpBB\cache" /grant "Users:(OI)(CI)F" /T
+                  mkdir "${env:GITHUB_WORKSPACE}\phpBB\cache\test"
+                  mkdir "${env:GITHUB_WORKSPACE}\phpBB\cache\test\twig"
+                  mkdir "${env:GITHUB_WORKSPACE}\phpBB\cache\installer"
                   icacls "${env:GITHUB_WORKSPACE}\phpBB\files" /grant Users:F /T
                   icacls "${env:GITHUB_WORKSPACE}\phpBB\store" /grant Users:F /T
                   icacls "${env:GITHUB_WORKSPACE}\phpBB\images\avatars\upload" /grant Users:F /T

--- a/phpBB/config/default/container/services_twig.yml
+++ b/phpBB/config/default/container/services_twig.yml
@@ -40,6 +40,7 @@ services:
             - '@template_context'
             - '@template.twig.environment'
             - '@language'
+            - '@dispatcher'
         tags:
             - { name: twig.extension }
 

--- a/phpBB/phpbb/template/twig/extension.php
+++ b/phpBB/phpbb/template/twig/extension.php
@@ -26,18 +26,23 @@ class extension extends \Twig\Extension\AbstractExtension
 	/** @var \phpbb\language\language */
 	protected $language;
 
+	/** @var \phpbb\event\dispatcher_interface */
+	protected $phpbb_dispatcher;
+
 	/**
 	* Constructor
 	*
 	* @param \phpbb\template\context $context
 	* @param \phpbb\template\twig\environment $environment
 	* @param \phpbb\language\language $language
+	* @param \phpbb\event\dispatcher_interface $phpbb_dispatcher
 	*/
-	public function __construct(\phpbb\template\context $context, \phpbb\template\twig\environment $environment, $language)
+	public function __construct(\phpbb\template\context $context, \phpbb\template\twig\environment $environment, $language, \phpbb\event\dispatcher_interface $phpbb_dispatcher)
 	{
 		$this->context = $context;
 		$this->environment = $environment;
 		$this->language = $language;
+		$this->phpbb_dispatcher = $phpbb_dispatcher;
 	}
 
 	/**
@@ -62,7 +67,7 @@ class extension extends \Twig\Extension\AbstractExtension
 			new \phpbb\template\twig\tokenparser\includeparser,
 			new \phpbb\template\twig\tokenparser\includejs,
 			new \phpbb\template\twig\tokenparser\includecss,
-			new \phpbb\template\twig\tokenparser\event($this->environment),
+			new \phpbb\template\twig\tokenparser\event($this->environment, $this->phpbb_dispatcher),
 			new \phpbb\template\twig\tokenparser\includephp($this->environment),
 			new \phpbb\template\twig\tokenparser\php($this->environment),
 		);

--- a/phpBB/phpbb/template/twig/node/event.php
+++ b/phpBB/phpbb/template/twig/node/event.php
@@ -21,12 +21,16 @@ class event extends \Twig\Node\Node
 	*/
 	protected $listener_directory = 'event/';
 
-	/** @var \Twig\Environment */
+	/** @var \phpbb\template\twig\environment */
 	protected $environment;
 
-	public function __construct(\Twig\Node\Expression\AbstractExpression $expr, \phpbb\template\twig\environment $environment, $lineno, $tag = null)
+	/** @var array */
+	protected $template_event_priority_array;
+
+	public function __construct(\Twig\Node\Expression\AbstractExpression $expr, \phpbb\template\twig\environment $environment, $lineno, $tag = null, $template_event_priority_array = [])
 	{
 		$this->environment = $environment;
+		$this->template_event_priority_array = $template_event_priority_array;
 
 		parent::__construct(array('expr' => $expr), array(), $lineno, $tag);
 	}
@@ -42,9 +46,18 @@ class event extends \Twig\Node\Node
 
 		$location = $this->listener_directory . $this->getNode('expr')->getAttribute('name');
 
+		$compiler_steps = [];
+
 		foreach ($this->environment->get_phpbb_extensions() as $ext_namespace => $ext_path)
 		{
 			$ext_namespace = str_replace('/', '_', $ext_namespace);
+
+			if (isset($this->template_event_priority_array[$ext_namespace][$location]))
+			{
+				$priority_key = $this->template_event_priority_array[$ext_namespace][$location];
+			}
+
+			$compiler_calls = [];
 
 			if ($this->environment->isDebug())
 			{
@@ -52,7 +65,7 @@ class event extends \Twig\Node\Node
 				//  templates on page load rather than at compile. This is
 				//  slower, but makes developing extensions easier (no need to
 				//  purge the cache when a new event template file is added)
-				$compiler
+				$compiler_calls[] = fn() => $compiler
 					->write("if (\$this->env->getLoader()->exists('@{$ext_namespace}/{$location}.html')) {\n")
 					->indent()
 				;
@@ -60,7 +73,7 @@ class event extends \Twig\Node\Node
 
 			if ($this->environment->isDebug() || $this->environment->getLoader()->exists('@' . $ext_namespace . '/' . $location . '.html'))
 			{
-				$compiler
+				$compiler_calls[] = fn() => $compiler
 					->write("\$previous_look_up_order = \$this->env->getNamespaceLookUpOrder();\n")
 
 					// We set the namespace lookup order to be this extension first, then the main path
@@ -72,10 +85,38 @@ class event extends \Twig\Node\Node
 
 			if ($this->environment->isDebug())
 			{
-				$compiler
+				$compiler_calls[] = fn() => $compiler
 					->outdent()
 					->write("}\n\n")
 				;
+			}
+
+			if (!empty($compiler_calls))
+			{
+				if (isset($priority_key))
+				{
+					if (array_key_exists($priority_key, $compiler_steps))
+					{
+						array_splice($compiler_steps, $priority_key, 0, [$compiler_calls]);
+					}
+					else
+					{
+						$compiler_steps[$priority_key] = $compiler_calls;
+					}
+				}
+				else
+				{
+					array_unshift($compiler_steps, $compiler_calls);
+				}
+			}
+		}
+
+		krsort($compiler_steps);
+		foreach ($compiler_steps as $ext_namespace_steps)
+		{
+			foreach ($ext_namespace_steps as $step)
+			{
+				$step();
 			}
 		}
 	}

--- a/phpBB/phpbb/template/twig/node/event.php
+++ b/phpBB/phpbb/template/twig/node/event.php
@@ -51,9 +51,12 @@ class event extends \Twig\Node\Node
 		// Group and sort extension template events in according to their priority (0 by default if not set)
 		foreach ($this->environment->get_phpbb_extensions() as $ext_namespace => $ext_path)
 		{
-			$ext_namespace = str_replace('/', '_', $ext_namespace);
-			$priority_key = $this->template_event_priority_array[$ext_namespace][$location] ?? 0;
-			$template_events[$priority_key][] = $ext_namespace;
+			if ($this->environment->isDebug() || $this->environment->getLoader()->exists('@' . $ext_namespace . '/' . $location . '.html'))
+			{
+				$ext_namespace = str_replace('/', '_', $ext_namespace);
+				$priority_key = $this->template_event_priority_array[$ext_namespace][$location] ?? 0;
+				$template_events[$priority_key][] = $ext_namespace;
+			}
 		}
 		krsort($template_events);
 
@@ -61,33 +64,30 @@ class event extends \Twig\Node\Node
 		{
 			foreach ($events as $ext_namespace)
 			{
-				if ($this->environment->isDebug() || $this->environment->getLoader()->exists('@' . $ext_namespace . '/' . $location . '.html'))
+				if ($this->environment->isDebug())
 				{
-					if ($this->environment->isDebug())
-					{
-						// If debug mode is enabled, lets check for new/removed EVENT
-						//  templates on page load rather than at compile. This is
-						//  slower, but makes developing extensions easier (no need to
-						//  purge the cache when a new event template file is added)
-						$compiler
-							->write("if (\$this->env->getLoader()->exists('@{$ext_namespace}/{$location}.html')) {\n")
-							->indent();
-					}
-
+					// If debug mode is enabled, lets check for new/removed EVENT
+					//  templates on page load rather than at compile. This is
+					//  slower, but makes developing extensions easier (no need to
+					//  purge the cache when a new event template file is added)
 					$compiler
-						->write("\$previous_look_up_order = \$this->env->getNamespaceLookUpOrder();\n")
+						->write("if (\$this->env->getLoader()->exists('@{$ext_namespace}/{$location}.html')) {\n")
+						->indent();
+				}
 
-						// We set the namespace lookup order to be this extension first, then the main path
-						->write("\$this->env->setNamespaceLookUpOrder(array('{$ext_namespace}', '__main__'));\n")
-						->write("\$this->env->loadTemplate('@{$ext_namespace}/{$location}.html')->display(\$context);\n")
-						->write("\$this->env->setNamespaceLookUpOrder(\$previous_look_up_order);\n");
+				$compiler
+					->write("\$previous_look_up_order = \$this->env->getNamespaceLookUpOrder();\n")
 
-					if ($this->environment->isDebug())
-					{
-						$compiler
-							->outdent()
-							->write("}\n\n");
-					}
+					// We set the namespace lookup order to be this extension first, then the main path
+					->write("\$this->env->setNamespaceLookUpOrder(array('{$ext_namespace}', '__main__'));\n")
+					->write("\$this->env->loadTemplate('@{$ext_namespace}/{$location}.html')->display(\$context);\n")
+					->write("\$this->env->setNamespaceLookUpOrder(\$previous_look_up_order);\n");
+
+				if ($this->environment->isDebug())
+				{
+					$compiler
+						->outdent()
+						->write("}\n\n");
 				}
 			}
 		}

--- a/phpBB/phpbb/template/twig/node/event.php
+++ b/phpBB/phpbb/template/twig/node/event.php
@@ -52,11 +52,6 @@ class event extends \Twig\Node\Node
 		{
 			$ext_namespace = str_replace('/', '_', $ext_namespace);
 
-			if (isset($this->template_event_priority_array[$ext_namespace][$location]))
-			{
-				$priority_key = $this->template_event_priority_array[$ext_namespace][$location];
-			}
-
 			$compiler_calls = [];
 
 			if ($this->environment->isDebug())
@@ -99,8 +94,10 @@ class event extends \Twig\Node\Node
 
 			if (!empty($compiler_calls))
 			{
-				if (isset($priority_key))
+				if (isset($this->template_event_priority_array[$ext_namespace][$location]))
 				{
+					$priority_key = $this->template_event_priority_array[$ext_namespace][$location];
+
 					if (array_key_exists($priority_key, $compiler_steps))
 					{
 						array_splice($compiler_steps, $priority_key, 0, [$compiler_calls]);

--- a/phpBB/phpbb/template/twig/node/event.php
+++ b/phpBB/phpbb/template/twig/node/event.php
@@ -65,30 +65,36 @@ class event extends \Twig\Node\Node
 				//  templates on page load rather than at compile. This is
 				//  slower, but makes developing extensions easier (no need to
 				//  purge the cache when a new event template file is added)
-				$compiler_calls[] = fn() => $compiler
-					->write("if (\$this->env->getLoader()->exists('@{$ext_namespace}/{$location}.html')) {\n")
-					->indent()
-				;
+				$compiler_calls[] = function() use($compiler, $ext_namespace, $location) {
+					$compiler
+						->write("if (\$this->env->getLoader()->exists('@{$ext_namespace}/{$location}.html')) {\n")
+						->indent()
+					;
+				};
 			}
 
 			if ($this->environment->isDebug() || $this->environment->getLoader()->exists('@' . $ext_namespace . '/' . $location . '.html'))
 			{
-				$compiler_calls[] = fn() => $compiler
-					->write("\$previous_look_up_order = \$this->env->getNamespaceLookUpOrder();\n")
+				$compiler_calls[] = function() use($compiler, $ext_namespace, $location) {
+					$compiler
+						->write("\$previous_look_up_order = \$this->env->getNamespaceLookUpOrder();\n")
 
-					// We set the namespace lookup order to be this extension first, then the main path
-					->write("\$this->env->setNamespaceLookUpOrder(array('{$ext_namespace}', '__main__'));\n")
-					->write("\$this->env->loadTemplate('@{$ext_namespace}/{$location}.html')->display(\$context);\n")
-					->write("\$this->env->setNamespaceLookUpOrder(\$previous_look_up_order);\n")
-				;
+						// We set the namespace lookup order to be this extension first, then the main path
+						->write("\$this->env->setNamespaceLookUpOrder(array('{$ext_namespace}', '__main__'));\n")
+						->write("\$this->env->loadTemplate('@{$ext_namespace}/{$location}.html')->display(\$context);\n")
+						->write("\$this->env->setNamespaceLookUpOrder(\$previous_look_up_order);\n")
+					;
+				};
 			}
 
 			if ($this->environment->isDebug())
 			{
-				$compiler_calls[] = fn() => $compiler
-					->outdent()
-					->write("}\n\n")
-				;
+				$compiler_calls[] = function() use($compiler) {
+					$compiler
+						->outdent()
+						->write("}\n\n")
+					;
+				};
 			}
 
 			if (!empty($compiler_calls))

--- a/phpBB/phpbb/template/twig/node/event.php
+++ b/phpBB/phpbb/template/twig/node/event.php
@@ -51,9 +51,9 @@ class event extends \Twig\Node\Node
 		// Group and sort extension template events in according to their priority (0 by default if not set)
 		foreach ($this->environment->get_phpbb_extensions() as $ext_namespace => $ext_path)
 		{
+			$ext_namespace = str_replace('/', '_', $ext_namespace);
 			if ($this->environment->isDebug() || $this->environment->getLoader()->exists('@' . $ext_namespace . '/' . $location . '.html'))
 			{
-				$ext_namespace = str_replace('/', '_', $ext_namespace);
 				$priority_key = $this->template_event_priority_array[$ext_namespace][$location] ?? 0;
 				$template_events[$priority_key][] = $ext_namespace;
 			}

--- a/phpBB/phpbb/template/twig/node/event.php
+++ b/phpBB/phpbb/template/twig/node/event.php
@@ -46,80 +46,49 @@ class event extends \Twig\Node\Node
 
 		$location = $this->listener_directory . $this->getNode('expr')->getAttribute('name');
 
-		$compiler_steps = [];
+		$template_events = [];
 
+		// Group and sort extension template events in according to their priority (0 by default if not set)
 		foreach ($this->environment->get_phpbb_extensions() as $ext_namespace => $ext_path)
 		{
 			$ext_namespace = str_replace('/', '_', $ext_namespace);
+			$priority_key = $this->template_event_priority_array[$ext_namespace][$location] ?? 0;
+			$template_events[$priority_key][] = $ext_namespace;
+		}
+		krsort($template_events);
 
-			$compiler_calls = [];
-
-			if ($this->environment->isDebug())
+		foreach ($template_events as $events)
+		{
+			foreach ($events as $ext_namespace)
 			{
-				// If debug mode is enabled, lets check for new/removed EVENT
-				//  templates on page load rather than at compile. This is
-				//  slower, but makes developing extensions easier (no need to
-				//  purge the cache when a new event template file is added)
-				$compiler_calls[] = function() use($compiler, $ext_namespace, $location) {
-					$compiler
-						->write("if (\$this->env->getLoader()->exists('@{$ext_namespace}/{$location}.html')) {\n")
-						->indent()
-					;
-				};
-			}
+				if ($this->environment->isDebug() || $this->environment->getLoader()->exists('@' . $ext_namespace . '/' . $location . '.html'))
+				{
+					if ($this->environment->isDebug())
+					{
+						// If debug mode is enabled, lets check for new/removed EVENT
+						//  templates on page load rather than at compile. This is
+						//  slower, but makes developing extensions easier (no need to
+						//  purge the cache when a new event template file is added)
+						$compiler
+							->write("if (\$this->env->getLoader()->exists('@{$ext_namespace}/{$location}.html')) {\n")
+							->indent();
+					}
 
-			if ($this->environment->isDebug() || $this->environment->getLoader()->exists('@' . $ext_namespace . '/' . $location . '.html'))
-			{
-				$compiler_calls[] = function() use($compiler, $ext_namespace, $location) {
 					$compiler
 						->write("\$previous_look_up_order = \$this->env->getNamespaceLookUpOrder();\n")
 
 						// We set the namespace lookup order to be this extension first, then the main path
 						->write("\$this->env->setNamespaceLookUpOrder(array('{$ext_namespace}', '__main__'));\n")
 						->write("\$this->env->loadTemplate('@{$ext_namespace}/{$location}.html')->display(\$context);\n")
-						->write("\$this->env->setNamespaceLookUpOrder(\$previous_look_up_order);\n")
-					;
-				};
-			}
+						->write("\$this->env->setNamespaceLookUpOrder(\$previous_look_up_order);\n");
 
-			if ($this->environment->isDebug())
-			{
-				$compiler_calls[] = function() use($compiler) {
-					$compiler
-						->outdent()
-						->write("}\n\n")
-					;
-				};
-			}
-
-			if (!empty($compiler_calls))
-			{
-				if (isset($this->template_event_priority_array[$ext_namespace][$location]))
-				{
-					$priority_key = $this->template_event_priority_array[$ext_namespace][$location];
-
-					if (array_key_exists($priority_key, $compiler_steps))
+					if ($this->environment->isDebug())
 					{
-						array_splice($compiler_steps, $priority_key, 0, [$compiler_calls]);
-					}
-					else
-					{
-						$compiler_steps[$priority_key] = $compiler_calls;
+						$compiler
+							->outdent()
+							->write("}\n\n");
 					}
 				}
-				else
-				{
-					array_unshift($compiler_steps, $compiler_calls);
-				}
-			}
-		}
-
-		krsort($compiler_steps);
-		foreach ($compiler_steps as $ext_namespace_steps)
-		{
-			foreach ($ext_namespace_steps as $step)
-			{
-				$step();
 			}
 		}
 	}

--- a/phpBB/phpbb/template/twig/tokenparser/event.php
+++ b/phpBB/phpbb/template/twig/tokenparser/event.php
@@ -40,7 +40,15 @@ class event extends \Twig\TokenParser\AbstractTokenParser
 		* Allow assigning priority to template events
 		*
 		* @event core.twig_tokenparser_constructor
-		* @var	array	template_event_priority_array	Array with template event priority assignments per extension namespace
+		* @var	array	template_event_priority_array	Array with template event priority assignments per extension namespace, usage:
+		*		'<author>_<extension_name>' => array(
+		*			'event/<template_event_name>'		=> priority_number,
+		*		),
+		*		Example:
+		*		'phpbb_viglink' => array(
+		*			'event/acp_help_phpbb_stats_after'	=> 80,
+		*			'event/overall_footer_after'		=> 100,
+		*		),
 		* @since 3.3.12-RC1
 		*/
 		if ($this->phpbb_dispatcher)

--- a/phpBB/phpbb/template/twig/tokenparser/event.php
+++ b/phpBB/phpbb/template/twig/tokenparser/event.php
@@ -38,9 +38,10 @@ class event extends \Twig\TokenParser\AbstractTokenParser
 
 		/**
 		* Allow assigning priority to template events
-		*
+		*f
 		* @event core.twig_tokenparser_constructor
-		* @var	array	template_event_priority_array	Array with template event priority assignments per extension namespace, usage:
+		* @var	array	template_event_priority_array	Array with template event priority assignments per extension namespace
+		*		Usage:
 		*		'<author>_<extension_name>' => array(
 		*			'event/<template_event_name>'		=> priority_number,
 		*		),

--- a/tests/controller/common_helper_route.php
+++ b/tests/controller/common_helper_route.php
@@ -119,6 +119,7 @@ abstract class phpbb_controller_common_helper_route extends phpbb_database_test_
 		$cache_path = $phpbb_root_path . 'cache/twig';
 		$context = new \phpbb\template\context();
 		$loader = new \phpbb\template\twig\loader($this->filesystem, '');
+		$this->dispatcher = new \phpbb\event\dispatcher($container);
 		$twig = new \phpbb\template\twig\environment(
 			$this->config,
 			$this->filesystem,
@@ -126,7 +127,7 @@ abstract class phpbb_controller_common_helper_route extends phpbb_database_test_
 			$cache_path,
 			null,
 			$loader,
-			new \phpbb\event\dispatcher($container),
+			$this->dispatcher,
 			array(
 				'cache'			=> false,
 				'debug'			=> false,
@@ -134,7 +135,7 @@ abstract class phpbb_controller_common_helper_route extends phpbb_database_test_
 				'autoescape'	=> false,
 			)
 		);
-		$this->template = new phpbb\template\twig\twig($this->phpbb_path_helper, $this->config, $context, $twig, $cache_path, $this->user, array(new \phpbb\template\twig\extension($context, $twig, $this->user)));
+		$this->template = new phpbb\template\twig\twig($this->phpbb_path_helper, $this->config, $context, $twig, $cache_path, $this->user, array(new \phpbb\template\twig\extension($context, $twig, $this->user, $this->dispatcher)));
 		$twig->setLexer(new \phpbb\template\twig\lexer($twig));
 
 		$this->extension_manager = new phpbb_mock_extension_manager(

--- a/tests/email/email_parsing_test.php
+++ b/tests/email/email_parsing_test.php
@@ -68,6 +68,7 @@ class phpbb_email_parsing_test extends phpbb_test_case
 		$phpbb_container->set('ext.manager', $extension_manager);
 
 		$context = new \phpbb\template\context();
+		$dispatcher = new \phpbb\event\dispatcher($phpbb_container);
 		$twig = new \phpbb\template\twig\environment(
 			$config,
 			$filesystem,
@@ -75,7 +76,7 @@ class phpbb_email_parsing_test extends phpbb_test_case
 			$cache_path,
 			null,
 			new \phpbb\template\twig\loader($filesystem, ''),
-			new \phpbb\event\dispatcher($phpbb_container),
+			$dispatcher,
 			array(
 				'cache'			=> false,
 				'debug'			=> false,
@@ -83,7 +84,7 @@ class phpbb_email_parsing_test extends phpbb_test_case
 				'autoescape'	=> false,
 			)
 		);
-		$twig_extension = new \phpbb\template\twig\extension($context, $twig, $lang);
+		$twig_extension = new \phpbb\template\twig\extension($context, $twig, $lang, $dispatcher);
 		$phpbb_container->set('template.twig.extensions.phpbb', $twig_extension);
 
 		$twig_extensions_collection = new \phpbb\di\service_collection($phpbb_container);

--- a/tests/extension/metadata_manager_test.php
+++ b/tests/extension/metadata_manager_test.php
@@ -112,7 +112,7 @@ class phpbb_extension_metadata_manager_test extends phpbb_database_test_case
 		$lang = new \phpbb\language\language($lang_loader);
 		$this->user = new \phpbb\user($lang, '\phpbb\datetime');
 
-		$this->template = new phpbb\template\twig\twig($phpbb_path_helper, $this->config, $context, $twig, $cache_path, $this->user, array(new \phpbb\template\twig\extension($context, $twig, $this->user)));
+		$this->template = new phpbb\template\twig\twig($phpbb_path_helper, $this->config, $context, $twig, $cache_path, $this->user, array(new \phpbb\template\twig\extension($context, $twig, $this->user, $phpbb_dispatcher)));
 		$twig->setLexer(new \phpbb\template\twig\lexer($twig));
 	}
 

--- a/tests/functional/extension_controller_test.php
+++ b/tests/functional/extension_controller_test.php
@@ -55,6 +55,13 @@ class phpbb_functional_extension_controller_test extends phpbb_functional_test_c
 		$this->purge_cache();
 	}
 
+	protected function tearDown(): void
+	{
+		$this->purge_cache();
+
+		parent::tearDown();
+	}
+
 	/**
 	* Check a controller for extension foo/bar.
 	*/

--- a/tests/functional/extension_controller_test.php
+++ b/tests/functional/extension_controller_test.php
@@ -55,13 +55,6 @@ class phpbb_functional_extension_controller_test extends phpbb_functional_test_c
 		$this->purge_cache();
 	}
 
-	protected function tearDown(): void
-	{
-		$this->purge_cache();
-
-		parent::tearDown();
-	}
-
 	/**
 	* Check a controller for extension foo/bar.
 	*/

--- a/tests/functional/extension_controller_test.php
+++ b/tests/functional/extension_controller_test.php
@@ -28,6 +28,7 @@ class phpbb_functional_extension_controller_test extends phpbb_functional_test_c
 		'foo/bar/styles/prosilver/template/',
 		'foo/foo/config/',
 		'foo/foo/controller/',
+		'foo/foo/event/',
 	);
 
 	static public function setUpBeforeClass(): void

--- a/tests/functional/extension_global_lang_test.php
+++ b/tests/functional/extension_global_lang_test.php
@@ -54,9 +54,9 @@ class phpbb_functional_extension_global_lang_test extends phpbb_functional_test_
 
 	protected function tearDown(): void
 	{
-		parent::tearDown();
-
 		$this->purge_cache();
+
+		parent::tearDown();
 	}
 
 	public function test_load_extension_lang_globally()
@@ -71,5 +71,7 @@ class phpbb_functional_extension_global_lang_test extends phpbb_functional_test_
 
 		// language from ext/foo/bar/language/en/foo_global.php
 		$this->assertStringContainsString('Overwritten by foo', $crawler->filter('.skiplink')->text());
+
+		$this->phpbb_extension_manager->purge('foo/bar');
 	}
 }

--- a/tests/functional/extension_global_lang_test.php
+++ b/tests/functional/extension_global_lang_test.php
@@ -52,13 +52,6 @@ class phpbb_functional_extension_global_lang_test extends phpbb_functional_test_
 		$this->purge_cache();
 	}
 
-	protected function tearDown(): void
-	{
-		$this->purge_cache();
-
-		parent::tearDown();
-	}
-
 	public function test_load_extension_lang_globally()
 	{
 		$this->phpbb_extension_manager->enable('foo/bar');

--- a/tests/functional/extension_module_test.php
+++ b/tests/functional/extension_module_test.php
@@ -40,6 +40,14 @@ class phpbb_functional_extension_module_test extends phpbb_functional_test_case
 		self::$helper->restore_original_ext_dir();
 	}
 
+	protected function tearDown(): void
+	{
+		$this->phpbb_extension_manager->purge('foo/bar');
+		$this->purge_cache();
+
+		parent::tearDown();
+	}
+
 	protected function setUp(): void
 	{
 		global $db;
@@ -131,7 +139,5 @@ class phpbb_functional_extension_module_test extends phpbb_functional_test_case
 		$link = $crawler->selectLink('UCP_FOOBAR_TITLE')->link()->getUri();
 		$crawler = self::request('GET', substr($link, strpos($link, 'ucp.')));
 		$this->assertStringContainsString('UCP Extension Template Test Passed!', $crawler->filter('#content')->text());
-
-		$this->phpbb_extension_manager->purge('foo/bar');
 	}
 }

--- a/tests/functional/extension_module_test.php
+++ b/tests/functional/extension_module_test.php
@@ -43,7 +43,6 @@ class phpbb_functional_extension_module_test extends phpbb_functional_test_case
 	protected function tearDown(): void
 	{
 		$this->phpbb_extension_manager->purge('foo/bar');
-		$this->purge_cache();
 
 		parent::tearDown();
 	}

--- a/tests/functional/extension_permission_lang_test.php
+++ b/tests/functional/extension_permission_lang_test.php
@@ -41,13 +41,6 @@ class phpbb_functional_extension_permission_lang_test extends phpbb_functional_t
 		self::$helper->restore_original_ext_dir();
 	}
 
-	protected function tearDown(): void
-	{
-		$this->purge_cache();
-
-		parent::tearDown();
-	}
-
 	protected function setUp(): void
 	{
 		parent::setUp();

--- a/tests/functional/extension_permission_lang_test.php
+++ b/tests/functional/extension_permission_lang_test.php
@@ -41,6 +41,13 @@ class phpbb_functional_extension_permission_lang_test extends phpbb_functional_t
 		self::$helper->restore_original_ext_dir();
 	}
 
+	protected function tearDown(): void
+	{
+		$this->purge_cache();
+
+		parent::tearDown();
+	}
+
 	protected function setUp(): void
 	{
 		parent::setUp();
@@ -82,5 +89,7 @@ class phpbb_functional_extension_permission_lang_test extends phpbb_functional_t
 
 		// language from ext/foo/bar/language/en/permissions_foo.php
 		$this->assertStringContainsString('Can view foobar', $crawler->filter('body')->text());
+
+		$this->phpbb_extension_manager->purge('foo/bar');
 	}
 }

--- a/tests/functional/extension_template_event_order_test.php
+++ b/tests/functional/extension_template_event_order_test.php
@@ -39,6 +39,13 @@ class phpbb_functional_extension_template_event_order_test extends phpbb_functio
 		self::$helper->restore_original_ext_dir();
 	}
 
+	protected function tearDown(): void
+	{
+		$this->purge_cache();
+
+		parent::tearDown();
+	}
+
 	protected function setUp(): void
 	{
 		parent::setUp();

--- a/tests/functional/extension_template_event_order_test.php
+++ b/tests/functional/extension_template_event_order_test.php
@@ -1,0 +1,86 @@
+<?php
+/**
+*
+* This file is part of the phpBB Forum Software package.
+*
+* @copyright (c) phpBB Limited <https://www.phpbb.com>
+* @license GNU General Public License, version 2 (GPL-2.0)
+*
+* For full copyright and license information, please see
+* the docs/CREDITS.txt file.
+*
+*/
+
+/**
+* @group functional
+*/
+class phpbb_functional_extension_template_event_order_test extends phpbb_functional_test_case
+{
+	protected $phpbb_extension_manager;
+
+	static private $helper;
+
+	static protected $fixtures = [
+		'./',
+	];
+
+	static public function setUpBeforeClass(): void
+	{
+		parent::setUpBeforeClass();
+
+		self::$helper = new phpbb_test_case_helpers(__CLASS__);
+		self::$helper->copy_ext_fixtures(__DIR__ . '/fixtures/ext/', self::$fixtures);
+	}
+
+	static public function tearDownAfterClass(): void
+	{
+		parent::tearDownAfterClass();
+
+		self::$helper->restore_original_ext_dir();
+	}
+
+	protected function setUp(): void
+	{
+		parent::setUp();
+
+		$this->phpbb_extension_manager = $this->get_extension_manager();
+
+		$this->purge_cache();
+	}
+
+	/**
+	* Check a controller for extension foo/bar.
+	*/
+	public function test_template_event_order()
+	{
+		global $phpbb_root_path;
+
+		$this->phpbb_extension_manager->enable('foo/bar');
+		$this->phpbb_extension_manager->enable('foo/foo');
+		$crawler = self::request('GET', 'index.php');
+		$quick_links_menu = $crawler->filter('ul[role="menu"]')->eq(0);
+		$quick_links_menu_nodes_count = (int) $quick_links_menu->filter('li')->count();
+		// Ensure foo/foo template event goes before foo/bar one
+		$this->assertStringContainsString('FOO_FOO_QUICK_LINK', $quick_links_menu->filter('li')->eq($quick_links_menu_nodes_count - 2)->filter('span')->text());
+		$this->assertStringContainsString('FOO_BAR_QUICK_LINK', $quick_links_menu->filter('li')->eq($quick_links_menu_nodes_count - 1)->filter('span')->text());
+
+		// Change template events order to default, put foo/bar event before foo/foo one
+		$this->phpbb_extension_manager->disable('foo/bar');
+		$this->phpbb_extension_manager->disable('foo/foo');
+		$this->assertTrue(copy(__DIR__ . '/fixtures/ext/foo/bar/event/template_event_order_higher.php', $phpbb_root_path . 'ext/foo/bar/event/template_event_order.php'));
+		$this->assertTrue(copy(__DIR__ . '/fixtures/ext/foo/foo/event/template_event_order_lower.php', $phpbb_root_path . 'ext/foo/foo/event/template_event_order.php'));
+		$this->phpbb_extension_manager->enable('foo/bar');
+		$this->phpbb_extension_manager->enable('foo/foo');
+		$this->purge_cache();
+		sleep(3);
+		$crawler = self::request('GET', 'index.php');
+		$quick_links_menu = $crawler->filter('ul[role="menu"]')->eq(0);
+		$quick_links_menu_nodes_count = (int) $quick_links_menu->filter('li')->count();
+		// Ensure foo/foo template event goes before foo/bar one
+		$this->assertStringContainsString('FOO_BAR_QUICK_LINK', $quick_links_menu->filter('li')->eq($quick_links_menu_nodes_count - 2)->filter('span')->text());
+		$this->assertStringContainsString('FOO_FOO_QUICK_LINK', $quick_links_menu->filter('li')->eq($quick_links_menu_nodes_count - 1)->filter('span')->text());
+
+		$this->phpbb_extension_manager->purge('foo/bar');
+		$this->phpbb_extension_manager->purge('foo/foo');
+	}
+}

--- a/tests/functional/extension_template_event_order_test.php
+++ b/tests/functional/extension_template_event_order_test.php
@@ -39,13 +39,6 @@ class phpbb_functional_extension_template_event_order_test extends phpbb_functio
 		self::$helper->restore_original_ext_dir();
 	}
 
-	protected function tearDown(): void
-	{
-		$this->purge_cache();
-
-		parent::tearDown();
-	}
-
 	protected function setUp(): void
 	{
 		parent::setUp();

--- a/tests/functional/fixtures/ext/foo/bar/config/services.yml
+++ b/tests/functional/fixtures/ext/foo/bar/config/services.yml
@@ -14,7 +14,13 @@ services:
         class: foo\bar\event\permission
         tags:
             - { name: event.listener }
+
     foo_bar.listener.user_setup:
         class: foo\bar\event\user_setup
+        tags:
+            - { name: event.listener }
+
+    foo_bar.listener.template_event_order:
+        class: foo\bar\event\template_event_order
         tags:
             - { name: event.listener }

--- a/tests/functional/fixtures/ext/foo/bar/event/template_event_order.php
+++ b/tests/functional/fixtures/ext/foo/bar/event/template_event_order.php
@@ -1,0 +1,38 @@
+<?php
+/**
+*
+* This file is part of the phpBB Forum Software package.
+*
+* @copyright (c) phpBB Limited <https://www.phpbb.com>
+* @license GNU General Public License, version 2 (GPL-2.0)
+*
+* For full copyright and license information, please see
+* the docs/CREDITS.txt file.
+*
+*/
+
+namespace foo\bar\event;
+
+/**
+* Event listener
+*/
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+class template_event_order implements EventSubscriberInterface
+{
+	static public function getSubscribedEvents()
+	{
+		return array(
+			'core.twig_tokenparser_constructor'	=> 'set_template_event_priority',
+		);
+	}
+
+	public function set_template_event_priority($event)
+	{
+		$template_event_priority_array = $event['template_event_priority_array'];
+		$template_event_priority_array['foo_bar'] = [
+			'event/navbar_header_quick_links_after' => -1,
+		];
+		$event['template_event_priority_array'] = $template_event_priority_array;
+	}
+}

--- a/tests/functional/fixtures/ext/foo/bar/event/template_event_order_higher.php
+++ b/tests/functional/fixtures/ext/foo/bar/event/template_event_order_higher.php
@@ -1,0 +1,38 @@
+<?php
+/**
+*
+* This file is part of the phpBB Forum Software package.
+*
+* @copyright (c) phpBB Limited <https://www.phpbb.com>
+* @license GNU General Public License, version 2 (GPL-2.0)
+*
+* For full copyright and license information, please see
+* the docs/CREDITS.txt file.
+*
+*/
+
+namespace foo\bar\event;
+
+/**
+* Event listener
+*/
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+class template_event_order implements EventSubscriberInterface
+{
+	static public function getSubscribedEvents()
+	{
+		return array(
+			'core.twig_tokenparser_constructor'	=> 'set_template_event_priority',
+		);
+	}
+
+	public function set_template_event_priority($event)
+	{
+		$template_event_priority_array = $event['template_event_priority_array'];
+		$template_event_priority_array['foo_bar'] = [
+			'event/navbar_header_quick_links_after' => 1,
+		];
+		$event['template_event_priority_array'] = $template_event_priority_array;
+	}
+}

--- a/tests/functional/fixtures/ext/foo/bar/styles/prosilver/template/event/navbar_header_quick_links_after.html
+++ b/tests/functional/fixtures/ext/foo/bar/styles/prosilver/template/event/navbar_header_quick_links_after.html
@@ -1,0 +1,1 @@
+<li><span>{{ lang('FOO_BAR_QUICK_LINK') }}</span></li>

--- a/tests/functional/fixtures/ext/foo/foo/config/services.yml
+++ b/tests/functional/fixtures/ext/foo/foo/config/services.yml
@@ -1,3 +1,8 @@
 services:
     foo_foo.controller:
         class: foo\foo\controller\controller
+
+    foo_foo.listener.template_event_order:
+        class: foo\foo\event\template_event_order
+        tags:
+            - { name: event.listener }

--- a/tests/functional/fixtures/ext/foo/foo/event/template_event_order.php
+++ b/tests/functional/fixtures/ext/foo/foo/event/template_event_order.php
@@ -30,7 +30,7 @@ class template_event_order implements EventSubscriberInterface
 	public function set_template_event_priority($event)
 	{
 		$template_event_priority_array = $event['template_event_priority_array'];
-		$template_event_priority_array['foo_bar'] = [
+		$template_event_priority_array['foo_foo'] = [
 			'event/navbar_header_quick_links_after' => 1,
 		];
 		$event['template_event_priority_array'] = $template_event_priority_array;

--- a/tests/functional/fixtures/ext/foo/foo/event/template_event_order.php
+++ b/tests/functional/fixtures/ext/foo/foo/event/template_event_order.php
@@ -1,0 +1,38 @@
+<?php
+/**
+*
+* This file is part of the phpBB Forum Software package.
+*
+* @copyright (c) phpBB Limited <https://www.phpbb.com>
+* @license GNU General Public License, version 2 (GPL-2.0)
+*
+* For full copyright and license information, please see
+* the docs/CREDITS.txt file.
+*
+*/
+
+namespace foo\foo\event;
+
+/**
+* Event listener
+*/
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+class template_event_order implements EventSubscriberInterface
+{
+	static public function getSubscribedEvents()
+	{
+		return array(
+			'core.twig_tokenparser_constructor'	=> 'set_template_event_priority',
+		);
+	}
+
+	public function set_template_event_priority($event)
+	{
+		$template_event_priority_array = $event['template_event_priority_array'];
+		$template_event_priority_array['foo_bar'] = [
+			'event/navbar_header_quick_links_after' => 1,
+		];
+		$event['template_event_priority_array'] = $template_event_priority_array;
+	}
+}

--- a/tests/functional/fixtures/ext/foo/foo/event/template_event_order_lower.php
+++ b/tests/functional/fixtures/ext/foo/foo/event/template_event_order_lower.php
@@ -1,0 +1,38 @@
+<?php
+/**
+*
+* This file is part of the phpBB Forum Software package.
+*
+* @copyright (c) phpBB Limited <https://www.phpbb.com>
+* @license GNU General Public License, version 2 (GPL-2.0)
+*
+* For full copyright and license information, please see
+* the docs/CREDITS.txt file.
+*
+*/
+
+namespace foo\foo\event;
+
+/**
+* Event listener
+*/
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+class template_event_order implements EventSubscriberInterface
+{
+	static public function getSubscribedEvents()
+	{
+		return array(
+			'core.twig_tokenparser_constructor'	=> 'set_template_event_priority',
+		);
+	}
+
+	public function set_template_event_priority($event)
+	{
+		$template_event_priority_array = $event['template_event_priority_array'];
+		$template_event_priority_array['foo_bar'] = [
+			'event/navbar_header_quick_links_after' => -1,
+		];
+		$event['template_event_priority_array'] = $template_event_priority_array;
+	}
+}

--- a/tests/functional/fixtures/ext/foo/foo/event/template_event_order_lower.php
+++ b/tests/functional/fixtures/ext/foo/foo/event/template_event_order_lower.php
@@ -30,7 +30,7 @@ class template_event_order implements EventSubscriberInterface
 	public function set_template_event_priority($event)
 	{
 		$template_event_priority_array = $event['template_event_priority_array'];
-		$template_event_priority_array['foo_bar'] = [
+		$template_event_priority_array['foo_foo'] = [
 			'event/navbar_header_quick_links_after' => -1,
 		];
 		$event['template_event_priority_array'] = $template_event_priority_array;

--- a/tests/functional/fixtures/ext/foo/foo/styles/prosilver/template/event/navbar_header_quick_links_after.html
+++ b/tests/functional/fixtures/ext/foo/foo/styles/prosilver/template/event/navbar_header_quick_links_after.html
@@ -1,0 +1,1 @@
+<li><span>{{ lang('FOO_FOO_QUICK_LINK') }}</span></li>

--- a/tests/functional/metadata_manager_test.php
+++ b/tests/functional/metadata_manager_test.php
@@ -27,7 +27,6 @@ class phpbb_functional_metadata_manager_test extends phpbb_functional_test_case
 	protected function tearDown(): void
 	{
 		$this->phpbb_extension_manager->purge('foo/bar');
-		$this->purge_cache();
 
 		parent::tearDown();
 	}

--- a/tests/functional/metadata_manager_test.php
+++ b/tests/functional/metadata_manager_test.php
@@ -26,6 +26,7 @@ class phpbb_functional_metadata_manager_test extends phpbb_functional_test_case
 
 	protected function tearDown(): void
 	{
+		$this->phpbb_extension_manager->purge('foo/bar');
 		$this->purge_cache();
 
 		parent::tearDown();

--- a/tests/template/extension_test.php
+++ b/tests/template/extension_test.php
@@ -74,6 +74,7 @@ class phpbb_template_extension_test extends phpbb_template_template_test_case
 		$cache_path = $phpbb_root_path . 'cache/twig';
 		$context = new \phpbb\template\context();
 		$loader = new \phpbb\template\twig\loader($filesystem);
+		$dispatcher = new \phpbb\event\dispatcher($phpbb_container);
 		$twig = new \phpbb\template\twig\environment(
 			$config,
 			$filesystem,
@@ -81,7 +82,7 @@ class phpbb_template_extension_test extends phpbb_template_template_test_case
 			$cache_path,
 			null,
 			$loader,
-			new \phpbb\event\dispatcher($phpbb_container),
+			$dispatcher,
 			array(
 				'cache'			=> false,
 				'debug'			=> false,
@@ -97,7 +98,7 @@ class phpbb_template_extension_test extends phpbb_template_template_test_case
 			$cache_path,
 			$this->user,
 			[
-				new \phpbb\template\twig\extension($context, $twig, $this->lang),
+				new \phpbb\template\twig\extension($context, $twig, $this->lang, $dispatcher),
 				new \phpbb\template\twig\extension\avatar(),
 				new \phpbb\template\twig\extension\config($config),
 				new \phpbb\template\twig\extension\username(),

--- a/tests/template/template_allfolder_test.php
+++ b/tests/template/template_allfolder_test.php
@@ -60,6 +60,7 @@ class phpbb_template_allfolder_test extends phpbb_template_template_test_case
 		$cache_path = $phpbb_root_path . 'cache/twig';
 		$context = new \phpbb\template\context();
 		$loader = new \phpbb\template\twig\loader(new \phpbb\filesystem\filesystem(), '');
+		$dispatcher = new \phpbb\event\dispatcher($container);
 		$twig = new \phpbb\template\twig\environment(
 			$config,
 			$filesystem,
@@ -67,7 +68,7 @@ class phpbb_template_allfolder_test extends phpbb_template_template_test_case
 			$cache_path,
 			$this->extension_manager,
 			$loader,
-			new \phpbb\event\dispatcher($container),
+			$dispatcher,
 			array(
 				'cache'			=> false,
 				'debug'			=> false,
@@ -75,7 +76,7 @@ class phpbb_template_allfolder_test extends phpbb_template_template_test_case
 				'autoescape'	=> false,
 			)
 		);
-		$this->template = new \phpbb\template\twig\twig($path_helper, $config, $context, $twig, $cache_path, $this->user, array(new \phpbb\template\twig\extension($context, $twig, $this->user)), $this->extension_manager);
+		$this->template = new \phpbb\template\twig\twig($path_helper, $config, $context, $twig, $cache_path, $this->user, array(new \phpbb\template\twig\extension($context, $twig, $this->user, $dispatcher)), $this->extension_manager);
 		$twig->setLexer(new \phpbb\template\twig\lexer($twig));
 
 		$this->template_path = $this->test_path . '/templates';

--- a/tests/template/template_events_test.php
+++ b/tests/template/template_events_test.php
@@ -154,6 +154,7 @@ Zeta test event in all',
 		$cache_path = $phpbb_root_path . 'cache/twig';
 		$context = new \phpbb\template\context();
 		$loader = new \phpbb\template\twig\loader(new \phpbb\filesystem\filesystem(), '');
+		$dispatcher = new \phpbb\event\dispatcher($container);
 		$twig = new \phpbb\template\twig\environment(
 			$config,
 			$filesystem,
@@ -161,7 +162,7 @@ Zeta test event in all',
 			$cache_path,
 			$this->extension_manager,
 			$loader,
-			new \phpbb\event\dispatcher($container),
+			$dispatcher,
 			array(
 				'cache'			=> false,
 				'debug'			=> false,
@@ -169,7 +170,7 @@ Zeta test event in all',
 				'autoescape'	=> false,
 			)
 		);
-		$this->template = new \phpbb\template\twig\twig($path_helper, $config, $context, $twig, $cache_path, $this->user, array(new \phpbb\template\twig\extension($context, $twig, $this->user)), $this->extension_manager);
+		$this->template = new \phpbb\template\twig\twig($path_helper, $config, $context, $twig, $cache_path, $this->user, array(new \phpbb\template\twig\extension($context, $twig, $this->user, $dispatcher)), $this->extension_manager);
 		$twig->setLexer(new \phpbb\template\twig\lexer($twig));
 
 		$this->template->set_custom_style(((!empty($style_names)) ? $style_names : 'silver'), array($this->template_path));

--- a/tests/template/template_includecss_test.php
+++ b/tests/template/template_includecss_test.php
@@ -46,6 +46,7 @@ class phpbb_template_template_includecss_test extends phpbb_template_template_te
 		$cache_path = $phpbb_root_path . 'cache/twig';
 		$context = new \phpbb\template\context();
 		$loader = new \phpbb\template\twig\loader(new \phpbb\filesystem\filesystem(), '');
+		$dispatcher = new \phpbb\event\dispatcher($container);
 		$twig = new \phpbb\template\twig\environment(
 			$config,
 			$filesystem,
@@ -53,7 +54,7 @@ class phpbb_template_template_includecss_test extends phpbb_template_template_te
 			$cache_path,
 			null,
 			$loader,
-			new \phpbb\event\dispatcher($container),
+			$dispatcher,
 			array(
 				'cache'			=> false,
 				'debug'			=> false,
@@ -68,7 +69,7 @@ class phpbb_template_template_includecss_test extends phpbb_template_template_te
 			$twig,
 			$cache_path,
 			$this->user,
-			array(new \phpbb\template\twig\extension($context, $twig, $this->user)),
+			array(new \phpbb\template\twig\extension($context, $twig, $this->user, $dispatcher)),
 			new phpbb_mock_extension_manager(
 				__DIR__ . '/',
 				array(

--- a/tests/template/template_test_case.php
+++ b/tests/template/template_test_case.php
@@ -98,6 +98,7 @@ class phpbb_template_template_test_case extends phpbb_test_case
 		$cache_path = $phpbb_root_path . 'cache/twig';
 		$context = new \phpbb\template\context();
 		$loader = new \phpbb\template\twig\loader(new \phpbb\filesystem\filesystem(), '');
+		$dispatcher = new \phpbb\event\dispatcher($container);
 		$twig = new \phpbb\template\twig\environment(
 			$config,
 			$filesystem,
@@ -105,7 +106,7 @@ class phpbb_template_template_test_case extends phpbb_test_case
 			$cache_path,
 			null,
 			$loader,
-			new \phpbb\event\dispatcher($container),
+			$dispatcher,
 			array(
 				'cache'			=> false,
 				'debug'			=> false,
@@ -113,7 +114,7 @@ class phpbb_template_template_test_case extends phpbb_test_case
 				'autoescape'	=> false,
 			)
 		);
-		$this->template = new phpbb\template\twig\twig($path_helper, $config, $context, $twig, $cache_path, $this->user, array(new \phpbb\template\twig\extension($context, $twig, $this->user)));
+		$this->template = new phpbb\template\twig\twig($path_helper, $config, $context, $twig, $cache_path, $this->user, array(new \phpbb\template\twig\extension($context, $twig, $this->user, $dispatcher)));
 		$twig->setLexer(new \phpbb\template\twig\lexer($twig));
 		$this->template->set_custom_style('tests', $this->template_path);
 	}

--- a/tests/template/template_test_case_with_tree.php
+++ b/tests/template/template_test_case_with_tree.php
@@ -41,6 +41,7 @@ class phpbb_template_template_test_case_with_tree extends phpbb_template_templat
 		$cache_path = $phpbb_root_path . 'cache/twig';
 		$context = new \phpbb\template\context();
 		$loader = new \phpbb\template\twig\loader(new \phpbb\filesystem\filesystem(), '');
+		$dispatcher = new \phpbb\event\dispatcher($container);
 		$twig = new \phpbb\template\twig\environment(
 			$config,
 			$filesystem,
@@ -48,7 +49,7 @@ class phpbb_template_template_test_case_with_tree extends phpbb_template_templat
 			$cache_path,
 			null,
 			$loader,
-			new \phpbb\event\dispatcher($container),
+			$dispatcher,
 			array(
 				'cache'			=> false,
 				'debug'			=> false,
@@ -56,7 +57,7 @@ class phpbb_template_template_test_case_with_tree extends phpbb_template_templat
 				'autoescape'	=> false,
 			)
 		);
-		$this->template = new phpbb\template\twig\twig($this->phpbb_path_helper, $config, $context, $twig, $cache_path, $this->user, array(new \phpbb\template\twig\extension($context, $twig, $this->user)));
+		$this->template = new phpbb\template\twig\twig($this->phpbb_path_helper, $config, $context, $twig, $cache_path, $this->user, array(new \phpbb\template\twig\extension($context, $twig, $this->user, $dispatcher)));
 		$twig->setLexer(new \phpbb\template\twig\lexer($twig));
 		$this->template->set_custom_style('tests', array($this->template_path, $this->parent_template_path));
 	}

--- a/tests/test_framework/phpbb_functional_test_case.php
+++ b/tests/test_framework/phpbb_functional_test_case.php
@@ -980,7 +980,7 @@ class phpbb_functional_test_case extends phpbb_test_case
 		// Any output before the doc type means there was an error
 		$content = self::get_content();
 		self::assertStringNotContainsString('[phpBB Debug]', $content);
-		self::assertStringStartsWith('<!DOCTYPE', strtoupper(substr(trim($content), 0, 10)), 'Output found before DOCTYPE specification.');
+		self::assertStringStartsWith('<!DOCTYPE', strtoupper(substr(trim($content), 0, 10000)), 'Output found before DOCTYPE specification.');
 
 		if ($status_code !== false)
 		{

--- a/tests/test_framework/phpbb_functional_test_case.php
+++ b/tests/test_framework/phpbb_functional_test_case.php
@@ -123,6 +123,9 @@ class phpbb_functional_test_case extends phpbb_test_case
 			// Close the database connections again this test
 			$this->db->sql_close();
 		}
+
+		$this->purge_cache();
+		sleep(3); // Give it some time to delete all the files correctly
 	}
 
 	/**


### PR DESCRIPTION
Event added to allow template events to be assigned priority per extension, event location chosen so that it only fires once.
Twig node event class refactored to allow template event priority assignment, compile calls are deferred until all locations are processed per extension namespace.
Priority precedence mirrors Symfony priority, with higher numbers being placed at the beginning of the array.
Duplicate priority assignment will currently have the later events compiled before the others.

PHPBB3-15214

Checklist:

- [x] Correct branch: master for new features; 3.3.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master](https://area51.phpbb.com/docs/master/coding-guidelines.html) and [3.3.x](https://area51.phpbb.com/docs/dev/3.3.x/development/coding_guidelines.html)
- [x] Commit follows commit message [format](https://area51.phpbb.com/docs/dev/3.3.x/development/git.html)

Tracker ticket:

https://tracker.phpbb.com/browse/PHPBB3-15214
