### PR TITLE
[ticket/17320] Remove unused js code from prosilver

### DIFF
--- a/phpBB/styles/prosilver/template/forum_fn.js
+++ b/phpBB/styles/prosilver/template/forum_fn.js
@@ -330,17 +330,6 @@ function parseDocument($container) {
 	});
 
 	/**
-	* Adjust HTML code for IE8 and older versions
-	*/
-	// if (oldBrowser) {
-	// 	// Fix .linklist.bulletin lists
-	// 	$container
-	// 		.find('ul.linklist.bulletin > li')
-	// 		.filter(':first-child, .rightside:last-child')
-	// 		.addClass('no-bulletin');
-	// }
-
-	/**
 	* Resize navigation (breadcrumbs) block to keep all links on same line
 	*/
 	$container.find('.navlinks').each(function() {


### PR DESCRIPTION
The forum_fn.js file contained a small block of code that was commented out so there is no need to keep it in the codebase, especially as it was a fix for IE8 and older browsers.

PHPBB3-17320

Checklist:

- [x] Correct branch: master for new features; 3.3.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master](https://area51.phpbb.com/docs/master/coding-guidelines.html) and [3.3.x](https://area51.phpbb.com/docs/dev/3.3.x/development/coding_guidelines.html)
- [x] Commit follows commit message [format](https://area51.phpbb.com/docs/dev/3.3.x/development/git.html)

Tracker ticket:

https://tracker.phpbb.com/browse/PHPBB3-17320
