### PR TITLE
[ticket/17608] Use the storage system when importing attachments and avatars

### DIFF
--- a/phpBB/includes/functions_convert.php
+++ b/phpBB/includes/functions_convert.php
@@ -585,6 +585,7 @@ function _import_check($config_var, $source, $use_target)
 	// (ranks, smilies, ...) are not storage-backed and keep using copy_file().
 	$storage_services = array(
 		'upload_path'	=> 'storage.attachment',
+		'avatar_path'	=> 'storage.avatar',
 	);
 
 	$use_storage = isset($storage_services[$config_var]);

--- a/phpBB/includes/functions_convert.php
+++ b/phpBB/includes/functions_convert.php
@@ -446,16 +446,88 @@ function import_avatar_gallery($gallery_name = '', $subdirs_as_galleries = false
 	}
 }
 
+/**
+* Copy a file into the storage system.
+*
+* @param \phpbb\storage\storage	$storage	Storage to write the file to
+* @param string					$source		Absolute path of the source file
+* @param string					$target		Target path relative to the storage root
+* @return bool	Whether the file is present in the storage afterwards
+*/
+function _copy_file_to_storage(\phpbb\storage\storage $storage, $source, $target)
+{
+	// A file that is already stored is treated as successfully copied, mirroring
+	// the non-overwriting behaviour of copy_file().
+	if ($storage->exists($target))
+	{
+		return true;
+	}
+
+	$fp = @fopen($source, 'rb');
+
+	if ($fp === false)
+	{
+		return false;
+	}
+
+	try
+	{
+		$storage->write($target, $fp);
+		$copied = true;
+	}
+	catch (\phpbb\storage\exception\storage_exception $e)
+	{
+		$copied = false;
+	}
+
+	fclose($fp);
+
+	return $copied;
+}
+
+/**
+* Recursively copy the contents of a directory into the storage system.
+*
+* @param \phpbb\storage\storage	$storage		Storage to write the files to
+* @param string					$source_dir		Absolute path of the source directory
+* @param string					$target_dir		Target directory relative to the storage root
+* @return void
+*/
+function _copy_dir_to_storage(\phpbb\storage\storage $storage, $source_dir, $target_dir = '')
+{
+	$source_dir = rtrim($source_dir, '/') . '/';
+	$target_dir = ($target_dir !== '') ? rtrim($target_dir, '/') . '/' : '';
+
+	$handle = @opendir($source_dir);
+
+	if ($handle === false)
+	{
+		return;
+	}
+
+	while (($entry = readdir($handle)) !== false)
+	{
+		if ($entry === '.' || $entry === '..')
+		{
+			continue;
+		}
+
+		if (is_dir($source_dir . $entry))
+		{
+			_copy_dir_to_storage($storage, $source_dir . $entry, $target_dir . $entry);
+		}
+		else if (is_file($source_dir . $entry))
+		{
+			_copy_file_to_storage($storage, $source_dir . $entry, $target_dir . $entry);
+		}
+	}
+
+	closedir($handle);
+}
+
 function import_attachment_files($category_name = '')
 {
-	global $config, $convert, $db, $user;
-
-	$sql = 'SELECT config_value AS upload_path
-		FROM ' . CONFIG_TABLE . "
-		WHERE config_name = 'storage\\attachment\\config\\path'";
-	$result = $db->sql_query($sql);
-	$config['upload_path'] = $db->sql_fetchfield('upload_path');
-	$db->sql_freeresult($result);
+	global $convert, $user, $phpbb_container;
 
 	$relative_path = empty($convert->convertor['source_path_absolute']);
 
@@ -464,9 +536,11 @@ function import_attachment_files($category_name = '')
 		$convert->p_master->error(sprintf($user->lang['CONV_ERROR_NO_UPLOAD_DIR'], 'import_attachment_files()'), __LINE__, __FILE__);
 	}
 
