### PR TITLE
[ticket/17384] Handle E_USER_ERROR for PHP 8.4 tests

### DIFF
--- a/tests/test_framework/phpbb_test_case.php
+++ b/tests/test_framework/phpbb_test_case.php
@@ -35,6 +35,8 @@ class phpbb_test_case extends TestCase
 			'phpbb_database_test_case' => ['already_connected', 'last_post_timestamp'],
 		];
 		$this->excludeBackupStaticAttributes($backupStaticAttributesBlacklist);
+
+		set_error_handler([$this, 'trigger_error_callback']);
 	}
 
 	public function get_test_case_helpers()
@@ -133,6 +135,33 @@ class phpbb_test_case extends TestCase
 		else
 		{
 			parent::assertFileNotExists($filename, $message);
+		}
+	}
+
+	/**
+	 * Passing E_USER_ERROR to trigger_error() is deprecated as of PHP 8.4, so it causes E_DEPRECATED
+	 * Use trigger_error() callback function to workaround this by handling E_USER_ERROR and suppressing E_DEPRECATED
+	 * "Passing E_USER_ERROR to trigger_error() is deprecated since 8.4, throw an exception or call exit with a string message instead"
+	 * 
+	 */
+	public function trigger_error_callback($errno, $errstr, $errfile, $errline)
+	{
+		// $errstr may need to be escaped
+		$errstr = htmlspecialchars($errstr);
+
+		switch ($errno) {
+			case E_USER_ERROR:
+				echo $errstr;
+				exit();
+			break;
+
+			case E_DEPRECATED:
+				return true;
+			break;
+
+			default:
+				return false;
+			break;
 		}
 	}
 }


### PR DESCRIPTION
Checklist:

- [ ] Correct branch: master for new features; 3.3.x for fixes
- [ ] Tests pass
- [ ] Code follows coding guidelines: [master](https://area51.phpbb.com/docs/master/coding-guidelines.html) and [3.3.x](https://area51.phpbb.com/docs/dev/3.3.x/development/coding_guidelines.html)
- [ ] Commit follows commit message [format](https://area51.phpbb.com/docs/dev/3.3.x/development/git.html)

Tracker ticket:

<a href="https://tracker.phpbb.com/browse/PHPBB-17384">PHPBB-17384</a>.
