### PR TITLE
[ticket/17543] Optimize functional tests running time

### DIFF
--- a/tests/functional/acp_permissions_test.php
+++ b/tests/functional/acp_permissions_test.php
@@ -98,6 +98,7 @@ class phpbb_functional_acp_permissions_test extends phpbb_functional_test_case
 		// XXX globals for \phpbb\auth\auth, refactor it later
 		global $db, $cache;
 		$db = $this->get_db();
+
 		$cache = new phpbb_mock_null_cache;
 
 		$auth = new \phpbb\auth\auth;

--- a/tests/functional/acp_registration_test.php
+++ b/tests/functional/acp_registration_test.php
@@ -28,9 +28,7 @@ class phpbb_functional_acp_registration_test extends phpbb_functional_test_case
 
 	public function test_submitting_activation_method()
 	{
-		$db = $this->get_db();
-
-		$this->set_email_enable($db, false);
+		$this->set_email_enable($this->db, false);
 
 		$this->add_lang('acp/board');
 		$this->login();
@@ -50,6 +48,6 @@ class phpbb_functional_acp_registration_test extends phpbb_functional_test_case
 		$crawler = self::submit($form);
 		$this->assertNotContainsLang('ACC_ACTIVATION_WARNING', $crawler->filter('div.main')->text());
 
-		$this->set_email_enable($db, true);
+		$this->set_email_enable($this->db, true);
 	}
 }

--- a/tests/functional/auth_test.php
+++ b/tests/functional/auth_test.php
@@ -40,15 +40,14 @@ class phpbb_functional_auth_test extends phpbb_functional_test_case
 	{
 		global $cache, $config;
 		$cache = new phpbb_mock_null_cache;
-		$db = $this->get_db();
 		$sql = 'UPDATE ' . CONFIG_TABLE . " SET config_value = 'foobar' WHERE config_name = 'auth_method'";
-		$db->sql_query($sql);
+		$this->db->sql_query($sql);
 		$config['auth_method'] = 'foobar';
 		$this->login('anothertestuser');
 		$crawler = self::request('GET', 'index.php');
 		$this->assertStringContainsString('anothertestuser', $crawler->filter('#username_logged_in')->text());
 		$sql = 'UPDATE ' . CONFIG_TABLE . " SET config_value = 'db' WHERE config_name =  'auth_method'";
-		$db->sql_query($sql);
+		$this->db->sql_query($sql);
 		$config['auth_method'] = 'db';
 	}
 

