### PR TITLE
[ticket/16553] Fix for General Error when approving/disapproving a reported post through the MCP

### DIFF
--- a/.devcontainer/resources/phpbb-config.yml
+++ b/.devcontainer/resources/phpbb-config.yml
@@ -30,7 +30,7 @@ installer:
     server:
         cookie_secure: false
         server_protocol: http://
-        force_server_vars: false
+        force_server_vars: true
         server_name: localhost
         server_port: 80
         script_path: /

--- a/.devcontainer/resources/setup.sh
+++ b/.devcontainer/resources/setup.sh
@@ -34,6 +34,14 @@ sudo ln -s /workspaces/phpbb/phpBB /var/www/html
 echo "[Codespaces] Copy phpBB configuration"
 cp /workspaces/phpbb/.devcontainer/resources/phpbb-config.yml /workspaces/phpbb/phpBB/install/install-config.yml
 
+# Force the server URL to reflect the Codespace
+# https://docs.github.com/en/codespaces/developing-in-a-codespace/default-environment-variables-for-your-codespace
+if [ "$CODESPACES" = true ] ; then
+    echo "[Codespaces] Set the phpBB server name using default environment variables"
+    codespaces_url="${CODESPACE_NAME}-80.${GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN}"
+    sed -i "s/localhost/$codespaces_url/g" /workspaces/phpbb/phpBB/install/install-config.yml
+fi
+
 # Install phpBB
 echo "[Codespaces] Run phpBB CLI installation"
 cd /workspaces/phpbb/phpBB && composer install --no-interaction

--- a/phpBB/includes/mcp/mcp_post.php
+++ b/phpBB/includes/mcp/mcp_post.php
@@ -222,6 +222,7 @@ function mcp_post_details($id, $mode, $action)
 		'U_POST_ACTION'			=> "$url&amp;i=$id&amp;mode=post_details", // Use this for action parameters
 		'U_APPROVE_ACTION'		=> append_sid("{$phpbb_root_path}mcp.$phpEx", "i=queue&amp;p=$post_id"),
 
+		'S_CAN_APPROVE'			=> $auth->acl_get('m_approve', $post_info['forum_id']),
 		'S_CAN_VIEWIP'			=> $auth->acl_get('m_info', $post_info['forum_id']),
 		'S_CAN_CHGPOSTER'		=> $auth->acl_get('m_chgposter', $post_info['forum_id']),
 		'S_CAN_LOCK_POST'		=> $auth->acl_get('m_lock', $post_info['forum_id']),

