### PR TITLE
[ticket/13446] Notify users by email on password and email changes

### DIFF
--- a/phpBB/includes/ucp/ucp_profile.php
+++ b/phpBB/includes/ucp/ucp_profile.php
@@ -180,6 +180,20 @@ class ucp_profile
 								$user->data['user_email'],
 								$data['email']
 							));
+
+							// Notify the previous email address that the account's email has been changed
+							if ($config['email_enable'])
+							{
+								$email_method = $phpbb_container->get('messenger.method.email');
+								$email_method->template('email_changed', $user->data['user_lang']);
+								$email_method->to($user->data['user_email'], $user->data['username']);
+								$email_method->anti_abuse_headers($config, $user);
+								$email_method->assign_vars([
+									'USERNAME'	=> html_entity_decode($user->data['username'], ENT_COMPAT),
+									'NEW_EMAIL'	=> html_entity_decode($data['email'], ENT_COMPAT),
+								]);
+								$email_method->send();
+							}
 						}
 
 						$message = 'PROFILE_UPDATED';

--- a/phpBB/includes/ucp/ucp_profile.php
+++ b/phpBB/includes/ucp/ucp_profile.php
@@ -157,6 +157,19 @@ class ucp_profile
 								'reportee_id' => $user->data['user_id'],
 								$user->data['username']
 							));
+
+							// Notify the account holder by email that their password has been changed
+							if ($config['email_enable'])
+							{
+								$email_method = $phpbb_container->get('messenger.method.email');
+								$email_method->template('password_changed', $user->data['user_lang']);
+								$email_method->to($user->data['user_email'], $user->data['username']);
+								$email_method->anti_abuse_headers($config, $user);
+								$email_method->assign_vars([
+									'USERNAME'	=> html_entity_decode($user->data['username'], ENT_COMPAT),
+								]);
+								$email_method->send();
+							}
 						}
 
 						if ($auth->acl_get('u_chgemail') && $data['email'] != $user->data['user_email'])

--- a/phpBB/language/en/email/email_changed.txt
+++ b/phpBB/language/en/email/email_changed.txt
@@ -1,0 +1,13 @@
+Subject: The email address on your account has been changed
+
+Hello {USERNAME},
+
+This is a confirmation that the email address associated with your account on "{SITENAME}" has just been changed to {NEW_EMAIL}.
+
+This message has been sent to your previous email address.
+
+If you made this change, no further action is required.
+
+If you did not change your email address, your account may have been compromised. Please contact the board administrator immediately.
+
+{EMAIL_SIG}

--- a/phpBB/language/en/email/password_changed.txt
+++ b/phpBB/language/en/email/password_changed.txt
@@ -1,0 +1,11 @@
+Subject: Your password has been changed
+
+Hello {USERNAME},
+
+This is a confirmation that the password for your account on "{SITENAME}" has just been changed.
+
+If you made this change, no further action is required.
+
+If you did not change your password, your account may have been compromised. Please reset your password immediately and contact the board administrator.
+
+{EMAIL_SIG}

--- a/tests/email/email_parsing_test.php
+++ b/tests/email/email_parsing_test.php
@@ -215,4 +215,30 @@ class phpbb_email_parsing_test extends phpbb_test_case
 		$this->assertStringNotContainsString('USERNAME', $msg);
 		$this->assertStringNotContainsString('EMAIL_SIG', $msg);
 	}
+
+	public function test_email_changed_email()
+	{
+		global $config, $user;
+
+		$this->email->set_addresses($user->data);
+
+		$this->email->assign_vars(array(
+			'EMAIL_SIG'	=> str_replace('<br />', "\n", "-- \n" . html_entity_decode($config['board_email_sig'], ENT_COMPAT)),
+			'SITENAME'	=> html_entity_decode($config['sitename'], ENT_COMPAT),
+			'USERNAME'	=> 'Test user',
+			'NEW_EMAIL'	=> 'new.address@example.com',
+		));
+		$this->email->template('email_changed', $user->data['user_lang'], '', '');
+
+		$reflection_template = $this->reflection_template_property->getValue($this->email);
+		$msg = trim($reflection_template->assign_display('body'));
+
+		$this->assertStringContainsString('Test user', $msg);
+		$this->assertStringContainsString('new.address@example.com', $msg);
+		$this->assertStringContainsString(html_entity_decode($config['sitename'], ENT_COMPAT), $msg);
+		$this->assertStringContainsString('has just been changed', $msg);
+		$this->assertStringContainsString(str_replace('<br />', "\n", "-- \n" . html_entity_decode($config['board_email_sig'], ENT_COMPAT)), $msg);
+		$this->assertStringNotContainsString('NEW_EMAIL', $msg);
+		$this->assertStringNotContainsString('EMAIL_SIG', $msg);
+	}
 }

