### PR TITLE
[ticket/17365] Enforce the search word limit on queries containing operators without white space

### DIFF
--- a/phpBB/phpbb/search/fulltext_native.php
+++ b/phpBB/phpbb/search/fulltext_native.php
@@ -289,7 +289,6 @@ class fulltext_native extends \phpbb\search\base
 			'#(\+|\-)(?:\+|\-)+#',
 			'#\(\|#',
 			'#\|\)#',
-			'#(?<!\s)(\+|\-|\|)#',
 		);
 		$replace = array(
 			' ',
@@ -297,11 +296,14 @@ class fulltext_native extends \phpbb\search\base
 			'$1',
 			'(',
 			')',
-			' $1',
 		);
 
 		$keywords = preg_replace($match, $replace, $keywords);
-		$num_keywords = count(explode(' ', $keywords));
+		
+		// Ensure a space exists before +, - and | to make the split and count work correctly
+		$countable_keywords = preg_replace('/(?<!\s)(\+|\-|\|)/', ' $1', $keywords);
+		
+		$num_keywords = count(explode(' ', $countable_keywords));
 
 		// We limit the number of allowed keywords to minimize load on the database
 		if ($this->config['max_num_search_keywords'] && $num_keywords > $this->config['max_num_search_keywords'])

--- a/phpBB/phpbb/search/fulltext_native.php
+++ b/phpBB/phpbb/search/fulltext_native.php
@@ -299,10 +299,10 @@ class fulltext_native extends \phpbb\search\base
 		);
 
 		$keywords = preg_replace($match, $replace, $keywords);
-		
+
 		// Ensure a space exists before +, - and | to make the split and count work correctly
 		$countable_keywords = preg_replace('/(?<!\s)(\+|\-|\|)/', ' $1', $keywords);
-		
+
 		$num_keywords = count(explode(' ', $countable_keywords));
 
 		// We limit the number of allowed keywords to minimize load on the database

--- a/phpBB/phpbb/search/fulltext_native.php
+++ b/phpBB/phpbb/search/fulltext_native.php
@@ -289,6 +289,7 @@ class fulltext_native extends \phpbb\search\base
 			'#(\+|\-)(?:\+|\-)+#',
 			'#\(\|#',
 			'#\|\)#',
+			'#(?<!\s)(\+|\-|\|)#',
 		);
 		$replace = array(
 			' ',
@@ -296,6 +297,7 @@ class fulltext_native extends \phpbb\search\base
 			'$1',
 			'(',
 			')',
+			' $1',
 		);
 
 		$keywords = preg_replace($match, $replace, $keywords);


### PR DESCRIPTION
Prevents keyword limit being bypassed with the use of `+`, `-` and `|` in search queries, because $num_keywords depends on spaces to count the number of words.

Checklist:

- [x] Correct branch: master for new features; 3.3.x for fixes
- [ ] Tests pass
- [x] Code follows coding guidelines: [master](https://area51.phpbb.com/docs/master/coding-guidelines.html) and [3.3.x](https://area51.phpbb.com/docs/dev/3.3.x/development/coding_guidelines.html)
- [x] Commit follows commit message [format](https://area51.phpbb.com/docs/dev/3.3.x/development/git.html)

Tracker ticket:

https://tracker.phpbb.com/browse/PHPBB-17365
