### PR TITLE
[ticket/17157] Fix for allowing user to see search results for topics if f_list_topics = yes

### DIFF
--- a/phpBB/search.php
+++ b/phpBB/search.php
@@ -247,7 +247,7 @@ if ($keywords || $author || $author_id || $search_id || $submit)
 		$ex_fid_ary = array_unique(array_merge(array_keys($auth->acl_getf('!f_read', true)), array_keys($auth->acl_getf('!f_search', true))));
 	}
 
-	// Consider if there are any forums where can read forum = no, can read topics = yes 
+	// Consider if there are any forums where can read forum = no, can read topics = yes
 	// In these cases, the user should see the topic title in the search results but not the link to the topic (or any posts) because they don't have the permissions
 	if ($request->variable('sr', '') == 'topics' && $search_fields == 'titleonly')
 	{

--- a/phpBB/styles/prosilver/template/search_results.html
+++ b/phpBB/styles/prosilver/template/search_results.html
@@ -80,15 +80,15 @@
 			<li class="row<!-- IF searchresults.S_ROW_COUNT is even --> bg1<!-- ELSE --> bg2<!-- ENDIF -->">
 				<dl class="row-item {searchresults.TOPIC_IMG_STYLE}">
 					<dt<!-- IF searchresults.TOPIC_ICON_IMG --> style="background-image: url({T_ICONS_PATH}{searchresults.TOPIC_ICON_IMG}); background-repeat: no-repeat;"<!-- ENDIF --> title="{searchresults.TOPIC_FOLDER_IMG_ALT}">
-						<!-- IF searchresults.S_UNREAD_TOPIC and not S_IS_BOT --><a href="{searchresults.U_NEWEST_POST}" class="row-item-link"></a><!-- ENDIF -->
+						{% if searchresults.U_NEWEST_POST and searchresults.S_UNREAD_TOPIC and not S_IS_BOT %}<a href="{searchresults.U_NEWEST_POST}" class="row-item-link"></a>{% endif %}
 						<div class="list-inner">
 							<!-- EVENT topiclist_row_prepend -->
-							<!-- IF searchresults.S_UNREAD_TOPIC and not S_IS_BOT -->
+							{% if searchresults.U_NEWEST_POST and searchresults.S_UNREAD_TOPIC and not S_IS_BOT %}
 								<a class="unread" href="{searchresults.U_NEWEST_POST}">
 									<i class="icon fa-file fa-fw icon-red icon-md" aria-hidden="true"></i><span class="sr-only">{L_NEW_POST}</span>
 								</a>
-							<!-- ENDIF -->
-							<a href="{searchresults.U_VIEW_TOPIC}" class="topictitle">{searchresults.TOPIC_TITLE}</a>
+							{% endif %}
+							{% if searchresults.U_VIEW_TOPIC %}<a href="{searchresults.U_VIEW_TOPIC}" class="topictitle">{searchresults.TOPIC_TITLE}</a>{% else %}{searchresults.TOPIC_TITLE}{% endif %}
 							<!-- IF searchresults.S_TOPIC_UNAPPROVED or searchresults.S_POSTS_UNAPPROVED -->
 								<a href="{searchresults.U_MCP_QUEUE}" title="{L_TOPIC_UNAPPROVED}">
 									<i class="icon fa-question fa-fw icon-blue" aria-hidden="true"></i><span class="sr-only">{L_TOPIC_UNAPPROVED}</span>
@@ -146,11 +146,11 @@
 					<dd class="views">{searchresults.TOPIC_VIEWS} <dfn>{L_VIEWS}</dfn></dd>
 					<dd class="lastpost">
 						<span><dfn>{L_LAST_POST} </dfn>{L_POST_BY_AUTHOR} <!-- EVENT search_results_last_post_author_username_prepend -->{searchresults.LAST_POST_AUTHOR_FULL}<!-- EVENT search_results_last_post_author_username_append -->
-							<!-- IF not S_IS_BOT -->
+							{% if not S_IS_BOT and searchresults.U_LAST_POST %}
 								<a href="{searchresults.U_LAST_POST}" title="{L_GOTO_LAST_POST}">
 									<i class="icon fa-external-link-square fa-fw icon-lightgray icon-md" aria-hidden="true"></i><span class="sr-only">{VIEW_LATEST_POST}</span>
 								</a>
-							<!-- ENDIF -->
+							{% endif %}
 							<br /><time datetime="{searchresults.LAST_POST_TIME_RFC3339}">{searchresults.LAST_POST_TIME}</time>
 						</span>
 					</dd>

--- a/phpBB/styles/prosilver/template/search_results.html
+++ b/phpBB/styles/prosilver/template/search_results.html
@@ -80,7 +80,7 @@
 			<li class="row<!-- IF searchresults.S_ROW_COUNT is even --> bg1<!-- ELSE --> bg2<!-- ENDIF -->">
 				<dl class="row-item {searchresults.TOPIC_IMG_STYLE}">
 					<dt<!-- IF searchresults.TOPIC_ICON_IMG --> style="background-image: url({T_ICONS_PATH}{searchresults.TOPIC_ICON_IMG}); background-repeat: no-repeat;"<!-- ENDIF --> title="{searchresults.TOPIC_FOLDER_IMG_ALT}">
-						{% if searchresults.U_NEWEST_POST and searchresults.S_UNREAD_TOPIC and not S_IS_BOT %}<a href="{searchresults.U_NEWEST_POST}" class="row-item-link"></a>{% endif %}
+						{% if searchresults.U_NEWEST_POST and searchresults.S_UNREAD_TOPIC and not S_IS_BOT %}<a href="{{ searchresults.U_NEWEST_POST }}" class="row-item-link"></a>{% endif %}
 						<div class="list-inner">
 							<!-- EVENT topiclist_row_prepend -->
 							{% if searchresults.U_NEWEST_POST and searchresults.S_UNREAD_TOPIC and not S_IS_BOT %}
@@ -88,7 +88,7 @@
 									<i class="icon fa-file fa-fw icon-red icon-md" aria-hidden="true"></i><span class="sr-only">{L_NEW_POST}</span>
 								</a>
 							{% endif %}
-							{% if searchresults.U_VIEW_TOPIC %}<a href="{searchresults.U_VIEW_TOPIC}" class="topictitle">{searchresults.TOPIC_TITLE}</a>{% else %}{searchresults.TOPIC_TITLE}{% endif %}
+							{% if searchresults.U_VIEW_TOPIC %}<a href="{{ searchresults.U_VIEW_TOPIC }}" class="topictitle">{{ searchresults.TOPIC_TITLE }}</a>{% else %}{{ searchresults.TOPIC_TITLE }}{% endif %}
 							<!-- IF searchresults.S_TOPIC_UNAPPROVED or searchresults.S_POSTS_UNAPPROVED -->
 								<a href="{searchresults.U_MCP_QUEUE}" title="{L_TOPIC_UNAPPROVED}">
 									<i class="icon fa-question fa-fw icon-blue" aria-hidden="true"></i><span class="sr-only">{L_TOPIC_UNAPPROVED}</span>

--- a/phpBB/styles/prosilver/template/viewforum_body.html
+++ b/phpBB/styles/prosilver/template/viewforum_body.html
@@ -158,14 +158,14 @@
 			<!-- EVENT viewforum_body_topic_row_prepend -->
 			<dl class="row-item {topicrow.TOPIC_IMG_STYLE}">
 				<dt<!-- IF topicrow.TOPIC_ICON_IMG and S_TOPIC_ICONS --> style="background-image: url('{T_ICONS_PATH}{topicrow.TOPIC_ICON_IMG}'); background-repeat: no-repeat;"<!-- ENDIF --> title="{topicrow.TOPIC_FOLDER_IMG_ALT}">
-					<!-- IF topicrow.S_UNREAD_TOPIC and not S_IS_BOT --><a href="{topicrow.U_NEWEST_POST}" class="row-item-link"></a><!-- ENDIF -->
+					{% if topicrow.U_NEWEST_POST and topicrow.S_UNREAD_TOPIC and not S_IS_BOT %}<a href="{topicrow.U_NEWEST_POST}" class="row-item-link"></a>{% endif %}
 					<div class="list-inner">
 						<!-- EVENT topiclist_row_prepend -->
-						<!-- IF topicrow.S_UNREAD_TOPIC and not S_IS_BOT -->
+						{% if topicrow.U_NEWEST_POST and topicrow.S_UNREAD_TOPIC and not S_IS_BOT %}
 							<a class="unread" href="{topicrow.U_NEWEST_POST}">
 								<i class="icon fa-file fa-fw icon-red icon-md" aria-hidden="true"></i><span class="sr-only">{NEW_POST}</span>
 							</a>
-						<!-- ENDIF -->
+						{% endif %}
 						<!-- IF topicrow.U_VIEW_TOPIC --><a href="{topicrow.U_VIEW_TOPIC}" class="topictitle">{topicrow.TOPIC_TITLE}</a><!-- ELSE -->{topicrow.TOPIC_TITLE}<!-- ENDIF -->
 						<!-- IF topicrow.S_TOPIC_UNAPPROVED or topicrow.S_POSTS_UNAPPROVED -->
 							<a href="{topicrow.U_MCP_QUEUE}" title="<!-- IF topicrow.S_TOPIC_UNAPPROVED -->{L_TOPIC_UNAPPROVED}<!-- ELSE -->{L_POSTS_UNAPPROVED}<!-- ENDIF -->">

--- a/phpBB/styles/prosilver/template/viewforum_body.html
+++ b/phpBB/styles/prosilver/template/viewforum_body.html
@@ -158,7 +158,7 @@
 			<!-- EVENT viewforum_body_topic_row_prepend -->
 			<dl class="row-item {topicrow.TOPIC_IMG_STYLE}">
 				<dt<!-- IF topicrow.TOPIC_ICON_IMG and S_TOPIC_ICONS --> style="background-image: url('{T_ICONS_PATH}{topicrow.TOPIC_ICON_IMG}'); background-repeat: no-repeat;"<!-- ENDIF --> title="{topicrow.TOPIC_FOLDER_IMG_ALT}">
-					{% if topicrow.U_NEWEST_POST and topicrow.S_UNREAD_TOPIC and not S_IS_BOT %}<a href="{topicrow.U_NEWEST_POST}" class="row-item-link"></a>{% endif %}
+					{% if topicrow.U_NEWEST_POST and topicrow.S_UNREAD_TOPIC and not S_IS_BOT %}<a href="{{ topicrow.U_NEWEST_POST }}" class="row-item-link"></a>{% endif %}
 					<div class="list-inner">
 						<!-- EVENT topiclist_row_prepend -->
 						{% if topicrow.U_NEWEST_POST and topicrow.S_UNREAD_TOPIC and not S_IS_BOT %}

--- a/phpBB/viewforum.php
+++ b/phpBB/viewforum.php
@@ -384,7 +384,12 @@ $post_alt = ($forum_data['forum_status'] == ITEM_LOCKED) ? $user->lang['FORUM_LO
 // Display active topics?
 $s_display_active = ($forum_data['forum_type'] == FORUM_CAT && ($forum_data['forum_flags'] & FORUM_FLAG_ACTIVE_TOPICS)) ? true : false;
 
-$s_search_hidden_fields = array('fid' => array($forum_id));
+// Send the forum id and send a parameter to make it clear it's a quick search
+$s_search_hidden_fields = [
+	'fid' => [$forum_id],
+	'viewforum' => $forum_id,
+];
+
 if ($_SID)
 {
 	$s_search_hidden_fields['sid'] = $_SID;
@@ -1017,7 +1022,7 @@ if (count($topic_list))
 			'S_TOPIC_MOVED'			=> ($row['topic_status'] == ITEM_MOVED) ? true : false,
 
 			'U_NEWEST_POST'			=> $auth->acl_get('f_read', $forum_id) ? append_sid("{$phpbb_root_path}viewtopic.$phpEx", $view_topic_url_params . '&amp;view=unread') . '#unread' : false,
-			'U_LAST_POST'			=> $auth->acl_get('f_read', $forum_id)  ? append_sid("{$phpbb_root_path}viewtopic.$phpEx", 'p=' . $row['topic_last_post_id']) . '#p' . $row['topic_last_post_id'] : false,
+			'U_LAST_POST'			=> $auth->acl_get('f_read', $forum_id) ? append_sid("{$phpbb_root_path}viewtopic.$phpEx", 'p=' . $row['topic_last_post_id']) . '#p' . $row['topic_last_post_id'] : false,
 			'U_LAST_POST_AUTHOR'	=> get_username_string('profile', $row['topic_last_poster_id'], $row['topic_last_poster_name'], $row['topic_last_poster_colour']),
 			'U_TOPIC_AUTHOR'		=> get_username_string('profile', $row['topic_poster'], $row['topic_first_poster_name'], $row['topic_first_poster_colour']),
 			'U_VIEW_TOPIC'			=> $view_topic_url,

--- a/phpBB/viewforum.php
+++ b/phpBB/viewforum.php
@@ -384,11 +384,17 @@ $post_alt = ($forum_data['forum_status'] == ITEM_LOCKED) ? $user->lang['FORUM_LO
 // Display active topics?
 $s_display_active = ($forum_data['forum_type'] == FORUM_CAT && ($forum_data['forum_flags'] & FORUM_FLAG_ACTIVE_TOPICS)) ? true : false;
 
-// Send the forum id and send a parameter to make it clear it's a quick search
+// Send the forum id... and maybe some other fields, depending on permissions
 $s_search_hidden_fields = [
 	'fid' => [$forum_id],
-	'viewforum' => $forum_id,
 ];
+
+if ($auth->acl_get('f_list_topics', $forum_id) && !$auth->acl_get('f_read', $forum_id))
+{
+	// If the user has list access but not read access, then force the search to only be a topic title search
+	$s_search_hidden_fields['sr'] = 'topics';
+	$s_search_hidden_fields['sf'] = 'titleonly';
+}
 
 if ($_SID)
 {


### PR DESCRIPTION
This addresses an interesting bug someone noticed whereby if someone has `f_list_topics = yes` permissions for a forum but `f_read = no`, then they get an incomplete listing in the search results. (i.e., the use case is the admin has set it up so a user is allowed to see the topic name, but can't click into it to read the post)

The fix in this PR is, for cases where those permission options above are in effect, to check if the search is for topic titles only (and results are displayed as topics; because we don't want posts being exposed), and if it is then allow any forums the user has `f_list_topics = yes` permission back into the search results but with the links removed, matching the viewforum.php behaviour.

Furthermore, if there is a forum where this permission set up applies for a user then the quick search (search bar in viewforum.php) will feed through `sr = topics` and `sf = titleonly` as the default search option.

Checklist:

- [x] Correct branch: master for new features; 3.3.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master](https://area51.phpbb.com/docs/master/coding-guidelines.html) and [3.3.x](https://area51.phpbb.com/docs/dev/3.3.x/development/coding_guidelines.html)
- [x] Commit follows commit message [format](https://area51.phpbb.com/docs/dev/3.3.x/development/git.html)

Tracker ticket:

https://tracker.phpbb.com/browse/PHPBB-17157

Screenshot of search results now without topic links:

<img width="1295" height="715" alt="image" src="https://github.com/user-attachments/assets/0c17a2a2-422c-411f-bf82-3f1b1cc49d17" />

When these are the permissions for that forum:

<img width="1399" height="609" alt="image" src="https://github.com/user-attachments/assets/4fdb51f6-f5f7-4e50-ba26-c43de55e6be6" />
