### PR TITLE
[ticket/17109] Don't show the attach signature option if the user doesn't have permission

### DIFF
--- a/phpBB/includes/ucp/ucp_prefs.php
+++ b/phpBB/includes/ucp/ucp_prefs.php
@@ -488,6 +488,8 @@ class ucp_prefs
 				}
 
 				$template->assign_vars(array(
+					'S_SIG_ALLOWED'	=> $config['allow_sig'] && $auth->acl_get('u_sig'),
+
 					'S_BBCODE'	=> $data['bbcode'],
 					'S_SMILIES'	=> $data['smilies'],
 					'S_SIG'		=> $data['sig'],

--- a/phpBB/posting.php
+++ b/phpBB/posting.php
@@ -1966,7 +1966,7 @@ $page_data = array(
 	'S_BBCODE_CHECKED'			=> ($bbcode_checked) ? ' checked="checked"' : '',
 	'S_SMILIES_ALLOWED'			=> $smilies_status,
 	'S_SMILIES_CHECKED'			=> ($smilies_checked) ? ' checked="checked"' : '',
-	'S_SIG_ALLOWED'				=> ($auth->acl_get('f_sigs', $forum_id) && $config['allow_sig'] && $user->data['is_registered']) ? true : false,
+	'S_SIG_ALLOWED'				=> ($user->data['is_registered'] && $config['allow_sig'] && $auth->acl_get('f_sigs', $forum_id) && $auth->acl_get('u_sig')) ? true : false,
 	'S_SIGNATURE_CHECKED'		=> ($sig_checked) ? ' checked="checked"' : '',
 	'S_NOTIFY_ALLOWED'			=> (!$user->data['is_registered'] || ($mode == 'edit' && $user->data['user_id'] != $post_data['poster_id']) || !$config['allow_topic_notify'] || !$config['email_enable']) ? false : true,
 	'S_NOTIFY_CHECKED'			=> ($notify_checked) ? ' checked="checked"' : '',

--- a/phpBB/styles/prosilver/template/ucp_prefs_post.html
+++ b/phpBB/styles/prosilver/template/ucp_prefs_post.html
@@ -23,6 +23,7 @@
 			<label for="smilies0"><input type="radio" name="smilies" id="smilies0" value="0"<!-- IF not S_SMILIES --> checked="checked"<!-- ENDIF --> /> {L_NO}</label>
 		</dd>
 	</dl>
+	{% if S_SIG_ALLOWED %}
 	<dl>
 		<dt><label for="sig1">{L_DEFAULT_ADD_SIG}{L_COLON}</label></dt>
 		<dd>
@@ -30,6 +31,7 @@
 			<label for="sig0"><input type="radio" name="sig" id="sig0" value="0"<!-- IF not S_SIG --> checked="checked"<!-- ENDIF --> /> {L_NO}</label>
 		</dd>
 	</dl>
+	{% endif %}
 	<dl>
 		<dt><label for="notify1">{L_DEFAULT_NOTIFY}{L_COLON}</label></dt>
 		<dd>


### PR DESCRIPTION
This fixes a bug on the posting page and on the UCP posting preferences page, the attach signature option was being displayed even if the user had the "Can use signature" option set to "never" in their user permissions.

PHPBB3-17109

Checklist:

- [x] Correct branch: master for new features; 3.3.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master](https://area51.phpbb.com/docs/master/coding-guidelines.html) and [3.3.x](https://area51.phpbb.com/docs/dev/3.3.x/development/coding_guidelines.html)
- [x] Commit follows commit message [format](https://area51.phpbb.com/docs/dev/3.3.x/development/git.html)

Tracker ticket:

https://tracker.phpbb.com/browse/PHPBB3-17109
