### PR TITLE
[feature/17326] Add icon text field for custom BBCodes

### DIFF
--- a/phpBB/adm/style/acp_bbcodes.html
+++ b/phpBB/adm/style/acp_bbcodes.html
@@ -45,6 +45,10 @@
 		<dt><label for="display_on_posting">{L_DISPLAY_ON_POSTING}</label></dt>
 		<dd><input type="checkbox" class="radio" name="display_on_posting" id="display_on_posting" value="1"<!-- IF DISPLAY_ON_POSTING --> checked="checked"<!-- ENDIF --> /></dd>
 	</dl>
+	<dl>
+		<dt><label for="bbcode_icon_name">{L_BBCODE_ICON_NAME}</label><br /><span>{L_BBCODE_ICON_NAME_EXPLAIN}</span></dt>
+		<dd><input type="text" name="bbcode_icon_name" id="bbcode_icon_name" value="{{ BBCODE_ICON_NAME }}" /></dd>
+	</dl>
 	</fieldset>
 
 	<!-- EVENT acp_bbcodes_edit_fieldsets_after -->

--- a/phpBB/includes/acp/acp_bbcodes.php
+++ b/phpBB/includes/acp/acp_bbcodes.php
@@ -44,12 +44,12 @@ class acp_bbcodes
 		switch ($action)
 		{
 			case 'add':
-				$bbcode_match = $bbcode_tpl = $bbcode_helpline = '';
+				$bbcode_match = $bbcode_tpl = $bbcode_helpline = $bbcode_icon_name = '';
 				$display_on_posting = 0;
 			break;
 
 			case 'edit':
-				$sql = 'SELECT bbcode_match, bbcode_tpl, display_on_posting, bbcode_helpline
+				$sql = 'SELECT bbcode_match, bbcode_tpl, display_on_posting, bbcode_helpline, bbcode_icon_name
 					FROM ' . BBCODES_TABLE . '
 					WHERE bbcode_id = ' . $bbcode_id;
 				$result = $db->sql_query($sql);
@@ -65,6 +65,7 @@ class acp_bbcodes
 				$bbcode_tpl = htmlspecialchars($row['bbcode_tpl'], ENT_COMPAT);
 				$display_on_posting = $row['display_on_posting'];
 				$bbcode_helpline = $row['bbcode_helpline'];
+				$bbcode_icon_name = $row['bbcode_icon_name'];
 			break;
 
 			case 'modify':
@@ -88,6 +89,7 @@ class acp_bbcodes
 				$bbcode_match = $request->variable('bbcode_match', '');
 				$bbcode_tpl = html_entity_decode($request->variable('bbcode_tpl', '', true), ENT_COMPAT);
 				$bbcode_helpline = $request->variable('bbcode_helpline', '', true);
+				$bbcode_icon_name = $request->variable('bbcode_icon_name', '');
 			break;
 		}
 
@@ -106,6 +108,7 @@ class acp_bbcodes
 					'BBCODE_MATCH'			=> $bbcode_match,
 					'BBCODE_TPL'			=> $bbcode_tpl,
 					'BBCODE_HELPLINE'		=> $bbcode_helpline,
+					'BBCODE_ICON_NAME'		=> $bbcode_icon_name,
 					'DISPLAY_ON_POSTING'	=> $display_on_posting,
 				);
 
@@ -156,6 +159,7 @@ class acp_bbcodes
 				* @var	string	bbcode_match		The bbcode usage string to match
 				* @var	string	bbcode_tpl			The bbcode HTML replacement string
 				* @var	string	bbcode_helpline		The bbcode help line string
+				* @var	string	bbcode_icon_name	The name of the bbcode FA icon
 				* @var	array	hidden_fields		Array of hidden fields for use when
 				*									submitting form when $warn_unsafe is true
 				* @since 3.1.0-a3
@@ -168,6 +172,7 @@ class acp_bbcodes
 					'bbcode_match',
 					'bbcode_tpl',
 					'bbcode_helpline',
+					'bbcode_icon_name',
 					'hidden_fields',
 				);
 				extract($phpbb_dispatcher->trigger_event('core.acp_bbcodes_modify_create', compact($vars)));
@@ -240,6 +245,11 @@ class acp_bbcodes
 						trigger_error($user->lang['BBCODE_HELPLINE_TOO_LONG'] . adm_back_link($this->u_action), E_USER_WARNING);
 					}
 
