### PR TITLE
[ticket/17470] Feed enable config not enforced

### DIFF
--- a/phpBB/phpbb/feed/controller/feed.php
+++ b/phpBB/phpbb/feed/controller/feed.php
@@ -123,6 +123,12 @@ class feed
 		$this->template = $twig;
 		$this->language = $language;
 		$this->phpbb_dispatcher = $phpbb_dispatcher;
+
+		// Feeds are disabled, no need to continue
+		if (!$this->config['feed_enable'])
+		{
+			$this->send_unavailable();
+		}
 	}
 
 	/**

--- a/phpBB/phpbb/feed/controller/feed.php
+++ b/phpBB/phpbb/feed/controller/feed.php
@@ -123,12 +123,6 @@ class feed
 		$this->template = $twig;
 		$this->language = $language;
 		$this->phpbb_dispatcher = $phpbb_dispatcher;
-
-		// Feeds are disabled, no need to continue
-		if (!$this->config['feed_enable'])
-		{
-			$this->send_unavailable();
-		}
 	}
 
 	/**
@@ -140,6 +134,8 @@ class feed
 	 */
 	public function forums()
 	{
+		$this->check_enabled();
+
 		if (!$this->config['feed_overall_forums'])
 		{
 			$this->send_unavailable();
@@ -157,6 +153,8 @@ class feed
 	 */
 	public function news()
 	{
+		$this->check_enabled();
+
 		// Get at least one news forum
 		$sql = 'SELECT forum_id
 					FROM ' . FORUMS_TABLE . '
@@ -182,6 +180,8 @@ class feed
 	 */
 	public function topics()
 	{
+		$this->check_enabled();
+
 		if (!$this->config['feed_topics_new'])
 		{
 			$this->send_unavailable();
@@ -199,6 +199,8 @@ class feed
 	 */
 	public function topics_new()
 	{
+		$this->check_enabled();
+
 		return $this->topics();
 	}
 
@@ -211,6 +213,8 @@ class feed
 	 */
 	public function topics_active()
 	{
+		$this->check_enabled();
+
 		if (!$this->config['feed_topics_active'])
 		{
 			$this->send_unavailable();
@@ -230,6 +234,8 @@ class feed
 	 */
 	public function forum($forum_id)
 	{
+		$this->check_enabled();
+
 		if (!$this->config['feed_forum'])
 		{
 			$this->send_unavailable();
@@ -249,6 +255,8 @@ class feed
 	 */
 	public function topic($topic_id)
 	{
+		$this->check_enabled();
+
 		if (!$this->config['feed_topic'])
 		{
 			$this->send_unavailable();
@@ -266,6 +274,8 @@ class feed
 	 */
 	public function overall()
 	{
+		$this->check_enabled();
+
 		if (!$this->config['feed_overall'])
 		{
 			$this->send_unavailable();
@@ -411,6 +421,22 @@ class feed
 		}
 
 		return $response;
+	}
+
+	/**
+	 * Check if feeds are enabled in the configuration.
+	 *
+	 * @throws http_exception If feeds are disabled.
+	 *
+	 * @return void
+	 */
+	protected function check_enabled()
+	{
+		// Feeds are disabled, no need to continue
+		if (!$this->config['feed_enable'])
+		{
+			throw new http_exception(404, 'NO_FEED_ENABLED');
+		}
 	}
 
 	/**

--- a/tests/functional/feed_test.php
+++ b/tests/functional/feed_test.php
@@ -261,6 +261,29 @@ class phpbb_functional_feed_test extends phpbb_functional_test_case
 		$this->data['topics']['Feeds #exclude - Topic #1'] = (int) $post['topic_id'];
 	}
 
+	public function test_feeds_disabled()
+	{
+		$this->login();
+		$this->admin_login();
+
+		// Disable feeds in ACP
+		$crawler = self::request('GET', "adm/index.php?sid={$this->sid}&i=acp_board&mode=feed");
+		$form = $crawler->selectButton('Submit')->form();
+		$crawler = self::submit($form, ['config[feed_enable]' => false]);
+		self::assertContainsLang('CONFIG_UPDATED', $crawler->filter('.successbox')->text());
+
+		// Assert that feeds aren't available
+		$crawler = self::request('GET', 'app.php/feed/overall', array(), false);
+		self::assert_response_status_code(404);
+		$this->assertContainsLang('NO_FEED_ENABLED', $crawler->text());
+
+		// Enable feeds again in ACP
+		$crawler = self::request('GET', "adm/index.php?sid={$this->sid}&i=acp_board&mode=feed");
+		$form = $crawler->selectButton('Submit')->form();
+		$crawler = self::submit($form, ['config[feed_enable]' => true]);
+		self::assertContainsLang('CONFIG_UPDATED', $crawler->filter('.successbox')->text());
+	}
+
 	public function test_feeds_exclude()
 	{
 		$this->load_ids(array(


### PR DESCRIPTION
The `feed_enable` config is never checked before generating the feeds. The effective result is that feeds are always enabled, regardless of the setting.

PHPBB-17470

Checklist:

- [x] Correct branch: master for new features; 3.3.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master](https://area51.phpbb.com/docs/master/coding-guidelines.html) and [3.3.x](https://area51.phpbb.com/docs/dev/3.3.x/development/coding_guidelines.html)
- [x] Commit follows commit message [format](https://area51.phpbb.com/docs/dev/3.3.x/development/git.html)

Tracker ticket:

https://tracker.phpbb.com/browse/PHPBB-17470
