### PR TITLE
[ticket/17316] Add template events to ucp_groups_manage

### DIFF
--- a/phpBB/docs/events.md
+++ b/phpBB/docs/events.md
@@ -2521,6 +2521,20 @@ ucp_friend_list_before
 * Since: 3.1.0-a4
 * Purpose: Add optional elements before list of friends in UCP
 
+ucp_group_settings_after
+===
+* Locations:
+    + styles/prosilver/template/ucp_groups_manage.html
+* Since: 3.3.13-RC1
+* Purpose: Add content after options for managing a group in the UCP
+
+ucp_group_settings_before
+===
+* Locations:
+    + styles/prosilver/template/ucp_groups_manage.html
+* Since: 3.3.13-RC1
+* Purpose: Add content before options for managing a group in the UCP
+
 ucp_header_content_before
 ===
 * Locations:

--- a/phpBB/styles/prosilver/template/ucp_groups_manage.html
+++ b/phpBB/styles/prosilver/template/ucp_groups_manage.html
@@ -52,6 +52,7 @@
 	<h3>{L_GROUP_SETTINGS_SAVE}</h3>
 
 	<fieldset>
+	<!-- EVENT ucp_group_settings_before -->
 	<dl>
 		<dt><label for="group_colour">{L_GROUP_COLOR}{L_COLON}</label><br /><span>{L_GROUP_COLOR_EXPLAIN}</span></dt>
 		<dd>
@@ -65,6 +66,7 @@
 		<dt><label for="group_rank">{L_GROUP_RANK}{L_COLON}</label></dt>
 		<dd><select name="group_rank" id="group_rank">{S_RANK_OPTIONS}</select></dd>
 	</dl>
+	<!-- EVENT ucp_group_settings_after -->
 	</fieldset>
 
 	</div>


### PR DESCRIPTION
Add new template events to the UCP group management page allowing extension developers to replicate group management forms from the ACP into the UCP.

Checklist:

- [X] Correct branch: master for new features; 3.3.x for fixes
- [x] Tests pass
- [X] Code follows coding guidelines: [master](https://area51.phpbb.com/docs/master/coding-guidelines.html) and [3.3.x](https://area51.phpbb.com/docs/dev/3.3.x/development/coding_guidelines.html)
- [X] Commit follows commit message [format](https://area51.phpbb.com/docs/dev/3.3.x/development/git.html)

Tracker ticket:

https://tracker.phpbb.com/browse/PHPBB3-17316
