### PR TITLE
[ticket/17352] Fix overflow of long rank titles on profile page

### DIFF
--- a/phpBB/styles/prosilver/template/memberlist_view.html
+++ b/phpBB/styles/prosilver/template/memberlist_view.html
@@ -9,7 +9,7 @@
 	<div class="inner">
 
 	<!-- IF AVATAR_IMG -->
-		<dl class="left-box">
+		<dl class="left-box avatar-rank-container">
 			<dt class="profile-avatar">{AVATAR_IMG}</dt>
 			<!-- EVENT memberlist_view_rank_avatar_before -->
 			<!-- IF RANK_TITLE --><dd style="text-align: center;">{RANK_TITLE}</dd><!-- ENDIF -->

--- a/phpBB/styles/prosilver/theme/common.css
+++ b/phpBB/styles/prosilver/theme/common.css
@@ -731,6 +731,10 @@ table.info tbody th {
 	max-width: 100%;
 }
 
+.avatar-rank-container {
+	max-width: 20%;
+}
+
 .left-box.profile-details {
 	width: 80%;
 }

--- a/phpBB/styles/prosilver/theme/responsive.css
+++ b/phpBB/styles/prosilver/theme/responsive.css
@@ -412,6 +412,10 @@
 		clear: both;
 	}
 
+	.avatar-rank-container {
+		max-width: 100%;
+	}
+
 	/* Polls
 	----------------------------------------*/
 	fieldset.polls dt {


### PR DESCRIPTION
Users that had very long rank titles would cause the rest of their profile details to be pushed down below the avatar and rank details breaking the layout. This change limits the width of the avatar and rank details.

PHPBB-17352

Checklist:

- [x] Correct branch: master for new features; 3.3.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master](https://area51.phpbb.com/docs/master/coding-guidelines.html) and [3.3.x](https://area51.phpbb.com/docs/dev/3.3.x/development/coding_guidelines.html)
- [x] Commit follows commit message [format](https://area51.phpbb.com/docs/dev/3.3.x/development/git.html)

Tracker ticket:

https://tracker.phpbb.com/browse/PHPBB-17352
