### PR TITLE
[ticket/17317] Change button text for pm recipient to increase readability

### DIFF
--- a/phpBB/styles/prosilver/template/posting_pm_header.html
+++ b/phpBB/styles/prosilver/template/posting_pm_header.html
@@ -77,8 +77,12 @@
 						<ul class="recipients">
 							<!-- BEGIN to_recipient -->
 							<li>
-								<!-- IF to_recipient.IS_GROUP --><a href="{to_recipient.U_VIEW}"><strong>{to_recipient.NAME}</strong></a><!-- ELSE -->{to_recipient.NAME_FULL}<!-- ENDIF -->&nbsp;
-								<!-- IF not S_EDIT_POST --><input type="submit" name="remove_{to_recipient.TYPE}[{to_recipient.UG_ID}]" value="x" class="button2" /><!-- ENDIF -->
+								<!-- IF not S_EDIT_POST -->
+									<button type="submit" name="remove_{to_recipient.TYPE}[{to_recipient.UG_ID}]">
+										<i class="icon fa-times icon-red" aria-hidden="true"></i><span class="sr-only">{L_REMOVE}</span>
+									</button>
+								<!-- ENDIF -->
+								<!-- IF to_recipient.IS_GROUP --><a href="{to_recipient.U_VIEW}"><strong>{to_recipient.NAME}</strong></a><!-- ELSE -->{to_recipient.NAME_FULL}<!-- ENDIF -->
 							</li>
 							<!-- END to_recipient -->
 						</ul>

--- a/phpBB/styles/prosilver/template/posting_pm_header.html
+++ b/phpBB/styles/prosilver/template/posting_pm_header.html
@@ -31,7 +31,11 @@
 					<ul class="recipients">
 						<!-- BEGIN to_recipient -->
 						<li>
-							<!-- IF not S_EDIT_POST --><input type="submit" name="remove_{to_recipient.TYPE}[{to_recipient.UG_ID}]" value="{L_REMOVE}" class="button2" /><!-- ENDIF -->
+							<!-- IF not S_EDIT_POST -->
+								<button type="submit" name="remove_{to_recipient.TYPE}[{to_recipient.UG_ID}]">
+									<i class="icon fa-times icon-red" aria-hidden="true"></i><span class="sr-only">{L_REMOVE}</span>
+								</button>
+							<!-- ENDIF -->
 							<!-- IF to_recipient.IS_GROUP --><a href="{to_recipient.U_VIEW}" style="color: {{ to_recipient.COLOUR }}"><strong>{to_recipient.NAME}</strong></a><!-- ELSE -->{to_recipient.NAME_FULL}<!-- ENDIF -->
 						</li>
 						<!-- END to_recipient -->
@@ -48,7 +52,11 @@
 					<ul class="recipients">
 						<!-- BEGIN bcc_recipient -->
 						<li>
-							<!-- IF not S_EDIT_POST --><input type="submit" name="remove_{bcc_recipient.TYPE}[{bcc_recipient.UG_ID}]" value="{L_REMOVE}" class="button2" /><!-- ENDIF -->
+							<!-- IF not S_EDIT_POST -->
+								<button type="submit" name="remove_{bcc_recipient.TYPE}[{bcc_recipient.UG_ID}]">
+									<i class="icon fa-times icon-red" aria-hidden="true"></i><span class="sr-only">{L_REMOVE}</span>
+								</button>
+							<!-- ENDIF -->
 							<!-- IF bcc_recipient.IS_GROUP --><a href="{bcc_recipient.U_VIEW}" style="color: {{ bcc_recipient.COLOUR }}"><strong>{bcc_recipient.NAME}</strong></a><!-- ELSE -->{bcc_recipient.NAME_FULL}<!-- ENDIF -->
 						</li>
 						<!-- END bcc_recipient -->

--- a/phpBB/styles/prosilver/template/posting_pm_header.html
+++ b/phpBB/styles/prosilver/template/posting_pm_header.html
@@ -31,7 +31,7 @@
 					<ul class="recipients">
 						<!-- BEGIN to_recipient -->
 						<li>
