### PR TITLE
[ticket/17660] Add allowed_classes => false to unserialize() to prevent PHP Object Injection

### DIFF
--- a/phpBB/includes/functions_display.php
+++ b/phpBB/includes/functions_display.php
@@ -880,7 +880,7 @@ function get_forum_parents(&$forum_data)
 		}
 		else
 		{
-			$forum_parents = unserialize($forum_data['forum_parents']);
+			$forum_parents = unserialize($forum_data['forum_parents'], ['allowed_classes' => false]);
 		}
 	}
 

--- a/phpBB/phpbb/extension/manager.php
+++ b/phpBB/phpbb/extension/manager.php
@@ -218,7 +218,7 @@ class manager
 			return false;
 		}
 
-		$old_state = (isset($this->extensions[$name]['ext_state'])) ? unserialize($this->extensions[$name]['ext_state']) : false;
+		$old_state = (isset($this->extensions[$name]['ext_state'])) ? unserialize($this->extensions[$name]['ext_state'], ['allowed_classes' => false]) : false;
 
 		$extension = $this->get_extension($name);
 
@@ -278,7 +278,7 @@ class manager
 			return false;
 		}
 
-		$old_state = unserialize($this->extensions[$name]['ext_state']);
+		$old_state = unserialize($this->extensions[$name]['ext_state'], ['allowed_classes' => false]);
 
 		$extension = $this->get_extension($name);
 		$state = $extension->disable_step($old_state);
@@ -330,7 +330,7 @@ class manager
 			$this->disable($name);
 		}
 
-		$old_state = unserialize($this->extensions[$name]['ext_state']);
+		$old_state = unserialize($this->extensions[$name]['ext_state'], ['allowed_classes' => false]);
 
 		$extension = $this->get_extension($name);
 		$state = $extension->purge_step($old_state);

--- a/phpBB/phpbb/notification/type/base.php
+++ b/phpBB/phpbb/notification/type/base.php
@@ -136,7 +136,7 @@ abstract class base implements \phpbb\notification\type\type_interface
 	{
 		// The row from the database (unless this is a new notification we're going to add)
 		$this->data = $data;
-		$this->data['notification_data'] = !empty($this->data['notification_data']) ? unserialize($this->data['notification_data']) : [];
+		$this->data['notification_data'] = !empty($this->data['notification_data']) ? unserialize($this->data['notification_data'], ['allowed_classes' => false]) : [];
 	}
 
 	/**

--- a/phpBB/phpbb/textreparser/manager.php
+++ b/phpBB/phpbb/textreparser/manager.php
@@ -61,7 +61,7 @@ class manager
 		if ($this->resume_data === null)
 		{
 			$resume_data = $this->config_text->get('reparser_resume');
-			$this->resume_data = !empty($resume_data) ? unserialize($resume_data) : array();
+			$this->resume_data = !empty($resume_data) ? unserialize($resume_data, ['allowed_classes' => false]) : array();
 		}
 
 		return isset($this->resume_data[$name]) ? $this->resume_data[$name] : array();


### PR DESCRIPTION
## Summary

Defence-in-depth hardening: add `allowed_classes => false` to `unserialize()` calls where only plain arrays are expected.

### Changed files

- `phpbb/notification/type/base.php` — notification_data stores arrays of scalar values only
- `phpbb/extension/manager.php` — ext_state stores arrays of progress/state data only
- `phpbb/textreparser/manager.php` — reparser_resume stores array of int pairs only
- `includes/functions_display.php` — forum_parents stores nested array of forum ancestor data only

### Security benefit

Restricting `allowed_classes` prevents PHP Object Injection gadget chains if an attacker can write to the relevant DB tables. This is standard defensive coding practice, not a fix for an active exploit.

### Notes

- No functional change — all deserialized values are plain arrays, no class instances
- Compatible with PHP 7.0+
- Follows PHP security best practices