### PR TITLE
Fix width of multi-digit topic pagination links

### DIFF
--- a/phpBB/styles/prosilver/theme/common.css
+++ b/phpBB/styles/prosilver/theme/common.css
@@ -1003,12 +1003,12 @@ fieldset.fields1 dl.pmlist dd.recipients {
 .row .pagination li span {
 	font-size: var(--ps-font-tiny);
 	border-radius: 2px;
-	min-width: calc(var(--ps-font-tiny) + 6px);
 	width: auto;
+	min-width: calc(var(--ps-font-tiny) + 6px);
 	height: calc(var(--ps-font-normal) + 6px);
-	padding: 1px 5px;
-	box-sizing: border-box;
 	text-align: center;
+	box-sizing: border-box;
+	padding: 1px 5px;
 }
 
 /* jQuery popups

--- a/phpBB/styles/prosilver/theme/common.css
+++ b/phpBB/styles/prosilver/theme/common.css
@@ -1003,9 +1003,12 @@ fieldset.fields1 dl.pmlist dd.recipients {
 .row .pagination li span {
 	font-size: var(--ps-font-tiny);
 	border-radius: 2px;
-	width: calc(var(--ps-font-tiny) + 6px);
+	min-width: calc(var(--ps-font-tiny) + 6px);
+	width: auto;
 	height: calc(var(--ps-font-normal) + 6px);
-	padding: 1px 3px;
+	padding: 1px 5px;
+	box-sizing: border-box;
+	text-align: center;
 }
 
 /* jQuery popups


### PR DESCRIPTION
Allow topic pagination links to grow automatically for multi-digit page numbers.

This prevents page numbers such as 10 and higher from appearing too narrow while preserving a minimum button width.

Checklist:

- [ ] Correct branch: master for new features; 3.3.x for fixes
- [ ] Tests pass
- [ ] Code follows coding guidelines: [master](https://area51.phpbb.com/docs/master/coding-guidelines.html) and [3.3.x](https://area51.phpbb.com/docs/dev/3.3.x/development/coding_guidelines.html)
- [ ] Commit follows commit message [format](https://area51.phpbb.com/docs/dev/3.3.x/development/git.html)



