### PR TITLE
[ticket/17522] Add event to member list to modify template vars

### DIFF
--- a/phpBB/memberlist.php
+++ b/phpBB/memberlist.php
@@ -1819,7 +1819,7 @@ switch ($mode)
 				 * @var integer	user_id		The current user ID.
 				 * @var array	row			Array of raw user data.
 				 * @var array	memberrow	Array of member template variables.
-				 * @since 3.3.16-B1
+				 * @since 3.3.16-RC1
 				 */
 				$vars = array('user_id', 'row', 'memberrow');
 				extract($phpbb_dispatcher->trigger_event('core.memberlist_memberrow_template_vars_before', compact($vars)));

--- a/phpBB/memberlist.php
+++ b/phpBB/memberlist.php
@@ -1815,14 +1815,14 @@ switch ($mode)
 				/**
 				 * Modify the memberrow data before template variables are assigned.
 				 *
-				 * @event core.memberlist_memberrow_template_vars_before
-				 * @var integer	user_id		The current user ID.
+				 * @event core.memberlist_modify_memberrow
+				 * @var int		user_id		The current user ID.
 				 * @var array	row			Array of raw user data.
 				 * @var array	memberrow	Array of member template variables.
 				 * @since 3.3.16-RC1
 				 */
 				$vars = ['user_id', 'row', 'memberrow'];
-				extract($phpbb_dispatcher->trigger_event('core.memberlist_memberrow_template_vars_before', compact($vars)));
+				extract($phpbb_dispatcher->trigger_event('core.memberlist_modify_memberrow', compact($vars)));
 
 				$template->assign_block_vars('memberrow', $memberrow);
 

--- a/phpBB/memberlist.php
+++ b/phpBB/memberlist.php
@@ -1812,6 +1812,18 @@ switch ($mode)
 					$memberrow = array_merge($memberrow, $cp_row['row']);
 				}
 
+				/**
+				 * Modify the memberrow data before template variables are assigned.
+				 *
+				 * @event core.memberlist_memberrow_template_vars_before
+				 * @var integer	user_id		The current user ID.
+				 * @var array	row			Array of raw user data.
+				 * @var array	memberrow	Array of member template variables.
+				 * @since 3.3.16-B1
+				 */
+				$vars = array('user_id', 'row', 'memberrow');
+				extract($phpbb_dispatcher->trigger_event('core.memberlist_memberrow_template_vars_before', compact($vars)));
+
 				$template->assign_block_vars('memberrow', $memberrow);
 
 				if (isset($cp_row['blockrow']) && count($cp_row['blockrow']))

--- a/phpBB/memberlist.php
+++ b/phpBB/memberlist.php
@@ -1821,7 +1821,7 @@ switch ($mode)
 				 * @var array	memberrow	Array of member template variables.
 				 * @since 3.3.16-RC1
 				 */
-				$vars = array('user_id', 'row', 'memberrow');
+				$vars = ['user_id', 'row', 'memberrow'];
 				extract($phpbb_dispatcher->trigger_event('core.memberlist_memberrow_template_vars_before', compact($vars)));
 
 				$template->assign_block_vars('memberrow', $memberrow);


### PR DESCRIPTION
Add a new event inside `memberlist.php` that allows extension developers to modify the memberrow data before the template variables are assigned. This will allow developers to alter user data shown within the table of users.

Checklist:

- [x] Correct branch: master for new features; 3.3.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master](https://area51.phpbb.com/docs/master/coding-guidelines.html) and [3.3.x](https://area51.phpbb.com/docs/dev/3.3.x/development/coding_guidelines.html)
- [x] Commit follows commit message [format](https://area51.phpbb.com/docs/dev/3.3.x/development/git.html)

Tracker ticket:

https://tracker.phpbb.com/browse/PHPBB-17522
