### PR TITLE
[ticket/17034] Fix minimum posts rank validation

### DIFF
--- a/phpBB/adm/style/acp_ranks.html
+++ b/phpBB/adm/style/acp_ranks.html
@@ -44,7 +44,7 @@
 	<div id="posts"<!-- IF S_SPECIAL_RANK --> style="display: none;"<!-- ENDIF -->>
 	<dl>
 		<dt><label for="min_posts">{L_RANK_MINIMUM}{L_COLON}</label></dt>
-		<dd><input name="min_posts" type="number" id="min_posts" min="0" max="9999999999" value="{MIN_POSTS}" /></dd>
+		<dd><input name="min_posts" type="number" id="min_posts" min="0" max="16777215" value="{MIN_POSTS}" /></dd>
 	</dl>
 	</div>
 


### PR DESCRIPTION
A user on the board (https://www.phpbb.com/community/viewtopic.php?t=2627491) found that in the ACP you would get a database error if you tried to set a rank with min_posts above 16777215 (mediumint limit). This change just brings the browser-side validation down to that value from 9999999999 so the user can't submit such a high value.

Interestingly, this fix is only required for 3.3.x. In master, rank_min:UINT maps to unsigned integer and not mediumint (see https://tracker.phpbb.com/projects/PHPBB/issues/PHPBB-17035 for more on that)

Checklist:

- [x] Correct branch: master for new features; 3.3.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master](https://area51.phpbb.com/docs/master/coding-guidelines.html) and [3.3.x](https://area51.phpbb.com/docs/dev/3.3.x/development/coding_guidelines.html)
- [x] Commit follows commit message [format](https://area51.phpbb.com/docs/dev/3.3.x/development/git.html)

Tracker ticket:

https://tracker.phpbb.com/browse/PHPBB-17034