### PR TITLE
[ticket/17607] Add missing COULD_NOT_COPY language key

### DIFF
--- a/phpBB/language/en/install.php
+++ b/phpBB/language/en/install.php
@@ -496,6 +496,7 @@ $lang = array_merge($lang, array(
 	// Common converter messages
 	'CONVERT_NOT_EXIST'			=> 'The specified convertor does not exist.',
 	'DEV_NO_TEST_FILE'			=> 'No value has been specified for the test_file variable in the convertor. If you are a user of this convertor, you should not be seeing this error, please report this message to the convertor author. If you are a convertor author, you must specify the name of a file which exists in the source board to allow the path to it to be verified.',
+	'COULD_NOT_COPY'			=> 'Could not copy file <strong>%1$s</strong> to <strong>%2$s</strong><br><br>Please check that the target directory exists and is writable by the webserver.',
 	'COULD_NOT_FIND_PATH'		=> 'Could not find path to your former board. Please check your settings and try again.<br />» %s was specified as the source path.',
 	'CONFIG_PHPBB_EMPTY'		=> 'The phpBB3 config variable for “%s” is empty.',
 


### PR DESCRIPTION
The convertor's `copy_file()` (`includes/functions_convert.php`) calls `sprintf($user->lang['COULD_NOT_COPY'], ...)` when a file copy fails during a board conversion, but the `COULD_NOT_COPY` key was missing from `language/en/install.php`, producing a broken/empty error message. This restores it.

Checklist:

- [x] Correct branch: 3.3.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines
- [x] Commit follows commit message format

Tracker ticket:

https://tracker.phpbb.com/browse/PHPBB-17607
