### PR TITLE
[ticket/17640] Add events to acp_groups allowing custom quick actions

### DIFF
--- a/phpBB/includes/acp/acp_groups.php
+++ b/phpBB/includes/acp/acp_groups.php
@@ -881,6 +881,20 @@ class acp_groups
 				$s_action_options = '';
 				$options = array('default' => 'DEFAULT', 'approve' => 'APPROVE', 'demote' => 'DEMOTE', 'promote' => 'PROMOTE', 'deleteusers' => 'DELETE');
 
+				/**
+				 * Modify the list of available quick actions for a group.
+				 *
+				 * @event core.acp_manage_group_action_options_before
+				 * @var	int		group_id	The current group ID.
+				 * @var array	options		An array of HTML for the action select element.
+				 * @since 3.3.16-b3
+				 */
+				$vars = array(
+					'group_id',
+					'options',
+				);
+				extract($phpbb_dispatcher->trigger_event('core.acp_manage_group_action_options_before', compact($vars)));
+
 				foreach ($options as $option => $lang)
 				{
 					$s_action_options .= '<option value="' . $option . '">' . $user->lang['GROUP_' . $lang] . '</option>';
@@ -938,6 +952,22 @@ class acp_groups
 				$db->sql_freeresult($result);
 
 				return;
+			break;
+
+			default:
+				/**
+				 * Handle any unspecified action for groups.
+				 *
+				 * @event core.acp_manage_group_default_action
+				 * @var	string	action				The current action.
+				 * @var	int		group_id			The current group ID.
+				 * @since 3.3.16-b3
+				 */
+				$vars = array(
+					'action',
+					'group_id',
+				);
+				extract($phpbb_dispatcher->trigger_event('core.acp_manage_group_default_action', compact($vars)));
 			break;
 		}
 

--- a/phpBB/includes/acp/acp_groups.php
+++ b/phpBB/includes/acp/acp_groups.php
@@ -887,7 +887,7 @@ class acp_groups
 				 * @event core.acp_manage_group_action_options_before
 				 * @var	int		group_id	The current group ID.
 				 * @var array	options		An array of HTML for the action select element.
-				 * @since 3.3.16-b3
+				 * @since 3.3.18-RC1
 				 */
 				$vars = array(
 					'group_id',
@@ -961,7 +961,7 @@ class acp_groups
 				 * @event core.acp_manage_group_default_action
 				 * @var	string	action				The current action.
 				 * @var	int		group_id			The current group ID.
-				 * @since 3.3.16-b3
+				 * @since 3.3.18-RC1
 				 */
 				$vars = array(
 					'action',


### PR DESCRIPTION
Add two new php events that allow extension authors to create a custom quick action which can be used when viewing the group member page within the ACP.

Checklist:

- [X] Correct branch: master for new features; 3.3.x for fixes
- [x] Tests pass
- [X] Code follows coding guidelines: [master](https://area51.phpbb.com/docs/master/coding-guidelines.html) and [3.3.x](https://area51.phpbb.com/docs/dev/3.3.x/development/coding_guidelines.html)
- [X] Commit follows commit message [format](https://area51.phpbb.com/docs/dev/3.3.x/development/git.html)

Tracker ticket:

https://tracker.phpbb.com/browse/PHPBB-17640
