### PR TITLE
[ticket/17365] Enforce the search word limit on queries containing operators without whitespace

### DIFF
--- a/phpBB/phpbb/search/fulltext_native.php
+++ b/phpBB/phpbb/search/fulltext_native.php
@@ -299,7 +299,11 @@ class fulltext_native extends \phpbb\search\base
 		);
 
 		$keywords = preg_replace($match, $replace, $keywords);
-		$num_keywords = count(explode(' ', $keywords));
+
+		// Ensure a space exists before +, - and | to make the split and count work correctly
+		$countable_keywords = preg_replace('/(?<!\s)(\+|\-|\|)/', ' $1', $keywords);
+
+		$num_keywords = count(explode(' ', $countable_keywords));
 
 		// We limit the number of allowed keywords to minimize load on the database
 		if ($this->config['max_num_search_keywords'] && $num_keywords > $this->config['max_num_search_keywords'])


### PR DESCRIPTION
Provided `$countable_keywords` wherein the existing `$keywords` value is modified so that any `-`, `+` and `|` characters without preceding spaces is replaced with the same but with a space in front of each. 

These spaces allow the string to be more accurately split when used instead of $keywords inside the $num_keywords calculation. 

This prevents the word limit being bypassed in search by the use of operators without whitespace.

PHPBB-17365

Checklist:

- [ ] Correct branch: master for new features; 3.3.x for fixes
- [ ] Tests pass
- [ ] Code follows coding guidelines: [master](https://area51.phpbb.com/docs/master/coding-guidelines.html) and [3.3.x](https://area51.phpbb.com/docs/dev/3.3.x/development/coding_guidelines.html)
- [ ] Commit follows commit message [format](https://area51.phpbb.com/docs/dev/3.3.x/development/git.html)

Tracker ticket:

https://tracker.phpbb.com/browse/PHPBB-17365