### PR TITLE
[ticket/17554] Mock Extensions Catalog cache in tests

### DIFF
--- a/tests/functional/acp_test.php
+++ b/tests/functional/acp_test.php
@@ -58,6 +58,12 @@ class phpbb_functional_acp_test extends phpbb_functional_test_case
 		// Browse all ACP submodules' modes
 		foreach ($acp_submodules as $acp_submodule)
 		{
+			// Don't click the ACP Extensions Catalog to prevent calling an external HTTP service in the test suite
+			if ($acp_submodule->getNode()->textContent === $this->lang('ACP_EXTENSIONS_CATALOG'))
+			{
+				continue;
+			}
+
 			self::$client->click($acp_submodule);
 			self::assert_response_html();
 		}

--- a/tests/functional/fixtures/files/extensions_catalog.json
+++ b/tests/functional/fixtures/files/extensions_catalog.json
@@ -1,0 +1,34 @@
+[
+	{
+		"name": "extension1\/vendor",
+		"display_name": "Extension 1",
+		"composer_name": "extension1\/vendor",
+		"version": "1.0.0",
+		"description": "Dummy extension 1 for testing.",
+		"url": "https:\/\/example.com\/extension1",
+		"authors": [
+			{
+				"name": "Author One",
+				"email": "author1@example.com",
+				"homepage": "https:\/\/author1.example.com",
+				"role": "Developer"
+			}
+		]
+	},
+	{
+		"name": "phpbb\/viglink",
+		"display_name": "VigLink",
+		"composer_name": "phpbb\/viglink",
+		"version": "dev-master",
+		"description": "The VigLink extension for phpBB makes it possible to earn revenue, without any change to the user experience, when users post and follow links to commercial sites.",
+		"url": "https:\/\/www.phpbb.com\/",
+		"authors": [
+			{
+				"name": "Author Two",
+				"email": "author2@example.com",
+				"homepage": "https:\/\/author2.example.com",
+				"role": "Developer"
+			}
+		]
+	}
+]

--- a/tests/functional/fixtures/files/extensions_catalog.json
+++ b/tests/functional/fixtures/files/extensions_catalog.json
@@ -1,32 +1,32 @@
 [
 	{
-		"name": "extension1\/vendor",
+		"name": "extension1/vendor",
 		"display_name": "Extension 1",
-		"composer_name": "extension1\/vendor",
+		"composer_name": "extension1/vendor",
 		"version": "1.0.0",
 		"description": "Dummy extension 1 for testing.",
-		"url": "https:\/\/example.com\/extension1",
+		"url": "https://example.com/extension1",
 		"authors": [
 			{
 				"name": "Author One",
 				"email": "author1@example.com",
-				"homepage": "https:\/\/author1.example.com",
+				"homepage": "https://author1.example.com",
 				"role": "Developer"
 			}
 		]
 	},
 	{
-		"name": "phpbb\/viglink",
+		"name": "phpbb/viglink",
 		"display_name": "VigLink",
-		"composer_name": "phpbb\/viglink",
+		"composer_name": "phpbb/viglink",
 		"version": "dev-master",
 		"description": "The VigLink extension for phpBB makes it possible to earn revenue, without any change to the user experience, when users post and follow links to commercial sites.",
-		"url": "https:\/\/www.phpbb.com\/",
+		"url": "https://www.phpbb.com/",
 		"authors": [
 			{
 				"name": "Author Two",
 				"email": "author2@example.com",
-				"homepage": "https:\/\/author2.example.com",
+				"homepage": "https://author2.example.com",
 				"role": "Developer"
 			}
 		]


### PR DESCRIPTION
PHPBB-17554

Checklist:

- [x] Correct branch: master for new features; 3.3.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master](https://area51.phpbb.com/docs/master/coding-guidelines.html) and [3.3.x](https://area51.phpbb.com/docs/dev/3.3.x/development/coding_guidelines.html)
- [x] Commit follows commit message [format](https://area51.phpbb.com/docs/dev/3.3.x/development/git.html)

Tracker ticket:

https://tracker.phpbb.com/browse/PHPBB-17554

**Reproduction steps**
Open `phpBB/phpbb/composer/manager.php`
Find: `$this->available_packages = $this->installer->get_available_packages($this->package_type);`
Before this line, add something like `die('no crawling');` and run the functional test suite.

Then all tests that connect to satis.phpbb.com or repo.packagist.org will fail.