+					if (strlen($bbcode_icon_name) > 255)
+					{
+						trigger_error($user->lang['BBCODE_ICON_NAME_TOO_LONG'] . adm_back_link($this->u_action), E_USER_WARNING);
+					}
+
 					/**
 					 * Replace Emojis and other 4bit UTF-8 chars not allowed by MySQL to UCR/NCR.
 					 * Using their Numeric Character Reference's Hexadecimal notation.
@@ -252,6 +262,7 @@ class acp_bbcodes
 						'bbcode_tpl'				=> $bbcode_tpl,
 						'display_on_posting'		=> $display_on_posting,
 						'bbcode_helpline'			=> $bbcode_helpline,
+						'bbcode_icon_name'			=> $bbcode_icon_name,
 						'first_pass_match'			=> $data['first_pass_match'],
 						'first_pass_replace'		=> $data['first_pass_replace'],
 						'second_pass_match'			=> $data['second_pass_match'],
@@ -336,6 +347,7 @@ class acp_bbcodes
 						'bbcode_match'			=> $bbcode_match,
 						'bbcode_tpl'			=> htmlspecialchars($bbcode_tpl, ENT_COMPAT),
 						'bbcode_helpline'		=> $bbcode_helpline,
+						'bbcode_icon_name'		=> $bbcode_icon_name,
 						'display_on_posting'	=> $display_on_posting,
 						)))
 					, 'confirm_bbcode.html');

--- a/phpBB/includes/functions_display.php
+++ b/phpBB/includes/functions_display.php
@@ -1087,7 +1087,7 @@ function display_custom_bbcodes()
 	$num_predefined_bbcodes = NUM_PREDEFINED_BBCODES;
 
 	$sql_ary = [
-		'SELECT'	=> 'b.bbcode_id, b.bbcode_tag, b.bbcode_helpline, b.bbcode_match',
+		'SELECT'	=> 'b.bbcode_id, b.bbcode_tag, b.bbcode_helpline, b.bbcode_icon_name, b.bbcode_match',
 		'FROM'		=> [BBCODES_TABLE => 'b'],
 		'WHERE'		=> 'b.display_on_posting = 1',
 		'ORDER_BY'	=> 'b.bbcode_tag',
@@ -1130,6 +1130,7 @@ function display_custom_bbcodes()
 			'BBCODE_TAG'		=> $row['bbcode_tag'],
 			'BBCODE_TAG_CLEAN'	=> str_replace('=', '-', $row['bbcode_tag']),
 			'BBCODE_HELPLINE'	=> $row['bbcode_helpline'],
+			'BBCODE_ICON_NAME'	=> $row['bbcode_icon_name'],
 		];
 
 		/**

--- a/phpBB/language/en/acp/posting.php
+++ b/phpBB/language/en/acp/posting.php
@@ -54,6 +54,10 @@ $lang = array_merge($lang, array(
 	'BBCODE_HELPLINE_TEXT'		=> 'Help line text',
 	'BBCODE_HELPLINE_TOO_LONG'	=> 'The help line you entered is too long.',
 
+	'BBCODE_ICON_NAME'			=> 'Button icon',
+	'BBCODE_ICON_NAME_EXPLAIN'	=> 'Enter the name of a Font Awesome icon to display instead of the BBCode name appearing on the button. Do not include the fa prefix.',
+	'BBCODE_ICON_NAME_TOO_LONG'	=> 'The icon name you have entered is too long.',
+
 	'BBCODE_INVALID_TAG_NAME'	=> 'The BBCode tag name that you selected already exists.',
 	'BBCODE_INVALID'			=> 'Your BBCode is constructed in an invalid form.',
 	'BBCODE_INVALID_TEMPLATE'	=> 'Your BBCode’s template is invalid.',

--- a/phpBB/phpbb/db/migration/data/v33x/add_bbcode_icon_name.php
+++ b/phpBB/phpbb/db/migration/data/v33x/add_bbcode_icon_name.php
@@ -1,0 +1,51 @@
+<?php
+/**
+*
+* This file is part of the phpBB Forum Software package.
+*
+* @copyright (c) phpBB Limited <https://www.phpbb.com>
+* @license GNU General Public License, version 2 (GPL-2.0)
+*
+* For full copyright and license information, please see
+* the docs/CREDITS.txt file.
+*
+*/
+
+namespace phpbb\db\migration\data\v33x;
+
+class add_bbcode_icon_name extends \phpbb\db\migration\migration
+{
+	public function effectively_installed()
+	{
+		return $this->db_tools->sql_column_exists($this->table_prefix . 'bbcodes', 'bbcode_icon_name');
+	}
+
+	static public function depends_on()
+	{
+		return [
+			'\phpbb\db\migration\data\v33x\v334'
+		];
+	}
+
+	public function update_schema()
+	{
+		return [
+			'add_columns'	=> [
+				$this->table_prefix . 'bbcodes'	=> [
+					'bbcode_icon_name'	=> ['VCHAR_UNI:255', ''],
+				],
+			],
+		];
+	}
+
+	public function revert_schema()
+	{
+		return [
+			'drop_columns'	=> [
+				$this->table_prefix . 'bbcodes'	=> [
+					'bbcode_icon_name',
+				],
+			],
+		];
+	}
+}

--- a/phpBB/styles/prosilver/template/posting_buttons.html
+++ b/phpBB/styles/prosilver/template/posting_buttons.html
@@ -97,7 +97,11 @@
 
 	<!-- BEGIN custom_tags -->
 	<button type="button" class="button button-secondary bbcode-{custom_tags.BBCODE_TAG_CLEAN}" name="addbbcode{custom_tags.BBCODE_ID}" value="{custom_tags.BBCODE_TAG}" onclick="bbstyle({custom_tags.BBCODE_ID})" title="{{ custom_tags.BBCODE_HELPLINE }}">
-		{custom_tags.BBCODE_TAG}
+		<!-- IF custom_tags.BBCODE_TAG != '' -->
+			<i class="icon fa-{custom_tags.BBCODE_ICON_NAME} fa-fw" aria-hidden="true"></i>
+		<!-- ELSE -->
+			{custom_tags.BBCODE_TAG}
+		<!-- ENDIF -->
 	</button>
 	<!-- END custom_tags -->
 </div>


### PR DESCRIPTION
Adds a text input field that allows admins to enter a (Font Awesome) icon name which will be displayed on the custom BBCode button instead of the default BBCode name.

PHPBB3-17326

Checklist:

- [ ] Correct branch: master for new features; 3.3.x for fixes
- [ ] Tests pass
- [ ] Code follows coding guidelines: [master](https://area51.phpbb.com/docs/master/coding-guidelines.html) and [3.3.x](https://area51.phpbb.com/docs/dev/3.3.x/development/coding_guidelines.html)
- [ ] Commit follows commit message [format](https://area51.phpbb.com/docs/dev/3.3.x/development/git.html)

Tracker ticket:

https://tracker.phpbb.com/browse/PHPBB3-17326
