### PR TITLE
[ticket/17373] Remove extra separator and change all separators to solid lines

### DIFF
--- a/phpBB/styles/prosilver/template/navbar_header.html
+++ b/phpBB/styles/prosilver/template/navbar_header.html
@@ -69,7 +69,6 @@
 								</li>
 							{% endif %}
 						{% endif %}
-						<li class="separator"></li>
 
 						{% EVENT navbar_header_quick_links_after %}
 

--- a/phpBB/styles/prosilver/theme/common.css
+++ b/phpBB/styles/prosilver/theme/common.css
@@ -560,7 +560,7 @@ a.header-avatar img {
 	line-height: normal !important;
 	text-align: left;
 	white-space: nowrap;
-	border-top: 1px dotted transparent;
+	border-top: 1px solid transparent;
 	display: list-item;
 	float: none !important;
 	margin: 0;


### PR DESCRIPTION
The quick links menu in the header navbar had an additional horizontal line at the bottom which did not need to be there. Additionally the separators for links that always display in the quick links menu had dotted underlines rather than the solid underlines that were under the links that only show up for mobile users when there's less screen space.

PHPBB-17373

Checklist:

- [x] Correct branch: master for new features; 3.3.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master](https://area51.phpbb.com/docs/master/coding-guidelines.html) and [3.3.x](https://area51.phpbb.com/docs/dev/3.3.x/development/coding_guidelines.html)
- [x] Commit follows commit message [format](https://area51.phpbb.com/docs/dev/3.3.x/development/git.html)

Tracker ticket:

https://tracker.phpbb.com/browse/PHPBB-17373