--- a/tests/functional/download_test.php
+++ b/tests/functional/download_test.php
@@ -225,8 +225,6 @@ class phpbb_functional_download_test extends phpbb_functional_test_case
 
 	public function load_ids($data)
 	{
-		$this->db = $this->get_db();
-
 		if (!empty($data['forums']))
 		{
 			array_walk($data['forums'], function(&$value, $key)

--- a/tests/functional/extension_controller_test.php
+++ b/tests/functional/extension_controller_test.php
@@ -39,7 +39,7 @@ class phpbb_functional_extension_controller_test extends phpbb_functional_test_c
 
 	protected static function setup_extensions()
 	{
-		return ['foo/bar', 'foo/foo'];
+		return self::$tests_count == self::$tests_number ? ['foo/bar', 'foo/foo'] : [];
 	}
 
 	protected function setUp(): void
@@ -51,8 +51,11 @@ class phpbb_functional_extension_controller_test extends phpbb_functional_test_c
 
 	protected function tearDown(): void
 	{
-		$this->uninstall_ext('foo/bar');
-		$this->uninstall_ext('foo/foo');
+		if (self::$tests_count == 1)
+		{
+			$this->uninstall_ext('foo/bar');
+			$this->uninstall_ext('foo/foo');
+		}
 
 		parent::tearDown();
 	}

--- a/tests/functional/extension_controller_test.php
+++ b/tests/functional/extension_controller_test.php
@@ -22,24 +22,24 @@ class phpbb_functional_extension_controller_test extends phpbb_functional_test_c
 		'./',
 	);
 
-	static public function setUpBeforeClass(): void
+	public static function setUpBeforeClass(): void
 	{
 		parent::setUpBeforeClass();
 
 		self::$helper = new phpbb_test_case_helpers(__CLASS__);
 		self::$helper->copy_ext_fixtures(__DIR__ . '/fixtures/ext/', self::$fixtures);
+
+		self::install_ext('foo/bar');
+		self::install_ext('foo/foo');
 	}
 
-	static public function tearDownAfterClass(): void
+	public static function tearDownAfterClass(): void
 	{
 		parent::tearDownAfterClass();
 
+		self::uninstall_ext('foo/bar');
+		self::uninstall_ext('foo/foo');
 		self::$helper->restore_original_ext_dir();
-	}
-
-	protected static function setup_extensions()
-	{
-		return self::$tests_count == self::$tests_number ? ['foo/bar', 'foo/foo'] : [];
 	}
 
 	protected function setUp(): void
@@ -47,17 +47,6 @@ class phpbb_functional_extension_controller_test extends phpbb_functional_test_c
 		parent::setUp();
 
 		$this->purge_cache();
-	}
-
-	protected function tearDown(): void
-	{
-		if (self::$tests_count == 1)
-		{
-			$this->uninstall_ext('foo/bar');
-			$this->uninstall_ext('foo/foo');
-		}
-
-		parent::tearDown();
 	}
 
 	/**

--- a/tests/functional/extension_module_test.php
+++ b/tests/functional/extension_module_test.php
@@ -23,34 +23,22 @@ class phpbb_functional_extension_module_test extends phpbb_functional_test_case
 		'./',
 	);
 
-	static public function setUpBeforeClass(): void
+	public static function setUpBeforeClass(): void
 	{
 		parent::setUpBeforeClass();
 
 		self::$helper = new phpbb_test_case_helpers(__CLASS__);
 		self::$helper->copy_ext_fixtures(__DIR__ . '/fixtures/ext/', self::$fixtures);
+
+		self::install_ext('foo/bar');
 	}
 
-	static public function tearDownAfterClass(): void
+	public static function tearDownAfterClass(): void
 	{
 		parent::tearDownAfterClass();
 
+		self::uninstall_ext('foo/bar');
 		self::$helper->restore_original_ext_dir();
-	}
-
-	protected function tearDown(): void
-	{
-		if (self::$tests_count == 1)
-		{
-			$this->uninstall_ext('foo/bar');
-		}
-
-		parent::tearDown();
-	}
-
-	protected static function setup_extensions()
-	{
-		return self::$tests_count == self::$tests_number ? ['foo/bar'] : [];
 	}
 
 	public function test_acp()

--- a/tests/functional/extension_module_test.php
+++ b/tests/functional/extension_module_test.php
@@ -40,14 +40,17 @@ class phpbb_functional_extension_module_test extends phpbb_functional_test_case
 
 	protected function tearDown(): void
 	{
-		$this->uninstall_ext('foo/bar');
+		if (self::$tests_count == 1)
+		{
+			$this->uninstall_ext('foo/bar');
+		}
 
 		parent::tearDown();
 	}
 
 	protected static function setup_extensions()
 	{
-		return ['foo/bar'];
+		return self::$tests_count == self::$tests_number ? ['foo/bar'] : [];
 	}
 
 	public function test_acp()

--- a/tests/functional/extension_template_event_order_test.php
+++ b/tests/functional/extension_template_event_order_test.php
@@ -46,15 +46,18 @@ class phpbb_functional_extension_template_event_order_test extends phpbb_functio
 
 	protected function tearDown(): void
 	{
-		$this->uninstall_ext('foo/bar');
-		$this->uninstall_ext('foo/foo');
+		if (self::$tests_count == 1)
+		{
+			$this->uninstall_ext('foo/bar');
+			$this->uninstall_ext('foo/foo');
+		}
 
 		parent::tearDown();
 	}
 
 	protected static function setup_extensions()
 	{
-		return ['foo/bar', 'foo/foo'];
+		return self::$tests_count == self::$tests_number ? ['foo/bar', 'foo/foo'] : [];
 	}
 
 	/**
@@ -84,7 +87,7 @@ class phpbb_functional_extension_template_event_order_test extends phpbb_functio
 		$crawler = self::request('GET', 'index.php');
 		$quick_links_menu = $crawler->filter('ul[role="menu"]')->eq(0);
 		$quick_links_menu_nodes_count = (int) $quick_links_menu->filter('li')->count();
-		// Ensure foo/foo template event goes before foo/bar one
+		// Ensure foo/bar template event goes before foo/foo one
 		$this->assertStringContainsString('FOO_BAR_QUICK_LINK', $quick_links_menu->filter('li')->eq($quick_links_menu_nodes_count - 4)->filter('span')->text());
 		$this->assertStringContainsString('FOO_FOO_QUICK_LINK', $quick_links_menu->filter('li')->eq($quick_links_menu_nodes_count - 3)->filter('span')->text());
 	}

--- a/tests/functional/extension_template_event_order_test.php
+++ b/tests/functional/extension_template_event_order_test.php
@@ -16,24 +16,29 @@
  */
 class phpbb_functional_extension_template_event_order_test extends phpbb_functional_test_case
 {
-	static private $helper;
+	private static $helper;
 
-	static protected $fixtures = [
+	protected static $fixtures = [
 		'./',
 	];
 
-	static public function setUpBeforeClass(): void
+	public static function setUpBeforeClass(): void
 	{
 		parent::setUpBeforeClass();
 
 		self::$helper = new phpbb_test_case_helpers(__CLASS__);
 		self::$helper->copy_ext_fixtures(__DIR__ . '/fixtures/ext/', self::$fixtures);
+
+		self::install_ext('foo/bar');
+		self::install_ext('foo/foo');
 	}
 
-	static public function tearDownAfterClass(): void
+	public static function tearDownAfterClass(): void
 	{
 		parent::tearDownAfterClass();
 
+		self::uninstall_ext('foo/bar');
+		self::uninstall_ext('foo/foo');
 		self::$helper->restore_original_ext_dir();
 	}
 
@@ -44,21 +49,6 @@ class phpbb_functional_extension_template_event_order_test extends phpbb_functio
 		$this->purge_cache();
 	}
 
-	protected function tearDown(): void
-	{
-		if (self::$tests_count == 1)
-		{
-			$this->uninstall_ext('foo/bar');
-			$this->uninstall_ext('foo/foo');
-		}
-
-		parent::tearDown();
-	}
-
-	protected static function setup_extensions()
-	{
-		return self::$tests_count == self::$tests_number ? ['foo/bar', 'foo/foo'] : [];
-	}
 
 	/**
 	 * Check extensions template event listener prioritizing

--- a/tests/functional/feed_test.php
+++ b/tests/functional/feed_test.php
@@ -1450,8 +1450,6 @@ class phpbb_functional_feed_test extends phpbb_functional_test_case
 
 	protected function load_ids($data)
 	{
-		$this->db = $this->get_db();
-
 		if (!empty($data['forums']))
 		{
 			$sql = 'SELECT *

--- a/tests/functional/forum_style_test.php
+++ b/tests/functional/forum_style_test.php
@@ -30,9 +30,8 @@ class phpbb_functional_forum_style_test extends phpbb_functional_test_case
 
 	public function test_custom_forum_style()
 	{
-		$db = $this->get_db();
 		$this->add_style(2, 'test_style');
-		$db->sql_query('UPDATE ' . FORUMS_TABLE . ' SET forum_style = 2 WHERE forum_id = 2');
+		$this->db->sql_query('UPDATE ' . FORUMS_TABLE . ' SET forum_style = 2 WHERE forum_id = 2');
 
 		$crawler = self::request('GET', 'viewtopic.php?t=1&f=2');
 		$this->assertStringContainsString('styles/test_style/', $crawler->filter('head > link[rel=stylesheet]')->eq(1)->attr('href'));
@@ -43,7 +42,7 @@ class phpbb_functional_forum_style_test extends phpbb_functional_test_case
 		$crawler = self::request('GET', 'viewtopic.php?t=1&view=next');
 		$this->assertStringContainsString('styles/test_style/', $crawler->filter('head > link[rel=stylesheet]')->eq(1)->attr('href'));
 
-		$db->sql_query('UPDATE ' . FORUMS_TABLE . ' SET forum_style = 0 WHERE forum_id = 2');
+		$this->db->sql_query('UPDATE ' . FORUMS_TABLE . ' SET forum_style = 0 WHERE forum_id = 2');
 		$this->delete_style(2, 'test_style');
 	}
 }

--- a/tests/functional/mcp/mcp_main_test.php
+++ b/tests/functional/mcp/mcp_main_test.php
@@ -208,7 +208,7 @@ class phpbb_functional_mcp_main_test extends phpbb_functional_test_case
 		// Create replies. Flood control was disabled above
 		for ($i = 1; $i <= 15; $i++)
 		{
-			sleep(1);
+			usleep(100000);
 			$post_text = "This is reply number $i to the Test Topic 4 to test moderation actions from MCP/View topic page.";
 			$post[$i] = $this->create_post(2, $post[0]['topic_id'], 'Re: Test Topic 4', $post_text);
 			$crawler = self::request('GET', "viewtopic.php?p={$post[$i]['post_id']}&sid={$this->sid}#p{$post[$i]['post_id']}");

--- a/tests/functional/metadata_manager_test.php
+++ b/tests/functional/metadata_manager_test.php
@@ -24,7 +24,10 @@ class phpbb_functional_metadata_manager_test extends phpbb_functional_test_case
 
 	protected function tearDown(): void
 	{
-		$this->uninstall_ext('foo/bar');
+		if (self::$tests_count == 1)
+		{
+			$this->uninstall_ext('foo/bar');
+		}
 
 		parent::tearDown();
 	}
@@ -55,7 +58,7 @@ class phpbb_functional_metadata_manager_test extends phpbb_functional_test_case
 
 	protected static function setup_extensions()
 	{
-		return ['foo/bar'];
+		return self::$tests_count == self::$tests_number ? ['foo/bar'] : [];
 	}
 
 	public function test_extensions_list()

--- a/tests/functional/metadata_manager_test.php
+++ b/tests/functional/metadata_manager_test.php
@@ -22,28 +22,21 @@ class phpbb_functional_metadata_manager_test extends phpbb_functional_test_case
 		'./',
 	);
 
-	protected function tearDown(): void
-	{
-		if (self::$tests_count == 1)
-		{
-			$this->uninstall_ext('foo/bar');
-		}
-
-		parent::tearDown();
-	}
-
 	public static function setUpBeforeClass(): void
 	{
 		parent::setUpBeforeClass();
 
 		self::$helper = new phpbb_test_case_helpers(__CLASS__);
 		self::$helper->copy_ext_fixtures(__DIR__ . '/fixtures/ext/', self::$fixtures);
+
+		self::install_ext('foo/bar');
 	}
 
 	public static function tearDownAfterClass(): void
 	{
 		parent::tearDownAfterClass();
 
+		self::uninstall_ext('foo/bar');
 		self::$helper->restore_original_ext_dir();
 	}
 
@@ -54,11 +47,6 @@ class phpbb_functional_metadata_manager_test extends phpbb_functional_test_case
 		$this->login();
 		$this->admin_login();
 		$this->add_lang('acp/extensions');
-	}
-
-	protected static function setup_extensions()
-	{
-		return self::$tests_count == self::$tests_number ? ['foo/bar'] : [];
 	}
 
 	public function test_extensions_list()

--- a/tests/functional/plupload_test.php
+++ b/tests/functional/plupload_test.php
@@ -21,13 +21,12 @@ class phpbb_functional_plupload_test extends phpbb_functional_test_case
 
 	protected function set_extension_group_permission($val)
 	{
-		$db = $this->get_db();
 		$query = "
 			UPDATE phpbb_extension_groups
 			SET allow_in_pm = '$val'
 			WHERE group_name = 'IMAGES'
 		";
-		$db->sql_query($query);
+		$this->db->sql_query($query);
 	}
 
 	protected function setUp(): void

--- a/tests/functional/prune_shadow_topic_test.php
+++ b/tests/functional/prune_shadow_topic_test.php
@@ -121,7 +121,6 @@ class phpbb_functional_prune_shadow_topic_test extends phpbb_functional_test_cas
 			'forum_topics_softdeleted'	=> 0,
 		), 'after moving');
 
-		$this->db = $this->get_db();
 		// Date topic 3 days back
 		$sql = 'UPDATE phpbb_topics
 			SET topic_last_post_time = ' . (time() - 60*60*24*3) . '
@@ -153,8 +152,6 @@ class phpbb_functional_prune_shadow_topic_test extends phpbb_functional_test_cas
 
 	public function assert_forum_details($forum_id, $details, $additional_error_message = '')
 	{
-		$this->db = $this->get_db();
-
 		$sql = 'SELECT ' . implode(', ', array_keys($details)) . '
 			FROM phpbb_forums
 			WHERE forum_id = ' . (int) $forum_id;
@@ -167,8 +164,6 @@ class phpbb_functional_prune_shadow_topic_test extends phpbb_functional_test_cas
 
 	public function load_ids($data)
 	{
-		$this->db = $this->get_db();
-
 		if (!empty($data['forums']))
 		{
 			$sql = 'SELECT *

--- a/tests/functional/prune_shadow_topic_test.php
+++ b/tests/functional/prune_shadow_topic_test.php
@@ -133,7 +133,7 @@ class phpbb_functional_prune_shadow_topic_test extends phpbb_functional_test_cas
 		self::request('GET', "app.php/cron/cron.task.core.prune_shadow_topics?f={$this->data['forums']['Prune Shadow']}&sid={$this->sid}", array(), false);
 
 		// Try to ensure that the cron can actually run before we start to wait for it
-		sleep(1);
+		usleep(100000);
 		$cron_lock = new \phpbb\lock\db('cron_lock', new \phpbb\config\db($this->db, new \phpbb\cache\driver\dummy(), 'phpbb_config'), $this->db);
 		while (!$cron_lock->acquire())
 		{

--- a/tests/functional/search/base.php
+++ b/tests/functional/search/base.php
@@ -137,8 +137,6 @@ abstract class phpbb_functional_search_base extends phpbb_functional_test_case
 		$this->login();
 		$this->admin_login();
 
-		$this->create_search_index('phpbb\\search\\backend\\fulltext_native');
-
 		$post = $this->create_topic(2, 'Test Topic 1 foosubject', 'This is a test topic posted by the barsearch testing framework.');
 		$topic_multiple_results_count1 = $this->create_topic(2, 'Test Topic for multiple search results', 'This is a test topic posted to test multiple results count.');
 		$this->create_post(2, $topic_multiple_results_count1['topic_id'], 'Re: Test Topic for multiple search results', 'This is a test post 2 posted to test multiple results count.');

--- a/tests/functional/search/mysql_test.php
+++ b/tests/functional/search/mysql_test.php
@@ -20,6 +20,17 @@ class phpbb_functional_search_mysql_test extends phpbb_functional_search_base
 {
 	protected $search_backend = 'phpbb\search\backend\fulltext_mysql';
 
+	protected function setUp(): void
+	{
+		$sql_layer = substr(self::$config['dbms'], strlen('phpbb\\db\\driver\\'));
+		if ($sql_layer !== 'mysqli') // MySQL search backend runs on MySQL/MariaDB only
+		{
+			$this->markTestSkipped($sql_layer . ': MySQL search is not supported');
+		}
+
+		parent::setUp();
+	}
+
 	protected function create_search_index($backend = null)
 	{
 		parent::create_search_index($backend);

--- a/tests/functional/search/mysql_test.php
+++ b/tests/functional/search/mysql_test.php
@@ -38,10 +38,9 @@ class phpbb_functional_search_mysql_test extends phpbb_functional_search_base
 		// Try optimizing posts table after creating search index.
 		// Some versions of MariaDB might not return any results in the search
 		// until the table has been optimized or the index deleted and re-created.
-		$db = $this->get_db();
-		$db->sql_return_on_error(true);
+		$this->db->sql_return_on_error(true);
 		$sql = 'OPTIMIZE TABLE ' . POSTS_TABLE;
-		$db->sql_query($sql);
-		$db->sql_return_on_error(false);
+		$this->db->sql_query($sql);
+		$this->db->sql_return_on_error(false);
 	}
 }

--- a/tests/functional/search/postgres_test.php
+++ b/tests/functional/search/postgres_test.php
@@ -20,4 +20,14 @@ class phpbb_functional_search_postgres_test extends phpbb_functional_search_base
 {
 	protected $search_backend = 'phpbb\search\backend\fulltext_postgres';
 
+	protected function setUp(): void
+	{
+		$sql_layer = substr(self::$config['dbms'], strlen('phpbb\\db\\driver\\'));
+		if ($sql_layer !== 'postgres') // PostgreSQL search backend runs on PostgreSQL only
+		{
+			$this->markTestSkipped($sql_layer . ': PostgreSQL search is not supported');
+		}
+
+		parent::setUp();
+	}
 }

--- a/tests/functional/search/sphinx_test.php
+++ b/tests/functional/search/sphinx_test.php
@@ -20,6 +20,17 @@ class phpbb_functional_search_sphinx_test extends phpbb_functional_search_base
 {
 	protected $search_backend = 'phpbb\search\backend\fulltext_sphinx';
 
+	protected function setUp(): void
+	{
+		$sql_layer = substr(self::$config['dbms'], strlen('phpbb\\db\\driver\\'));
+		if ($sql_layer !== 'mysqli') // Sphinx search backend runs on MySQL/MariaDB only so far
+		{
+			$this->markTestSkipped($sql_layer . ': Sphinx search is not supported');
+		}
+
+		parent::setUp();
+	}
+
 	protected function create_search_index($backend = null)
 	{
 		parent::create_search_index($backend);
@@ -33,18 +44,6 @@ class phpbb_functional_search_sphinx_test extends phpbb_functional_search_base
 			exec('sudo -S service sphinxsearch stop', $output, $retval); // Attempt to stop sphinxsearch service in case it's running
 			exec('sudo -S indexer --all', $output, $retval); // Run sphinxsearch indexer
 			exec('sudo -S service sphinxsearch start', $output, $retval); // Attempt to start sphinxsearch service again
-		}
-	}
-
-	public function test_search_backend()
-	{
-		if ($this->db->sql_layer != 'mysqli') // Sphinx test runs on MySQL/MariaDB only so far
-		{
-			$this->markTestIncomplete('Sphinx Tests are not supported');
-		}
-		else
-		{
-			parent::test_search_backend();
 		}
 	}
 }

--- a/tests/functional/session_page_update_test.php
+++ b/tests/functional/session_page_update_test.php
@@ -21,35 +21,29 @@ class phpbb_functional_session_page_update_test extends phpbb_functional_test_ca
 	{
 		parent::setUp();
 
-		global $db;
-
-		$db = $this->db;
-
 		// Delete previous session info for admin user
 		$sql = 'DELETE FROM ' . SESSIONS_TABLE . ' WHERE session_user_id = 2';
-		$db->sql_query($sql);
+		$this->db->sql_query($sql);
 
 		$this->login();
 	}
 
 	public function test_session_page_update()
 	{
-		$db = $this->get_db();
-
 		// Request index page
 		self::request('GET', 'index.php');
 		$this->assertEquals(200, self::$client->getInternalResponse()->getStatusCode(), 'Failed asserting that status of index page is 200');
 
 		$sql = 'SELECT session_page FROM ' . SESSIONS_TABLE . ' WHERE session_user_id = 2 ORDER BY session_time DESC';
-		$db->sql_query_limit($sql, 1);
-		$this->assertEquals('index.php', $db->sql_fetchfield('session_page'), 'Failed asserting that session_page is index.php for admin user');
+		$this->db->sql_query_limit($sql, 1);
+		$this->assertEquals('index.php', $this->db->sql_fetchfield('session_page'), 'Failed asserting that session_page is index.php for admin user');
 
 		// Request non-existent url
 		self::request('GET', 'nonexistent.jpg', [], false);
 		$this->assertEquals(404, self::$client->getInternalResponse()->getStatusCode(), 'Failed asserting that status of non-existent image is 404');
 
-		$db->sql_query_limit($sql, 1);
+		$this->db->sql_query_limit($sql, 1);
 		// User page should not be updated to non-existent one
-		$this->assertEquals('index.php', $db->sql_fetchfield('session_page'), 'Failed asserting that session page has not changed after 404');
+		$this->assertEquals('index.php', $this->db->sql_fetchfield('session_page'), 'Failed asserting that session page has not changed after 404');
 	}
 }

--- a/tests/functional/smilies_test.php
+++ b/tests/functional/smilies_test.php
@@ -21,19 +21,18 @@ class phpbb_functional_smilies_test extends phpbb_functional_test_case
 		$this->login();
 
 		// Get smilies data
-		$db = $this->get_db();
 		$sql_ary = [
 			'SELECT'	=> 's.smiley_url, MIN(s.emotion) AS emotion, MIN(s.code) AS code, s.smiley_width, s.smiley_height, MIN(s.smiley_order) AS min_smiley_order',
 			'FROM'		=> [
 				SMILIES_TABLE => 's',
 			],
 			'GROUP_BY'	=> 's.smiley_url, s.smiley_width, s.smiley_height',
-			'ORDER_BY'	=> $db->sql_quote('min_smiley_order'),
+			'ORDER_BY'	=> $this->db->sql_quote('min_smiley_order'),
 		];
-		$sql = $db->sql_build_query('SELECT', $sql_ary);
-		$result = $db->sql_query($sql);
-		$smilies = $db->sql_fetchrowset($result);
-		$db->sql_freeresult($result);
+		$sql = $this->db->sql_build_query('SELECT', $sql_ary);
+		$result = $this->db->sql_query($sql);
+		$smilies = $this->db->sql_fetchrowset($result);
+		$this->db->sql_freeresult($result);
 
 		// Visit smilies page
 		$crawler = self::request('GET', 'posting.php?mode=smilies');

--- a/tests/functional/subforum_test.php
+++ b/tests/functional/subforum_test.php
@@ -91,7 +91,6 @@ class phpbb_functional_subforum_test extends phpbb_functional_test_case
 
 	protected function get_forum_id($forum_name)
 	{
-		$this->db = $this->get_db();
 		$forum_id = 0;
 
 		$sql = 'SELECT *

--- a/tests/functional/switch_permissions_test.php
+++ b/tests/functional/switch_permissions_test.php
@@ -73,13 +73,12 @@ class phpbb_functional_switch_permissions_test extends phpbb_functional_test_cas
 	 */
 	public function test_switch_permissions_ucp()
 	{
-		$db = $this->get_db();
 		$sql = 'SELECT user_id
 			FROM ' . USERS_TABLE . "
 			WHERE username = '" . self::TEST_USER . "'";
-		$result = $db->sql_query($sql);
-		$user_id = $db->sql_fetchfield('user_id');
-		$db->sql_freeresult($result);
+		$result = $this->db->sql_query($sql);
+		$user_id = $this->db->sql_fetchfield('user_id');
+		$this->db->sql_freeresult($result);
 
 		// Open memberlist profile page for user
 		$crawler = self::request('GET', "memberlist.php?mode=viewprofile&u={$user_id}&sid={$this->sid}");

--- a/tests/functional/ucp_allow_pm_test.php
+++ b/tests/functional/ucp_allow_pm_test.php
@@ -64,11 +64,10 @@ class phpbb_functional_ucp_allow_pm_test extends phpbb_functional_test_case
 	// enable or disable PM for a user, like from ucp
 	protected function set_user_allow_pm($user_id, $allow)
 	{
-		$db = $this->get_db();
 		$sql = 'UPDATE ' . USERS_TABLE . "
 			SET user_allow_pm = " . $allow . "
 			WHERE user_id = " . $user_id;
-		$result = $db->sql_query($sql);
-		$db->sql_freeresult($result);
+		$result = $this->db->sql_query($sql);
+		$this->db->sql_freeresult($result);
 	}
 }

--- a/tests/functional/ucp_groups_test.php
+++ b/tests/functional/ucp_groups_test.php
@@ -18,8 +18,6 @@ require_once __DIR__ . '/common_groups_test_case.php';
 */
 class phpbb_functional_ucp_groups_test extends phpbb_functional_common_groups_test_case
 {
-	protected $db;
-
 	protected function get_url()
 	{
 		return 'ucp.php?i=groups&mode=manage&action=edit';
@@ -27,10 +25,6 @@ class phpbb_functional_ucp_groups_test extends phpbb_functional_common_groups_te
 
 	protected function get_teampage_settings()
 	{
-		if (!isset($this->db))
-		{
-			$this->db = $this->get_db();
-		}
 		$sql = 'SELECT g.group_legend AS group_legend, t.teampage_position AS group_teampage
 			FROM ' . GROUPS_TABLE . ' g
 			LEFT JOIN ' . TEAMPAGE_TABLE . ' t

--- a/tests/functional/ucp_profile_test.php
+++ b/tests/functional/ucp_profile_test.php
@@ -73,7 +73,6 @@ class phpbb_functional_ucp_profile_test extends phpbb_functional_test_case
 	{
 		$this->add_lang('ucp');
 		$this->login('admin', true);
-		$db = $this->get_db();
 
 		$crawler = self::request('GET', 'ucp.php?i=ucp_profile&mode=autologin_keys');
 		$this->assertContainsLang('UCP_PROFILE_AUTOLOGIN_KEYS', $crawler->filter('#cp-main h2')->text());
@@ -87,9 +86,9 @@ class phpbb_functional_ucp_profile_test extends phpbb_functional_test_case
 			'WHERE'		=> 'sk.user_id = ' . (int) $user_id,
 			'ORDER_BY'	=> 'sk.last_login ASC',
 		];
-		$result = $db->sql_query_limit($db->sql_build_query('SELECT', $sql_ary), 1);
-		$key_id = substr($db->sql_fetchfield('key_id'), 0, 8);
-		$db->sql_freeresult($result);
+		$result = $this->db->sql_query_limit($this->db->sql_build_query('SELECT', $sql_ary), 1);
+		$key_id = substr($this->db->sql_fetchfield('key_id'), 0, 8);
+		$this->db->sql_freeresult($result);
 
 		$this->assertStringContainsString($key_id, $crawler->filter('label[for="' . $key_id . '"]')->text());
 

--- a/tests/functional/user_password_reset_test.php
+++ b/tests/functional/user_password_reset_test.php
@@ -241,12 +241,10 @@ class phpbb_functional_user_password_reset_test extends phpbb_functional_test_ca
 		$this->assertNotEmpty($this->user_data['user_actkey']);
 
 		// Change reason for inactivity
-		$db = $this->get_db();
-
 		$sql = 'UPDATE ' . USERS_TABLE . '
 			SET user_inactive_reason = ' . INACTIVE_REMIND . '
 			WHERE user_id = ' . (int) $this->user_data['user_id'];
-		$db->sql_query($sql);
+		$this->db->sql_query($sql);
 
 		$this->add_lang('ucp');
 
@@ -262,12 +260,11 @@ class phpbb_functional_user_password_reset_test extends phpbb_functional_test_ca
 
 	protected function get_user_data($username)
 	{
-		$db = $this->get_db();
 		$sql = 'SELECT user_id, username, user_type, user_email, user_newpasswd, user_lang, user_actkey, user_inactive_reason, reset_token, reset_token_expiration
 			FROM ' . USERS_TABLE . "
-			WHERE username = '" . $db->sql_escape($username) . "'";
-		$result = $db->sql_query($sql);
-		$this->user_data = $db->sql_fetchrow($result);
-		$db->sql_freeresult($result);
+			WHERE username = '" . $this->db->sql_escape($username) . "'";
+		$result = $this->db->sql_query($sql);
+		$this->user_data = $this->db->sql_fetchrow($result);
+		$this->db->sql_freeresult($result);
 	}
 }

--- a/tests/functional/user_password_reset_test.php
+++ b/tests/functional/user_password_reset_test.php
@@ -153,17 +153,6 @@ class phpbb_functional_user_password_reset_test extends phpbb_functional_test_ca
 		$crawler = self::submit($form, array('username' => self::TEST_USER, 'password' => self::TEST_USER));
 		$this->assertStringNotContainsString($this->lang('LOGIN'), $crawler->filter('.navbar')->text());
 
-		$cookies = self::$cookieJar->all();
-
-		// The session id is stored in a cookie that ends with _sid - we assume there is only one such cookie
-		foreach ($cookies as $cookie)
-		{
-			if (substr($cookie->getName(), -4) == '_sid')
-			{
-				$this->sid = $cookie->getValue();
-			}
-		}
-
 		$this->logout();
 
 		$crawler = self::request('GET', 'ucp.php');

--- a/tests/functional/viewforum_paging_test.php
+++ b/tests/functional/viewforum_paging_test.php
@@ -163,8 +163,6 @@ class viewforum_paging_test extends phpbb_functional_test_case
 
 	protected function assert_forum_details($forum_id, $details, $additional_error_message = '')
 	{
-		$this->db = $this->get_db();
-
 		$sql = 'SELECT ' . implode(', ', array_keys($details)) . '
 			FROM phpbb_forums
 			WHERE forum_id = ' . (int) $forum_id;
@@ -203,8 +201,6 @@ class viewforum_paging_test extends phpbb_functional_test_case
 	 */
 	protected function load_ids($data)
 	{
-		$this->db = $this->get_db();
-
 		if (!empty($data['forums']))
 		{
 			$sql = 'SELECT *

--- a/tests/functional/viewonline_test.php
+++ b/tests/functional/viewonline_test.php
@@ -18,31 +18,27 @@ class phpbb_functional_viewonline_test extends phpbb_functional_test_case
 {
 	protected function get_forum_name_by_topic_id($topic_id)
 	{
-		$db = $this->get_db();
-
 		// Forum info
 		$sql =  'SELECT f.forum_name
 			FROM ' . FORUMS_TABLE . ' f,' . TOPICS_TABLE . ' t
 			WHERE t.forum_id = f.forum_id
 				AND t.topic_id = ' . (int) $topic_id;
-		$result = $db->sql_query($sql);
-		$forum_name = $db->sql_fetchfield('forum_name');
-		$db->sql_freeresult($result, 1800); // cache for 30 minutes
+		$result = $this->db->sql_query($sql);
+		$forum_name = $this->db->sql_fetchfield('forum_name');
+		$this->db->sql_freeresult($result, 1800); // cache for 30 minutes
 
 		return $forum_name;
 	}
 
 	protected function get_forum_name_by_forum_id($forum_id)
 	{
-		$db = $this->get_db();
-
 		// Forum info
 		$sql =  'SELECT forum_name
 			FROM ' . FORUMS_TABLE . '
 			WHERE forum_id = ' . (int) $forum_id;
-		$result = $db->sql_query($sql);
-		$forum_name = $db->sql_fetchfield('forum_name');
-		$db->sql_freeresult($result, 1800); // cache for 30 minutes
+		$result = $this->db->sql_query($sql);
+		$forum_name = $this->db->sql_fetchfield('forum_name');
+		$this->db->sql_freeresult($result, 1800); // cache for 30 minutes
 
 		return $forum_name;
 	}

--- a/tests/functional/visibility_disapprove_test.php
+++ b/tests/functional/visibility_disapprove_test.php
@@ -243,8 +243,6 @@ class phpbb_functional_visibility_disapprove_test extends phpbb_functional_test_
 
 	protected function assert_forum_details($forum_id, $details, $additional_error_message = '')
 	{
-		$this->db = $this->get_db();
-
 		$sql = 'SELECT ' . implode(', ', array_keys($details)) . '
 			FROM phpbb_forums
 			WHERE forum_id = ' . (int) $forum_id;
@@ -257,8 +255,6 @@ class phpbb_functional_visibility_disapprove_test extends phpbb_functional_test_
 
 	protected function load_ids($data)
 	{
-		$this->db = $this->get_db();
-
 		if (!empty($data['forums']))
 		{
 			$sql = 'SELECT *

--- a/tests/functional/visibility_reapprove_test.php
+++ b/tests/functional/visibility_reapprove_test.php
@@ -339,8 +339,6 @@ class phpbb_functional_visibility_reapprove_test extends phpbb_functional_test_c
 
 	protected function assert_forum_details($forum_id, $details, $additional_error_message = '')
 	{
-		$this->db = $this->get_db();
-
 		$sql = 'SELECT ' . implode(', ', array_keys($details)) . '
 			FROM phpbb_forums
 			WHERE forum_id = ' . (int) $forum_id;
@@ -353,8 +351,6 @@ class phpbb_functional_visibility_reapprove_test extends phpbb_functional_test_c
 
 	protected function load_ids($data)
 	{
-		$this->db = $this->get_db();
-
 		if (!empty($data['forums']))
 		{
 			$sql = 'SELECT *

--- a/tests/functional/visibility_softdelete_test.php
+++ b/tests/functional/visibility_softdelete_test.php
@@ -783,8 +783,6 @@ class phpbb_functional_visibility_softdelete_test extends phpbb_functional_test_
 
 	public function assert_forum_details($forum_id, $details, $additional_error_message = '')
 	{
-		$this->db = $this->get_db();
-
 		$sql = 'SELECT ' . implode(', ', array_keys($details)) . '
 			FROM phpbb_forums
 			WHERE forum_id = ' . (int) $forum_id;
@@ -797,8 +795,6 @@ class phpbb_functional_visibility_softdelete_test extends phpbb_functional_test_
 
 	public function load_ids($data)
 	{
-		$this->db = $this->get_db();
-
 		if (!empty($data['forums']))
 		{
 			$sql = 'SELECT *

--- a/tests/functional/visibility_unapproved_posts_test.php
+++ b/tests/functional/visibility_unapproved_posts_test.php
@@ -256,8 +256,6 @@ class phpbb_functional_visibility_unapproved_posts_test extends phpbb_functional
 
 	protected function assert_forum_details($forum_id, $details, $additional_error_message = '')
 	{
-		$this->db = $this->get_db();
-
 		$sql = 'SELECT ' . implode(', ', array_keys($details)) . '
 			FROM phpbb_forums
 			WHERE forum_id = ' . (int) $forum_id;
@@ -270,8 +268,6 @@ class phpbb_functional_visibility_unapproved_posts_test extends phpbb_functional
 
 	protected function load_ids($data)
 	{
-		$this->db = $this->get_db();
-
 		if (!empty($data['forums']))
 		{
 			$sql = 'SELECT forum_id, forum_name

--- a/tests/test_framework/phpbb_functional_test_case.php
+++ b/tests/test_framework/phpbb_functional_test_case.php
@@ -119,15 +119,15 @@ class phpbb_functional_test_case extends phpbb_test_case
 		$this->lang = array();
 		$this->add_lang('common');
 
-		$db = $this->get_db();
+		$this->get_db();
 
 		// Special flag for testing without possibility to run into lock scenario.
 		// Unset entry and add it back if lock behavior for posting should be tested.
 		// Unset ci_tests_no_lock_posting from config
-		$db->sql_return_on_error(true);
+		$this->db->sql_return_on_error(true);
 		$sql = 'INSERT INTO ' . CONFIG_TABLE . " (config_name, config_value) VALUES ('ci_tests_no_lock_posting', '1')";
 		$this->db->sql_query($sql);
-		$db->sql_return_on_error(false);
+		$this->db->sql_return_on_error(false);
 
 		foreach (static::setup_extensions() as $extension)
 		{
@@ -135,10 +135,10 @@ class phpbb_functional_test_case extends phpbb_test_case
 
 			$sql = 'SELECT ext_active
 				FROM ' . EXT_TABLE . "
-				WHERE ext_name = '" . $db->sql_escape($extension). "'";
-			$result = $db->sql_query($sql);
-			$status = (bool) $db->sql_fetchfield('ext_active');
-			$db->sql_freeresult($result);
+				WHERE ext_name = '" . $this->db->sql_escape($extension). "'";
+			$result = $this->db->sql_query($sql);
+			$status = (bool) $this->db->sql_fetchfield('ext_active');
+			$this->db->sql_freeresult($result);
 
 			if (!$status)
 			{
@@ -289,7 +289,7 @@ class phpbb_functional_test_case extends phpbb_test_case
 		global $phpbb_root_path, $phpEx;
 
 		$config = new \phpbb\config\config(array('version' => PHPBB_VERSION));
-		$db = $this->get_db();
+		$this->get_db();
 		$db_doctrine = $this->get_db_doctrine();
 		$factory = new \phpbb\db\tools\factory();
 		$finder_factory = new \phpbb\finder\factory(null, false, $phpbb_root_path, $phpEx);
@@ -300,7 +300,7 @@ class phpbb_functional_test_case extends phpbb_test_case
 		$migrator = new \phpbb\db\migrator(
 			$container,
 			$config,
-			$db,
+			$this->db,
 			$db_tools,
 			self::$config['table_prefix'] . 'migrations',
 			$phpbb_root_path,
@@ -322,7 +322,7 @@ class phpbb_functional_test_case extends phpbb_test_case
 
 		$extension_manager = new \phpbb\extension\manager(
 			$container,
-			$db,
+			$this->db,
 			$config,
 			$finder_factory,
 			self::$config['table_prefix'] . 'ext',
@@ -737,10 +737,10 @@ class phpbb_functional_test_case extends phpbb_test_case
 	{
 		global $phpbb_root_path;
 
-		$db = $this->get_db();
+		$this->get_db();
 		if (version_compare(PHPBB_VERSION, '3.1.0-dev', '<'))
 		{
-			$sql = 'INSERT INTO ' . STYLES_TABLE . ' ' . $db->sql_build_array('INSERT', array(
+			$sql = 'INSERT INTO ' . STYLES_TABLE . ' ' . $this->db->sql_build_array('INSERT', array(
 				'style_id' => $style_id,
 				'style_name' => $style_path,
 				'style_copyright' => '',
@@ -749,17 +749,17 @@ class phpbb_functional_test_case extends phpbb_test_case
 				'theme_id' => $style_id,
 				'imageset_id' => $style_id,
 			));
-			$db->sql_query($sql);
+			$this->db->sql_query($sql);
 
-			$sql = 'INSERT INTO ' . STYLES_IMAGESET_TABLE . ' ' . $db->sql_build_array('INSERT', array(
+			$sql = 'INSERT INTO ' . STYLES_IMAGESET_TABLE . ' ' . $this->db->sql_build_array('INSERT', array(
 				'imageset_id' => $style_id,
 				'imageset_name' => $style_path,
 				'imageset_copyright' => '',
 				'imageset_path' => $style_path,
 			));
-			$db->sql_query($sql);
+			$this->db->sql_query($sql);
 
-			$sql = 'INSERT INTO ' . STYLES_TEMPLATE_TABLE . ' ' . $db->sql_build_array('INSERT', array(
+			$sql = 'INSERT INTO ' . STYLES_TEMPLATE_TABLE . ' ' . $this->db->sql_build_array('INSERT', array(
 				'template_id' => $style_id,
 				'template_name' => $style_path,
 				'template_copyright' => '',
@@ -768,9 +768,9 @@ class phpbb_functional_test_case extends phpbb_test_case
 				'template_inherits_id' => $parent_style_id,
 				'template_inherit_path' => $parent_style_path,
 			));
-			$db->sql_query($sql);
+			$this->db->sql_query($sql);
 
-			$sql = 'INSERT INTO ' . STYLES_THEME_TABLE . ' ' . $db->sql_build_array('INSERT', array(
+			$sql = 'INSERT INTO ' . STYLES_THEME_TABLE . ' ' . $this->db->sql_build_array('INSERT', array(
 				'theme_id' => $style_id,
 				'theme_name' => $style_path,
 				'theme_copyright' => '',
@@ -779,7 +779,7 @@ class phpbb_functional_test_case extends phpbb_test_case
 				'theme_mtime' => 0,
 				'theme_data' => '',
 			));
-			$db->sql_query($sql);
+			$this->db->sql_query($sql);
 
 			if ($style_path != 'prosilver')
 			{
@@ -789,7 +789,7 @@ class phpbb_functional_test_case extends phpbb_test_case
 		}
 		else
 		{
-			$db->sql_multi_insert(STYLES_TABLE, array(array(
+			$this->db->sql_multi_insert(STYLES_TABLE, array(array(
 				'style_name' => $style_path,
 				'style_copyright' => '',
 				'style_active' => 1,
@@ -811,13 +811,13 @@ class phpbb_functional_test_case extends phpbb_test_case
 	{
 		global $phpbb_root_path;
 
-		$db = $this->get_db();
-		$db->sql_query('DELETE FROM ' . STYLES_TABLE . ' WHERE style_id = ' . $style_id);
+		$this->get_db();
+		$this->db->sql_query('DELETE FROM ' . STYLES_TABLE . ' WHERE style_id = ' . $style_id);
 		if (version_compare(PHPBB_VERSION, '3.1.0-dev', '<'))
 		{
-			$db->sql_query('DELETE FROM ' . STYLES_IMAGESET_TABLE . ' WHERE imageset_id = ' . $style_id);
-			$db->sql_query('DELETE FROM ' . STYLES_TEMPLATE_TABLE . ' WHERE template_id = ' . $style_id);
-			$db->sql_query('DELETE FROM ' . STYLES_THEME_TABLE . ' WHERE theme_id = ' . $style_id);
+			$this->db->sql_query('DELETE FROM ' . STYLES_IMAGESET_TABLE . ' WHERE imageset_id = ' . $style_id);
+			$this->db->sql_query('DELETE FROM ' . STYLES_TEMPLATE_TABLE . ' WHERE template_id = ' . $style_id);
+			$this->db->sql_query('DELETE FROM ' . STYLES_THEME_TABLE . ' WHERE theme_id = ' . $style_id);
 
 			if ($style_path != 'prosilver')
 			{
@@ -904,13 +904,13 @@ class phpbb_functional_test_case extends phpbb_test_case
 	 */
 	protected function get_group_id($group_name)
 	{
-		$db = $this->get_db();
+		$this->get_db();
 		$sql = 'SELECT group_id
 			FROM ' . GROUPS_TABLE . "
-			WHERE group_name = '" . $db->sql_escape($group_name) . "'";
-		$result = $db->sql_query($sql);
-		$group_id = (int) $db->sql_fetchfield('group_id');
-		$db->sql_freeresult($result);
+			WHERE group_name = '" . $this->db->sql_escape($group_name) . "'";
+		$result = $this->db->sql_query($sql);
+		$group_id = (int) $this->db->sql_fetchfield('group_id');
+		$this->db->sql_freeresult($result);
 
 		return $group_id;
 	}
@@ -922,13 +922,12 @@ class phpbb_functional_test_case extends phpbb_test_case
 	 */
 	protected function get_search_type()
 	{
-		$db = $this->get_db();
 		$sql = 'SELECT config_value as search_type
 			FROM ' . CONFIG_TABLE . "
-			WHERE config_name = '" . $db->sql_escape('search_type') . "'";
-		$result = $db->sql_query($sql);
-		$search_type = $db->sql_fetchfield('search_type');
-		$db->sql_freeresult($result);
+			WHERE config_name = '" . $this->db->sql_escape('search_type') . "'";
+		$result = $this->db->sql_query($sql);
+		$search_type = $this->db->sql_fetchfield('search_type');
+		$this->db->sql_freeresult($result);
 
 		return $search_type;
 	}

--- a/tests/test_framework/phpbb_functional_test_case.php
+++ b/tests/test_framework/phpbb_functional_test_case.php
@@ -48,6 +48,8 @@ class phpbb_functional_test_case extends phpbb_test_case
 
 	protected static $config = array();
 	protected static $already_installed = false;
+	protected static $tests_count = 0;
+	protected static $tests_number = 0;
 
 	static public function setUpBeforeClass(): void
 	{
@@ -73,6 +75,12 @@ class phpbb_functional_test_case extends phpbb_test_case
 			self::install_board();
 			self::$already_installed = true;
 		}
+
+		self::$tests_number = self::$tests_count = count(array_filter(get_class_methods(static::class), function($val)
+			{
+				return str_starts_with($val, 'test_');
+			})
+		);
 	}
 
 	/**
@@ -143,7 +151,9 @@ class phpbb_functional_test_case extends phpbb_test_case
 	{
 		parent::tearDown();
 
-		if ($this->db instanceof \phpbb\db\driver\driver_interface)
+		self::$tests_count--;
+
+		if (self::$tests_count === 0 && $this->db instanceof \phpbb\db\driver\driver_interface)
 		{
 			// Unset ci_tests_no_lock_posting from config
 			$sql = 'DELETE FROM ' . CONFIG_TABLE . "
@@ -234,7 +244,7 @@ class phpbb_functional_test_case extends phpbb_test_case
 		{
 			$dbms = self::$config['dbms'];
 			$this->db = new $dbms();
-			$this->db->sql_connect(self::$config['dbhost'], self::$config['dbuser'], self::$config['dbpasswd'], self::$config['dbname'], self::$config['dbport']);
+			$this->db->sql_connect(self::$config['dbhost'], self::$config['dbuser'], self::$config['dbpasswd'], self::$config['dbname'], self::$config['dbport'], true);
 		}
 		return $this->db;
 	}


### PR DESCRIPTION
Slight functional tests framework optimization by:

- using persistent database connection
- closing database connection only after the last test got finished  in a testsuite
- only performing extensions setup before the 1st test in a testsuite
- only performing extensions uninstall after the last test in a testsuite
- skip unsupported search backends tests before the `setUp()` method call
- decreasing pausing time in some tests

This seems to save 1-2 minutes for Unix-based tests and 8-9 minutes for Windows functional tests.

Checklist:

- [x] Correct branch: master for new features; 3.3.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master](https://area51.phpbb.com/docs/master/coding-guidelines.html) and [3.3.x](https://area51.phpbb.com/docs/dev/3.3.x/development/coding_guidelines.html)
- [x] Commit follows commit message [format](https://area51.phpbb.com/docs/dev/3.3.x/development/git.html)

Tracker ticket:

https://tracker.phpbb.com/browse/PHPBB-17543
