### PR TITLE
[ticket/17117] Do not load non-existent/disabled notification methods

### DIFF
--- a/phpBB/phpbb/notification/manager.php
+++ b/phpBB/phpbb/notification/manager.php
@@ -411,12 +411,17 @@ class manager
 
 			foreach ($methods as $method)
 			{
-				// setup the notification methods and add the notification to the queue
+				// Do not load non-existent notification methods
+				if (!isset($this->notification_methods[$method]))
+				{
+					continue;
+				}
+
+				// Setup the notification methods and add the notification to the queue
 				if (!isset($notification_methods[$method]))
 				{
 					$notification_methods[$method] = $this->get_method_class($method);
 				}
-
 				$notification_methods[$method]->add_to_queue($notification);
 			}
 		}

--- a/tests/notification/fixtures/submit_post_notification.type.bookmark.xml
+++ b/tests/notification/fixtures/submit_post_notification.type.bookmark.xml
@@ -159,5 +159,12 @@
 			<value>notification.method.board</value>
 			<value>0</value>
 		</row>
+		<row>
+			<value>notification.type.bookmark</value>
+			<value>0</value>
+			<value>3</value>
+			<value>notification.method.nonexistent</value>
+			<value>1</value>
+		</row>
 	</table>
 </dataset>


### PR DESCRIPTION
Non-existent or disabled notification methods (f.e. added by extensions which were later disabled/purged) should not be loaded.

Checklist:

- [x] Correct branch: master for new features; 3.3.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master](https://area51.phpbb.com/docs/master/coding-guidelines.html) and [3.3.x](https://area51.phpbb.com/docs/dev/3.3.x/development/coding_guidelines.html)
- [x] Commit follows commit message [format](https://area51.phpbb.com/docs/dev/3.3.x/development/git.html)

Tracker ticket:

<a href="https://tracker.phpbb.com/browse/PHPBB3-17117">PHPBB3-17117</a>.
