### PR TITLE
[ticket/17550] Log uncaught server errors to the PHP error log

### DIFF
--- a/phpBB/phpbb/event/kernel_exception_subscriber.php
+++ b/phpBB/phpbb/event/kernel_exception_subscriber.php
@@ -142,6 +142,20 @@ class kernel_exception_subscriber implements EventSubscriberInterface
 			$response->headers->add($exception->getHeaders());
 		}
 
+		// Log server errors (HTTP 5xx) to the PHP error log so they can be
+		// diagnosed. Client errors such as 404 or 403 are expected and are not
+		// logged, to avoid noise.
+		if ($response->getStatusCode() >= 500)
+		{
+			error_log(sprintf(
+				'%s: %s in %s on line %d',
+				get_class($exception),
+				$exception->getMessage(),
+				$exception->getFile(),
+				$exception->getLine()
+			) . "\n" . $exception->getTraceAsString());
+		}
+
 		$event->setResponse($response);
 	}
 

--- a/tests/event/exception_listener_test.php
+++ b/tests/event/exception_listener_test.php
@@ -13,6 +13,35 @@
 
 class exception_listener_test extends phpbb_test_case
 {
+	/** @var string */
+	protected $error_log_file;
+
+	/** @var string */
+	protected $original_error_log;
+
+	protected function setUp(): void
+	{
+		parent::setUp();
+
+		// Redirect error_log() to a temporary file so logged exceptions can be
+		// asserted and do not leak to stderr during the test run.
+		$this->error_log_file = tempnam(sys_get_temp_dir(), 'phpbb_exception_log_');
+		$this->original_error_log = ini_get('error_log');
+		ini_set('error_log', $this->error_log_file);
+	}
+
+	protected function tearDown(): void
+	{
+		ini_set('error_log', $this->original_error_log);
+
+		if (file_exists($this->error_log_file))
+		{
+			unlink($this->error_log_file);
+		}
+
+		parent::tearDown();
+	}
+
 	public static function phpbb_exception_data()
 	{
 		return array(
@@ -97,5 +126,44 @@ class exception_listener_test extends phpbb_test_case
 		{
 			$this->assertStringContainsString($expected['content'], $response->getContent());
 		}
+	}
+
+	protected function dispatch_exception($exception)
+	{
+		$request = \Symfony\Component\HttpFoundation\Request::create('test.php', 'GET', array(), array(), array(), array('HTTP_X_REQUESTED_WITH' => 'XMLHttpRequest'));
+
+		$template = $this->getMockBuilder('\phpbb\template\twig\twig')
+			->disableOriginalConstructor()
+			->getMock();
+
+		global $phpbb_root_path, $phpEx;
+
+		$lang_loader = new \phpbb\language\language_file_loader($phpbb_root_path, $phpEx);
+		$lang = new \phpbb\language\language($lang_loader);
+		$user = new \phpbb\user($lang, '\phpbb\datetime');
+
+		$exception_listener = new \phpbb\event\kernel_exception_subscriber($template, $lang, $user);
+
+		$event = new \Symfony\Component\HttpKernel\Event\ExceptionEvent($this->createMock('Symfony\Component\HttpKernel\HttpKernelInterface'), $request, \Symfony\Component\HttpKernel\HttpKernelInterface::MAIN_REQUEST, $exception);
+		$exception_listener->on_kernel_exception($event);
+	}
+
+	public function test_server_error_is_logged()
+	{
+		$this->dispatch_exception(new \Exception('Something went very wrong'));
+
+		$logged = file_get_contents($this->error_log_file);
+
+		$this->assertStringContainsString('Exception: Something went very wrong', $logged);
+		$this->assertStringContainsString('on line', $logged);
+	}
+
+	public function test_client_error_is_not_logged()
+	{
+		$this->dispatch_exception(new \Symfony\Component\HttpKernel\Exception\HttpException(404, 'This must not be logged'));
+
+		$logged = file_get_contents($this->error_log_file);
+
+		$this->assertStringNotContainsString('This must not be logged', $logged);
 	}
 }


### PR DESCRIPTION
Uncaught exceptions that result in an HTTP 500 response were rendered as the generic error page but were never logged anywhere, so they could not be diagnosed (PHPBB-17550).

This logs server errors (HTTP 5xx) from `kernel_exception_subscriber` to the PHP error log, including the exception message and stack trace. Client errors such as 404/403 are intentionally not logged, to avoid noise. `error_log()` is used rather than the database-backed log because the database may itself be unavailable during a 500.

Note: the same gap exists in the analogous 3.3.x exception subscriber. I've targeted master because the ticket is filed against 4.0.0-a1 and the symptom is the Symfony 4.x error page, but I'm happy to provide a 3.3.x backport if the team prefers.

Checklist:

- [x] Correct branch: master for new features; 3.3.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master](https://area51.phpbb.com/docs/master/coding-guidelines.html) and [3.3.x](https://area51.phpbb.com/docs/dev/3.3.x/development/coding_guidelines.html)
- [x] Commit follows commit message [format](https://area51.phpbb.com/docs/dev/3.3.x/development/git.html)

Tracker ticket:

https://tracker.phpbb.com/browse/PHPBB-17550
