### PR TITLE
[ticket/17561] Use ext-catalog for compatible extension catalog items

### DIFF
--- a/phpBB/phpbb/composer/installer.php
+++ b/phpBB/phpbb/composer/installer.php
@@ -525,6 +525,12 @@ class installer
 					}
 				}
 
+				// Check for ext-catalog in 'extra' section - must be present and set to true
+				if (!isset($extra['ext-catalog']) || $extra['ext-catalog'] !== true)
+				{
+					continue;
+				}
+
 				$compatible_packages[$package_name][] = $version;
 			}
 			catch (\Exception $e)


### PR DESCRIPTION
PHPBB-17561

Checklist:

- [ ] Correct branch: master for new features; 3.3.x for fixes
- [ ] Tests pass
- [ ] Code follows coding guidelines: [master](https://area51.phpbb.com/docs/master/coding-guidelines.html) and [3.3.x](https://area51.phpbb.com/docs/dev/3.3.x/development/coding_guidelines.html)
- [ ] Commit follows commit message [format](https://area51.phpbb.com/docs/dev/3.3.x/development/git.html)

Tracker ticket:

https://tracker.phpbb.com/browse/PHPBB-17561

This PR will warrant further discussion if this approach is the best way to address this issue. 

Also, if the extension catalog functional tests are failing right now, that means this is working (and we'll need to update the test extension to get the tests working again).