### PR TITLE
[ticket/16957] Improve ACP extension explanations and remove HTML

### DIFF
--- a/phpBB/adm/style/acp_ext_catalog.html
+++ b/phpBB/adm/style/acp_ext_catalog.html
@@ -4,7 +4,8 @@
 
 <h1>{{ lang( 'EXTENSIONS_CATALOG') }}</h1>
 
-<p>{{ lang( 'EXTENSIONS_CATALOG_EXPLAIN') }}</p>
+<p>{{ lang('EXTENSIONS_CATALOG_EXPLAIN') }}</p>
+<p><strong class="error">{{ lang('WARNING') }}{{ lang('COLON') }}</strong> {{ lang('EXTENSIONS_CATALOG_WARNING') }}</p>
 
 <fieldset class="quick quick-left">
 	<span class="small"><a href="https://www.phpbb.com/go/customise/extensions/{{ PHPBB_MAJOR }}" target="_blank">{{ lang('BROWSE_EXTENSIONS_DATABASE') }}</a> &bull; <a href="javascript:phpbb.toggleDisplay('catalog_settings');">{{ lang('SETTINGS') }}</a></span>

--- a/phpBB/language/en/acp/extensions.php
+++ b/phpBB/language/en/acp/extensions.php
@@ -50,7 +50,8 @@ $lang = array_merge($lang, array(
 	'DISABLING_EXTENSIONS'	=> 'Disabling extensions',
 
 	'EXTENSIONS_CATALOG'			=> 'Extensions Catalog',
-	'EXTENSIONS_CATALOG_EXPLAIN'	=> 'Here you can browse all the extensions available for your phpBB board. Extensions can easily be installed or removed with just a click. Adjust the settings to allow instant enabling and purging of extensions.<br><br><strong>Warning:</strong> Please be aware that the Extensions Catalog is currently in an Alpha development phase. Enabling this in a production environment carries a significant risk and is strongly discouraged.',
+	'EXTENSIONS_CATALOG_EXPLAIN'	=> 'Here you can browse all the extensions available for your phpBB board. Extensions can easily be installed or removed with just a click. Adjust the settings to allow instant enabling and purging of extensions.',
+	'EXTENSIONS_CATALOG_WARNING'	=> 'Please be aware that the Extensions Catalog is currently in an Alpha development phase. Enabling this in a production environment carries a significant risk and is strongly discouraged.',
 
 	'EXTENSION'					=> 'Extension',
 	'EXTENSIONS'				=> 'Extensions',
@@ -76,8 +77,8 @@ $lang = array_merge($lang, array(
 	'EXTENSION_DELETE_DATA_EXPLAIN'	=> 'Deleting an extension’s data removes all of its data and settings. The extension files are retained so it can be enabled again.',
 	'EXTENSION_DISABLE_EXPLAIN'		=> 'Disabling an extension retains its files, data and settings but removes any functionality added by the extension.',
 	'EXTENSION_ENABLE_EXPLAIN'		=> 'Enabling an extension allows you to use it on your board.',
-	'EXTENSION_REMOVE_EXPLAIN'		=> 'Removing an extension removes all of its files, data and settings.',
-	'EXTENSION_UPDATE_EXPLAIN'		=> 'Updating an extension will install the latest version compatible with your board, removing old files and replacing them with new ones, and updating the database if necessary.',
+	'EXTENSION_REMOVE_EXPLAIN'		=> 'Removing an extension will remove all of its data and settings and delete the extension’s files from the filesystem.',
+	'EXTENSION_UPDATE_EXPLAIN'		=> 'Updating an extension will disable the currently installed extension and delete the extension’s files from the filesystem. The extension’s most recent compatible release will be uploaded to your board and re-enabled.',
 
 	'EXTENSION_DELETE_DATA_IN_PROGRESS'	=> 'The extension’s data is currently being deleted. Please do not leave or refresh this page until it is completed.',
 	'EXTENSION_DISABLE_IN_PROGRESS'	=> 'The extension is currently being disabled. Please do not leave or refresh this page until it is completed.',
@@ -93,7 +94,7 @@ $lang = array_merge($lang, array(
 
 	'EXTENSION_INSTALLING_HEADLINE'			=> 'Installing an extension',
 	'EXTENSION_INSTALLING_EXPLAIN_STEP1'	=> 'Download an extension from phpBB’s extensions database',
-	'EXTENSION_INSTALLING_EXPLAIN_STEP2'	=> 'Unzip the extension and upload it to the <samp>ext/</samp> directory of your phpBB board',
+	'EXTENSION_INSTALLING_EXPLAIN_STEP2'	=> 'Unzip the extension and upload it to the “ext/” directory of your phpBB board',
 	'EXTENSION_INSTALLING_EXPLAIN_STEP3'	=> 'Enable the extension, here in the Extensions manager',
 
 	'EXTENSION_REMOVING_HEADLINE'			=> 'Deleting an extension from your board',
@@ -178,6 +179,6 @@ $lang = array_merge($lang, array(
 	'STABILITY_DEV'		=> 'dev',
 
 	'COMPOSER_MINIMUM_STABILITY'			=> 'Minimum stability',
-	'COMPOSER_MINIMUM_STABILITY_EXPLAIN'	=> 'Always use <samp>stable</samp> versions on a live forum. Non-stable versions may still be in development and could cause unexpected problems with your forum and should only be used for development purposes in local or staging environments.',
+	'COMPOSER_MINIMUM_STABILITY_EXPLAIN'	=> 'Always use “stable” versions on a live forum. Non-stable versions may still be in development and could cause unexpected problems with your forum and should only be used for development purposes in local or staging environments.',
 
 ));

--- a/tests/functional/extension_acp_test.php
+++ b/tests/functional/extension_acp_test.php
@@ -120,6 +120,13 @@ class phpbb_functional_extension_acp_test extends phpbb_functional_test_case
 		$this->assertStringNotContainsString('barfoo', $crawler->filter('.table1')->text());
 
 		$this->assertStringNotContainsString('vendor3/bar', $crawler->filter('.table1')->text());
+
+		// Action tooltips are rendered as title attributes and must not
+		// contain HTML, as it would be displayed literally. See PHPBB-16957.
+		foreach ($crawler->filter('a[title]') as $link)
+		{
+			$this->assertStringNotContainsString('<', $link->getAttribute('title'));
+		}
 	}
 
 	public function test_details()
@@ -266,6 +273,11 @@ class phpbb_functional_extension_acp_test extends phpbb_functional_test_case
 		$this->assertContainsLang('BROWSE_EXTENSIONS_DATABASE', $crawler->filter('fieldset[class="quick quick-left"] > span > a')->eq(0)->text());
 		$this->assertContainsLang('SETTINGS', $crawler->filter('fieldset[class="quick quick-left"] > span > a')->eq(1)->text());
 
+		// The alpha-phase warning is rendered by the template, separately
+		// from the HTML-free explanation. See PHPBB-16957.
+		$this->assertContainsLang('EXTENSIONS_CATALOG_EXPLAIN', $this->get_content());
+		$this->assertContainsLang('EXTENSIONS_CATALOG_WARNING', $this->get_content());
+
 		$form = $crawler->selectButton('Submit')->form();
 		$form['minimum_stability']->select('dev');
 		$form['repositories'] = 'https://satis.phpbb.com/';
@@ -337,6 +349,19 @@ class phpbb_functional_extension_acp_test extends phpbb_functional_test_case
 		// Ensure installed extension appears in available extensions list
 		$crawler = self::request('GET', 'adm/index.php?i=acp_extensions&mode=main&sid=' . $this->sid);
 		$this->assertStringContainsString('VigLink', $crawler->filter('strong[title="phpbb/viglink"]')->text());
+
+		// The composer-managed extension row offers the remove action; its
+		// tooltip carries the HTML-free explanation. See PHPBB-16957.
+		$viglink_row = $crawler->filter('tr')->reduce(
+			function ($node, $i)
+			{
+				return strpos($node->text(), 'VigLink') !== false;
+			}
+		);
+		$this->assertSame(
+			$this->lang('EXTENSION_REMOVE_EXPLAIN'),
+			$viglink_row->selectLink($this->lang('EXTENSION_REMOVE'))->attr('title')
+		);
 	}
 
 	public function test_extensions_catalog_updating_extension()
@@ -356,12 +381,18 @@ class phpbb_functional_extension_acp_test extends phpbb_functional_test_case
 
 		// Update 'VigLink' enabled extension
 		$crawler = self::request('GET', 'adm/index.php?i=acp_extensions&mode=main&sid=' . $this->sid);
-		$viglink_update_link = $crawler->filter('tr')->reduce(
+		$viglink_update_node = $crawler->filter('tr')->reduce(
 			function ($node, $i)
 			{
 				return (bool) (strpos($node->text(), 'VigLink') !== false);
 			}
-		)->selectLink($this->lang('EXTENSION_UPDATE'))->link();
+		)->selectLink($this->lang('EXTENSION_UPDATE'));
+
+		// The update tooltip of the composer-managed extension carries the
+		// HTML-free explanation. See PHPBB-16957.
+		$this->assertSame($this->lang('EXTENSION_UPDATE_EXPLAIN'), $viglink_update_node->attr('title'));
+
+		$viglink_update_link = $viglink_update_node->link();
 		$crawler = self::$client->click($viglink_update_link);
 		$this->assertContainsLang('EXTENSIONS_UPDATED', $crawler->filter('.successbox > p')->text());
 		// Assert there's console log output


### PR DESCRIPTION
Checklist:

- [x] Correct branch: master for new features; 3.3.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master](https://area51.phpbb.com/docs/master/coding-guidelines.html) and [3.3.x](https://area51.phpbb.com/docs/dev/3.3.x/development/coding_guidelines.html)
- [x] Commit follows commit message [format](https://area51.phpbb.com/docs/dev/3.3.x/development/git.html)

The `EXTENSION_*_EXPLAIN` language keys are used as `title` attributes for the
action links on the extensions list, where any HTML is displayed literally
(see the screenshot in the ticket). This removes the remaining HTML from the
explanation strings on the ACP extensions pages and applies the wording for
composer-managed extensions proposed in the ticket:

- `EXTENSION_UPDATE_EXPLAIN` and `EXTENSION_REMOVE_EXPLAIN` now use the
  ticket's wording — they describe the composer flow (disable, delete files,
  upload the most recent compatible release, re-enable), since these two
  actions are only offered for catalog-managed extensions.
- The alpha-phase warning inside `EXTENSIONS_CATALOG_EXPLAIN` (added in
  PHPBB-17682) moved to a new `EXTENSIONS_CATALOG_WARNING` key; the warning
  markup now lives in the template, using the same
  `<strong class="error">{{ lang('WARNING') }}…` pattern the page already
  uses for the packagist and minimum-stability warnings.
- `<samp>` markup in `EXTENSION_INSTALLING_EXPLAIN_STEP2` and
  `COMPOSER_MINIMUM_STABILITY_EXPLAIN` replaced with typographic quotes.

Not touched, deliberately: `EXTENSION_INVALID_LIST` and
`EXTENSION_DELETE_DATA_CONFIRM` still contain `<br />` — they are an error
message and a confirm-box message rather than explanation lines, they never
reach a `title` attribute, and confirm-box messages use `<br />` throughout
the language files. Happy to include them if preferred.

The functional tests now also assert that no action tooltip on the
extensions list contains HTML, that the composer-managed update and remove
tooltips carry the new explanations, and that the catalog page renders the
explanation and the warning separately.

Tracker ticket:

https://tracker.phpbb.com/browse/PHPBB-16957
