### PR TITLE
[ticket/17463] Remove extraneous '&' from search page urls

### DIFF
--- a/phpBB/search.php
+++ b/phpBB/search.php
@@ -697,10 +697,10 @@ if ($keywords || $author || $author_id || $search_id || $submit)
 	$hilit = str_replace(' ', '|', $hilit);
 
 	$u_hilit = urlencode(html_entity_decode(str_replace('|', ' ', $hilit), ENT_COMPAT));
-	$u_show_results = '&amp;sr=' . $show_results;
+	$u_show_results = 'sr=' . $show_results;
 	$u_search_forum = implode('&amp;fid%5B%5D=', $search_forum);
 
-	$u_search = append_sid("{$phpbb_root_path}search.$phpEx", $u_sort_param . $u_show_results);
+	$u_search = append_sid("{$phpbb_root_path}search.$phpEx", (($u_sort_param) ? $u_sort_param . '&amp;' : '') . $u_show_results);
 	$u_search .= ($search_id) ? '&amp;search_id=' . $search_id : '';
 	$u_search .= ($u_hilit) ? '&amp;keywords=' . urlencode(html_entity_decode($keywords, ENT_COMPAT)) : '';
 	$u_search .= ($search_terms != 'all') ? '&amp;terms=' . $search_terms : '';


### PR DESCRIPTION
Normally the links within `search.php` always include sorting parameters and is joined with the show results parameter using `&`. Which is fine if the sorting parameters are always populated, which they are, except when searching for new or unread posts. This fix adds a check for when those sorting parameters are empty.

PHPBB-17463

Checklist:

- [x] Correct branch: master for new features; 3.3.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master](https://area51.phpbb.com/docs/master/coding-guidelines.html) and [3.3.x](https://area51.phpbb.com/docs/dev/3.3.x/development/coding_guidelines.html)
- [x] Commit follows commit message [format](https://area51.phpbb.com/docs/dev/3.3.x/development/git.html)

Tracker ticket:

https://tracker.phpbb.com/browse/PHPBB-17463
