### PR TITLE
[ticket/17488] Fix PHP error when MySQL PDO driver is not enabled

### DIFF
--- a/phpBB/phpbb/db/doctrine/connection_parameter_factory.php
+++ b/phpBB/phpbb/db/doctrine/connection_parameter_factory.php
@@ -164,7 +164,7 @@ class connection_parameter_factory
 			],
 		];
 
-		if ($params['driver'] === 'pdo_mysql')
+		if ($params['driver'] === 'pdo_mysql' && extension_loaded('pdo_mysql'))
 		{
 			$enrichment_tags['pdo_mysql'][\PDO::MYSQL_ATTR_FOUND_ROWS] = true;
 		}


### PR DESCRIPTION
Check pdo_mysql extension for being loaded
to use respective \PDO::MYSQL_ATTR_FOUND_ROWS constant.

Checklist:

- [x] Correct branch: master for new features; 3.3.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master](https://area51.phpbb.com/docs/master/coding-guidelines.html) and [3.3.x](https://area51.phpbb.com/docs/dev/3.3.x/development/coding_guidelines.html)
- [x] Commit follows commit message [format](https://area51.phpbb.com/docs/dev/3.3.x/development/git.html)

Tracker ticket:

<a href="https://tracker.phpbb.com/browse/PHPBB-17488">PHPBB-17488</a>.
