### PR TITLE
[ticket/17175] Fix topic title in the breadcrumbs when emailing a topic

### DIFF
--- a/phpBB/memberlist.php
+++ b/phpBB/memberlist.php
@@ -941,10 +941,19 @@ switch ($mode)
 		}
 		else if ($topic_id)
 		{
-			$sql = 'SELECT f.parent_id, f.forum_parents, f.left_id, f.right_id, f.forum_type, f.forum_name, f.forum_id, f.forum_desc, f.forum_desc_uid, f.forum_desc_bitfield, f.forum_desc_options, f.forum_options, t.topic_title
-					FROM ' . FORUMS_TABLE . ' as f,
-						' . TOPICS_TABLE . ' as t
-					WHERE t.forum_id = f.forum_id';
+			// Generate the navlinks based on the selected topic
+			$navlinks_sql_array = [
+				'SELECT'    => 'f.parent_id, f.forum_parents, f.left_id, f.right_id, f.forum_type, f.forum_name, 
+					f.forum_id, f.forum_desc, f.forum_desc_uid, f.forum_desc_bitfield, f.forum_desc_options, 
+					f.forum_options, t.topic_title',
+				'FROM'      => [
+					FORUMS_TABLE  => 'f',
+					TOPICS_TABLE  => 't',
+				],
+				'WHERE'     => 't.forum_id = f.forum_id AND t.topic_id = ' . (int) $topic_id,
+			];
+
+			$sql = $db->sql_build_query('SELECT', $navlinks_sql_array);
 			$result = $db->sql_query($sql);
 			$topic_data = $db->sql_fetchrow($result);
 			$db->sql_freeresult($result);


### PR DESCRIPTION
PHPBB3-17175

This fixes a bug whereby the wrong topic title would show in the breadcrumbs when emailing a topic. (The cause was that the SQL query was missing `t.topic_id = ' . (int) $topic_id`)

Checklist:

- [x] Correct branch: master for new features; 3.3.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master](https://area51.phpbb.com/docs/master/coding-guidelines.html) and [3.3.x](https://area51.phpbb.com/docs/dev/3.3.x/development/coding_guidelines.html)
- [x] Commit follows commit message [format](https://area51.phpbb.com/docs/dev/3.3.x/development/git.html)

Tracker ticket:

https://tracker.phpbb.com/projects/PHPBB3/issues/PHPBB3-17175

Screenshot:

(Previously, no matter what the topic id was it would always show the name of the first topic posted in that forum. Now, the breadcrumb will reflect the correct topic title associated with the topic id.)

![Screenshot 2024-05-12 at 5 47 16 PM](https://github.com/phpbb/phpbb/assets/2110222/a3e9f62d-3cdf-4052-a59d-5885f3617b80)