-	if (is_dir(relative_base(path($convert->convertor['upload_path'], $relative_path), $relative_path)))
+	$source_dir = relative_base(path($convert->convertor['upload_path'], $relative_path), $relative_path);
+
+	if (is_dir($source_dir))
 	{
-		copy_dir($convert->convertor['upload_path'], path($config['upload_path']) . $category_name, true, false, true, $relative_path);
+		_copy_dir_to_storage($phpbb_container->get('storage.attachment'), $source_dir, $category_name);
 	}
 }
 
@@ -504,7 +578,16 @@ function base64_unpack($string)
 
 function _import_check($config_var, $source, $use_target)
 {
-	global $convert, $config;
+	global $convert, $config, $phpbb_container;
+
+	// Asset types that are managed by the storage system are written through it
+	// instead of being copied to a fixed path on the local disk. Other types
+	// (ranks, smilies, ...) are not storage-backed and keep using copy_file().
+	$storage_services = array(
+		'upload_path'	=> 'storage.attachment',
+	);
+
+	$use_storage = isset($storage_services[$config_var]);
 
 	$result = array(
 		'orig_source'	=> $source,
@@ -512,8 +595,10 @@ function _import_check($config_var, $source, $use_target)
 		'relative_path'	=> (empty($convert->convertor['source_path_absolute'])) ? true : false,
 	);
 
-	// copy file will prepend $phpBB_root_path
-	$target = $config[$config_var] . '/' . utf8_basename(($use_target === false) ? $source : $use_target);
+	$filename = utf8_basename(($use_target === false) ? $source : $use_target);
+
+	// copy_file will prepend $phpbb_root_path; storage paths are relative to the storage root
+	$target = ($use_storage) ? $filename : $config[$config_var] . '/' . $filename;
 
 	if (!empty($convert->convertor[$config_var]) && strpos($source, $convert->convertor[$config_var]) !== 0)
 	{
@@ -522,9 +607,18 @@ function _import_check($config_var, $source, $use_target)
 
 	$result['source'] = $source;
 
-	if (file_exists(relative_base($source, $result['relative_path'], __LINE__, __FILE__)))
+	$source_path = relative_base($source, $result['relative_path'], __LINE__, __FILE__);
+
+	if (file_exists($source_path))
 	{
-		$result['copied'] = copy_file($source, $target, false, false, $result['relative_path']);
+		if ($use_storage)
+		{
+			$result['copied'] = _copy_file_to_storage($phpbb_container->get($storage_services[$config_var]), $source_path, $target);
+		}
+		else
+		{
+			$result['copied'] = copy_file($source, $target, false, false, $result['relative_path']);
+		}
 	}
 
 	if ($result['copied'])
@@ -546,7 +640,7 @@ function import_attachment($source, $use_target = false)
 		return '';
 	}
 
-	global $convert, $config, $user;
+	global $convert, $user, $phpbb_container;
 
 	// check for trailing slash
 	if (rtrim($convert->convertor['upload_path'], '/') === '')
@@ -569,11 +663,12 @@ function import_attachment($source, $use_target = false)
 			{
 				$thumb_source = $convert->convertor['upload_path'] . $thumb_source;
 			}
-			$thumb_target = $config['upload_path'] . '/thumb_' . $result['target'];
 
-			if (file_exists(relative_base($thumb_source, $result['relative_path'], __LINE__, __FILE__)))
+			$thumb_source_path = relative_base($thumb_source, $result['relative_path'], __LINE__, __FILE__);
+
+			if (file_exists($thumb_source_path))
 			{
-				copy_file($thumb_source, $thumb_target, false, false, $result['relative_path']);
+				_copy_file_to_storage($phpbb_container->get('storage.attachment'), $thumb_source_path, 'thumb_' . $result['target']);
 			}
 		}
 	}

