### PR TITLE
[ticket/17391] Fix PHP warning on creating group with the name already in use

### DIFF
--- a/phpBB/includes/acp/acp_groups.php
+++ b/phpBB/includes/acp/acp_groups.php
@@ -396,7 +396,7 @@ class acp_groups
 					$allow_desc_urls	= $request->variable('desc_parse_urls', false);
 					$allow_desc_smilies	= $request->variable('desc_parse_smilies', false);
 
-					$submit_ary = array(
+					$submit_ary = [
 						'colour'			=> $request->variable('group_colour', ''),
 						'rank'				=> $request->variable('group_rank', 0),
 						'receive_pm'		=> isset($_REQUEST['group_receive_pm']) ? 1 : 0,
@@ -406,7 +406,13 @@ class acp_groups
 						'max_recipients'	=> $request->variable('group_max_recipients', 0),
 						'founder_manage'	=> 0,
 						'skip_auth'			=> $request->variable('group_skip_auth', 0),
-					);
+
+						// Initialize avatar data
+						'avatar'			=> $avatar_data['avatar'] ?? '',
+						'avatar_type'		=> $avatar_data['avatar_type'] ?? '',
+						'avatar_height'		=> $avatar_data['avatar_height'] ?? 0,
+						'avatar_width'		=> $avatar_data['avatar_width'] ?? 0,
+					];
 
 					if ($user->data['user_type'] == USER_FOUNDER)
 					{

--- a/tests/functional/acp_groups_test.php
+++ b/tests/functional/acp_groups_test.php
@@ -123,4 +123,20 @@ class phpbb_functional_acp_groups_test extends phpbb_functional_common_groups_te
 			$this->assertEquals((bool) $tick_teampage, (bool) ($this->form_data['group_teampage'] ?? false));
 		}
 	}
+
+	public function test_acp_groups_create_existing_name()
+	{
+		$this->group_manage_login();
+
+		$crawler = self::request('GET', 'adm/index.php?i=groups&mode=manage&sid=' . $this->sid);
+		$form = $crawler->selectButton($this->lang('SUBMIT'))->form([
+			'group_name'	=> 'Guests', // 'Guests' is the group name already in use for predefined Guests group
+		]);
+
+		$crawler = self::submit($form);
+		$form = $crawler->selectButton($this->lang('SUBMIT'))->form();
+		$crawler = self::submit($form); // Just submit the form with selected group name
+
+		$this->assertStringContainsString($this->lang('GROUP_NAME_TAKEN'), $crawler->text());
+	}
 }


### PR DESCRIPTION
Checklist:

- [x] Correct branch: master for new features; 3.3.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master](https://area51.phpbb.com/docs/master/coding-guidelines.html) and [3.3.x](https://area51.phpbb.com/docs/dev/3.3.x/development/coding_guidelines.html)
- [x] Commit follows commit message [format](https://area51.phpbb.com/docs/dev/3.3.x/development/git.html)

Tracker ticket:

<a href="https://tracker.phpbb.com/browse/PHPBB-17391">PHPBB-17391</a>.