--- a/tests/email/email_parsing_test.php
+++ b/tests/email/email_parsing_test.php
@@ -191,4 +191,28 @@ class phpbb_email_parsing_test extends phpbb_test_case
 		$this->assertStringNotContainsString('EMAIL_SIG', $msg);
 		$this->assertStringNotContainsString('U_STOP_WATCHING_FORUM', $msg);
 	}
+
+	public function test_password_changed_email()
+	{
+		global $config, $user;
+
+		$this->email->set_addresses($user->data);
+
+		$this->email->assign_vars(array(
+			'EMAIL_SIG'	=> str_replace('<br />', "\n", "-- \n" . html_entity_decode($config['board_email_sig'], ENT_COMPAT)),
+			'SITENAME'	=> html_entity_decode($config['sitename'], ENT_COMPAT),
+			'USERNAME'	=> 'Test user',
+		));
+		$this->email->template('password_changed', $user->data['user_lang'], '', '');
+
+		$reflection_template = $this->reflection_template_property->getValue($this->email);
+		$msg = trim($reflection_template->assign_display('body'));
+
+		$this->assertStringContainsString('Test user', $msg);
+		$this->assertStringContainsString(html_entity_decode($config['sitename'], ENT_COMPAT), $msg);
+		$this->assertStringContainsString('has just been changed', $msg);
+		$this->assertStringContainsString(str_replace('<br />', "\n", "-- \n" . html_entity_decode($config['board_email_sig'], ENT_COMPAT)), $msg);
+		$this->assertStringNotContainsString('USERNAME', $msg);
+		$this->assertStringNotContainsString('EMAIL_SIG', $msg);
+	}
 }

--- a/tests/functional/ucp_profile_test.php
+++ b/tests/functional/ucp_profile_test.php
@@ -105,6 +105,49 @@ class phpbb_functional_ucp_profile_test extends phpbb_functional_test_case
 		$this->db->sql_query($sql);
 	}
 
