### PR TITLE
[ticket/17337] Fix mysqli driver is missing transaction begin statement - 3.3.x

### DIFF
--- a/phpBB/phpbb/db/driver/mysqli.php
+++ b/phpBB/phpbb/db/driver/mysqli.php
@@ -155,7 +155,9 @@ class mysqli extends \phpbb\db\driver\mysql_base
 		switch ($status)
 		{
 			case 'begin':
-				return @mysqli_autocommit($this->db_connect_id, false);
+				@mysqli_autocommit($this->db_connect_id, false);
+				$result = @mysqli_begin_transaction($this->db_connect_id);
+				return $result;
 			break;
 
 			case 'commit':

--- a/tests/dbal/write_test.php
+++ b/tests/dbal/write_test.php
@@ -77,6 +77,13 @@ class phpbb_dbal_write_test extends phpbb_database_test_case
 	{
 		$db = $this->new_dbal();
 
+		$is_myisam = false;
+		if ($db->get_sql_layer() === 'mysqli')
+		{
+			$table_status = $db->get_table_status('phpbb_config');
+			$is_myisam = isset($table_status['Engine']) && $table_status['Engine'] === 'MyISAM';
+		}
+
 		$db->sql_transaction('begin');
 
 		$sql = "DELETE FROM phpbb_config
@@ -92,8 +99,21 @@ class phpbb_dbal_write_test extends phpbb_database_test_case
 		$rows = $db->sql_fetchrowset($result);
 		$db->sql_freeresult($result);
 
-		$this->assertEquals(2, count($rows));
-		$this->assertEquals('config1', $rows[0]['config_name']);
+		if (!$is_myisam)
+		{
+			$this->assertEquals(2, count($rows));
+			$this->assertEquals('config1', $rows[0]['config_name']);
+		}
+		else
+		{
+			// Rollback does not work on MyISAM
+			$this->assertEquals(1, count($rows));
+			$this->assertEquals('config2', $rows[0]['config_name']);
+
+			// Restore deleted config value on MyISAM
+			$sql = "INSERT INTO phpbb_config (config_name, config_value, is_dynamic) VALUES ('config1', 'foo', 0)";
+			$db->sql_query($sql);
+		}
 
 		$db->sql_transaction('begin');
 

--- a/tests/dbal/write_test.php
+++ b/tests/dbal/write_test.php
@@ -73,6 +73,47 @@ class phpbb_dbal_write_test extends phpbb_database_test_case
 		$db->sql_freeresult($result);
 	}
 
+	public function test_delete_rollback()
+	{
+		$db = $this->new_dbal();
+
+		$db->sql_transaction('begin');
+
+		$sql = "DELETE FROM phpbb_config
+			WHERE config_name = 'config1'";
+		$db->sql_query($sql);
+
+		// Rollback and check that nothing was changed
+		$db->sql_transaction('rollback');
+
+		$sql = 'SELECT *
+			FROM phpbb_config';
+		$result = $db->sql_query($sql);
+		$rows = $db->sql_fetchrowset($result);
+		$db->sql_freeresult($result);
+
+		$this->assertEquals(2, count($rows));
+		$this->assertEquals('config1', $rows[0]['config_name']);
+
+		$db->sql_transaction('begin');
+
+		$sql = "DELETE FROM phpbb_config
+			WHERE config_name = 'config1'";
+		$db->sql_query($sql);
+
+		// Commit and check that data was actually changed
+		$db->sql_transaction('commit');
+
+		$sql = 'SELECT *
+			FROM phpbb_config';
+		$result = $db->sql_query($sql);
+		$rows = $db->sql_fetchrowset($result);
+		$db->sql_freeresult($result);
+
+		$this->assertEquals(1, count($rows));
+		$this->assertEquals('config2', $rows[0]['config_name']);
+	}
+
 	public function test_multiple_insert()
 	{
 		$db = $this->new_dbal();

--- a/tests/test_framework/phpbb_database_test_case.php
+++ b/tests/test_framework/phpbb_database_test_case.php
@@ -285,7 +285,7 @@ abstract class phpbb_database_test_case extends TestCase
 		return $this->createDefaultDBConnection($manager->get_pdo(), 'testdb');
 	}
 
-	public function new_dbal()
+	public function new_dbal() : \phpbb\db\driver\driver_interface
 	{
 		$config = $this->get_database_config();
 


### PR DESCRIPTION
For `3.3.x`.

Checklist:

- [x] Correct branch: master for new features; 3.3.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master](https://area51.phpbb.com/docs/master/coding-guidelines.html) and [3.3.x](https://area51.phpbb.com/docs/dev/3.3.x/development/coding_guidelines.html)
- [x] Commit follows commit message [format](https://area51.phpbb.com/docs/dev/3.3.x/development/git.html)

Tracker ticket:

<a href="https://tracker.phpbb.com/browse/PHPBB-17337">PHPBB-17337</a>.
