### PR TITLE
[ticket/17350] Add IP Address of user during install process

### DIFF
--- a/phpBB/phpbb/install/module/install_finish/task/install_extensions.php
+++ b/phpBB/phpbb/install/module/install_finish/task/install_extensions.php
@@ -144,7 +144,7 @@ class install_extensions extends \phpbb\install\task_base
 				if (isset($extensions[$ext_name]) && $extensions[$ext_name]['ext_active'])
 				{
 					// Create log
-					$this->log->add('admin', ANONYMOUS, '', 'LOG_EXT_ENABLE', time(), array($ext_name));
+					$this->log->add('admin', ANONYMOUS, $this->user->ip, 'LOG_EXT_ENABLE', time(), array($ext_name));
 					$this->iohandler->add_success_message(array('CLI_EXTENSION_ENABLE_SUCCESS', $ext_name));
 				}
 				else

--- a/phpBB/phpbb/install/module/update_database/task/update_extensions.php
+++ b/phpBB/phpbb/install/module/update_database/task/update_extensions.php
@@ -174,7 +174,7 @@ class update_extensions extends task_base
 						if (isset($extensions[$ext_name]) && $extensions[$ext_name]['ext_active'])
 						{
 							// Create log
-							$this->log->add('admin', ANONYMOUS, '', 'LOG_EXT_UPDATE', time(), array($ext_name));
+							$this->log->add('admin', ANONYMOUS, $this->user->ip, 'LOG_EXT_UPDATE', time(), array($ext_name));
 							$this->iohandler->add_success_message(array('CLI_EXTENSION_UPDATE_SUCCESS', $ext_name));
 						}
 						else


### PR DESCRIPTION
Adds the IP address of the user completing the installation process while extensions are being installed or updated. Prior to this change the IP address field was being left blank however other logs created during the install process for other actions does record the users IP.

PHPBB-17350

Checklist:

- [x] Correct branch: master for new features; 3.3.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master](https://area51.phpbb.com/docs/master/coding-guidelines.html) and [3.3.x](https://area51.phpbb.com/docs/dev/3.3.x/development/coding_guidelines.html)
- [x] Commit follows commit message [format](https://area51.phpbb.com/docs/dev/3.3.x/development/git.html)

Tracker ticket:

https://tracker.phpbb.com/browse/PHPBB-17350