-							<!-- IF not S_EDIT_POST --><input type="submit" name="remove_{to_recipient.TYPE}[{to_recipient.UG_ID}]" value="x" class="button2" /><!-- ENDIF -->
+							<!-- IF not S_EDIT_POST --><input type="submit" name="remove_{to_recipient.TYPE}[{to_recipient.UG_ID}]" value="{L_REMOVE}" class="button2" /><!-- ENDIF -->
 							<!-- IF to_recipient.IS_GROUP --><a href="{to_recipient.U_VIEW}" style="color: {{ to_recipient.COLOUR }}"><strong>{to_recipient.NAME}</strong></a><!-- ELSE -->{to_recipient.NAME_FULL}<!-- ENDIF -->
 						</li>
 						<!-- END to_recipient -->
@@ -48,7 +48,7 @@
 					<ul class="recipients">
 						<!-- BEGIN bcc_recipient -->
 						<li>
-							<!-- IF not S_EDIT_POST --><input type="submit" name="remove_{bcc_recipient.TYPE}[{bcc_recipient.UG_ID}]" value="x" class="button2" /><!-- ENDIF -->
+							<!-- IF not S_EDIT_POST --><input type="submit" name="remove_{bcc_recipient.TYPE}[{bcc_recipient.UG_ID}]" value="{L_REMOVE}" class="button2" /><!-- ENDIF -->
 							<!-- IF bcc_recipient.IS_GROUP --><a href="{bcc_recipient.U_VIEW}" style="color: {{ bcc_recipient.COLOUR }}"><strong>{bcc_recipient.NAME}</strong></a><!-- ELSE -->{bcc_recipient.NAME_FULL}<!-- ENDIF -->
 						</li>
 						<!-- END bcc_recipient -->

--- a/phpBB/styles/prosilver/theme/common.css
+++ b/phpBB/styles/prosilver/theme/common.css
@@ -780,12 +780,6 @@ fieldset.fields1 dd.recipients {
 	margin-left: 1em;
 }
 
-fieldset.fields1 ul.recipients input.button2 {
-	font-size: 0.8em;
-	margin-right: 0;
-	padding: 0;
-}
-
 fieldset.fields1 dl.pmlist > dt {
 	width: auto !important;
 }

--- a/phpBB/styles/prosilver/theme/common.css
+++ b/phpBB/styles/prosilver/theme/common.css
@@ -780,10 +780,10 @@ fieldset.fields1 dd.recipients {
 	margin-left: 1em;
 }
 
-fieldset.fields1 ul.recipients  input.button2 {
+fieldset.fields1 ul.recipients input.button2 {
 	font-size: 0.8em;
 	margin-right: 0;
-	padding: 0;
+	padding: 2px 0;
 }
 
 fieldset.fields1 dl.pmlist > dt {

--- a/phpBB/styles/prosilver/theme/common.css
+++ b/phpBB/styles/prosilver/theme/common.css
@@ -783,7 +783,7 @@ fieldset.fields1 dd.recipients {
 fieldset.fields1 ul.recipients input.button2 {
 	font-size: 0.8em;
 	margin-right: 0;
-	padding: 2px 0;
+	padding: 0 2px;
 }
 
 fieldset.fields1 dl.pmlist > dt {

--- a/phpBB/styles/prosilver/theme/common.css
+++ b/phpBB/styles/prosilver/theme/common.css
@@ -783,7 +783,7 @@ fieldset.fields1 dd.recipients {
 fieldset.fields1 ul.recipients input.button2 {
 	font-size: 0.8em;
 	margin-right: 0;
-	padding: 0 2px;
+	padding: 0;
 }
 
 fieldset.fields1 dl.pmlist > dt {


### PR DESCRIPTION
I've updated the text on the submit button used to remove recipients from a PM that is currently being composed. It used to just be a small `x` that was hard (for me and of course others) to see.

I've updated it to say `Remove` which is already an existing language string so no new translations are required for this change. I also added a 2px padding so the text isn't flush to the edges of the button.

It makes it more readable and actually looks styled as opposed to looking like an element that was forgotten about. I think this makes the interface much better to use.

PHPBB3-17317

Checklist:

- [x] Correct branch: master for new features; 3.3.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master](https://area51.phpbb.com/docs/master/coding-guidelines.html) and [3.3.x](https://area51.phpbb.com/docs/dev/3.3.x/development/coding_guidelines.html)
- [x] Commit follows commit message [format](https://area51.phpbb.com/docs/dev/3.3.x/development/git.html)

Tracker ticket:

https://tracker.phpbb.com/browse/PHPBB3-17317
