### PR TITLE
[ticket/17345] Original time of last post when bump topic

### DIFF
--- a/phpBB/includes/functions_posting.php
+++ b/phpBB/includes/functions_posting.php
@@ -2673,13 +2673,6 @@ function phpbb_bump_topic($forum_id, $topic_id, $post_data, $bump_time = false)
 	// Begin bumping
 	$db->sql_transaction('begin');
 
-	// Update the topic's last post post_time
-	$sql = 'UPDATE ' . POSTS_TABLE . "
-		SET post_time = $bump_time
-		WHERE post_id = {$post_data['topic_last_post_id']}
-			AND topic_id = $topic_id";
-	$db->sql_query($sql);
-
 	// Sync the topic's last post time, the rest of the topic's last post data isn't changed
 	$sql = 'UPDATE ' . TOPICS_TABLE . "
 		SET topic_last_post_time = $bump_time,


### PR DESCRIPTION
The original time of last post should not be updated when bump topic

Checklist:

- [x] Correct branch: master for new features; 3.3.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master](https://area51.phpbb.com/docs/master/coding-guidelines.html) and [3.3.x](https://area51.phpbb.com/docs/dev/3.3.x/development/coding_guidelines.html)
- [x] Commit follows commit message [format](https://area51.phpbb.com/docs/dev/3.3.x/development/git.html)

Tracker ticket:

https://tracker.phpbb.com/browse/PHPBB-17345
