### PR TITLE
[ticket/17652] Use adm relative path instead of hardcoded adm path

### DIFF
--- a/phpBB/includes/acp/acp_extensions.php
+++ b/phpBB/includes/acp/acp_extensions.php
@@ -42,7 +42,7 @@ class acp_extensions
 	function main($id, $mode)
 	{
 		// Start the page
-		global $config, $user, $template, $request, $phpbb_extension_manager, $phpbb_root_path, $phpbb_log, $phpbb_dispatcher, $phpbb_container;
+		global $config, $user, $template, $request, $phpbb_extension_manager, $phpbb_admin_path, $phpbb_root_path, $phpbb_log, $phpbb_dispatcher, $phpbb_container;
 
 		$this->config = $config;
 		$this->template = $template;
@@ -224,7 +224,7 @@ class acp_extensions
 							'name' 		=> 'adm',
 							'ext_path' 	=> 'adm/style/',
 						),
-					), array($phpbb_root_path . 'adm/style'));
+					), $phpbb_admin_path . 'style');
 
 					$this->log->add('admin', $this->user->data['user_id'], $this->user->ip, 'LOG_EXT_ENABLE', time(), array($ext_name));
 				}


### PR DESCRIPTION
set_custom_style() in acp_extensions used a hardcoded 'adm/style' path for the admin area's custom style, which broke style loading on boards that have renamed their ACP directory. Use $phpbb_adm_relative_path so the correct admin folder is resolved regardless of its name.

PHPBB3-17652

Checklist:

- [x ] Correct branch: master for new features; 3.3.x for fixes
- [x] Tests pass
- [x ] Code follows coding guidelines: [master](https://area51.phpbb.com/docs/master/coding-guidelines.html) and [3.3.x](https://area51.phpbb.com/docs/dev/3.3.x/development/coding_guidelines.html)
- [x ] Commit follows commit message [format](https://area51.phpbb.com/docs/dev/3.3.x/development/git.html)

Tracker ticket:

https://tracker.phpbb.com/browse/PHPBB-17652