--- a/tests/functions/import_attachment_test.php
+++ b/tests/functions/import_attachment_test.php
@@ -1,0 +1,161 @@
+<?php
+/**
+*
+* This file is part of the phpBB Forum Software package.
+*
+* @copyright (c) phpBB Limited <https://www.phpbb.com>
+* @license GNU General Public License, version 2 (GPL-2.0)
+*
+* For full copyright and license information, please see
+* the docs/CREDITS.txt file.
+*
+*/
+
+require_once __DIR__ . '/../../phpBB/includes/functions_convert.php';
+
+class phpbb_functions_import_attachment_test extends phpbb_test_case
+{
+	/** @var \PHPUnit\Framework\MockObject\MockObject */
+	protected $storage;
+
+	/** @var string */
+	protected $source_dir;
+
+	protected function setUp(): void
+	{
+		parent::setUp();
+
+		$this->storage = $this->getMockBuilder('\phpbb\storage\storage')
+			->disableOriginalConstructor()
+			->getMock();
+
+		$this->source_dir = sys_get_temp_dir() . '/phpbb_convert_' . uniqid() . '/';
+		mkdir($this->source_dir);
+	}
+
+	protected function tearDown(): void
+	{
+		foreach (glob($this->source_dir . '*') ?: array() as $file)
+		{
+			@unlink($file);
+		}
+
+		if (is_dir($this->source_dir))
+		{
+			rmdir($this->source_dir);
+		}
+
+		parent::tearDown();
+	}
+
+	public function test_copy_file_to_storage_writes_through_storage()
+	{
+		$source = $this->source_dir . 'attach.txt';
+		file_put_contents($source, 'attachment contents');
+
+		$this->storage->method('exists')->willReturn(false);
+		$this->storage->expects($this->once())
+			->method('write')
+			->with('attach.txt', $this->isType('resource'));
+
+		$this->assertTrue(_copy_file_to_storage($this->storage, $source, 'attach.txt'));
+	}
+
+	public function test_copy_file_to_storage_skips_existing_file()
+	{
+		$source = $this->source_dir . 'attach.txt';
+		file_put_contents($source, 'data');
+
+		$this->storage->method('exists')->willReturn(true);
+		$this->storage->expects($this->never())->method('write');
+
+		$this->assertTrue(_copy_file_to_storage($this->storage, $source, 'attach.txt'));
+	}
+
+	public function test_copy_file_to_storage_missing_source()
+	{
+		$this->storage->method('exists')->willReturn(false);
+		$this->storage->expects($this->never())->method('write');
+
+		$this->assertFalse(_copy_file_to_storage($this->storage, $this->source_dir . 'nope.txt', 'nope.txt'));
+	}
+
+	public function test_copy_dir_to_storage_writes_all_files_recursively()
+	{
+		file_put_contents($this->source_dir . 'a.txt', 'a');
+		file_put_contents($this->source_dir . 'b.txt', 'b');
+		mkdir($this->source_dir . 'sub');
+		file_put_contents($this->source_dir . 'sub/c.txt', 'c');
+
+		$this->storage->method('exists')->willReturn(false);
+
+		$written = array();
+		$this->storage->method('write')->willReturnCallback(function ($path, $resource) use (&$written) {
+			$written[] = $path;
+		});
+
+		_copy_dir_to_storage($this->storage, $this->source_dir, 'category');
+
+		sort($written);
+		$this->assertEquals(array('category/a.txt', 'category/b.txt', 'category/sub/c.txt'), $written);
+
+		@unlink($this->source_dir . 'sub/c.txt');
+		@rmdir($this->source_dir . 'sub');
+	}
+
+	public function test_import_check_attachment_uses_storage()
+	{
+		global $convert, $config, $phpbb_container;
+
+		file_put_contents($this->source_dir . 'file.png', 'image');
+
+		$convert = new stdClass();
+		$convert->convertor = array('source_path_absolute' => false, 'upload_path' => '');
+		$convert->options = array('forum_path' => rtrim($this->source_dir, '/'));
+
+		$config = array();
+
+		$phpbb_container = new phpbb_mock_container_builder();
+		$phpbb_container->set('storage.attachment', $this->storage);
+
+		$this->storage->method('exists')->willReturn(false);
+		$this->storage->expects($this->once())
+			->method('write')
+			->with('file.png', $this->isType('resource'));
+
+		$result = _import_check('upload_path', 'file.png', false);
+
+		$this->assertTrue($result['copied']);
+		$this->assertSame('file.png', $result['target']);
+	}
+
+	public function test_import_check_ranks_use_copy_file_not_storage()
+	{
+		global $convert, $config, $phpbb_container, $phpbb_root_path, $phpbb_filesystem;
+
+		file_put_contents($this->source_dir . 'rank.gif', 'gif');
+
+		$convert = new stdClass();
+		$convert->convertor = array('source_path_absolute' => false, 'ranks_path' => '');
+		$convert->options = array('forum_path' => rtrim($this->source_dir, '/'));
+
+		$target_dir = 'cache/test_ranks_' . uniqid();
+		$config = array('ranks_path' => $target_dir);
+
+		$phpbb_filesystem = new \phpbb\filesystem\filesystem();
+
+		// Ranks are not storage-backed: storage must never be touched.
+		$phpbb_container = new phpbb_mock_container_builder();
+		$phpbb_container->set('storage.attachment', $this->storage);
+		$this->storage->expects($this->never())->method('write');
+
+		$result = _import_check('ranks_path', 'rank.gif', false);
+
+		// The file was copied to the local disk via copy_file(), not storage.
+		$this->assertTrue($result['copied']);
+		$this->assertFileExists($phpbb_root_path . $target_dir . '/rank.gif');
+
+		@unlink($phpbb_root_path . $target_dir . '/rank.gif');
+		@rmdir($phpbb_root_path . $target_dir);
+	}
+}

