### PR TITLE
[ticket/17232] Improve SQL error messages handling

### DIFF
--- a/phpBB/phpbb/db/driver/mssql_odbc.php
+++ b/phpBB/phpbb/db/driver/mssql_odbc.php
@@ -166,7 +166,16 @@ class mssql_odbc extends \phpbb\db\driver\mssql_base
 
 			if ($this->query_result === false)
 			{
-				if (($this->query_result = @odbc_exec($this->db_connect_id, $query)) === false)
+				try
+				{
+					$this->query_result = @odbc_exec($this->db_connect_id, $query);
+				}
+				catch (\Error $e)
+				{
+					// Do nothing as SQL driver will report the error
+				}
+
+				if ($this->query_result === false)
 				{
 					$this->sql_error($query);
 				}

--- a/phpBB/phpbb/db/driver/mssqlnative.php
+++ b/phpBB/phpbb/db/driver/mssqlnative.php
@@ -138,12 +138,22 @@ class mssqlnative extends \phpbb\db\driver\mssql_base
 
 			if ($this->query_result === false)
 			{
-				if (($this->query_result = @sqlsrv_query($this->db_connect_id, $query, array(), $this->query_options)) === false)
+				try
+				{
+					$this->query_result = @sqlsrv_query($this->db_connect_id, $query, array(), $this->query_options);
+				}
+				catch (\Error $e)
+				{
+					// Do nothing as SQL driver will report the error
+				}
+
+				if ($this->query_result === false)
 				{
 					$this->sql_error($query);
 				}
-				// reset options for next query
-				$this->query_options = array();
+
+				// Reset options for the next query
+				$this->query_options = [];
 
 				if ($this->debug_sql_explain)
 				{

--- a/phpBB/phpbb/db/driver/mysqli.php
+++ b/phpBB/phpbb/db/driver/mysqli.php
@@ -197,7 +197,16 @@ class mysqli extends \phpbb\db\driver\mysql_base
 
 			if ($this->query_result === false)
 			{
-				if (($this->query_result = @mysqli_query($this->db_connect_id, $query)) === false)
+				try
+				{
+					$this->query_result = @mysqli_query($this->db_connect_id, $query);
+				}
+				catch (\Error $e)
+				{
+					// Do nothing as SQL driver will report the error
+				}
+
+				if ($this->query_result === false)
 				{
 					$this->sql_error($query);
 				}
@@ -345,24 +354,24 @@ class mysqli extends \phpbb\db\driver\mysql_base
 	{
 		if ($this->db_connect_id)
 		{
-			$error = array(
-				'message'	=> @mysqli_error($this->db_connect_id),
-				'code'		=> @mysqli_errno($this->db_connect_id)
-			);
+			$error = [
+				'message'	=> $this->db_connect_id->error,
+				'code'		=> $this->db_connect_id->errno,
+			];
 		}
 		else if (function_exists('mysqli_connect_error'))
 		{
-			$error = array(
-				'message'	=> @mysqli_connect_error(),
-				'code'		=> @mysqli_connect_errno(),
-			);
+			$error = [
+				'message'	=> $this->db_connect_id->connect_error,
+				'code'		=> $this->db_connect_id->connect_errno,
+			];
 		}
 		else
 		{
-			$error = array(
+			$error = [
 				'message'	=> $this->connect_error,
 				'code'		=> '',
-			);
+			];
 		}
 
 		return $error;

--- a/phpBB/phpbb/db/driver/postgres.php
+++ b/phpBB/phpbb/db/driver/postgres.php
@@ -188,7 +188,16 @@ class postgres extends \phpbb\db\driver\driver
 
 			if ($this->query_result === false)
 			{
-				if (($this->query_result = @pg_query($this->db_connect_id, $query)) === false)
+				try
+				{
+					$this->query_result = @pg_query($this->db_connect_id, $query);
+				}
+				catch (\Error $e)
+				{
+					// Do nothing as SQL driver will report the error
+				}
+
+				if ($this->query_result === false)
 				{
 					$this->sql_error($query);
 				}

--- a/phpBB/phpbb/db/driver/sqlite3.php
+++ b/phpBB/phpbb/db/driver/sqlite3.php
@@ -138,7 +138,16 @@ class sqlite3 extends \phpbb\db\driver\driver
 					$query = preg_replace('/^INSERT INTO/', 'INSERT OR ROLLBACK INTO', $query);
 				}
 
-				if (($this->query_result = @$this->dbo->query($query)) === false)
+				try
+				{
+					$this->query_result = @$this->dbo->query($query);
+				}
+				catch (\Error $e)
+				{
+					// Do nothing as SQL driver will report the error
+				}
+
+				if ($this->query_result === false)
 				{
 					// Try to recover a lost database connection
 					if ($this->dbo && !@$this->dbo->lastErrorMsg())

--- a/phpBB/phpbb/db/tools/factory.php
+++ b/phpBB/phpbb/db/tools/factory.php
@@ -33,6 +33,10 @@ class factory
 		{
 			return new \phpbb\db\tools\postgres($db_driver, $return_statements);
 		}
+		else if ($db_driver instanceof \phpbb\db\driver\sqlite3)
+		{
+			return new \phpbb\db\tools\sqlite3($db_driver, $return_statements);
+		}
 		else if ($db_driver instanceof \phpbb\db\driver\driver_interface)
 		{
 			return new \phpbb\db\tools\tools($db_driver, $return_statements);

--- a/phpBB/phpbb/db/tools/sqlite3.php
+++ b/phpBB/phpbb/db/tools/sqlite3.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ *
+ * This file is part of the phpBB Forum Software package.
+ *
+ * @copyright (c) phpBB Limited <https://www.phpbb.com>
+ * @license GNU General Public License, version 2 (GPL-2.0)
+ *
+ * For full copyright and license information, please see
+ * the docs/CREDITS.txt file.
+ *
+ */
+
+namespace phpbb\db\tools;
+
+/**
+ * Database Tools for handling cross-db actions such as altering columns, etc.
+ * Currently not supported is returning SQL for creating tables.
+ */
+class sqlite3 extends tools
+{
+	/**
+	 * {@inheritDoc}
+	 */
+	function sql_table_exists($table_name)
+	{
+		$this->db->sql_return_on_error(true);
+		$result = $this->db->sql_query("SELECT name FROM sqlite_master WHERE type='table' AND name='{$table_name}'");
+		$this->db->sql_return_on_error(false);
+
+		if (!empty($this->db->sql_fetchrowset($result)))
+		{
+			$this->db->sql_freeresult($result);
+			return true;
+		}
+
+		return false;
+	}
+}


### PR DESCRIPTION
PHP 7 changes how most errors are reported by PHP. Instead of reporting errors through the traditional error reporting mechanism used by PHP 5, most errors are now reported by throwing Error exceptions.
Use it to display meaningful SQL error messages instead of PHP fatal errors for SQL errors.

Checklist:

- [x] Correct branch: master for new features; 3.3.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master](https://area51.phpbb.com/docs/master/coding-guidelines.html) and [3.3.x](https://area51.phpbb.com/docs/dev/3.3.x/development/coding_guidelines.html)
- [x] Commit follows commit message [format](https://area51.phpbb.com/docs/dev/3.3.x/development/git.html)

Tracker ticket:

<a href="https://tracker.phpbb.com/browse/PHPBB3-17232">PHPBB3-17232</a>.