--- a/phpBB/includes/mcp/mcp_reports.php
+++ b/phpBB/includes/mcp/mcp_reports.php
@@ -252,6 +252,7 @@ class mcp_reports
 				$report_template = array(
 					'S_MCP_REPORT'			=> true,
 					'S_CLOSE_ACTION'		=> append_sid("{$phpbb_root_path}mcp.$phpEx", 'i=reports&amp;mode=report_details&amp;p=' . $post_id),
+					'S_CAN_APPROVE'			=> $auth->acl_get('m_approve', $post_info['forum_id']),
 					'S_CAN_VIEWIP'			=> $auth->acl_get('m_info', $post_info['forum_id']),
 					'S_POST_REPORTED'		=> $post_info['post_reported'],
 					'S_POST_UNAPPROVED'		=> $post_info['post_visibility'] == ITEM_UNAPPROVED || $post_info['post_visibility'] == ITEM_REAPPROVE,
@@ -260,6 +261,7 @@ class mcp_reports
 					'S_USER_NOTES'			=> true,
 
 					'U_EDIT'					=> ($auth->acl_get('m_edit', $post_info['forum_id'])) ? append_sid("{$phpbb_root_path}posting.$phpEx", "mode=edit&amp;p={$post_info['post_id']}") : '',
+					'U_APPROVE_ACTION'			=> append_sid("{$phpbb_root_path}mcp.$phpEx", "i=queue&amp;p=" . $post_id),
 					'U_MCP_APPROVE'				=> append_sid("{$phpbb_root_path}mcp.$phpEx", 'i=queue&amp;mode=approve_details&amp;p=' . $post_id),
 					'U_MCP_REPORT'				=> append_sid("{$phpbb_root_path}mcp.$phpEx", 'i=reports&amp;mode=report_details&amp;p=' . $post_id),
 					'U_MCP_REPORTER_NOTES'		=> append_sid("{$phpbb_root_path}mcp.$phpEx", 'i=notes&amp;mode=user_notes&amp;u=' . $report['user_id']),

--- a/phpBB/includes/mcp/mcp_reports.php
+++ b/phpBB/includes/mcp/mcp_reports.php
@@ -261,7 +261,7 @@ class mcp_reports
 					'S_USER_NOTES'			=> true,
 
 					'U_EDIT'					=> ($auth->acl_get('m_edit', $post_info['forum_id'])) ? append_sid("{$phpbb_root_path}posting.$phpEx", "mode=edit&amp;p={$post_info['post_id']}") : '',
-					'U_APPROVE_ACTION'			=> append_sid("{$phpbb_root_path}mcp.$phpEx", "i=queue&amp;p=" . $post_id),
+					'U_APPROVE_ACTION'			=> append_sid("{$phpbb_root_path}mcp.$phpEx", 'i=queue&amp;p=' . $post_id),
 					'U_MCP_APPROVE'				=> append_sid("{$phpbb_root_path}mcp.$phpEx", 'i=queue&amp;mode=approve_details&amp;p=' . $post_id),
 					'U_MCP_REPORT'				=> append_sid("{$phpbb_root_path}mcp.$phpEx", 'i=reports&amp;mode=report_details&amp;p=' . $post_id),
 					'U_MCP_REPORTER_NOTES'		=> append_sid("{$phpbb_root_path}mcp.$phpEx", 'i=notes&amp;mode=user_notes&amp;u=' . $report['user_id']),

--- a/phpBB/styles/prosilver/template/mcp_post.html
+++ b/phpBB/styles/prosilver/template/mcp_post.html
@@ -78,6 +78,7 @@
 		<p class="author"><span><i class="icon fa-file fa-fw icon-lightgray icon-md" aria-hidden="true"></i><span class="sr-only">{MINI_POST_IMG}</span></span> {L_POSTED} {L_POST_BY_AUTHOR} {POST_AUTHOR_FULL} &raquo; {POST_DATE}</p>
 		<!-- ENDIF -->
 
+		{% if S_CAN_APPROVE %}
 		<!-- IF S_POST_UNAPPROVED -->
 			<form method="post" id="mcp_approve" action="{U_APPROVE_ACTION}">
 
@@ -101,6 +102,7 @@
 			</p>
 			</form>
 		<!-- ENDIF -->
+		{% endif %}
 
 		{% if S_POST_REPORTED and not S_MCP_REPORT %}
 			<p class="post-notice reported">


### PR DESCRIPTION
## Overview
This PR fixes the module not accessible error which appears when trying to approve or disapprove (through the `MCP -> Reported Messages` page) a post which has been reported. 

To summarise: `U_APPROVE_ACTION` was not present on the mcp_reports page, so the form action was empty and clicking it led to a General Error.

The fix involves making sure that action is passed through to the template. I've also added an `S_CAN_APPROVE` permissions check.

PHPBB3-16553

Checklist:

- [x] Correct branch: master for new features; 3.3.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master](https://area51.phpbb.com/docs/master/coding-guidelines.html) and [3.3.x](https://area51.phpbb.com/docs/dev/3.3.x/development/coding_guidelines.html)
- [x] Commit follows commit message [format](https://area51.phpbb.com/docs/dev/3.3.x/development/git.html)

Tracker ticket:

https://tracker.phpbb.com/browse/PHPBB3-16553

## Screenshots

**BEFORE:**

<img width="289" alt="Screenshot_Missing_Action" src="https://github.com/phpbb/phpbb/assets/2110222/d2e759e9-dfbd-489e-9262-464ef5ba86af">

<img width="309" alt="Screenshot _missing_module" src="https://github.com/phpbb/phpbb/assets/2110222/a53f6422-1ed1-4aac-8e63-55e48b7df46c">

**AFTER:**

<img width="420" alt="Screenshot _with_fix" src="https://github.com/phpbb/phpbb/assets/2110222/2d4da9ff-ea5b-435d-978e-8929075ed1a5">

