### PR TITLE
[ticket/17399] Fix selected language bug in installer

### DIFF
--- a/phpBB/adm/style/installer_header.html
+++ b/phpBB/adm/style/installer_header.html
@@ -19,7 +19,7 @@
 		<form method="post" action="#" id="language_selector">
 			<fieldset class="nobg">
 				<label for="language">{L_SELECT_LANG}{L_COLON}</label>
-				<select  id="language" name="language">
+				<select id="language" name="language">
 					<!-- BEGIN language_select_item -->
 					<option value="{language_select_item.VALUE}"<!-- IF language_select_item.SELECTED --> selected="selected"<!-- ENDIF -->>{language_select_item.NAME}</option>
 					<!-- END language_select_item -->

--- a/phpBB/phpbb/install/controller/helper.php
+++ b/phpBB/phpbb/install/controller/helper.php
@@ -339,6 +339,14 @@ class helper
 	protected function render_language_select($selected_language = null)
 	{
 		$langs = $this->lang_helper->get_available_languages();
+
+		// The first language will be selected by default. Unless a user has consciously included
+		// other languages in the installation process, it will be British English anyway.
+		if ($selected_language === null && count($langs))
+		{
+			$selected_language = $langs[0]['iso'];
+		}
+
 		foreach ($langs as $lang)
 		{
 			$this->template->assign_block_vars('language_select_item', array(

--- a/phpBB/phpbb/language/language_file_helper.php
+++ b/phpBB/phpbb/language/language_file_helper.php
@@ -67,6 +67,18 @@ class language_file_helper
 			);
 		}
 
+		usort($available_languages, [$this, 'sort_by_local_name']);
+
 		return $available_languages;
+	}
+
+	/**
+	 * Sorts the languages by their name instead of iso code
+	 *
+	 * @return array
+	 */
+	private static function sort_by_local_name($a, $b)
+	{
+		return $a['local_name'] > $b['local_name'];
 	}
 }


### PR DESCRIPTION
This fixes a bug where a user could have other languages in the installer but the language dropdown did not match the language shown (e.g., in the ticket example, Danish was uploaded and shown as the selected option in the dropdown menu due to its index positioning, but English was actually the language being displayed). 

This change also sorts the languages alphabetically by their name rather than ISO code to avoid the funny situation shown by the bug submitter in https://www.phpbb.com/community/viewtopic.php?p=16032040

<img width="1428" alt="Screenshot 2025-06-14 at 10 19 51 PM" src="https://github.com/user-attachments/assets/d35dda4c-52b6-4158-923e-70e775181ff6" />

Checklist:

- [x] Correct branch: master for new features; 3.3.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master](https://area51.phpbb.com/docs/master/coding-guidelines.html) and [3.3.x](https://area51.phpbb.com/docs/dev/3.3.x/development/coding_guidelines.html)
- [x] Commit follows commit message [format](https://area51.phpbb.com/docs/dev/3.3.x/development/git.html)

Tracker ticket:

https://tracker.phpbb.com/browse/PHPBB-17399
