### PR TITLE
[ticket/17134] Strip non-hex characters from bbcode uid before base_convert

### DIFF
--- a/phpBB/includes/functions_convert.php
+++ b/phpBB/includes/functions_convert.php
@@ -223,7 +223,8 @@ function make_uid($timestamp)
 
 	if (empty($last_timestamp) || $timestamp != $last_timestamp)
 	{
-		$last_uid = substr(base_convert(unique_id(), 16, 36), 0, BBCODE_UID_LEN);
+		$unique_id = preg_replace('/[^0-9a-f]/', '', unique_id());
+		$last_uid = substr(base_convert($unique_id, 16, 36), 0, BBCODE_UID_LEN);
 	}
 	$last_timestamp = $timestamp;
 	return $last_uid;

--- a/phpBB/includes/message_parser.php
+++ b/phpBB/includes/message_parser.php
@@ -1115,7 +1115,8 @@ class parse_message extends bbcode_firstpass
 	function __construct($message = '')
 	{
 		// Init BBCode UID
-		$this->bbcode_uid = substr(base_convert(unique_id(), 16, 36), 0, BBCODE_UID_LEN);
+		$unique_id = preg_replace('/[^0-9a-f]/', '', unique_id());
+		$this->bbcode_uid = substr(base_convert($unique_id, 16, 36), 0, BBCODE_UID_LEN);
 		$this->message = $message;
 	}
 


### PR DESCRIPTION
Since PHP 7.4, `base_convert()` emits `Deprecated: Invalid characters passed for attempted conversion` when the input contains characters invalid for the source base. `unique_id()` returns an alphanumeric (`a-z0-9`) string, but it is passed to `base_convert(..., 16, 36)`, which only accepts hex (`0-9a-f`), so the `g-z` characters trigger the deprecation.

The `message_parser.php` occurrence listed in the ticket was already fixed in 4.0.0-a1 by commit [`daf30b89`](https://github.com/phpbb/phpbb/commit/daf30b89f133aee0beb09d6bd1d00decc471ba46), but that fix did not cover the other call site and was never back-ported to `3.3.x`. The `functions_convert.php` occurrence remains present in 3.3.x, 4.0.0-a1 and 4.0.0-a2, and is fixed here.

This completes PHPBB-17134 by:
- applying the same guard to the remaining unguarded call in `functions_convert.php` (`make_uid()`);
- back-porting the `message_parser.php` guard to `3.3.x`.

The guard strips the input to valid hex before conversion; output shape is unchanged (8-char base-36 string), so the change is behaviour-preserving. `master` already carries the identical `message_parser` guard, so this branch converges cleanly on up-merge.

Checklist:

- [x] Correct branch: 3.3.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines
- [x] Commit follows commit message format

Tracker ticket:

https://tracker.phpbb.com/browse/PHPBB-17134
