### PR TITLE
[ticket/17580] Downloading a byte range of 8192 cause fatal errors - 2nd pull

### DIFF
--- a/phpBB/includes/functions_download.php
+++ b/phpBB/includes/functions_download.php
@@ -267,16 +267,12 @@ function send_file_to_browser($attachment, $upload_dir, $category)
 				header('Content-Range: bytes ' . $range['byte_pos_start'] . '-' . $range['byte_pos_end'] . '/' . $range['bytes_total']);
 				header('Content-Length: ' . $range['bytes_requested']);
 
-				// First read chunks
-				while (!feof($fp) && ftell($fp) <= $range['byte_pos_end'] - 8191)
+				$bytes_to_read = $range['bytes_requested'];
+				while ($bytes_to_read > 0 && !feof($fp))
 				{
-					echo fread($fp, 8192);
-				}
-				// Then, read the remainder
-				$remainder = $range['bytes_requested'] % 8192;
-				if ($remainder > 0)
-				{
-					echo fread($fp, $remainder);
+					$chunk = ($bytes_to_read > 8192) ? 8192 : $bytes_to_read;
+					echo fread($fp, $chunk);
+					$bytes_to_read -= $chunk;
 				}
 			}
 			else

--- a/phpBB/includes/functions_download.php
+++ b/phpBB/includes/functions_download.php
@@ -268,7 +268,7 @@ function send_file_to_browser($attachment, $upload_dir, $category)
 				header('Content-Length: ' . $range['bytes_requested']);
 
 				// First read chunks
-				while (!feof($fp) && ftell($fp) < $range['byte_pos_end'] - 8192)
+				while (!feof($fp) && ftell($fp) <= $range['byte_pos_end'] - 8191)
 				{
 					echo fread($fp, 8192);
 				}


### PR DESCRIPTION
This reverts commit a6356b682a79601e977efd90f122468f966abe51.

The `$range['byte_pos_end']` variable is inclusive of the byte range. By using `$range['byte_pos_end'] - 8191` gives a total of 8192 bytes from the end. If the file pointer is further from (less than) or equal to 8192 bytes from the end then there is enough data to read a 8192 byte chunk.
```php
while (!feof($fp) && ftell($fp) <= $range['byte_pos_end'] - 8191)
```


Checklist:

- [x] Correct branch: master for new features; 3.3.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master](https://area51.phpbb.com/docs/master/coding-guidelines.html) and [3.3.x](https://area51.phpbb.com/docs/dev/3.3.x/development/coding_guidelines.html)
- [x] Commit follows commit message [format](https://area51.phpbb.com/docs/dev/3.3.x/development/git.html)

Tracker ticket:

https://tracker.phpbb.com/browse/PHPBB-17580
