### PR TITLE
Bug-Fix: Edit profile with deactivated Modul Edit profile

### DIFF
--- a/phpBB/memberlist.php
+++ b/phpBB/memberlist.php
@@ -795,7 +795,7 @@ switch ($mode)
 			'U_MCP_QUEUE'				=> ($auth->acl_getf_global('m_approve')) ? append_sid("{$phpbb_root_path}mcp.$phpEx") : '',
 
 			'U_SWITCH_PERMISSIONS'		=> ($auth->acl_get('a_switchperm') && $user->data['user_id'] != $user_id) ? append_sid("{$phpbb_root_path}ucp.$phpEx", "mode=switch_perm&amp;u={$user_id}&amp;hash=" . generate_link_hash('switchperm')) : '',
-			'U_EDIT_SELF'				=> ($user_id == $user->data['user_id'] && $auth->acl_get('u_chgprofileinfo')) ? append_sid("{$phpbb_root_path}ucp.$phpEx", 'i=ucp_profile&amp;mode=profile_info') : '',
+			'U_EDIT_SELF'				=> ($user_id == $user->data['user_id'] && $auth->acl_get('u_chgprofileinfo')) ? append_sid("{$phpbb_root_path}ucp.$phpEx", 'i=ucp_profile') : '',
 
 			'S_USER_NOTES'				=> ($user_notes_enabled) ? true : false,
 			'S_WARN_USER'				=> ($warn_user_enabled) ? true : false,


### PR DESCRIPTION
Removes "&mode=profile_info" `&amp;mode=profile_info`
If the module (Edit profile) is deactivated in ACP -> System -> Module management -> Profile, the ‘Edit profile’ function no longer works. This change corrects the error.

Checklist:

- [ ] Correct branch: master for new features; 3.3.x for fixes
- [x] Tests pass
- [ ] Code follows coding guidelines: [master](https://area51.phpbb.com/docs/master/coding-guidelines.html) and [3.3.x](https://area51.phpbb.com/docs/dev/3.3.x/development/coding_guidelines.html)
- [ ] Commit follows commit message [format](https://area51.phpbb.com/docs/dev/3.3.x/development/git.html)