--- a/tests/functions/import_attachment_test.php
+++ b/tests/functions/import_attachment_test.php
@@ -129,6 +129,35 @@ class phpbb_functions_import_attachment_test extends phpbb_test_case
 		$this->assertSame('file.png', $result['target']);
 	}
 
+	public function test_import_check_avatar_uses_storage()
+	{
+		global $convert, $config, $phpbb_container;
+
+		file_put_contents($this->source_dir . 'avatar.png', 'avatar');
+
+		$convert = new stdClass();
+		$convert->convertor = array('source_path_absolute' => false, 'avatar_path' => '');
+		$convert->options = array('forum_path' => rtrim($this->source_dir, '/'));
+
+		$config = array();
+
+		$avatar_storage = $this->getMockBuilder('\phpbb\storage\storage')
+			->disableOriginalConstructor()
+			->getMock();
+		$avatar_storage->method('exists')->willReturn(false);
+		$avatar_storage->expects($this->once())
+			->method('write')
+			->with('avatar.png', $this->isType('resource'));
+
+		$phpbb_container = new phpbb_mock_container_builder();
+		$phpbb_container->set('storage.avatar', $avatar_storage);
+
+		$result = _import_check('avatar_path', 'avatar.png', false);
+
+		$this->assertTrue($result['copied']);
+		$this->assertSame('avatar.png', $result['target']);
+	}
+
 	public function test_import_check_ranks_use_copy_file_not_storage()
 	{
 		global $convert, $config, $phpbb_container, $phpbb_root_path, $phpbb_filesystem;


### PR DESCRIPTION
The converter wrote imported attachment and avatar files straight to disk via `copy_dir()` and `copy_file()`, bypassing phpBB 4.0's storage system and its file tracker. `import_attachment()` also relied on `import_attachment_files()` to populate `$config['upload_path']`.

This routes attachment imports through the `storage.attachment` service and avatar imports through `storage.avatar`, and removes that implicit coupling. Asset types that are not managed by storage (ranks, smilies, icons, avatar gallery) keep using `copy_file()`.

The ticket describes the attachment functions; the avatar handling shares the same `_import_check()` helper and the same defect, so it is fixed in a second commit. Happy to move avatars to their own ticket if preferred.

Two small internal helpers were added to `functions_convert.php` (`_copy_file_to_storage`, `_copy_dir_to_storage`); happy to relocate that logic into the storage service if the team would rather have it there.

Checklist:

- [x] Correct branch: master for new features; 3.3.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master](https://area51.phpbb.com/docs/master/coding-guidelines.html) and [3.3.x](https://area51.phpbb.com/docs/dev/3.3.x/development/coding_guidelines.html)
- [x] Commit follows commit message [format](https://area51.phpbb.com/docs/dev/3.3.x/development/git.html)

Tracker ticket:

https://tracker.phpbb.com/browse/PHPBB-17608
