### PR TITLE
[ticket/17486] Fix SQL error on phpBB v.3.0 to v.3.3 upgrade

### DIFF
--- a/phpBB/phpbb/db/migration/data/v310/bot_update.php
+++ b/phpBB/phpbb/db/migration/data/v310/bot_update.php
@@ -17,7 +17,10 @@ class bot_update extends \phpbb\db\migration\migration
 {
 	static public function depends_on()
 	{
-		return array('\phpbb\db\migration\data\v310\rc6');
+		return array(
+			'\phpbb\db\migration\data\v310\rc6',
+			'\phpbb\db\migration\data\v310\avatars',
+		);
 	}
 
 	public function update_data()


### PR DESCRIPTION
Ensure `v310/bot_update` runs after `v310/avatars` migration which changes `user_avatar_type` column type from `tinyint(2)` to `varchar(255)`.

Checklist:

- [x] Correct branch: master for new features; 3.3.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master](https://area51.phpbb.com/docs/master/coding-guidelines.html) and [3.3.x](https://area51.phpbb.com/docs/dev/3.3.x/development/coding_guidelines.html)
- [x] Commit follows commit message [format](https://area51.phpbb.com/docs/dev/3.3.x/development/git.html)

Tracker ticket:

<a href="https://tracker.phpbb.com/browse/PHPBB-17486">PHPBB-17486</a>.
