### PR TITLE
[ticket/17390] Fix unset template variable for topic approval in mcp

### DIFF
--- a/phpBB/includes/mcp/mcp_queue.php
+++ b/phpBB/includes/mcp/mcp_queue.php
@@ -284,6 +284,7 @@ class mcp_queue
 				$post_data = array(
 					'S_MCP_QUEUE'			=> true,
 					'U_APPROVE_ACTION'		=> append_sid("{$phpbb_root_path}mcp.$phpEx", "i=queue&amp;p=$post_id"),
+					'S_CAN_APPROVE'			=> $auth->acl_get('m_approve', $post_info['forum_id']),
 					'S_CAN_DELETE_POST'		=> $auth->acl_get('m_delete', $post_info['forum_id']),
 					'S_CAN_VIEWIP'			=> $auth->acl_get('m_info', $post_info['forum_id']),
 					'S_POST_REPORTED'		=> $post_info['post_reported'],


### PR DESCRIPTION
Fixes a bug that was introduced in 558b8ae whereby a template variable was added to wrap around the approve / disapprove UI however that variable was not set in mcp_queue so the check failed every time meaning you couldn't approve from the MCP.

PHPBB-17390

Checklist:

- [x] Correct branch: master for new features; 3.3.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master](https://area51.phpbb.com/docs/master/coding-guidelines.html) and [3.3.x](https://area51.phpbb.com/docs/dev/3.3.x/development/coding_guidelines.html)
- [x] Commit follows commit message [format](https://area51.phpbb.com/docs/dev/3.3.x/development/git.html)

Tracker ticket:

https://tracker.phpbb.com/browse/PHPBB-17390