+	public function test_changing_email_notifies_old_address()
+	{
+		$this->add_lang('ucp');
+		$this->login();
+
+		// Disable the MX-record check so the test does not depend on DNS, and
+		// remember the original value to restore it afterwards.
+		$result = $this->db->sql_query('SELECT config_value FROM ' . CONFIG_TABLE . "
+			WHERE config_name = 'email_check_mx'");
+		$original_check_mx = $this->db->sql_fetchfield('config_value');
+		$this->db->sql_freeresult($result);
+		$this->db->sql_query('UPDATE ' . CONFIG_TABLE . "
+			SET config_value = '0'
+			WHERE config_name = 'email_check_mx'");
+		$this->purge_cache();
+
+		// The default board require_activation is "none", so the email change
+		// applies immediately and the email-changed notice is sent to the old
+		// address. Capture the original email to restore it afterwards.
+		$crawler = self::request('GET', 'ucp.php?i=ucp_profile&mode=reg_details');
+		$form = $crawler->selectButton('submit')->form();
+		$original_email = $form->get('email')->getValue();
+
+		$form['cur_password'] = 'adminadmin';
+		$form['email'] = 'changed.address@example.com';
+		$crawler = self::submit($form);
+		$this->assertContainsLang('PROFILE_UPDATED', $crawler->filter('#message')->text());
+
+		// Restore the original email and MX-check setting so the shared board
+		// state is left unchanged for the rest of the suite.
+		$crawler = self::request('GET', 'ucp.php?i=ucp_profile&mode=reg_details');
+		$form = $crawler->selectButton('submit')->form();
+		$form['cur_password'] = 'adminadmin';
+		$form['email'] = $original_email;
+		$crawler = self::submit($form);
+		$this->assertContainsLang('PROFILE_UPDATED', $crawler->filter('#message')->text());
+
+		$this->db->sql_query('UPDATE ' . CONFIG_TABLE . "
+			SET config_value = '" . $this->db->sql_escape($original_check_mx) . "'
+			WHERE config_name = 'email_check_mx'");
+		$this->purge_cache();
+	}
+
 	public function test_autologin_keys_manage()
 	{
 		$this->add_lang('ucp');

--- a/tests/functional/ucp_profile_test.php
+++ b/tests/functional/ucp_profile_test.php
@@ -133,14 +133,14 @@ class phpbb_functional_ucp_profile_test extends phpbb_functional_test_case
 		$crawler = self::submit($form);
 		$this->assertContainsLang('PROFILE_UPDATED', $crawler->filter('#message')->text());
 
-		// Restore the original email and MX-check setting so the shared board
-		// state is left unchanged for the rest of the suite.
-		$crawler = self::request('GET', 'ucp.php?i=ucp_profile&mode=reg_details');
-		$form = $crawler->selectButton('submit')->form();
-		$form['cur_password'] = 'adminadmin';
-		$form['email'] = $original_email;
-		$crawler = self::submit($form);
-		$this->assertContainsLang('PROFILE_UPDATED', $crawler->filter('#message')->text());
+		// Restore the original email directly. Restoring it through the UCP
+		// form would fail with EMAIL_TAKEN whenever earlier tests in the suite
+		// have created users through create_user(), whose default address is
+		// the same nobody@example.com the admin account is installed with.
+		$sql = 'UPDATE ' . USERS_TABLE . "
+			SET user_email = '" . $this->db->sql_escape($original_email) . "'
+			WHERE username_clean = 'admin'";
+		$this->db->sql_query($sql);
 
 		$this->db->sql_query('UPDATE ' . CONFIG_TABLE . "
 			SET config_value = '" . $this->db->sql_escape($original_check_mx) . "'

--- a/tests/functional/ucp_profile_test.php
+++ b/tests/functional/ucp_profile_test.php
@@ -69,6 +69,42 @@ class phpbb_functional_ucp_profile_test extends phpbb_functional_test_case
 		$this->assertEquals('😁', $form->get('pf_phpbb_location')->getValue());
 	}
 
+	public function test_changing_password_sends_email()
+	{
+		$this->add_lang('ucp');
+		$this->login();
+
+		// Capture the original password hash. The board's password-complexity
+		// rules do not allow changing back to the install default through the
+		// UCP form, so it is restored directly afterwards to keep the shared
+		// admin account usable by the rest of the suite.
+		$sql = 'SELECT user_id, user_password
+			FROM ' . USERS_TABLE . "
+			WHERE username_clean = 'admin'";
+		$result = $this->db->sql_query($sql);
+		$row = $this->db->sql_fetchrow($result);
+		$this->db->sql_freeresult($result);
+
+		// Change the password. Board email is enabled in the test board, so
+		// this exercises the new password-changed confirmation email send.
+		$crawler = self::request('GET', 'ucp.php?i=ucp_profile&mode=reg_details');
+		$this->assertContainsLang('UCP_PROFILE_REG_DETAILS', $crawler->filter('#cp-main h2')->text());
+
+		$form = $crawler->selectButton('submit')->form(array(
+			'cur_password'		=> 'adminadmin',
+			'new_password'		=> 'AdminAdmin1',
+			'password_confirm'	=> 'AdminAdmin1',
+		));
+		$crawler = self::submit($form);
+		$this->assertContainsLang('PROFILE_UPDATED', $crawler->filter('#message')->text());
+
+		// Restore the original password hash for the rest of the suite.
+		$sql = 'UPDATE ' . USERS_TABLE . "
+			SET user_password = '" . $this->db->sql_escape($row['user_password']) . "'
+			WHERE user_id = " . (int) $row['user_id'];
+		$this->db->sql_query($sql);
+	}
+
 	public function test_autologin_keys_manage()
 	{
 		$this->add_lang('ucp');


### PR DESCRIPTION
This addresses PHPBB-13446 by adding account-security email notifications when a user changes their password or email address from the UCP.

**What it does**

- **Password change** – sends a confirmation email to the account holder's address on file, advising them to reset their password and contact the administrator if they did not make the change.
- **Email change** – sends a notification to the **previous** email address whenever the account email is changed, in both the immediate and activation-required paths. phpBB's existing new-email verification (account deactivation + reactivation via the activation link sent to the new address) is unchanged and continues to serve as the verification step.

Both emails are gated by the board `email_enable` setting and follow the existing direct-messenger pattern already used for account-activation and password-reset mails, via new templates `password_changed.txt` and `email_changed.txt`.

**Notes for reviewers**

- The notifications are not behind a separate admin toggle, consistent with phpBB's other non-optional account emails (activation, forgot-password). Happy to add a config setting + migration if preferred.

Checklist:

- [x] Correct branch: master for new features; 3.3.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master](https://area51.phpbb.com/docs/master/coding-guidelines.html) and [3.3.x](https://area51.phpbb.com/docs/dev/3.3.x/development/coding_guidelines.html)
- [x] Commit follows commit message [format](https://area51.phpbb.com/docs/dev/3.3.x/development/git.html)

Tracker ticket:

https://tracker.phpbb.com/browse/PHPBB-13446
