### PR TITLE
[ticket/17384] Stop overriding error handler in test case and ignore E_DEPRECATED for expecting errors

### DIFF
--- a/tests/test_framework/phpbb_test_case.php
+++ b/tests/test_framework/phpbb_test_case.php
@@ -31,8 +31,6 @@ class phpbb_test_case extends TestCase
 
 			'phpbb_database_test_case' => ['already_connected', 'last_post_timestamp'],
 		];
-
-		set_error_handler([$this, 'trigger_error_callback']);
 	}
 
 	public function get_test_case_helpers()
@@ -48,32 +46,5 @@ class phpbb_test_case extends TestCase
 	public function setExpectedTriggerError($errno, $message = '')
 	{
 		$this->get_test_case_helpers()->setExpectedTriggerError($errno, $message);
-	}
-
-	/**
-	 * Passing E_USER_ERROR to trigger_error() is deprecated as of PHP 8.4, so it causes E_DEPRECATED
-	 * Use trigger_error() callback function to workaround this by handling E_USER_ERROR and suppressing E_DEPRECATED
-	 * "Passing E_USER_ERROR to trigger_error() is deprecated since 8.4, throw an exception or call exit with a string message instead"
-	 * 
-	 */
-	public function trigger_error_callback($errno, $errstr, $errfile, $errline)
-	{
-		// $errstr may need to be escaped
-		$errstr = htmlspecialchars($errstr);
-
-		switch ($errno) {
-			case E_USER_ERROR:
-				echo $errstr;
-				exit();
-			break;
-
-			case E_DEPRECATED:
-				return true;
-			break;
-
-			default:
-				return false;
-			break;
-		}
 	}
 }

--- a/tests/test_framework/phpbb_test_case_helpers.php
+++ b/tests/test_framework/phpbb_test_case_helpers.php
@@ -104,7 +104,7 @@ class phpbb_test_case_helpers
 		}
 	}
 
-	public function setExpectedTriggerError($errno, $message = '')
+	public function setExpectedTriggerError($errno, $message = ''): void
 	{
 		set_error_handler(
 			static function ($errno, $errstr)
@@ -112,7 +112,7 @@ class phpbb_test_case_helpers
 				restore_error_handler();
 				throw new Exception($errstr, $errno);
 			},
-			E_ALL
+			E_ALL ^ E_DEPRECATED
 		);
 
 		$this->expectedTriggerError = true;


### PR DESCRIPTION
Master version of https://github.com/phpbb/phpbb/pull/6710

Checklist:

- [x] Correct branch: master for new features; 3.3.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master](https://area51.phpbb.com/docs/master/coding-guidelines.html) and [3.3.x](https://area51.phpbb.com/docs/dev/3.3.x/development/coding_guidelines.html)
- [x] Commit follows commit message [format](https://area51.phpbb.com/docs/dev/3.3.x/development/git.html)

Tracker ticket:

https://tracker.phpbb.com/browse/PHPBB-17384
