### PR TITLE
[ticket/17365] Prevent search limit being bypassed with operators

### DIFF
--- a/phpBB/phpbb/search/fulltext_native.php
+++ b/phpBB/phpbb/search/fulltext_native.php
@@ -299,7 +299,11 @@ class fulltext_native extends \phpbb\search\base
 		);
 
 		$keywords = preg_replace($match, $replace, $keywords);
-		$num_keywords = count(explode(' ', $keywords));
+
+		// Ensure a space exists before +, - and | to make the split and count work correctly
+		$countable_keywords = preg_replace('/(?<!\s)(\+|\-|\|)/', ' $1', $keywords);
+
+		$num_keywords = count(explode(' ', $countable_keywords));
 
 		// We limit the number of allowed keywords to minimize load on the database
 		if ($this->config['max_num_search_keywords'] && $num_keywords > $this->config['max_num_search_keywords'])

--- a/tests/search/native_test.php
+++ b/tests/search/native_test.php
@@ -25,12 +25,16 @@ class phpbb_search_native_test extends phpbb_search_test_case
 
 	protected function setUp(): void
 	{
-		global $phpbb_root_path, $phpEx, $config, $user, $cache;
+		global $phpbb_root_path, $phpEx, $config, $cache;
 
 		parent::setUp();
 
 		// dbal uses cache
 		$cache = new phpbb_mock_cache();
+
+		$lang_loader = new \phpbb\language\language_file_loader($phpbb_root_path, $phpEx);
+		$lang = new \phpbb\language\language($lang_loader);
+		$user = new \phpbb\user($lang, '\phpbb\datetime');;
 
 		$this->db = $this->new_dbal();
 		$phpbb_dispatcher = new phpbb_mock_event_dispatcher();
@@ -38,6 +42,7 @@ class phpbb_search_native_test extends phpbb_search_test_case
 		$class = self::get_search_wrapper('\phpbb\search\fulltext_native');
 		$config['fulltext_native_min_chars'] = 2;
 		$config['fulltext_native_max_chars'] = 14;
+		$config['max_num_search_keywords'] = 10;
 		$this->search = new $class($error, $phpbb_root_path, $phpEx, null, $config, $this->db, $user, $phpbb_dispatcher);
 	}
 
@@ -258,5 +263,79 @@ class phpbb_search_native_test extends phpbb_search_test_case
 			$this->assert_array_content_equals($must_not_contain, $this->search->get_must_not_contain_ids());
 		}
 		$this->assert_array_content_equals($common, $this->search->get_common_words());
+	}
+
+	public function data_split_keywords_max(): array
+	{
+		return [
+			'character count within limits separated by more spaces' => [
+				'foo    bar    baz    boo    far   faz    roo     rar    raz    zoo',
+				'all',
+				false,
+			],
+			'character count within limits separated by spaces' => [
+				'foo bar baz boo far faz roo rar raz zoo',
+				'all',
+				false,
+			],
+			'character count within limits separated by +, spaces after +' => [
+				'foo+ bar+ baz+ boo+ far+ faz+ roo+ rar+ raz+ zoo',
+				'all',
+				false,
+			],
+			'character count within limits separated by +, no spaces' => [
+				'foo+bar+baz+boo+far+faz+roo+rar+raz+zoo',
+				'all',
+				false,
+			],
+			'character count outside limits separated by +, no spaces' => [
+				'foo+bar+baz+boo+far+faz+roo+rar+raz+zoo+zar',
+				'all',
+				true,
+			],
+			'character count outside limits separated by + and spaces' => [
+				'foo +bar +baz +boo +far +faz +roo +rar +raz +zoo +zar',
+				'all',
+				true,
+			],
+			'character count outside limits separated by spaces' => [
+				'foo bar baz boo far faz roo rar raz zoo zar',
+				'all',
+				true,
+			],
+			'character count outside limits separated by -, no spaces' => [
+				'foo-bar-baz-boo-far-faz-roo-rar-raz-zoo-zar',
+				'all',
+				true,
+			],
+			'character count outside limits separated by - and spaces' => [
+				'foo -bar -baz -boo -far -faz -roo -rar -raz -zoo -zar',
+				'all',
+				true,
+			],
+			'character count outside limits separated by |, no spaces' => [
+				'foo|bar|baz|boo|far|faz|roo|rar|raz|zoo|zar',
+				'all',
+				true,
+			],
+			'character count outside limits separated by | and spaces' => [
+				'foo |bar |baz |boo |far |faz |roo |rar |raz |zoo |zar',
+				'all',
+				true,
+			],
+		];
+	}
+
+	/**
+	 * @dataProvider data_split_keywords_max
+	 */
+	public function test_split_max_keywords($keywords, $terms, $expect_error)
+	{
+		if ($expect_error)
+		{
+			$this->setExpectedTriggerError(E_USER_NOTICE, 'MAX_NUM_SEARCH_KEYWORDS_REFINE');
+		}
+
+		$this->assertTrue($this->search->split_keywords($keywords, $terms));
 	}
 }


### PR DESCRIPTION
Provided `$countable_keywords` wherein the existing `$keywords` value is modified so that any `-`, `+` and `|` characters without preceding spaces is replaced with the same but with a space in front of each. 

These spaces allow the string to be more accurately split when used instead of $keywords inside the $num_keywords calculation. 

This prevents the word limit being bypassed in search by the use of operators without whitespace.

PHPBB-17365

Checklist:

- [x] Correct branch: master for new features; 3.3.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master](https://area51.phpbb.com/docs/master/coding-guidelines.html) and [3.3.x](https://area51.phpbb.com/docs/dev/3.3.x/development/coding_guidelines.html)
- [x] Commit follows commit message [format](https://area51.phpbb.com/docs/dev/3.3.x/development/git.html)

Tracker ticket:

https://tracker.phpbb.com/browse/PHPBB-17365
