### PR TITLE
[ticket/17381] Topic view count validation

### DIFF
--- a/phpBB/phpbb/db/migration/data/v33x/topic_views_update.php
+++ b/phpBB/phpbb/db/migration/data/v33x/topic_views_update.php
@@ -1,0 +1,47 @@
+<?php
+/**
+*
+* This file is part of the phpBB Forum Software package.
+*
+* @copyright (c) phpBB Limited <https://www.phpbb.com>
+* @license GNU General Public License, version 2 (GPL-2.0)
+*
+* For full copyright and license information, please see
+* the docs/CREDITS.txt file.
+*
+*/
+
+namespace phpbb\db\migration\data\v33x;
+
+class topic_views_update extends \phpbb\db\migration\migration
+{
+	public static function depends_on()
+	{
+		return [
+			'\phpbb\db\migration\data\v33x\v3314',
+		];
+	}
+
+	public function update_schema(): array
+	{
+		// This extends the topic view count field so we can support much larger values.
+		return [
+			'change_columns' => [
+				$this->table_prefix . 'topics' => [
+					'topic_views'  => ['ULINT', 0],
+				],
+			]
+		];
+	}
+
+	public function revert_schema(): array
+	{
+		return [
+			'change_columns' => [
+				$this->table_prefix . 'topics' => [
+					'topic_views'  => ['UINT', 0],
+				],
+			]
+		];
+	}
+}


### PR DESCRIPTION
The user mentioned in the ticket that they were getting an error `SQL ERROR [ mysqli ] Out of range value for column 'topic_views' at row 1 [1264]` and I was able to replicate this by forcing the topic_views for a topic to to 16777215 and trying to load the page.

This fix validates that the incremented topic_views value won't exceed that mediumint maximum figure.

Note: I was hesitant to use a magic number for this, but that's how we've previously handled this exact use case in two other places:

https://github.com/phpbb/phpbb/blob/259d086e456cf642aca1b822dc63323512dead34/phpBB/phpbb/session.php#L147 https://github.com/phpbb/phpbb/blob/259d086e456cf642aca1b822dc63323512dead34/phpBB/includes/acp/acp_groups.php#L464

PHPBB-17381

Checklist:

- [x] Correct branch: master for new features; 3.3.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master](https://area51.phpbb.com/docs/master/coding-guidelines.html) and [3.3.x](https://area51.phpbb.com/docs/dev/3.3.x/development/coding_guidelines.html)
- [x] Commit follows commit message [format](https://area51.phpbb.com/docs/dev/3.3.x/development/git.html)

Tracker ticket:

https://tracker.phpbb.com/projects/PHPBB/issues/PHPBB-17381
