### PR TITLE
[ticket/17376] Add aria label to quote reference link

### DIFF
--- a/phpBB/language/en/viewtopic.php
+++ b/phpBB/language/en/viewtopic.php
@@ -112,6 +112,7 @@ $lang = array_merge($lang, array(
 	'VIEW_INFO'				=> 'Post details',
 	'VIEW_NEXT_TOPIC'		=> 'Next topic',
 	'VIEW_PREVIOUS_TOPIC'	=> 'Previous topic',
+	'VIEW_QUOTED_POST'		=> 'View quoted post',
 	'VIEW_RESULTS'			=> 'View results',
 	'VIEW_TOPIC_POSTS'		=> array(
 		1	=> '%d post',

--- a/phpBB/styles/prosilver/template/bbcode.html
+++ b/phpBB/styles/prosilver/template/bbcode.html
@@ -38,11 +38,11 @@
 				<xsl:value-of select="$L_COLON"/>
 				<xsl:if test="@post_url">
 					<xsl:text> </xsl:text>
-					<a href="{@post_url}" aria-label="{L_VIEW_QUOTED_POST}" data-post-id="{@post_id}" onclick="if(document.getElementById(hash.substr(1)))href=hash">&#8593;</a>
+					<a href="{@post_url}" aria-label="{L_VIEW_QUOTED_POST}" data-post-id="{@post_id}" onclick="if(document.getElementById(hash.substr(1)))href=hash"><i class="icon fa-arrow-circle-up fa-fw" aria-hidden="true"></i></a>
 				</xsl:if>
 				<xsl:if test="@msg_url">
 					<xsl:text> </xsl:text>
-					<a href="{@msg_url}" data-msg-id="{@msg_id}">&#8593;</a>
+					<a href="{@msg_url}" aria-label="{L_VIEW_QUOTED_POST}" data-msg-id="{@msg_id}"><i class="icon fa-arrow-circle-up fa-fw" aria-hidden="true"></i></a>
 				</xsl:if>
 				<xsl:if test="@date">
 					<span class="responsive-hide"><xsl:value-of select="@date"/></span>

--- a/phpBB/styles/prosilver/template/bbcode.html
+++ b/phpBB/styles/prosilver/template/bbcode.html
@@ -38,7 +38,7 @@
 				<xsl:value-of select="$L_COLON"/>
 				<xsl:if test="@post_url">
 					<xsl:text> </xsl:text>
-					<a href="{@post_url}" data-post-id="{@post_id}" onclick="if(document.getElementById(hash.substr(1)))href=hash">&#8593;</a>
+					<a href="{@post_url}" aria-label="{L_VIEW_QUOTED_POST}" data-post-id="{@post_id}" onclick="if(document.getElementById(hash.substr(1)))href=hash">&#8593;</a>
 				</xsl:if>
 				<xsl:if test="@msg_url">
 					<xsl:text> </xsl:text>

--- a/tests/text_formatter/s9e/default_formatting_test.php
+++ b/tests/text_formatter/s9e/default_formatting_test.php
@@ -283,7 +283,7 @@ class phpbb_textformatter_s9e_default_formatting_test extends phpbb_test_case
 			),
 			array(
 				'[quote=Username post_id=123]...[/quote]',
-				'<blockquote cite="phpBB/viewtopic.php?p=123#p123"><div><cite>Username wrote: <a href="phpBB/viewtopic.php?p=123#p123" data-post-id="123" onclick="if(document.getElementById(hash.substr(1)))href=hash">↑</a></cite>...</div></blockquote>'
+				'<blockquote cite="phpBB/viewtopic.php?p=123#p123"><div><cite>Username wrote: <a href="phpBB/viewtopic.php?p=123#p123" aria-label="VIEW_QUOTED_POST" data-post-id="123" onclick="if(document.getElementById(hash.substr(1)))href=hash"><i class="icon fa-arrow-circle-up fa-fw" aria-hidden="true"></i></a></cite>...</div></blockquote>'
 			),
 			array(
 				// Users are not allowed to submit their own URL for the post


### PR DESCRIPTION
Adds an aria label attribute to the quoted post reference link so that screen readers can inform the user of what the link is used for. Before this change the link was too vague and would not have been well described to users of its purpose if they couldn't see it.

PHPBB-17376

Checklist:

- [x] Correct branch: master for new features; 3.3.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master](https://area51.phpbb.com/docs/master/coding-guidelines.html) and [3.3.x](https://area51.phpbb.com/docs/dev/3.3.x/development/coding_guidelines.html)
- [x] Commit follows commit message [format](https://area51.phpbb.com/docs/dev/3.3.x/development/git.html)

Tracker ticket:

https://tracker.phpbb.com/browse/PHPBB-17376
