### PR TITLE
[ticket/17417] Day selection not visible when no results

### DIFF
--- a/phpBB/styles/prosilver/template/search_results.html
+++ b/phpBB/styles/prosilver/template/search_results.html
@@ -226,7 +226,7 @@
 <!-- ENDIF -->
 
 <div class="action-bar bottom">
-	<!-- IF .searchresults and (S_SELECT_SORT_DAYS or S_SELECT_SORT_KEY) -->
+	<!-- IF S_SELECT_SORT_DAYS or S_SELECT_SORT_KEY -->
 	<form method="post" action="{S_SEARCH_ACTION}">
 		<!-- INCLUDE display_options.html -->
 	</form>


### PR DESCRIPTION
Day selection does not appear when there are no search results in searches for active topics and unanswered topics.

Checklist:

- [ ] Correct branch: master for new features; 3.3.x for fixes
- [ ] Tests pass
- [ ] Code follows coding guidelines: [master](https://area51.phpbb.com/docs/master/coding-guidelines.html) and [3.3.x](https://area51.phpbb.com/docs/dev/3.3.x/development/coding_guidelines.html)
- [ ] Commit follows commit message [format](https://area51.phpbb.com/docs/dev/3.3.x/development/git.html)

Tracker ticket:

https://tracker.phpbb.com/browse/PHPBB-17417
