### PR TITLE
[ticket/17365] Add spaces before +, -, and | to correct search keyword count & limit.

### DIFF
--- a/phpBB/phpbb/search/fulltext_native.php
+++ b/phpBB/phpbb/search/fulltext_native.php
@@ -289,6 +289,7 @@ class fulltext_native extends \phpbb\search\base
 			'#(\+|\-)(?:\+|\-)+#',
 			'#\(\|#',
 			'#\|\)#',
+			'#(?<!\s)(\+|\-|\|)#',
 		);
 		$replace = array(
 			' ',
@@ -296,6 +297,7 @@ class fulltext_native extends \phpbb\search\base
 			'$1',
 			'(',
 			')',
+			' $1',
 		);
 
 		$keywords = preg_replace($match, $replace, $keywords);


### PR DESCRIPTION
Prevents keyword limit being bypassed with the use of `+`, `-` and `|` in search queries, because $num_keywords depends on spaces to count the number of words.

Checklist:

- [ ] Correct branch: master for new features; 3.3.x for fixes
- [ ] Tests pass
- [ ] Code follows coding guidelines: [master](https://area51.phpbb.com/docs/master/coding-guidelines.html) and [3.3.x](https://area51.phpbb.com/docs/dev/3.3.x/development/coding_guidelines.html)
- [ ] Commit follows commit message [format](https://area51.phpbb.com/docs/dev/3.3.x/development/git.html)

Tracker ticket:

https://tracker.phpbb.com/browse/PHPBB-12345
