### PR TITLE
[ticket/17589] Check confirm id for QA captcha

### DIFF
--- a/phpBB/phpbb/captcha/plugins/qa.php
+++ b/phpBB/phpbb/captcha/plugins/qa.php
@@ -573,6 +573,7 @@ class qa
 		global $db, $request;
 
 		$answer = ($this->question_strict) ? $request->variable('qa_answer', '', true) : utf8_clean_string($request->variable('qa_answer', '', true));
+		$confirm_id = $request->variable('qa_confirm_id', '');
 
 		$sql = 'SELECT answer_text
 			FROM ' . $this->table_captcha_answers . '
@@ -583,7 +584,7 @@ class qa
 		{
 			$solution = ($this->question_strict) ? $row['answer_text'] : utf8_clean_string($row['answer_text']);
 
-			if ($solution === $answer)
+			if ($solution === $answer && $this->confirm_id === $confirm_id)
 			{
 				$this->solved = true;
 


### PR DESCRIPTION
When a login fails the qa captcha is reset and creates a new `confirm_id`. However, the `confirm_id` is never checked for changes causing the captcha to believe it's still solved and thus no need to generate a new captcha.

This commit checks the known `confirm_id` against the `confirm_id` given by the user, marking the captcha solved accordingly.

PHPBB-17589

Checklist:

- [x] Correct branch: master for new features; 3.3.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master](https://area51.phpbb.com/docs/master/coding-guidelines.html) and [3.3.x](https://area51.phpbb.com/docs/dev/3.3.x/development/coding_guidelines.html)
- [x] Commit follows commit message [format](https://area51.phpbb.com/docs/dev/3.3.x/development/git.html)

Tracker ticket:

https://tracker.phpbb.com/browse/PHPBB-17589
