### PR TITLE
[ticket/17684] Ext catalog bug fixes and security improvements

### DIFF
--- a/phpBB/adm/style/acp_ext_catalog.html
+++ b/phpBB/adm/style/acp_ext_catalog.html
@@ -42,6 +42,8 @@
 			</dt>
 			<dd>
 				<textarea id="repositories" name="repositories" rows="5" cols="30">{{ settings.repositories|join('\n') }}</textarea>
+				<br />
+				<input class="button2" type="button" id="restore_default_repositories" value="{{ lang('RESTORE_DEFAULT_REPOSITORIES') }}" title="{{ lang('RESTORE_DEFAULT_REPOSITORIES_EXPLAIN') }}" data-default-repositories="{{ settings.default_repositories|json_encode|e('html_attr') }}" />
 			</dd>
 		</dl>
 		<dl>
@@ -126,5 +128,20 @@
 		{% include('pagination.html') %}
 	</div>
 {% endif %}
+
+<script>
+(function() {
+	'use strict';
+
+	var restoreButton = document.getElementById('restore_default_repositories');
+	var repositories = document.getElementById('repositories');
+
+	if (restoreButton && repositories) {
+		restoreButton.addEventListener('click', function() {
+			repositories.value = JSON.parse(restoreButton.dataset.defaultRepositories).join('\n');
+		});
+	}
+}());
+</script>
 
 {% include('overall_footer.html') %}

--- a/phpBB/adm/style/acp_ext_catalog.html
+++ b/phpBB/adm/style/acp_ext_catalog.html
@@ -20,14 +20,14 @@
 	<fieldset style="clear: both;">
 		<legend>{{ lang('EXTENSIONS_CATALOG_SETTINGS') }}</legend>
 		<dl>
-			<dt><label for="enable_on_install">{{ lang('ENABLE_ON_INSTALL') }}{{ lang('COLON') }}</label></dt>
+			<dt><label for="enable_on_install">{{ lang('ENABLE_ON_INSTALL') }}{{ lang('COLON') }}</label><br><span>{{ lang('ENABLE_ON_INSTALL_EXPLAIN') }}</span></dt>
 			<dd>
 				<label><input type="radio" id="enable_on_install" name="enable_on_install" class="radio" value="1"{% if settings.enable_on_install %} checked="checked" {% endif %} /> {{ lang('YES') }}</label>
 				<label><input type="radio" name="enable_on_install" class="radio" value="0"{% if not settings.enable_on_install %} checked="checked" {% endif %} /> {{ lang('NO') }}</label>
 			</dd>
 		</dl>
 		<dl>
-			<dt><label for="purge_on_remove">{{ lang('PURGE_ON_REMOVE') }}{{ lang('COLON') }}</label></dt>
+			<dt><label for="purge_on_remove">{{ lang('PURGE_ON_REMOVE') }}{{ lang('COLON') }}</label><br><span>{{ lang('PURGE_ON_REMOVE_EXPLAIN') }}</span></dt>
 			<dd>
 				<label><input type="radio" id="purge_on_remove" name="purge_on_remove" class="radio" value="1"{% if settings.purge_on_remove %} checked="checked" {% endif %} /> {{ lang('YES') }}</label>
 				<label><input type="radio" name="purge_on_remove" class="radio" value="0"{% if not settings.purge_on_remove %} checked="checked" {% endif %} /> {{ lang('NO') }}</label>

--- a/phpBB/adm/style/acp_ext_catalog.html
+++ b/phpBB/adm/style/acp_ext_catalog.html
@@ -130,6 +130,7 @@
 {% endif %}
 
 <script>
+// Restores the repository field to phpBB's installed defaults.
 (function() {
 	'use strict';
 

--- a/phpBB/includes/acp/acp_extensions.php
+++ b/phpBB/includes/acp/acp_extensions.php
@@ -25,6 +25,11 @@ if (!defined('IN_PHPBB'))
 
 class acp_extensions
 {
+	/**
+	 * Defines the default Composer repositories installed by phpBB.
+	 *
+	 * @var string[]
+	 */
 	private const DEFAULT_COMPOSER_REPOSITORIES = [
 		'https://satis.phpbb.com/',
 		'https://www.phpbb.com/customise/db/composer/40/',
@@ -93,7 +98,7 @@ class acp_extensions
 
 	public function main_mode($id, $mode)
 	{
-		global $phpbb_extension_manager, $phpbb_container;
+		global $phpbb_extension_manager, $phpbb_container, $phpbb_admin_path;
 
 		$this->page_title = 'ACP_EXTENSIONS';
 
@@ -786,7 +791,7 @@ class acp_extensions
 	}
 
 	/**
-	 * Display an exception raised by the composer manager
+	 * Displays an exception raised by the Composer manager.
 	 *
 	 * @param \phpbb\language\language           $language
 	 * @param \phpbb\exception\runtime_exception $e
@@ -829,7 +834,11 @@ class acp_extensions
 	}
 
 	/**
-	 * Validate a Composer package name before passing it to Composer.
+	 * Validates a Composer package name before passing it to Composer.
+	 *
+	 * @param string $package Composer package name
+	 *
+	 * @return bool Whether the package name is valid
 	 */
 	private function is_valid_composer_package_name(string $package): bool
 	{
@@ -837,7 +846,16 @@ class acp_extensions
 	}
 
 	/**
-	 * Ensure ACP actions can only target packages exposed by the catalog or already managed by phpBB.
+	 * Ensures ACP actions can only target packages exposed by the catalog or already managed by phpBB.
+	 *
+	 * @param string                              $action             Composer action
+	 * @param string                              $extension          Composer package name
+	 * @param \phpbb\composer\manager_interface   $composer_manager   Composer extension manager
+	 * @param \phpbb\extension\manager             $extensions_manager phpBB extension manager
+	 * @param \phpbb\language\language             $language           Language service
+	 * @param string                               $origin             Trusted action origin
+	 *
+	 * @return void
 	 */
 	private function validate_composer_action($action, $extension, \phpbb\composer\manager_interface $composer_manager, \phpbb\extension\manager $extensions_manager, \phpbb\language\language $language, string $origin)
 	{
@@ -866,7 +884,9 @@ class acp_extensions
 	}
 
 	/**
-	 * Return the trusted page from which a Composer action originated.
+	 * Returns the trusted page from which a Composer action originated.
+	 *
+	 * @return string Trusted action origin
 	 */
 	private function get_composer_action_origin(): string
 	{
@@ -876,7 +896,11 @@ class acp_extensions
 	}
 
 	/**
-	 * Return the ACP URL matching a trusted Composer action origin.
+	 * Returns the ACP URL matching a trusted Composer action origin.
+	 *
+	 * @param string $origin Trusted action origin
+	 *
+	 * @return string ACP return URL
 	 */
 	private function get_composer_return_url(string $origin): string
 	{
@@ -884,7 +908,11 @@ class acp_extensions
 	}
 
 	/**
-	 * Build explicit links to both extension management pages, with the origin first.
+	 * Builds explicit links to both extension management pages, with the origin first.
+	 *
+	 * @param string $origin Trusted action origin
+	 *
+	 * @return string HTML links to the extension management pages
 	 */
 	private function get_composer_back_links(string $origin): string
 	{
@@ -898,7 +926,7 @@ class acp_extensions
 			$links = array_reverse($links, true);
 		}
 
-		return '<br /><br />' . implode('<br />', $links);
+		return '<br><br>' . implode('<br>', $links);
 	}
 
 	/**

--- a/phpBB/includes/acp/acp_extensions.php
+++ b/phpBB/includes/acp/acp_extensions.php
@@ -25,6 +25,11 @@ if (!defined('IN_PHPBB'))
 
 class acp_extensions
 {
+	private const DEFAULT_COMPOSER_REPOSITORIES = [
+		'https://satis.phpbb.com/',
+		'https://www.phpbb.com/customise/db/composer/40/',
+	];
+
 	public $u_action;
 	public $tpl_name;
 	public $page_title;
@@ -49,6 +54,7 @@ class acp_extensions
 	private $phpbb_container;
 	private $php_ini;
 	private $u_catalog_action;
+	private $u_manager_action;
 
 	/** @var string */
 	private $phpbb_root_path;
@@ -56,7 +62,7 @@ class acp_extensions
 	function main($id, $mode)
 	{
 		// Start the page
-		global $config, $user, $template, $request, $phpbb_extension_manager, $db, $phpbb_log, $phpbb_dispatcher, $phpbb_container, $phpbb_admin_path,  $phpbb_root_path;
+		global $config, $user, $template, $request, $phpbb_extension_manager, $db, $phpbb_log, $phpbb_dispatcher, $phpbb_container, $phpbb_admin_path, $phpbb_root_path, $phpEx;
 
 		$this->db       = $db;
 		$this->config = $config;
@@ -70,6 +76,8 @@ class acp_extensions
 		$this->php_ini = $this->phpbb_container->get('php_ini');
 		$this->phpbb_root_path = $phpbb_root_path;
 		$is_catalog_available = $phpbb_container->hasParameter('extensions.enable_catalog') && $phpbb_container->getParameter('extensions.enable_catalog') === true;
+		$this->u_catalog_action = append_sid("{$phpbb_admin_path}index.$phpEx", "i=$id&amp;mode=catalog");
+		$this->u_manager_action = append_sid("{$phpbb_admin_path}index.$phpEx", "i=$id&amp;mode=main");
 
 		$this->user->add_lang(['install', 'acp/extensions', 'acp/modules', 'migrator']);
 
@@ -85,7 +93,7 @@ class acp_extensions
 
 	public function main_mode($id, $mode)
 	{
-		global $phpbb_extension_manager, $phpbb_container, $phpbb_admin_path, $phpEx;
+		global $phpbb_extension_manager, $phpbb_container;
 
 		$this->page_title = 'ACP_EXTENSIONS';
 
@@ -146,8 +154,6 @@ class acp_extensions
 			}
 		}
 
-		$this->u_catalog_action = append_sid("{$phpbb_admin_path}index.$phpEx", "i=$id&amp;mode=catalog");
-
 		// What are we doing?
 		switch ($action)
 		{
@@ -185,13 +191,15 @@ class acp_extensions
 				$composer_manager = $phpbb_container->get('ext.composer.manager');
 
 				$managed_packages = [];
+				$available_updates = [];
 				if ($composer_manager->check_requirements())
 				{
 					$managed_packages = $composer_manager->get_managed_packages();
+					$available_updates = $composer_manager->get_available_updates();
 				}
 
-				$this->list_enabled_exts($phpbb_extension_manager, $managed_packages);
-				$this->list_disabled_exts($phpbb_extension_manager, $managed_packages);
+				$this->list_enabled_exts($phpbb_extension_manager, $managed_packages, $available_updates);
+				$this->list_disabled_exts($phpbb_extension_manager, $managed_packages, $available_updates);
 				$this->list_available_exts($managed_packages);
 
 				$this->tpl_name = 'acp_ext_list';
@@ -459,6 +467,7 @@ class acp_extensions
 		global $phpbb_container;
 
 		$action = $this->request->variable('action', 'list');
+		$origin = $this->get_composer_action_origin();
 
 		/** @var \phpbb\language\language $language */
 		$language = $phpbb_container->get('language');
@@ -469,6 +478,33 @@ class acp_extensions
 		/** @var \phpbb\extension\manager $extensions_manager */
 		$extensions_manager = $phpbb_container->get('ext.manager');
 
+		$composer_actions = ['install', 'remove', 'update', 'manage'];
+		if (in_array($action, $composer_actions, true))
+		{
+			$extension = $this->request->variable('extension', '');
+
+			if ($this->request->is_set_post('cancel'))
+			{
+				redirect($this->get_composer_return_url($origin));
+			}
+
+			if (!$this->is_valid_composer_package_name($extension))
+			{
+				trigger_error($language->lang('EXTENSIONS_INVALID_PACKAGE') . $this->get_composer_back_links($origin), E_USER_WARNING);
+			}
+
+			if (!confirm_box(true))
+			{
+				confirm_box(false, $language->lang('EXTENSIONS_' . strtoupper($action) . '_CONFIRM', $extension), build_hidden_fields([
+					'action' => $action,
+					'extension' => $extension,
+					'origin' => $origin,
+				]));
+			}
+
+			$this->validate_composer_action($action, $extension, $composer_manager, $extensions_manager, $language, $origin);
+		}
+
 		if (!$composer_manager->check_requirements())
 		{
 			$this->page_title = 'ACP_EXTENSIONS_CATALOG';
@@ -476,7 +512,7 @@ class acp_extensions
 
 			$this->template->assign_vars([
 				'MESSAGE_TITLE'	=> $language->lang('EXTENSIONS_CATALOG_NOT_AVAILABLE'),
-				'MESSAGE_TEXT'	=> $language->lang('EXTENSIONS_COMPOSER_NOT_WRITABLE'),
+				'MESSAGE_TEXT'	=> $language->lang('EXTENSIONS_COMPOSER_NOT_WRITABLE') . $this->get_composer_back_links($origin),
 			]);
 
 			return;
@@ -491,7 +527,7 @@ class acp_extensions
 
 				if (empty($extension))
 				{
-					redirect($this->u_action);
+					redirect($this->get_composer_return_url($origin));
 				}
 
 				$formatter = new \phpbb\composer\io\html_output_formatter([
@@ -506,14 +542,14 @@ class acp_extensions
 				}
 				catch (\phpbb\exception\runtime_exception $e)
 				{
-					$this->display_composer_exception($language, $e, $composer_io);
+					$this->display_composer_exception($language, $e, $composer_io, $origin);
 					return;
 				}
 				$this->tpl_name = 'detailed_message_body';
 
 				$this->template->assign_vars(array(
 						'MESSAGE_TITLE'			=> $language->lang('ACP_EXTENSIONS_INSTALL'),
-						'MESSAGE_TEXT'			=> $language->lang('EXTENSIONS_INSTALLED') . adm_back_link($this->u_action),
+						'MESSAGE_TEXT'			=> $language->lang('EXTENSIONS_INSTALLED') . $this->get_composer_back_links($origin),
 						'MESSAGE_DETAIL'		=> $composer_io->getOutput(),
 						'MESSAGE_DETAIL_LEGEND'	=> $language->lang('COMPOSER_OUTPUT'),
 						'S_USER_NOTICE'			=> true,
@@ -528,7 +564,7 @@ class acp_extensions
 
 				if (empty($extension))
 				{
-					redirect($this->u_action);
+					redirect($this->get_composer_return_url($origin));
 				}
 
 				$formatter = new \phpbb\composer\io\html_output_formatter([
@@ -543,14 +579,14 @@ class acp_extensions
 				}
 				catch (\phpbb\exception\runtime_exception $e)
 				{
-					$this->display_composer_exception($language, $e, $composer_io);
+					$this->display_composer_exception($language, $e, $composer_io, $origin);
 					return;
 				}
 				$this->tpl_name = 'detailed_message_body';
 
 				$this->template->assign_vars(array(
 						'MESSAGE_TITLE'			=> $language->lang('ACP_EXTENSIONS_REMOVE'),
-						'MESSAGE_TEXT'			=> $language->lang('EXTENSIONS_REMOVED') . adm_back_link($this->u_action),
+						'MESSAGE_TEXT'			=> $language->lang('EXTENSIONS_REMOVED') . $this->get_composer_back_links($origin),
 						'MESSAGE_DETAIL'		=> $composer_io->getOutput(),
 						'MESSAGE_DETAIL_LEGEND'	=> $language->lang('COMPOSER_OUTPUT'),
 						'S_USER_NOTICE'			=> true,
@@ -565,7 +601,7 @@ class acp_extensions
 
 				if (empty($extension))
 				{
-					redirect($this->u_action);
+					redirect($this->get_composer_return_url($origin));
 				}
 
 				$formatter = new \phpbb\composer\io\html_output_formatter([
@@ -580,14 +616,14 @@ class acp_extensions
 				}
 				catch (\phpbb\exception\runtime_exception $e)
 				{
-					$this->display_composer_exception($language, $e, $composer_io);
+					$this->display_composer_exception($language, $e, $composer_io, $origin);
 					return;
 				}
 				$this->tpl_name = 'detailed_message_body';
 
 				$this->template->assign_vars(array(
 						'MESSAGE_TITLE'			=> $language->lang('ACP_EXTENSIONS_UPDATE'),
-						'MESSAGE_TEXT'			=> $language->lang('EXTENSIONS_UPDATED') . adm_back_link($this->u_action),
+						'MESSAGE_TEXT'			=> $language->lang('EXTENSIONS_UPDATED') . $this->get_composer_back_links($origin),
 						'MESSAGE_DETAIL'		=> $composer_io->getOutput(),
 						'MESSAGE_DETAIL_LEGEND'	=> $language->lang('COMPOSER_OUTPUT'),
 						'S_USER_NOTICE'			=> true,
@@ -602,7 +638,7 @@ class acp_extensions
 
 				if (empty($extension))
 				{
-					redirect($this->u_action);
+					redirect($this->get_composer_return_url($origin));
 				}
 
 				$formatter = new \phpbb\composer\io\html_output_formatter([
@@ -617,14 +653,14 @@ class acp_extensions
 				}
 				catch (\phpbb\exception\runtime_exception $e)
 				{
-					$this->display_composer_exception($language, $e, $composer_io);
+					$this->display_composer_exception($language, $e, $composer_io, $origin);
 					return;
 				}
 				$this->tpl_name = 'detailed_message_body';
 
 				$this->template->assign_vars(array(
 						'MESSAGE_TITLE'			=> $language->lang('ACP_EXTENSIONS_MANAGE'),
-						'MESSAGE_TEXT'			=> $language->lang('EXTENSION_MANAGED_SUCCESS', $extension) . adm_back_link($this->u_action),
+						'MESSAGE_TEXT'			=> $language->lang('EXTENSION_MANAGED_SUCCESS', $extension) . $this->get_composer_back_links($origin),
 						'MESSAGE_DETAIL'		=> $composer_io->getOutput(),
 						'MESSAGE_DETAIL_LEGEND'	=> $language->lang('COMPOSER_OUTPUT'),
 						'S_USER_NOTICE'			=> true,
@@ -654,17 +690,31 @@ class acp_extensions
 					$enable_on_install = $this->request->variable('enable_on_install', false);
 					$purge_on_remove = $this->request->variable('purge_on_remove', false);
 					$minimum_stability = $this->request->variable('minimum_stability', 'stable');
-					$repositories = array_unique(
+					$repositories = array_values(array_unique(
 						array_filter(
 							array_map(
 								'trim',
 								explode("\n", $this->request->variable('repositories', ''))
 							)
 						)
-					);
+					));
+
+					if (!array_key_exists($minimum_stability, \Composer\Package\BasePackage::$stabilities))
+					{
+						trigger_error($language->lang('EXTENSIONS_INVALID_STABILITY') . adm_back_link($this->u_action), E_USER_WARNING);
+					}
+
+					foreach ($repositories as $repository)
+					{
+						$parts = parse_url($repository);
+						if ($parts === false || ($parts['scheme'] ?? '') !== 'https' || empty($parts['host']) || isset($parts['user']) || isset($parts['pass']))
+						{
+							trigger_error($language->lang('EXTENSIONS_INVALID_REPOSITORY', $repository) . adm_back_link($this->u_action), E_USER_WARNING);
+						}
+					}
 
 					$previous_minimum_stability = $this->config['exts_composer_minimum_stability'];
-					$previous_repositories = $this->config['exts_composer_repositories'];
+					$previous_repositories = array_values(json_decode($this->config['exts_composer_repositories'], true) ?: []);
 					$previous_enable_packagist = $this->config['exts_composer_packagist'];
 
 					$this->config->set('exts_composer_enable_on_install', $enable_on_install);
@@ -673,7 +723,7 @@ class acp_extensions
 					$this->config->set('exts_composer_repositories', json_encode($repositories, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
 
 					if ($minimum_stability != $previous_minimum_stability
-						|| $repositories != $previous_repositories
+						|| $repositories !== $previous_repositories
 						|| $enable_packagist != $previous_enable_packagist)
 					{
 						$composer_manager->reset_cache();
@@ -725,6 +775,7 @@ class acp_extensions
 						'minimum_stability'	=> $this->config['exts_composer_minimum_stability'],
 						'stabilities'		=> array_keys(\Composer\Package\BasePackage::$stabilities),
 						'repositories'		=> json_decode($this->config['exts_composer_repositories'], true),
+						'default_repositories'	=> self::DEFAULT_COMPOSER_REPOSITORIES,
 					],
 				]);
 
@@ -740,8 +791,9 @@ class acp_extensions
 	 * @param \phpbb\language\language           $language
 	 * @param \phpbb\exception\runtime_exception $e
 	 * @param \phpbb\composer\io\web_io          $composer_io
+	 * @param string                               $origin
 	 */
-	private function display_composer_exception(\phpbb\language\language $language, \phpbb\exception\runtime_exception $e, \phpbb\composer\io\web_io $composer_io)
+	private function display_composer_exception(\phpbb\language\language $language, \phpbb\exception\runtime_exception $e, \phpbb\composer\io\web_io $composer_io, string $origin)
 	{
 		$this->tpl_name = 'detailed_message_body';
 
@@ -751,18 +803,20 @@ class acp_extensions
 
 			if ($e->getPrevious() instanceof \phpbb\exception\exception_interface)
 			{
-				$message_text  = $language->lang_array($e->getPrevious()->getMessage(), $e->getPrevious()->get_parameters()) . adm_back_link($this->u_action);
+				$message_text  = $language->lang_array($e->getPrevious()->getMessage(), $e->getPrevious()->get_parameters());
 			}
 			else
 			{
-				$message_text = $e->getPrevious()->getMessage() . adm_back_link($this->u_action);
+				$message_text = $e->getPrevious()->getMessage();
 			}
 		}
 		else
 		{
 			$message_title = $language->lang('INFORMATION');
-			$message_text  = $language->lang_array($e->getMessage(), $e->get_parameters()) . adm_back_link($this->u_action);
+			$message_text  = $language->lang_array($e->getMessage(), $e->get_parameters());
 		}
+
+		$message_text .= $this->get_composer_back_links($origin);
 
 		$this->template->assign_vars(array(
 				'MESSAGE_TITLE'			=> $message_title,
@@ -775,14 +829,88 @@ class acp_extensions
 	}
 
 	/**
+	 * Validate a Composer package name before passing it to Composer.
+	 */
+	private function is_valid_composer_package_name(string $package): bool
+	{
+		return \Composer\Package\Loader\ValidatingArrayLoader::hasPackageNamingError($package, true) === null;
+	}
+
+	/**
+	 * Ensure ACP actions can only target packages exposed by the catalog or already managed by phpBB.
+	 */
+	private function validate_composer_action($action, $extension, \phpbb\composer\manager_interface $composer_manager, \phpbb\extension\manager $extensions_manager, \phpbb\language\language $language, string $origin)
+	{
+		$allowed = false;
+
+		if ($action === 'install' || $action === 'manage')
+		{
+			foreach ($composer_manager->get_available_packages() as $package)
+			{
+				if (isset($package['composer_name']) && $package['composer_name'] === $extension)
+				{
+					$allowed = $action === 'install' || $extensions_manager->is_available($extension);
+					break;
+				}
+			}
+		}
+		else
+		{
+			$allowed = array_key_exists($extension, $composer_manager->get_managed_packages());
+		}
+
+		if (!$allowed)
+		{
+			trigger_error($language->lang('EXTENSIONS_ACTION_NOT_ALLOWED') . $this->get_composer_back_links($origin), E_USER_WARNING);
+		}
+	}
+
+	/**
+	 * Return the trusted page from which a Composer action originated.
+	 */
+	private function get_composer_action_origin(): string
+	{
+		$origin = $this->request->variable('origin', 'catalog');
+
+		return $origin === 'manager' ? 'manager' : 'catalog';
+	}
+
+	/**
+	 * Return the ACP URL matching a trusted Composer action origin.
+	 */
+	private function get_composer_return_url(string $origin): string
+	{
+		return $origin === 'manager' ? $this->u_manager_action : $this->u_catalog_action;
+	}
+
+	/**
+	 * Build explicit links to both extension management pages, with the origin first.
+	 */
+	private function get_composer_back_links(string $origin): string
+	{
+		$links = [
+			'manager' => '<a href="' . $this->u_manager_action . '">&laquo; ' . $this->user->lang('RETURN_TO_EXTENSION_MANAGER') . '</a>',
+			'catalog' => '<a href="' . $this->u_catalog_action . '">&laquo; ' . $this->user->lang('RETURN_TO_EXTENSION_CATALOG') . '</a>',
+		];
+
+		if ($origin === 'catalog')
+		{
+			$links = array_reverse($links, true);
+		}
+
+		return '<br /><br />' . implode('<br />', $links);
+	}
+
+	/**
 	 * Lists all the enabled extensions and dumps to the template
 	 *
 	 * @param \phpbb\extension\manager  $phpbb_extension_manager     An instance of the extension manager
 	 * @param array                     $managed_packages            List of managed packages
+	 * @param array                     $available_updates           List of managed packages with updates
 	 *
 	 * @return void
 	 */
-	public function list_enabled_exts(\phpbb\extension\manager $phpbb_extension_manager, array $managed_packages)
+	public function list_enabled_exts(\phpbb\extension\manager $phpbb_extension_manager, array $managed_packages, array $available_updates)
 	{
 		$enabled_extension_meta_data = array();
 
@@ -849,10 +977,18 @@ class acp_extensions
 
 			if (isset($managed_packages[$block_vars['META_NAME']]))
 			{
-				$this->output_actions('enabled', [
-					'UPDATE' => $this->u_catalog_action . '&amp;action=update&amp;extension=' . urlencode($block_vars['META_NAME']),
-					'REMOVE' => $this->u_catalog_action . '&amp;action=remove&amp;extension=' . urlencode($block_vars['META_NAME']),
-				]);
+				$actions = [
+					'REMOVE' => $this->u_catalog_action . '&amp;action=remove&amp;origin=manager&amp;extension=' . urlencode($block_vars['META_NAME']),
+				];
+
+				if (isset($available_updates[$block_vars['META_NAME']]))
+				{
+					$actions = [
+						'UPDATE' => $this->u_catalog_action . '&amp;action=update&amp;origin=manager&amp;extension=' . urlencode($block_vars['META_NAME']),
+					] + $actions;
+				}
+
+				$this->output_actions('enabled', $actions);
 			}
 		}
 	}
@@ -862,10 +998,11 @@ class acp_extensions
 	 *
 	 * @param \phpbb\extension\manager  $phpbb_extension_manager     An instance of the extension manager
 	 * @param array                     $managed_packages            List of managed packages
+	 * @param array                     $available_updates           List of managed packages with updates
 	 *
 	 * @return void
 	 */
-	public function list_disabled_exts(\phpbb\extension\manager $phpbb_extension_manager, array $managed_packages)
+	public function list_disabled_exts(\phpbb\extension\manager $phpbb_extension_manager, array $managed_packages, array $available_updates)
 	{
 		$disabled_extension_meta_data = array();
 
@@ -930,10 +1067,18 @@ class acp_extensions
 
 			if (isset($managed_packages[$block_vars['META_NAME']]))
 			{
-				$this->output_actions('disabled', [
-					'UPDATE' => $this->u_catalog_action . '&amp;action=update&amp;extension=' . urlencode($block_vars['META_NAME']),
-					'REMOVE' => $this->u_catalog_action . '&amp;action=remove&amp;extension=' . urlencode($block_vars['META_NAME']),
-				]);
+				$actions = [
+					'REMOVE' => $this->u_catalog_action . '&amp;action=remove&amp;origin=manager&amp;extension=' . urlencode($block_vars['META_NAME']),
+				];
+
+				if (isset($available_updates[$block_vars['META_NAME']]))
+				{
+					$actions = [
+						'UPDATE' => $this->u_catalog_action . '&amp;action=update&amp;origin=manager&amp;extension=' . urlencode($block_vars['META_NAME']),
+					] + $actions;
+				}
+
+				$this->output_actions('disabled', $actions);
 			}
 		}
 	}
@@ -1003,7 +1148,7 @@ class acp_extensions
 
 			$this->output_actions('not_installed', array(
 				'ENABLE'		=> $this->u_action . '&amp;action=enable_pre&amp;ext_name=' . urlencode($name),
-				'REMOVE' => $this->u_catalog_action . '&amp;action=remove&amp;extension=' . urlencode($block_vars['META_NAME']),
+				'REMOVE' => $this->u_catalog_action . '&amp;action=remove&amp;origin=manager&amp;extension=' . urlencode($block_vars['META_NAME']),
 			));
 		}
 	}

--- a/phpBB/language/en/acp/extensions.php
+++ b/phpBB/language/en/acp/extensions.php
@@ -45,6 +45,8 @@ $lang = array_merge($lang, array(
 	'EXTENSIONS_MANAGED_WITH_ENABLE_ERROR'		=> 'The “%s” extension has been installed but an error occurred while enabling it.',
 	'EXTENSIONS_NOT_INSTALLED'					=> 'The “%s” extension is not installed.',
 	'EXTENSIONS_NOT_MANAGED'					=> 'The “%s” extension is not being managed.',
+	'EXTENSIONS_LIFECYCLE_ERROR'				=> 'The “%s” extension could not be safely disabled or purged, so Composer did not change its files.',
+	'EXTENSIONS_INVALID_PACKAGE'				=> 'The requested Composer package name or version constraint is invalid.',
 
 	'ENABLING_EXTENSIONS'	=> 'Enabling extensions',
 	'DISABLING_EXTENSIONS'	=> 'Disabling extensions',
@@ -117,6 +119,8 @@ $lang = array_merge($lang, array(
 	'INSTALLED_MANUALLY'	=> 'Installed manually',
 
 	'RETURN_TO_EXTENSION_LIST'	=> 'Return to the extension list',
+	'RETURN_TO_EXTENSION_MANAGER'	=> 'Back to the Extension Manager',
+	'RETURN_TO_EXTENSION_CATALOG'	=> 'Back to the Extension Catalog',
 
 	'EXT_DETAILS'			=> 'Extension Details',
 	'DISPLAY_NAME'			=> 'Display Name',
@@ -161,15 +165,28 @@ $lang = array_merge($lang, array(
 	'ENABLE_PACKAGIST_CONFIRM'		=> 'Are you sure you want to search packagist?',
 	'COMPOSER_REPOSITORIES'			=> 'Repositories',
 	'COMPOSER_REPOSITORIES_EXPLAIN'	=> 'Add URLs to Composer repositories of phpBB extensions to search here, one per line (must be the base url of the packages.json file).',
+	'RESTORE_DEFAULT_REPOSITORIES'	=> 'Restore defaults',
+	'RESTORE_DEFAULT_REPOSITORIES_EXPLAIN'	=> 'Restore the repositories supplied with phpBB. The change is not saved until you submit this form.',
 	'NO_EXTENSION_AVAILABLE'		=> 'There are no extension available for your board',
 
 	'EXTENSION_MANAGED_SUCCESS'		=> 'The extension %s is now being managed automatically.',
 	'EXTENSIONS_INSTALLED'			=> 'Extensions successfully installed.',
 	'EXTENSIONS_REMOVED'			=> 'Extensions successfully removed.',
 	'EXTENSIONS_UPDATED'			=> 'Extensions successfully updated.',
+	'EXTENSIONS_INSTALL_CONFIRM'	=> 'Installing “%s” will download and run extension code on this board. Only continue if you trust its publisher and repository.',
+	'EXTENSIONS_UPDATE_CONFIRM'	=> 'Updating “%s” will download and run new extension code on this board. Only continue if you trust its publisher and repository.',
+	'EXTENSIONS_REMOVE_CONFIRM'	=> 'Are you sure you want to remove “%s”? Depending on your catalog settings, its data may also be permanently purged.',
+	'EXTENSIONS_MANAGE_CONFIRM'	=> 'Are you sure you want Composer to replace the manually installed files for “%s”?',
+	'EXTENSIONS_ACTION_NOT_ALLOWED'	=> 'The requested package action is not allowed. The catalog may have changed; return to the catalog and try again.',
+	'EXTENSIONS_INVALID_STABILITY'	=> 'The selected minimum stability is invalid.',
+	'EXTENSIONS_INVALID_REPOSITORY'	=> '“%s” is not a valid secure Composer repository URL. Repository URLs must use HTTPS and must not contain credentials.',
 
 	'EXTENSIONS_CATALOG_NOT_AVAILABLE'	=> 'The extensions catalog is not available',
-	'EXTENSIONS_COMPOSER_NOT_WRITABLE'	=> 'In order to use the catalog, the following files and directories must be writable: ext/ vendor-ext/ composer-ext.json and composer-ext.lock',
+	'EXTENSIONS_COMPOSER_NOT_WRITABLE'	=> 'In order to use the catalog, the following files and directories must be writable: ext/ vendor-ext/ store/ composer-ext.json and composer-ext.lock',
+	'COMPOSER_OPERATION_LOCK_FAILED'		=> 'The Composer operation could not obtain an exclusive lock. Check that the store directory is writable and try again.',
+	'COMPOSER_OPERATION_IN_PROGRESS'		=> 'Another Composer operation is already in progress. Wait for it to finish and try again.',
+	'COMPOSER_CANNOT_INSTALL'				=> 'Composer could not complete the requested package changes.',
+	'COMPOSER_CANNOT_RESTORE'				=> 'Composer failed and phpBB could not restore the previous extension manifest and lockfile. Check composer-ext.json and composer-ext.lock before trying another package operation.',
 
 	'STABILITY_STABLE'	=> 'stable',
 	'STABILITY_RC'		=> 'RC',

--- a/phpBB/language/en/acp/extensions.php
+++ b/phpBB/language/en/acp/extensions.php
@@ -46,6 +46,7 @@ $lang = array_merge($lang, array(
 	'EXTENSIONS_NOT_INSTALLED'					=> 'The “%s” extension is not installed.',
 	'EXTENSIONS_NOT_MANAGED'					=> 'The “%s” extension is not being managed.',
 	'EXTENSIONS_LIFECYCLE_ERROR'				=> 'The “%s” extension could not be safely disabled or purged, so Composer did not change its files.',
+	'EXTENSIONS_REMOVE_REQUIRES_PURGE'			=> 'The “%s” extension still has stored data, so Composer did not remove its files. Delete the extension’s data first or enable “Purge extensions while removing”.',
 	'EXTENSIONS_INVALID_PACKAGE'				=> 'The requested Composer package name or version constraint is invalid.',
 
 	'ENABLING_EXTENSIONS'	=> 'Enabling extensions',
@@ -159,7 +160,9 @@ $lang = array_merge($lang, array(
 
 	'EXTENSIONS_CATALOG_SETTINGS'	=> 'Extensions catalog settings',
 	'ENABLE_ON_INSTALL'				=> 'Enable extensions while installing',
+	'ENABLE_ON_INSTALL_EXPLAIN'		=> 'If enabled, newly installed extensions will immediately begin running on your board.',
 	'PURGE_ON_REMOVE'				=> 'Purge extensions while removing',
+	'PURGE_ON_REMOVE_EXPLAIN'		=> 'If disabled, extensions with stored data must be disabled and have their data deleted manually before Composer can remove their files.',
 	'ENABLE_PACKAGIST'				=> 'Search packagist',
 	'ENABLE_PACKAGIST_EXPLAIN'		=> 'Search packagist for phpBB extensions. Beware that packagist may contain extensions not validated by the phpBB Extension Customisations Team.',
 	'ENABLE_PACKAGIST_CONFIRM'		=> 'Are you sure you want to search packagist?',

--- a/phpBB/phpbb/composer/extension_manager.php
+++ b/phpBB/phpbb/composer/extension_manager.php
@@ -227,11 +227,8 @@ class extension_manager extends manager
 	 */
 	public function pre_remove(array $packages, IOInterface|null $io = null)
 	{
-		if ($this->purge_on_remove)
-		{
-			/** @psalm-suppress InvalidArgument */
-			$io->writeError([['DISABLING_EXTENSIONS', [], 1]]);
-		}
+		/** @psalm-suppress InvalidArgument */
+		$io->writeError([['DISABLING_EXTENSIONS', [], 1]]);
 
 		foreach ($packages as $package => $version)
 		{
@@ -253,6 +250,14 @@ class extension_manager extends manager
 			catch (\Exception $e)
 			{
 				throw new runtime_exception($this->exception_prefix, 'LIFECYCLE_ERROR', [$package], $e);
+			}
+
+			// Removing the files of a configured extension would leave an invalid
+			// entry in the extension manager. Respect the no-purge setting by
+			// requiring the administrator to delete its data explicitly first.
+			if (!$this->purge_on_remove && $this->extension_manager->is_configured($package))
+			{
+				throw new runtime_exception($this->exception_prefix, 'REMOVE_REQUIRES_PURGE', [$package]);
 			}
 		}
 	}

--- a/phpBB/phpbb/composer/extension_manager.php
+++ b/phpBB/phpbb/composer/extension_manager.php
@@ -46,7 +46,7 @@ class extension_manager extends manager
 	/**
 	 * @var array
 	 */
-	private $enabled_extensions;
+	private $enabled_extensions = [];
 
 	/**
 	 * @var bool Enables extensions when installing them?
@@ -144,14 +144,39 @@ class extension_manager extends manager
 			}
 			catch (\phpbb\exception\runtime_exception $e)
 			{
-				/** @psalm-suppress InvalidArgument */
-				$io->writeError([[$e->getMessage(), $e->get_parameters(), 4]]);
+				throw new runtime_exception($this->exception_prefix, 'LIFECYCLE_ERROR', [$package], $e);
 			}
 			catch (\Exception $e)
 			{
-				/** @psalm-suppress InvalidArgument */
-				$io->writeError([[$e->getMessage(), [], 4]]);
+				throw new runtime_exception($this->exception_prefix, 'LIFECYCLE_ERROR', [$package], $e);
 			}
+		}
+	}
+
+	/**
+	 * Keep extensions operational if dependency resolution or installation fails after they were disabled.
+	 */
+	public function update(array $packages, IOInterface|null $io = null)
+	{
+		try
+		{
+			parent::update($packages, $io);
+		}
+		catch (\Exception $e)
+		{
+			foreach ($this->enabled_extensions as $package)
+			{
+				try
+				{
+					$this->extension_manager->enable($package);
+				}
+				catch (\Exception $ignored)
+				{
+					// Preserve the original Composer/lifecycle failure for the caller.
+				}
+			}
+
+			throw $e;
 		}
 	}
 
@@ -212,27 +237,22 @@ class extension_manager extends manager
 		{
 			try
 			{
-				if ($this->extension_manager->is_enabled($package))
+				if ($this->purge_on_remove && $this->extension_manager->is_configured($package))
 				{
-					if ($this->purge_on_remove)
-					{
-						$this->extension_manager->purge($package);
-					}
-					else
-					{
-						$this->extension_manager->disable($package);
-					}
+					$this->extension_manager->purge($package);
+				}
+				else if (!$this->purge_on_remove && $this->extension_manager->is_enabled($package))
+				{
+					$this->extension_manager->disable($package);
 				}
 			}
 			catch (\phpbb\exception\runtime_exception $e)
 			{
-				/** @psalm-suppress InvalidArgument */
-				$io->writeError([[$e->getMessage(), $e->get_parameters(), 4]]);
+				throw new runtime_exception($this->exception_prefix, 'LIFECYCLE_ERROR', [$package], $e);
 			}
 			catch (\Exception $e)
 			{
-				/** @psalm-suppress InvalidArgument */
-				$io->writeError([[$e->getMessage(), [], 4]]);
+				throw new runtime_exception($this->exception_prefix, 'LIFECYCLE_ERROR', [$package], $e);
 			}
 		}
 	}

--- a/phpBB/phpbb/composer/extension_manager.php
+++ b/phpBB/phpbb/composer/extension_manager.php
@@ -44,7 +44,7 @@ class extension_manager extends manager
 	protected $root_path;
 
 	/**
-	 * @var array
+	 * @var string[] Extensions that must be re-enabled after an update
 	 */
 	private $enabled_extensions = [];
 
@@ -154,7 +154,9 @@ class extension_manager extends manager
 	}
 
 	/**
-	 * Keep extensions operational if dependency resolution or installation fails after they were disabled.
+	 * Updates extensions and restores their enabled state if Composer fails.
+	 *
+	 * {@inheritdoc}
 	 */
 	public function update(array $packages, IOInterface|null $io = null)
 	{

--- a/phpBB/phpbb/composer/installer.php
+++ b/phpBB/phpbb/composer/installer.php
@@ -27,6 +27,10 @@ use Composer\Package\CompletePackage;
 use Composer\Package\PackageInterface;
 use Composer\PartialComposer;
 use Composer\Repository\ComposerRepository;
+use Composer\Repository\FilterRepository;
+use Composer\Repository\PlatformRepository;
+use Composer\Repository\RepositorySet;
+use Composer\Semver\Constraint\Constraint;
 use Composer\Semver\Constraint\ConstraintInterface;
 use Composer\Semver\VersionParser;
 use Composer\Util\HttpDownloader;
@@ -81,9 +85,14 @@ class installer
 	private $original_cwd;
 
 	/**
-	 * @var array|null Stores the content of the ext json file before generate_ext_json_file() overrides it
+	 * @var string|null Stores the content of the ext json file before generate_ext_json_file() overrides it
 	 */
 	private $ext_json_file_backup;
+
+	/**
+	 * @var string|null Stores the content of the ext lock file before generate_ext_json_file() overrides it
+	 */
+	private $ext_lock_file_backup;
 
 	/**
 	 * @var request phpBB request object
@@ -138,7 +147,27 @@ class installer
 	public function install(array $packages, $whitelist, IOInterface|null $io = null)
 	{
 		$this->wrap(function() use ($packages, $whitelist, $io) {
-			$this->do_install($packages, $whitelist, $io);
+			$lock = @fopen('store/composer-operation.lock', 'c');
+			if ($lock === false)
+			{
+				throw new runtime_exception('COMPOSER_OPERATION_LOCK_FAILED');
+			}
+
+			if (!flock($lock, LOCK_EX | LOCK_NB))
+			{
+				fclose($lock);
+				throw new runtime_exception('COMPOSER_OPERATION_IN_PROGRESS');
+			}
+
+			try
+			{
+				$this->do_install($packages, $whitelist, $io);
+			}
+			finally
+			{
+				flock($lock, LOCK_UN);
+				fclose($lock);
+			}
 		});
 	}
 
@@ -164,7 +193,7 @@ class installer
 			$this->move_to_root();
 		}
 
-		$this->generate_ext_json_file($packages);
+		$this->generate_ext_json_file($packages, $io, true);
 
 		$composer = $this->get_composer($this->get_composer_ext_json_filename());
 
@@ -206,6 +235,9 @@ class installer
 
 			throw new runtime_exception($io->get_composer_error(), []);
 		}
+
+		$this->ext_json_file_backup = null;
+		$this->ext_lock_file_backup = null;
 	}
 
 	/**
@@ -221,6 +253,24 @@ class installer
 	{
 		return $this->wrap(function() use ($types) {
 			return $this->do_get_installed_packages($types);
+		});
+	}
+
+	/**
+	 * Returns the exact installed versions of packages of the supplied type(s)
+	 *
+	 * /!\ Doesn't change the current working directory
+	 *
+	 * @param string|array $types Returns only the packages with the given type(s)
+	 *
+	 * @return array The installed packages associated to their normalized version.
+	 *
+	 * @throws runtime_exception
+	 */
+	public function get_installed_package_versions($types)
+	{
+		return $this->wrap(function() use ($types) {
+			return $this->do_get_installed_package_versions($types);
 		});
 	}
 
@@ -292,6 +342,38 @@ class installer
 	}
 
 	/**
+	 * Returns the exact installed versions of packages of the supplied type(s)
+	 *
+	 * @param string|array $types Returns only the packages with the given type(s)
+	 *
+	 * @return array The installed packages associated to their normalized version.
+	 */
+	protected function do_get_installed_package_versions($types)
+	{
+		$types = (array) $types;
+
+		try
+		{
+			$composer = $this->get_composer($this->get_composer_ext_json_filename());
+			$installed = [];
+
+			foreach ($composer->getRepositoryManager()->getLocalRepository()->getCanonicalPackages() as $package)
+			{
+				if (in_array($package->getType(), $types, true))
+				{
+					$installed[$package->getName()] = $package->getVersion();
+				}
+			}
+
+			return $installed;
+		}
+		catch (\Exception $e)
+		{
+			return [];
+		}
+	}
+
+	/**
 	 * Gets the list of the available packages of the configured type in the configured repositories
 	 *
 	 * /!\ Doesn't change the current working directory
@@ -328,11 +410,15 @@ class installer
 			/** @var ConstraintInterface $core_constraint */
 			$core_constraint = $composer->getPackage()->getRequires()['phpbb/phpbb']->getConstraint();
 			$core_stability = $composer->getPackage()->getMinimumStability();
+			$installers_constraint = $composer->getPackage()->getRequires()['composer/installers']->getConstraint();
+			$provided_constraints = $this->get_provided_constraints($composer);
+			$platform_constraints = $this->get_platform_constraints($composer);
 
 			$available = [];
 
 			$compatible_packages = [];
 			$repositories = $composer->getRepositoryManager()->getRepositories();
+			$repository_set = $this->get_repository_set($repositories, $core_stability);
 
 			/** @var \Composer\Repository\RepositoryInterface $repository */
 			foreach ($repositories as $repository)
@@ -359,7 +445,7 @@ class installer
 							foreach (JsonFile::parseJson($json, $url)['packageNames'] as $package)
 							{
 								$versions            = $repository->findPackages($package);
-								$compatible_packages = $this->get_compatible_versions($compatible_packages, $core_constraint, $core_stability, $package, $versions);
+								$compatible_packages = $this->get_compatible_versions($compatible_packages, $core_constraint, $core_stability, $installers_constraint, $provided_constraints, $platform_constraints, $repository_set, $package, $versions);
 							}
 						}
 					}
@@ -379,7 +465,7 @@ class installer
 						// Filter the compatibles versions
 						foreach ($packages as $package => $versions)
 						{
-							$compatible_packages = $this->get_compatible_versions($compatible_packages, $core_constraint, $core_stability, $package, $versions);
+							$compatible_packages = $this->get_compatible_versions($compatible_packages, $core_constraint, $core_stability, $installers_constraint, $provided_constraints, $platform_constraints, $repository_set, $package, $versions);
 						}
 					}
 				}
@@ -397,10 +483,7 @@ class installer
 				$highest_version = null;
 
 				// Sort the versions array in descending order
-				usort($package_versions, function ($a, $b)
-				{
-					return version_compare($b->getVersion(), $a->getVersion());
-				});
+				$this->sort_package_versions($package_versions);
 
 				// The first element in the sorted array is the highest version
 				if (!empty($package_versions))
@@ -421,6 +504,7 @@ class installer
 				$available[$package_name]['display_name'] = $highest_version->getExtra()['display-name'];
 				$available[$package_name]['composer_name'] = $highest_version->getName();
 				$available[$package_name]['version'] = $highest_version->getPrettyVersion();
+				$available[$package_name]['normalized_version'] = $highest_version->getVersion();
 
 				if ($highest_version instanceof CompletePackage)
 				{
@@ -460,6 +544,7 @@ class installer
 			$this->root_path . $this->composer_filename,
 			$this->root_path . $this->packages_vendor_dir,
 			$this->root_path . substr($this->composer_filename, 0, -5) . '.lock',
+			$this->root_path . 'store/',
 		]);
 	}
 
@@ -469,12 +554,16 @@ class installer
 	 * @param array $compatible_packages List of compatibles versions
 	 * @param ConstraintInterface $core_constraint Constraint against the phpBB version
 	 * @param string $core_stability Core stability
+	 * @param ConstraintInterface $installers_constraint Constraint of the composer/installers version used by phpBB
+	 * @param array $provided_constraints Versions of packages fixed/provided by phpBB
+	 * @param array $platform_constraints Versions of platform packages available to Composer
+	 * @param RepositorySet $repository_set Composer repositories in installation priority order
 	 * @param string $package_name Considered package
 	 * @param array $versions List of available versions
 	 *
 	 * @return array
 	 */
-	private function get_compatible_versions(array $compatible_packages, ConstraintInterface $core_constraint, $core_stability, $package_name, array $versions)
+	private function get_compatible_versions(array $compatible_packages, ConstraintInterface $core_constraint, $core_stability, ConstraintInterface $installers_constraint, array $provided_constraints, array $platform_constraints, RepositorySet $repository_set, $package_name, array $versions)
 	{
 		$version_parser = new VersionParser();
 
@@ -493,6 +582,13 @@ class installer
 
 				$requires = $version->getRequires();
 				$extra = $version->getExtra();
+				$conflicts = $version->getConflicts();
+
+				// Extensions must explicitly declare the phpBB versions they support.
+				if (!isset($requires['phpbb/phpbb']) && !isset($extra['soft-require']['phpbb/phpbb']))
+				{
+					continue;
+				}
 
 				// Check for compatibility with phpBB if 'phpbb/phpbb' exists in 'requires'
 				if (isset($requires['phpbb/phpbb']))
@@ -514,23 +610,20 @@ class installer
 					}
 				}
 
-				// Check for compatibility with php if 'php' exists in 'requires'
-				if (isset($requires['php']))
+				// Check all platform requirements, including PHP extensions and Composer APIs.
+				foreach ($requires as $required_name => $required_link)
 				{
-					$php_constraint = $version_parser->parseConstraints(PHP_VERSION);
-					$package_constraint = $requires['php']->getConstraint();
-					if (!$package_constraint->matches($php_constraint))
+					if (PlatformRepository::isPlatformPackage($required_name)
+						&& !$this->matches_any_constraint($required_link->getConstraint(), $platform_constraints[$required_name] ?? []))
 					{
-						continue;
+						continue 2;
 					}
 				}
 
-				// Check for composer/installers requirement - must support version 2.0 or later
+				// The extension must support the exact composer/installers version pinned by phpBB.
 				if (isset($requires['composer/installers']))
 				{
-					$installers_constraint = $requires['composer/installers']->getConstraint();
-					$min_version_constraint = $version_parser->parseConstraints('>=2.0');
-					if (!$min_version_constraint->matches($installers_constraint))
+					if (!$requires['composer/installers']->getConstraint()->matches($installers_constraint))
 					{
 						continue;
 					}
@@ -538,6 +631,33 @@ class installer
 				else
 				{
 					continue;
+				}
+
+				// phpBB fixes its core dependency versions in composer-ext.json. Reject extensions whose
+				// direct requirements or conflicts cannot coexist with those fixed packages.
+				foreach ($requires as $required_name => $required_link)
+				{
+					if (isset($provided_constraints[$required_name])
+						&& !$this->matches_any_constraint($required_link->getConstraint(), $provided_constraints[$required_name]))
+					{
+						continue 2;
+					}
+
+					if (!isset($provided_constraints[$required_name])
+						&& !PlatformRepository::isPlatformPackage($required_name)
+						&& empty($repository_set->findPackages($required_name, $required_link->getConstraint())))
+					{
+						continue 2;
+					}
+				}
+
+				foreach ($conflicts as $conflicted_name => $conflicted_link)
+				{
+					if (isset($provided_constraints[$conflicted_name])
+						&& $this->matches_any_constraint($conflicted_link->getConstraint(), $provided_constraints[$conflicted_name]))
+					{
+						continue 2;
+					}
 				}
 
 				$compatible_packages[$package_name][] = $version;
@@ -552,13 +672,122 @@ class installer
 	}
 
 	/**
+	 * Check whether a requirement/conflict intersects any available exact constraint.
+	 *
+	 * @param ConstraintInterface $constraint Constraint to test
+	 * @param ConstraintInterface[] $available_constraints Available constraints
+	 * @return bool
+	 */
+	private function matches_any_constraint(ConstraintInterface $constraint, array $available_constraints): bool
+	{
+		foreach ($available_constraints as $available_constraint)
+		{
+			if ($constraint->matches($available_constraint))
+			{
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
+	 * Get exact versions of packages provided by phpBB's generated root package.
+	 *
+	 * @param Composer|PartialComposer $composer Composer instance
+	 * @return array<string, ConstraintInterface[]>
+	 */
+	private function get_provided_constraints($composer): array
+	{
+		$provided_constraints = [];
+		$root_package = $composer->getPackage();
+
+		foreach (array_merge($root_package->getProvides(), $root_package->getReplaces()) as $package => $link)
+		{
+			$provided_constraints[$package][] = $link->getConstraint();
+		}
+
+		foreach ($root_package->getRequires() as $package => $link)
+		{
+			if (!PlatformRepository::isPlatformPackage($package))
+			{
+				$provided_constraints[$package][] = $link->getConstraint();
+			}
+		}
+
+		return $provided_constraints;
+	}
+
+	/**
+	 * Get exact constraints for platform packages available to Composer.
+	 *
+	 * @param Composer|PartialComposer $composer Composer instance
+	 * @return array<string, ConstraintInterface[]>
+	 */
+	private function get_platform_constraints($composer): array
+	{
+		$platform_constraints = [];
+		$platform_repository = new PlatformRepository([], $composer->getConfig()->get('platform') ?: []);
+
+		foreach ($platform_repository->getPackages() as $package)
+		{
+			$platform_constraints[$package->getName()][] = new Constraint('==', $package->getVersion());
+		}
+
+		return $platform_constraints;
+	}
+
+	/**
+	 * Create a repository set matching Composer's installation priority behavior.
+	 *
+	 * @param array $repositories Composer repositories
+	 * @param string $minimum_stability Minimum package stability
+	 * @return RepositorySet
+	 */
+	private function get_repository_set(array $repositories, string $minimum_stability): RepositorySet
+	{
+		$repository_set = new RepositorySet($minimum_stability);
+
+		foreach ($repositories as $repository)
+		{
+			$repository_set->addRepository($repository);
+		}
+
+		return $repository_set;
+	}
+
+	/**
+	 * Sort packages the same way as a prefer-stable Composer update.
+	 *
+	 * @param PackageInterface[] $package_versions Package versions to sort in place
+	 */
+	private function sort_package_versions(array &$package_versions): void
+	{
+		usort($package_versions, function (PackageInterface $a, PackageInterface $b)
+		{
+			$a_priority = BasePackage::$stabilities[$a->getStability()];
+			$b_priority = BasePackage::$stabilities[$b->getStability()];
+			$stable_priority = BasePackage::STABILITY_STABLE;
+
+			if ($a_priority !== $b_priority && ($a_priority > $stable_priority || $b_priority > $stable_priority))
+			{
+				return $a_priority <=> $b_priority;
+			}
+
+			return version_compare($b->getVersion(), $a->getVersion());
+		});
+	}
+
+	/**
 	 * Generates and write the json file used to install the set of packages
 	 *
 	 * @param array $packages Packages to update.
 	 *        Each entry may be a name or an array associating a version constraint to a name
+	 * @param io\io_interface|null $io Composer output
+	 * @param bool $skip_unavailable_repositories Whether unavailable custom repositories may be skipped
 	 * @throws JsonValidationException
 	 */
-	protected function generate_ext_json_file(array $packages)
+	protected function generate_ext_json_file(array $packages, io\io_interface|null $io = null, bool $skip_unavailable_repositories = false)
 	{
 		$composer = $this->get_composer(null);
 
@@ -578,6 +807,8 @@ class installer
 			'repositories' => $this->get_composer_repositories(),
 			'config' => [
 				'vendor-dir'	=> $this->packages_vendor_dir,
+				'secure-http' => true,
+				'preferred-install' => 'dist',
 				'allow-plugins'	=> [
 					'composer/installers' => true,
 				]
@@ -586,16 +817,21 @@ class installer
 		];
 
 		$this->ext_json_file_backup = null;
+		$ext_lock_file_backup = @file_get_contents(substr($this->get_composer_ext_json_filename(), 0, -5) . '.lock');
+		$this->ext_lock_file_backup = $ext_lock_file_backup === false ? null : $ext_lock_file_backup;
 		$json_file = new JsonFile($this->get_composer_ext_json_filename());
+		$ext_json_file_backup = @file_get_contents($this->get_composer_ext_json_filename());
+		if ($ext_json_file_backup === false)
+		{
+			$ext_json_file_backup = "{}\n";
+		}
 
 		try
 		{
-			$ext_json_file_backup = $json_file->read();
+			$json_file->read();
 		}
 		catch (ParsingException $e)
 		{
-			$ext_json_file_backup = '{}';
-
 			$lockFile = new JsonFile(substr($this->get_composer_ext_json_filename(), 0, -5) . '.lock');
 			$lockFile->write([]);
 		}
@@ -603,6 +839,23 @@ class installer
 		// First pass write: base file with requested packages as provided
 		$json_file->write($ext_json_data);
 		$this->ext_json_file_backup = $ext_json_file_backup;
+
+		if ($skip_unavailable_repositories && $this->packagist && !empty($ext_json_data['repositories']))
+		{
+			$ext_composer = $this->get_composer($this->get_composer_ext_json_filename());
+			$repositories = $this->filter_unavailable_repositories(
+				$ext_json_data['repositories'],
+				$ext_composer->getRepositoryManager()->getRepositories(),
+				array_keys($packages),
+				$io ?? new null_io()
+			);
+
+			if ($repositories !== $ext_json_data['repositories'])
+			{
+				$ext_json_data['repositories'] = $repositories;
+				$json_file->write($ext_json_data);
+			}
+		}
 
 		// Second pass: resolve and pin the highest compatible versions for unconstrained requested packages
 		try
@@ -661,6 +914,61 @@ class installer
 	}
 
 	/**
+	 * Remove temporarily unavailable configured repositories when Packagist can provide a fallback.
+	 *
+	 * @param array $repository_configs Composer repository configuration
+	 * @param array $repositories Instantiated Composer repositories
+	 * @param array $package_names Package names involved in the operation
+	 * @param io\io_interface $io Composer output
+	 * @return array Available repository configuration
+	 */
+	protected function filter_unavailable_repositories(array $repository_configs, array $repositories, array $package_names, io\io_interface $io): array
+	{
+		$available = [];
+		foreach ($repository_configs as $repository_config)
+		{
+			if (isset($repository_config['url']))
+			{
+				$available[rtrim($repository_config['url'], '/')] = true;
+			}
+		}
+
+		$probe_package = reset($package_names) ?: 'phpbb/phpbb';
+
+		foreach ($repositories as $repository)
+		{
+			$composer_repository = $repository instanceof FilterRepository ? $repository->getRepository() : $repository;
+			if (!$composer_repository instanceof ComposerRepository)
+			{
+				continue;
+			}
+
+			$repository_config = $composer_repository->getRepoConfig();
+			$repository_url = isset($repository_config['url']) ? rtrim($repository_config['url'], '/') : '';
+			if (!isset($available[$repository_url]))
+			{
+				continue;
+			}
+
+			try
+			{
+				$repository->findPackages($probe_package);
+			}
+			catch (\Exception $e)
+			{
+				$available[$repository_url] = false;
+				/** @psalm-suppress InvalidArgument phpBB IO accepts translated message tuples. */
+				$io->writeError([['COMPOSER_REPOSITORY_UNAVAILABLE', [$repository_config['url']], 3]]);
+			}
+		}
+
+		return array_values(array_filter($repository_configs, function(array $repository_config) use ($available)
+		{
+			return !isset($repository_config['url']) || $available[rtrim($repository_config['url'], '/')];
+		}));
+	}
+
+	/**
 	 * Resolve the highest compatible versions for the given package names
 	 * based on repositories and phpBB/PHP constraints from the provided Composer instance.
 	 *
@@ -674,6 +982,10 @@ class installer
 	{
 		$compatible_packages = [];
 		$repositories = $composer->getRepositoryManager()->getRepositories();
+		$repository_set = $this->get_repository_set($repositories, $core_stability);
+		$installers_constraint = $composer->getPackage()->getRequires()['composer/installers']->getConstraint();
+		$provided_constraints = $this->get_provided_constraints($composer);
+		$platform_constraints = $this->get_platform_constraints($composer);
 
 		foreach ($repositories as $repository)
 		{
@@ -686,7 +998,7 @@ class installer
 						$versions = $repository->findPackages($name);
 						if (!empty($versions))
 						{
-							$compatible_packages = $this->get_compatible_versions($compatible_packages, $core_constraint, $core_stability, $name, $versions);
+							$compatible_packages = $this->get_compatible_versions($compatible_packages, $core_constraint, $core_stability, $installers_constraint, $provided_constraints, $platform_constraints, $repository_set, $name, $versions);
 						}
 					}
 				}
@@ -705,7 +1017,7 @@ class installer
 
 					foreach ($package_name as $name => $versions)
 					{
-						$compatible_packages = $this->get_compatible_versions($compatible_packages, $core_constraint, $core_stability, $name, $versions);
+						$compatible_packages = $this->get_compatible_versions($compatible_packages, $core_constraint, $core_stability, $installers_constraint, $provided_constraints, $platform_constraints, $repository_set, $name, $versions);
 					}
 				}
 			}
@@ -726,10 +1038,7 @@ class installer
 
 			$package_versions = $compatible_packages[$name];
 
-			// Sort descending by normalized version
-			usort($package_versions, function ($a, $b) {
-				return version_compare($b->getVersion(), $a->getVersion());
-			});
+			$this->sort_package_versions($package_versions);
 
 			$highest = $package_versions[0];
 			if ($highest instanceof CompleteAliasPackage)
@@ -749,18 +1058,31 @@ class installer
 	 */
 	protected function restore_ext_json_file()
 	{
-		if ($this->ext_json_file_backup)
+		$restore_failed = false;
+
+		if ($this->ext_json_file_backup !== null)
 		{
-			try
+			if (@file_put_contents($this->get_composer_ext_json_filename(), $this->ext_json_file_backup, LOCK_EX) === false)
 			{
-				$json_file = new JsonFile($this->get_composer_ext_json_filename());
-				$json_file->write($this->ext_json_file_backup);
-			}
-			catch (\Exception $e)
-			{
+				$restore_failed = true;
 			}
 
 			$this->ext_json_file_backup = null;
+		}
+
+		if ($this->ext_lock_file_backup !== null)
+		{
+			if (@file_put_contents(substr($this->get_composer_ext_json_filename(), 0, -5) . '.lock', $this->ext_lock_file_backup, LOCK_EX) === false)
+			{
+				$restore_failed = true;
+			}
+
+			$this->ext_lock_file_backup = null;
+		}
+
+		if ($restore_failed)
+		{
+			throw new runtime_exception('COMPOSER_CANNOT_RESTORE');
 		}
 	}
 
@@ -812,12 +1134,20 @@ class installer
 
 		foreach ($this->repositories as $repository)
 		{
-			if (preg_match('#^' . get_preg_expression('url') . '$#iu', $repository))
+			$parts = is_string($repository) ? parse_url($repository) : false;
+			if ($parts !== false
+				&& ($parts['scheme'] ?? '') === 'https'
+				&& !empty($parts['host'])
+				&& !isset($parts['user'])
+				&& !isset($parts['pass'])
+				&& preg_match('#^' . get_preg_expression('url') . '$#iu', $repository))
 			{
 				$repositories[] = [
 					'type' => 'composer',
 					'url' => $repository,
-					'canonical' => $this->packagist ? false : true,
+					// When Packagist is enabled, allow dependencies missing from or outdated in this repository
+					// to be selected from Packagist. Without Packagist, keep configured repositories canonical.
+					'canonical' => !$this->packagist,
 				];
 			}
 		}

--- a/phpBB/phpbb/composer/installer.php
+++ b/phpBB/phpbb/composer/installer.php
@@ -135,7 +135,7 @@ class installer
 	}
 
 	/**
-	 * Update the current installed set of packages
+	 * Updates the currently installed set of packages.
 	 *
 	 * @param array $packages Packages to install.
 	 *        Each entry may be a name or an array associating a version constraint to a name
@@ -172,9 +172,9 @@ class installer
 	}
 
 	/**
-	 * Update the current installed set of packages
+	 * Updates the currently installed set of packages.
 	 *
-	 * /!\ Doesn't change the current working directory
+	 * Does not change the current working directory.
 	 *
 	 * @param array $packages Packages to install.
 	 *        Each entry may be a name or an array associating a version constraint to a name
@@ -257,9 +257,9 @@ class installer
 	}
 
 	/**
-	 * Returns the exact installed versions of packages of the supplied type(s)
+	 * Returns the exact installed versions of packages of the supplied type(s).
 	 *
-	 * /!\ Doesn't change the current working directory
+	 * Does not change the current working directory.
 	 *
 	 * @param string|array $types Returns only the packages with the given type(s)
 	 *
@@ -342,7 +342,7 @@ class installer
 	}
 
 	/**
-	 * Returns the exact installed versions of packages of the supplied type(s)
+	 * Returns the exact installed versions of packages of the supplied type(s).
 	 *
 	 * @param string|array $types Returns only the packages with the given type(s)
 	 *
@@ -672,7 +672,7 @@ class installer
 	}
 
 	/**
-	 * Check whether a requirement/conflict intersects any available exact constraint.
+	 * Checks whether a requirement/conflict intersects any available exact constraint.
 	 *
 	 * @param ConstraintInterface $constraint Constraint to test
 	 * @param ConstraintInterface[] $available_constraints Available constraints
@@ -692,7 +692,7 @@ class installer
 	}
 
 	/**
-	 * Get exact versions of packages provided by phpBB's generated root package.
+	 * Gets exact versions of packages provided by phpBB's generated root package.
 	 *
 	 * @param Composer|PartialComposer $composer Composer instance
 	 * @return array<string, ConstraintInterface[]>
@@ -719,7 +719,7 @@ class installer
 	}
 
 	/**
-	 * Get exact constraints for platform packages available to Composer.
+	 * Gets exact constraints for platform packages available to Composer.
 	 *
 	 * @param Composer|PartialComposer $composer Composer instance
 	 * @return array<string, ConstraintInterface[]>
@@ -738,7 +738,7 @@ class installer
 	}
 
 	/**
-	 * Create a repository set matching Composer's installation priority behavior.
+	 * Creates a repository set matching Composer's installation priority behavior.
 	 *
 	 * @param array $repositories Composer repositories
 	 * @param string $minimum_stability Minimum package stability
@@ -757,9 +757,11 @@ class installer
 	}
 
 	/**
-	 * Sort packages the same way as a prefer-stable Composer update.
+	 * Sorts packages the same way as a prefer-stable Composer update.
 	 *
 	 * @param PackageInterface[] $package_versions Package versions to sort in place
+	 *
+	 * @return void
 	 */
 	private function sort_package_versions(array &$package_versions): void
 	{
@@ -779,7 +781,7 @@ class installer
 	}
 
 	/**
-	 * Generates and write the json file used to install the set of packages
+	 * Generates and writes the JSON file used to install the set of packages.
 	 *
 	 * @param array $packages Packages to update.
 	 *        Each entry may be a name or an array associating a version constraint to a name
@@ -914,7 +916,7 @@ class installer
 	}
 
 	/**
-	 * Remove temporarily unavailable configured repositories when Packagist can provide a fallback.
+	 * Removes temporarily unavailable configured repositories when Packagist can provide a fallback.
 	 *
 	 * @param array $repository_configs Composer repository configuration
 	 * @param array $repositories Instantiated Composer repositories
@@ -969,7 +971,7 @@ class installer
 	}
 
 	/**
-	 * Resolve the highest compatible versions for the given package names
+	 * Resolves the highest compatible versions for the given package names
 	 * based on repositories and phpBB/PHP constraints from the provided Composer instance.
 	 *
 	 * @param array $package_names list of package names to resolve
@@ -1054,7 +1056,11 @@ class installer
 	}
 
 	/**
-	 * Restore the json file overridden by generate_ext_json_file()
+	 * Restores the JSON file overridden by generate_ext_json_file().
+	 *
+	 * @return void
+	 *
+	 * @throws runtime_exception
 	 */
 	protected function restore_ext_json_file()
 	{
@@ -1119,7 +1125,7 @@ class installer
 	}
 
 	/**
-	 * Generate the repositories entry of the packages json file
+	 * Generates the repositories entry of the packages JSON file.
 	 *
 	 * @return array repositories entry
 	 */

--- a/phpBB/phpbb/composer/manager.php
+++ b/phpBB/phpbb/composer/manager.php
@@ -14,6 +14,9 @@
 namespace phpbb\composer;
 
 use Composer\IO\IOInterface;
+use Composer\Package\Loader\ValidatingArrayLoader;
+use Composer\Semver\Comparator;
+use Composer\Semver\VersionParser;
 use phpbb\cache\driver\driver_interface;
 use phpbb\composer\exception\runtime_exception;
 
@@ -76,6 +79,7 @@ class manager implements manager_interface
 	 */
 	public function install(array $packages, IOInterface|null $io = null)
 	{
+		$io ??= new \phpbb\composer\io\null_io();
 		$packages = $this->normalize_version($packages);
 
 		$already_managed = array_intersect(array_keys($this->get_managed_packages()), array_keys($packages));
@@ -93,7 +97,7 @@ class manager implements manager_interface
 
 		$this->post_install($packages, $io);
 
-		$this->managed_packages = null;
+		$this->invalidate_installed_packages();
 	}
 
 	/**
@@ -123,6 +127,7 @@ class manager implements manager_interface
 	 */
 	public function update(array $packages, IOInterface|null $io = null)
 	{
+		$io ??= new \phpbb\composer\io\null_io();
 		$packages = $this->normalize_version($packages);
 
 		$not_managed = array_diff_key($packages, $this->get_managed_packages());
@@ -139,6 +144,8 @@ class manager implements manager_interface
 		$this->installer->install($managed_packages, array_keys($packages), $io);
 
 		$this->post_update($packages, $io);
+
+		$this->invalidate_installed_packages();
 	}
 
 	/**
@@ -168,6 +175,7 @@ class manager implements manager_interface
 	 */
 	public function remove(array $packages, IOInterface|null $io = null)
 	{
+		$io ??= new \phpbb\composer\io\null_io();
 		$packages = $this->normalize_version($packages);
 
 		$not_managed = array_diff_key($packages, $this->get_managed_packages());
@@ -185,7 +193,7 @@ class manager implements manager_interface
 
 		$this->post_remove($packages, $io);
 
-		$this->managed_packages = null;
+		$this->invalidate_installed_packages();
 	}
 
 	/**
@@ -266,6 +274,62 @@ class manager implements manager_interface
 	/**
 	 * {@inheritdoc}
 	 */
+	public function get_available_updates()
+	{
+		$available_packages = $this->available_packages ?? $this->cache->get('_composer_' . $this->package_type . '_available');
+		if (!is_array($available_packages) || !$available_packages)
+		{
+			return [];
+		}
+
+		$installed_versions = $this->installer->get_installed_package_versions($this->package_type);
+		$version_parser = new VersionParser();
+		$updates = [];
+
+		foreach ($available_packages as $package)
+		{
+			if (!is_array($package))
+			{
+				continue;
+			}
+
+			$package_name = $package['composer_name'] ?? '';
+			if (!is_string($package_name) || $package_name === '' || !isset($installed_versions[$package_name]) || !is_string($installed_versions[$package_name]))
+			{
+				continue;
+			}
+
+			try
+			{
+				$available_version = $package['normalized_version'] ?? null;
+				if (!is_string($available_version))
+				{
+					if (!isset($package['version']) || !is_string($package['version']))
+					{
+						continue;
+					}
+
+					$available_version = $version_parser->normalize($package['version']);
+				}
+
+				if (Comparator::greaterThan($available_version, $installed_versions[$package_name]))
+				{
+					$updates[$package_name] = $package;
+				}
+			}
+			catch (\UnexpectedValueException $e)
+			{
+				// An invalid or incomplete catalog entry must not advertise an update.
+				continue;
+			}
+		}
+
+		return $updates;
+	}
+
+	/**
+	 * {@inheritdoc}
+	 */
 	public function reset_cache()
 	{
 		$this->cache->destroy('_composer_' . $this->package_type . '_available');
@@ -306,14 +370,24 @@ class manager implements manager_interface
 	protected function normalize_version(array $packages)
 	{
 		$normalized_packages = [];
+		$version_parser = new VersionParser();
 
 		foreach ($packages as $package => $version)
 		{
 			if (is_numeric($package))
 			{
+				if (!is_string($version) || $version === '')
+				{
+					throw new runtime_exception($this->exception_prefix, 'INVALID_PACKAGE');
+				}
+
 				if (strpos($version, ':') !== false)
 				{
-					$parts = explode(':', $version);
+					$parts = explode(':', $version, 2);
+					if ($parts[0] === '' || $parts[1] === '')
+					{
+						throw new runtime_exception($this->exception_prefix, 'INVALID_PACKAGE');
+					}
 					$normalized_packages[$parts[0]] = $parts[1];
 				}
 				else
@@ -323,10 +397,40 @@ class manager implements manager_interface
 			}
 			else
 			{
+				if (!is_string($version) || $version === '')
+				{
+					throw new runtime_exception($this->exception_prefix, 'INVALID_PACKAGE');
+				}
 				$normalized_packages[$package] = $version;
 			}
 		}
 
+		foreach ($normalized_packages as $package => $version)
+		{
+			if (ValidatingArrayLoader::hasPackageNamingError($package, true) !== null)
+			{
+				throw new runtime_exception($this->exception_prefix, 'INVALID_PACKAGE');
+			}
+
+			try
+			{
+				$version_parser->parseConstraints($version);
+			}
+			catch (\UnexpectedValueException $e)
+			{
+				throw new runtime_exception($this->exception_prefix, 'INVALID_PACKAGE');
+			}
+		}
+
 		return $normalized_packages;
+	}
+
+	/**
+	 * Clear request-local installed package state after Composer changes it.
+	 */
+	private function invalidate_installed_packages(): void
+	{
+		$this->managed_packages = null;
+		$this->all_managed_packages = null;
 	}
 }

--- a/phpBB/phpbb/composer/manager.php
+++ b/phpBB/phpbb/composer/manager.php
@@ -356,16 +356,16 @@ class manager implements manager_interface
 	}
 
 	/**
-	 * Normalize a packages/version array. Every entry can have 3 different forms:
+	 * Normalizes a packages/version array. Every entry can have 3 different forms:
 	 *  - $package => $version
 	 *  - $indice => $package:$version
 	 *  - $indice => $package
-	 * They are converted to he form:
+	 * They are converted to the form:
 	 *  - $package => $version ($version is set to '*' for the third form)
 	 *
-	 * @param array $packages
+	 * @param array $packages Packages to normalize
 	 *
-	 * @return array
+	 * @return array Normalized packages and version constraints
 	 */
 	protected function normalize_version(array $packages)
 	{
@@ -426,7 +426,9 @@ class manager implements manager_interface
 	}
 
 	/**
-	 * Clear request-local installed package state after Composer changes it.
+	 * Clears request-local installed package state after Composer changes it.
+	 *
+	 * @return void
 	 */
 	private function invalidate_installed_packages(): void
 	{

--- a/phpBB/phpbb/composer/manager_interface.php
+++ b/phpBB/phpbb/composer/manager_interface.php
@@ -85,6 +85,13 @@ interface manager_interface
 	public function get_available_packages();
 
 	/**
+	 * Returns managed packages with a newer compatible version in the cached catalog
+	 *
+	 * @return array The package names associated to their available definition.
+	 */
+	public function get_available_updates();
+
+	/**
 	 * Reset the cache
 	 */
 	public function reset_cache();

--- a/phpBB/phpbb/composer/manager_interface.php
+++ b/phpBB/phpbb/composer/manager_interface.php
@@ -85,7 +85,7 @@ interface manager_interface
 	public function get_available_packages();
 
 	/**
-	 * Returns managed packages with a newer compatible version in the cached catalog
+	 * Returns managed packages with a newer compatible version in the cached catalog.
 	 *
 	 * @return array The package names associated to their available definition.
 	 */

--- a/tests/composer/extension_manager_test.php
+++ b/tests/composer/extension_manager_test.php
@@ -1,0 +1,113 @@
+<?php
+/**
+ *
+ * This file is part of the phpBB Forum Software package.
+ *
+ * @copyright (c) phpBB Limited <https://www.phpbb.com>
+ * @license GNU General Public License, version 2 (GPL-2.0)
+ *
+ * For full copyright and license information, please see
+ * the docs/CREDITS.txt file.
+ *
+ */
+
+namespace phpbb\tests\composer;
+
+use phpbb\cache\driver\driver_interface;
+use phpbb\composer\exception\runtime_exception;
+use phpbb\composer\extension_manager;
+use phpbb\composer\installer;
+use phpbb\composer\io\null_io;
+use phpbb\extension\manager as phpbb_extension_manager;
+use phpbb\filesystem\filesystem;
+
+class extension_manager_test extends \phpbb_test_case
+{
+	public function test_remove_without_purge_disables_extension_and_preserves_files(): void
+	{
+		$phpbb_extension_manager = $this->createMock(phpbb_extension_manager::class);
+		$phpbb_extension_manager->expects($this->once())
+			->method('is_enabled')
+			->with('vendor/extension')
+			->willReturn(true);
+		$phpbb_extension_manager->expects($this->once())
+			->method('disable')
+			->with('vendor/extension');
+		$phpbb_extension_manager->expects($this->once())
+			->method('is_configured')
+			->with('vendor/extension')
+			->willReturn(true);
+		$phpbb_extension_manager->expects($this->never())
+			->method('purge');
+
+		$manager = $this->get_manager($phpbb_extension_manager);
+		$manager->set_purge_on_remove(false);
+
+		try
+		{
+			$manager->pre_remove(['vendor/extension' => '*'], new null_io());
+			$this->fail('Removing a configured extension without purging should fail.');
+		}
+		catch (runtime_exception $e)
+		{
+			$this->assertSame('EXTENSIONS_REMOVE_REQUIRES_PURGE', $e->getMessage());
+			$this->assertSame(['vendor/extension'], $e->get_parameters());
+		}
+	}
+
+	public function test_remove_without_purge_allows_unconfigured_extension(): void
+	{
+		$phpbb_extension_manager = $this->createMock(phpbb_extension_manager::class);
+		$phpbb_extension_manager->expects($this->once())
+			->method('is_enabled')
+			->with('vendor/extension')
+			->willReturn(false);
+		$phpbb_extension_manager->expects($this->once())
+			->method('is_configured')
+			->with('vendor/extension')
+			->willReturn(false);
+
+		$manager = $this->get_manager($phpbb_extension_manager);
+		$manager->set_purge_on_remove(false);
+		$manager->pre_remove(['vendor/extension' => '*'], new null_io());
+
+		$this->addToAssertionCount(1);
+	}
+
+	public function test_remove_with_purge_deletes_extension_data(): void
+	{
+		$phpbb_extension_manager = $this->createMock(phpbb_extension_manager::class);
+		$phpbb_extension_manager->expects($this->once())
+			->method('is_configured')
+			->with('vendor/extension')
+			->willReturn(true);
+		$phpbb_extension_manager->expects($this->once())
+			->method('purge')
+			->with('vendor/extension');
+		$phpbb_extension_manager->expects($this->never())
+			->method('disable');
+
+		$manager = $this->get_manager($phpbb_extension_manager);
+		$manager->set_purge_on_remove(true);
+		$manager->pre_remove(['vendor/extension' => '*'], new null_io());
+
+		$this->addToAssertionCount(1);
+	}
+
+	private function get_manager(phpbb_extension_manager $phpbb_extension_manager): extension_manager
+	{
+		$installer = $this->getMockBuilder(installer::class)
+			->disableOriginalConstructor()
+			->getMock();
+
+		return new extension_manager(
+			$installer,
+			$this->createMock(driver_interface::class),
+			$phpbb_extension_manager,
+			$this->createMock(filesystem::class),
+			'phpbb-extension',
+			'EXTENSIONS_',
+			'./'
+		);
+	}
+}

--- a/tests/composer/extension_manager_test.php
+++ b/tests/composer/extension_manager_test.php
@@ -21,6 +21,9 @@ use phpbb\composer\io\null_io;
 use phpbb\extension\manager as phpbb_extension_manager;
 use phpbb\filesystem\filesystem;
 
+/**
+ * Tests Composer-managed phpBB extension lifecycle handling.
+ */
 class extension_manager_test extends \phpbb_test_case
 {
 	public function test_remove_without_purge_disables_extension_and_preserves_files(): void
@@ -94,6 +97,13 @@ class extension_manager_test extends \phpbb_test_case
 		$this->addToAssertionCount(1);
 	}
 
+	/**
+	 * Creates an extension manager with mocked dependencies.
+	 *
+	 * @param phpbb_extension_manager $phpbb_extension_manager phpBB extension manager
+	 *
+	 * @return extension_manager Composer extension manager
+	 */
 	private function get_manager(phpbb_extension_manager $phpbb_extension_manager): extension_manager
 	{
 		$installer = $this->getMockBuilder(installer::class)

--- a/tests/composer/installer_test.php
+++ b/tests/composer/installer_test.php
@@ -1,0 +1,198 @@
+<?php
+/**
+ *
+ * This file is part of the phpBB Forum Software package.
+ *
+ * @copyright (c) phpBB Limited <https://www.phpbb.com>
+ * @license GNU General Public License, version 2 (GPL-2.0)
+ *
+ * For full copyright and license information, please see
+ * the docs/CREDITS.txt file.
+ *
+ */
+
+namespace phpbb\tests\composer;
+
+use Composer\Package\CompletePackage;
+use Composer\Package\Link;
+use Composer\Repository\ComposerRepository;
+use Composer\Repository\FilterRepository;
+use Composer\Repository\RepositorySet;
+use Composer\Semver\Constraint\ConstraintInterface;
+use Composer\Semver\VersionParser;
+use phpbb\composer\installer;
+use phpbb\composer\io\null_io;
+use phpbb\filesystem\filesystem;
+use phpbb\request\request;
+
+class installer_test extends \phpbb_test_case
+{
+	public function test_packagist_keeps_configured_repositories_non_canonical(): void
+	{
+		$installer = $this->get_installer();
+		$installer->set_repositories(['https://satis.phpbb.com']);
+		$installer->set_packagist(true);
+
+		$this->assertSame([[
+			'type' => 'composer',
+			'url' => 'https://satis.phpbb.com',
+			'canonical' => false,
+		]], $installer->get_repositories());
+	}
+
+	public function test_disabled_packagist_keeps_configured_repositories_canonical(): void
+	{
+		$installer = $this->get_installer();
+		$installer->set_repositories(['https://satis.phpbb.com']);
+		$installer->set_packagist(false);
+
+		$this->assertSame([
+			['packagist' => false],
+			[
+				'type' => 'composer',
+				'url' => 'https://satis.phpbb.com',
+				'canonical' => true,
+			],
+		], $installer->get_repositories());
+	}
+
+	public function test_unavailable_repository_is_skipped_when_fallback_is_allowed(): void
+	{
+		$available_config = [
+			'type' => 'composer',
+			'url' => 'https://available.example.com/',
+			'canonical' => false,
+		];
+		$unavailable_config = [
+			'type' => 'composer',
+			'url' => 'https://unavailable.example.com/',
+			'canonical' => false,
+		];
+
+		$available_repository = $this->get_repository($available_config);
+		$available_repository->expects($this->once())
+			->method('findPackages')
+			->with('vendor/extension')
+			->willReturn([]);
+
+		$unavailable_repository = $this->get_repository($unavailable_config);
+		$unavailable_repository->expects($this->once())
+			->method('findPackages')
+			->with('vendor/extension')
+			->willThrowException(new \RuntimeException('HTTP 403'));
+
+		$repositories = $this->get_installer()->filter_repositories(
+			[$available_config, $unavailable_config],
+			[
+				new FilterRepository($available_repository, ['canonical' => false]),
+				new FilterRepository($unavailable_repository, ['canonical' => false]),
+			],
+			['vendor/extension'],
+			new null_io()
+		);
+
+		$this->assertSame([$available_config], $repositories);
+	}
+
+	public function test_extension_supporting_installer_v1_or_v2_is_compatible(): void
+	{
+		$versions = $this->get_compatible_versions($this->get_extension('^1.0 || ^2.0'));
+
+		$this->assertArrayHasKey('phpbb/viglink', $versions);
+	}
+
+	public function test_extension_supporting_only_installer_v1_is_incompatible(): void
+	{
+		$versions = $this->get_compatible_versions($this->get_extension('^1.0'));
+
+		$this->assertArrayNotHasKey('phpbb/viglink', $versions);
+	}
+
+	public function test_extension_with_missing_platform_requirement_is_incompatible(): void
+	{
+		$extension = $this->get_extension('^2.0');
+		$requires = $extension->getRequires();
+		$requires['ext-not-installed'] = $this->get_link('ext-not-installed', '*');
+		$extension->setRequires($requires);
+
+		$versions = $this->get_compatible_versions($extension);
+
+		$this->assertArrayNotHasKey('phpbb/viglink', $versions);
+	}
+
+	public function test_extension_with_missing_package_requirement_is_incompatible(): void
+	{
+		$extension = $this->get_extension('^2.0');
+		$requires = $extension->getRequires();
+		$requires['example/missing'] = $this->get_link('example/missing', '^1.0');
+		$extension->setRequires($requires);
+
+		$versions = $this->get_compatible_versions($extension);
+
+		$this->assertArrayNotHasKey('phpbb/viglink', $versions);
+	}
+
+	private function get_installer(): test_installer
+	{
+		return new test_installer('./', new filesystem(), new request(null, false));
+	}
+
+	private function get_repository(array $config): ComposerRepository
+	{
+		$repository = $this->getMockBuilder(ComposerRepository::class)
+			->disableOriginalConstructor()
+			->onlyMethods(['getRepoConfig', 'findPackages'])
+			->getMock();
+		$repository->method('getRepoConfig')->willReturn($config);
+
+		return $repository;
+	}
+
+	private function get_extension(string $installer_constraint): CompletePackage
+	{
+		$extension = new CompletePackage('phpbb/viglink', 'dev-dev/4.0', 'dev-dev/4.0');
+		$extension->setType('phpbb-extension');
+		$extension->setRequires([
+			'phpbb/phpbb' => $this->get_link('phpbb/phpbb', '^4.0'),
+			'composer/installers' => $this->get_link('composer/installers', $installer_constraint),
+		]);
+
+		return $extension;
+	}
+
+	private function get_link(string $target, string $constraint): Link
+	{
+		return new Link('phpbb/viglink', $target, $this->parse_constraint($constraint), Link::TYPE_REQUIRE, $constraint);
+	}
+
+	private function parse_constraint(string $constraint): ConstraintInterface
+	{
+		return (new VersionParser())->parseConstraints($constraint);
+	}
+
+	private function get_compatible_versions(CompletePackage $extension): array
+	{
+		$installer = $this->get_installer();
+		$method = new \ReflectionMethod(installer::class, 'get_compatible_versions');
+
+		$phpbb_constraint = $this->parse_constraint('4.0.0-a3-dev');
+		$installers_constraint = $this->parse_constraint('2.3.0');
+		$provided_constraints = [
+			'phpbb/phpbb' => [$phpbb_constraint],
+			'composer/installers' => [$installers_constraint],
+		];
+
+		return $method->invoke(
+			$installer,
+			[],
+			$phpbb_constraint,
+			'dev',
+			$installers_constraint,
+			$provided_constraints,
+			[],
+			new RepositorySet('dev'),
+			'phpbb/viglink',
+			[$extension]
+		);
+	}
+}

--- a/tests/composer/installer_test.php
+++ b/tests/composer/installer_test.php
@@ -25,6 +25,9 @@ use phpbb\composer\io\null_io;
 use phpbb\filesystem\filesystem;
 use phpbb\request\request;
 
+/**
+ * Tests Composer extension installer repository and compatibility handling.
+ */
 class installer_test extends \phpbb_test_case
 {
 	public function test_packagist_keeps_configured_repositories_non_canonical(): void
@@ -132,11 +135,23 @@ class installer_test extends \phpbb_test_case
 		$this->assertArrayNotHasKey('phpbb/viglink', $versions);
 	}
 
+	/**
+	 * Creates the testable Composer installer.
+	 *
+	 * @return test_installer
+	 */
 	private function get_installer(): test_installer
 	{
 		return new test_installer('./', new filesystem(), new request(null, false));
 	}
 
+	/**
+	 * Creates a mocked Composer repository.
+	 *
+	 * @param array $config Composer repository configuration
+	 *
+	 * @return ComposerRepository
+	 */
 	private function get_repository(array $config): ComposerRepository
 	{
 		$repository = $this->getMockBuilder(ComposerRepository::class)
@@ -148,6 +163,13 @@ class installer_test extends \phpbb_test_case
 		return $repository;
 	}
 
+	/**
+	 * Creates a phpBB extension package with an installer constraint.
+	 *
+	 * @param string $installer_constraint Composer Installers constraint
+	 *
+	 * @return CompletePackage
+	 */
 	private function get_extension(string $installer_constraint): CompletePackage
 	{
 		$extension = new CompletePackage('phpbb/viglink', 'dev-dev/4.0', 'dev-dev/4.0');
@@ -160,16 +182,38 @@ class installer_test extends \phpbb_test_case
 		return $extension;
 	}
 
+	/**
+	 * Creates a package requirement link.
+	 *
+	 * @param string $target     Required package name
+	 * @param string $constraint Required package constraint
+	 *
+	 * @return Link
+	 */
 	private function get_link(string $target, string $constraint): Link
 	{
 		return new Link('phpbb/viglink', $target, $this->parse_constraint($constraint), Link::TYPE_REQUIRE, $constraint);
 	}
 
+	/**
+	 * Parses a Composer version constraint.
+	 *
+	 * @param string $constraint Composer version constraint
+	 *
+	 * @return ConstraintInterface
+	 */
 	private function parse_constraint(string $constraint): ConstraintInterface
 	{
 		return (new VersionParser())->parseConstraints($constraint);
 	}
 
+	/**
+	 * Runs compatibility filtering for an extension package.
+	 *
+	 * @param CompletePackage $extension Extension package
+	 *
+	 * @return array Compatible extension versions
+	 */
 	private function get_compatible_versions(CompletePackage $extension): array
 	{
 		$installer = $this->get_installer();

--- a/tests/composer/manager_test.php
+++ b/tests/composer/manager_test.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ *
+ * This file is part of the phpBB Forum Software package.
+ *
+ * @copyright (c) phpBB Limited <https://www.phpbb.com>
+ * @license GNU General Public License, version 2 (GPL-2.0)
+ *
+ * For full copyright and license information, please see
+ * the docs/CREDITS.txt file.
+ *
+ */
+
+namespace phpbb\tests\composer;
+
+use phpbb\cache\driver\driver_interface;
+use phpbb\composer\installer;
+use phpbb\composer\manager;
+
+class manager_test extends \phpbb_test_case
+{
+	public static function get_available_updates_data(): array
+	{
+		return [
+			'newer stable version' => ['1.0.0.0', ['version' => '1.1.0'], true],
+			'current stable version' => ['1.0.0.0', ['version' => '1.0.0'], false],
+			'older catalog version' => ['1.1.0.0', ['version' => '1.0.0'], false],
+			'normalized catalog version' => ['1.0.0.0', ['version' => 'invalid', 'normalized_version' => '1.1.0.0'], true],
+			'invalid catalog version' => ['1.0.0.0', ['version' => 'invalid'], false],
+		];
+	}
+
+	/**
+	 * @dataProvider get_available_updates_data
+	 */
+	public function test_get_available_updates(string $installed_version, array $catalog_version, bool $expected): void
+	{
+		$package = array_merge([
+			'composer_name' => 'vendor/extension',
+		], $catalog_version);
+
+		$installer = $this->getMockBuilder(installer::class)
+			->disableOriginalConstructor()
+			->onlyMethods(['get_installed_package_versions'])
+			->getMock();
+		$installer->expects($this->once())
+			->method('get_installed_package_versions')
+			->with('phpbb-extension')
+			->willReturn(['vendor/extension' => $installed_version]);
+
+		$cache = $this->createMock(driver_interface::class);
+		$cache->expects($this->once())
+			->method('get')
+			->with('_composer_phpbb-extension_available')
+			->willReturn([$package]);
+
+		$manager = new manager($installer, $cache, 'phpbb-extension', 'EXTENSION');
+		$updates = $manager->get_available_updates();
+
+		$this->assertSame($expected, isset($updates['vendor/extension']));
+	}
+
+	public function test_get_available_updates_does_not_fetch_missing_catalog(): void
+	{
+		$installer = $this->getMockBuilder(installer::class)
+			->disableOriginalConstructor()
+			->onlyMethods(['get_installed_package_versions'])
+			->getMock();
+		$installer->expects($this->never())
+			->method('get_installed_package_versions');
+
+		$cache = $this->createMock(driver_interface::class);
+		$cache->expects($this->once())
+			->method('get')
+			->with('_composer_phpbb-extension_available')
+			->willReturn(false);
+
+		$manager = new manager($installer, $cache, 'phpbb-extension', 'EXTENSION');
+
+		$this->assertSame([], $manager->get_available_updates());
+	}
+}

--- a/tests/composer/manager_test.php
+++ b/tests/composer/manager_test.php
@@ -17,8 +17,16 @@ use phpbb\cache\driver\driver_interface;
 use phpbb\composer\installer;
 use phpbb\composer\manager;
 
+/**
+ * Tests Composer package manager update discovery.
+ */
 class manager_test extends \phpbb_test_case
 {
+	/**
+	 * Provides installed and catalog versions for update discovery tests.
+	 *
+	 * @return array<string, array>
+	 */
 	public static function get_available_updates_data(): array
 	{
 		return [
@@ -31,6 +39,14 @@ class manager_test extends \phpbb_test_case
 	}
 
 	/**
+	 * Tests whether only newer compatible catalog versions are offered.
+	 *
+	 * @param string $installed_version Installed normalized version
+	 * @param array  $catalog_version   Catalog package definition
+	 * @param bool   $expected          Whether an update is expected
+	 *
+	 * @return void
+	 *
 	 * @dataProvider get_available_updates_data
 	 */
 	public function test_get_available_updates(string $installed_version, array $catalog_version, bool $expected): void
@@ -60,6 +76,11 @@ class manager_test extends \phpbb_test_case
 		$this->assertSame($expected, isset($updates['vendor/extension']));
 	}
 
+	/**
+	 * Tests that update discovery does not fetch a missing catalog.
+	 *
+	 * @return void
+	 */
 	public function test_get_available_updates_does_not_fetch_missing_catalog(): void
 	{
 		$installer = $this->getMockBuilder(installer::class)

--- a/tests/composer/test_installer.php
+++ b/tests/composer/test_installer.php
@@ -1,0 +1,30 @@
+<?php
+/**
+ *
+ * This file is part of the phpBB Forum Software package.
+ *
+ * @copyright (c) phpBB Limited <https://www.phpbb.com>
+ * @license GNU General Public License, version 2 (GPL-2.0)
+ *
+ * For full copyright and license information, please see
+ * the docs/CREDITS.txt file.
+ *
+ */
+
+namespace phpbb\tests\composer;
+
+use phpbb\composer\io\io_interface;
+use phpbb\composer\installer;
+
+class test_installer extends installer
+{
+	public function get_repositories(): array
+	{
+		return $this->get_composer_repositories();
+	}
+
+	public function filter_repositories(array $repository_configs, array $repositories, array $package_names, io_interface $io): array
+	{
+		return $this->filter_unavailable_repositories($repository_configs, $repositories, $package_names, $io);
+	}
+}

--- a/tests/composer/test_installer.php
+++ b/tests/composer/test_installer.php
@@ -16,13 +16,31 @@ namespace phpbb\tests\composer;
 use phpbb\composer\io\io_interface;
 use phpbb\composer\installer;
 
+/**
+ * Exposes protected installer methods for unit tests.
+ */
 class test_installer extends installer
 {
+	/**
+	 * Returns generated Composer repository configuration.
+	 *
+	 * @return array Composer repository configuration
+	 */
 	public function get_repositories(): array
 	{
 		return $this->get_composer_repositories();
 	}
 
+	/**
+	 * Filters unavailable Composer repositories.
+	 *
+	 * @param array        $repository_configs Composer repository configuration
+	 * @param array        $repositories        Instantiated Composer repositories
+	 * @param array        $package_names       Package names involved in the operation
+	 * @param io_interface $io                  Composer output
+	 *
+	 * @return array Available repository configuration
+	 */
 	public function filter_repositories(array $repository_configs, array $repositories, array $package_names, io_interface $io): array
 	{
 		return $this->filter_unavailable_repositories($repository_configs, $repositories, $package_names, $io);

--- a/tests/functional/extension_acp_test.php
+++ b/tests/functional/extension_acp_test.php
@@ -266,6 +266,14 @@ class phpbb_functional_extension_acp_test extends phpbb_functional_test_case
 		$this->assertContainsLang('BROWSE_EXTENSIONS_DATABASE', $crawler->filter('fieldset[class="quick quick-left"] > span > a')->eq(0)->text());
 		$this->assertContainsLang('SETTINGS', $crawler->filter('fieldset[class="quick quick-left"] > span > a')->eq(1)->text());
 
+		$restore_repositories = $crawler->filter('#restore_default_repositories');
+		$this->assertCount(1, $restore_repositories);
+		$this->assertSame($this->lang('RESTORE_DEFAULT_REPOSITORIES'), $restore_repositories->attr('value'));
+		$this->assertSame([
+			'https://satis.phpbb.com/',
+			'https://www.phpbb.com/customise/db/composer/40/',
+		], json_decode($restore_repositories->attr('data-default-repositories'), true));
+
 		$form = $crawler->selectButton('Submit')->form();
 		$form['minimum_stability']->select('dev');
 		$form['repositories'] = 'https://satis.phpbb.com/';
@@ -279,6 +287,44 @@ class phpbb_functional_extension_acp_test extends phpbb_functional_test_case
 
 		// Ensure catalog has any records in extensions list
 		$this->assertGreaterThan(0, $crawler->filter('tbody > tr > td > strong')->count());
+	}
+
+	public function test_extensions_catalog_cancelling_install()
+	{
+		$this->mock_extensions_catalog_cache();
+		$crawler = self::request('GET', 'adm/index.php?i=acp_extensions&mode=catalog&action=install&extension=phpbb%2Fviglink&sid=' . $this->sid);
+		$this->assertContainsLang('CONFIRM', $crawler->filter('form#confirm h1')->text());
+
+		$form = $crawler->selectButton($this->lang('NO'))->form();
+		$crawler = self::submit($form);
+		$this->assertContainsLang('ACP_EXTENSIONS_CATALOG', $this->get_content());
+		$this->assertGreaterThan(0, $crawler->selectLink($this->lang('INSTALL'))->count());
+
+		// A cancelled action originating in the manager returns to the manager
+		$crawler = self::request('GET', 'adm/index.php?i=acp_extensions&mode=catalog&action=install&origin=manager&extension=phpbb%2Fviglink&sid=' . $this->sid);
+		$form = $crawler->selectButton($this->lang('NO'))->form();
+		$crawler = self::submit($form);
+		$this->assertStringContainsString('mode=main', $crawler->getUri());
+		$this->assertGreaterThan(0, $crawler->filter('.ext_enabled')->count());
+
+		// Arbitrary return URLs are not accepted
+		$crawler = self::request('GET', 'adm/index.php?i=acp_extensions&mode=catalog&action=install&origin=https%3A%2F%2Fexample.com&extension=phpbb%2Fviglink&sid=' . $this->sid);
+		$form = $crawler->selectButton($this->lang('NO'))->form();
+		$crawler = self::submit($form);
+		$this->assertStringContainsString('mode=catalog', $crawler->getUri());
+		$this->assertStringNotContainsString('example.com', $crawler->getUri());
+	}
+
+	public function test_extensions_catalog_rejects_package_outside_catalog()
+	{
+		$this->mock_extensions_catalog_cache();
+		$crawler = self::request('GET', 'adm/index.php?i=acp_extensions&mode=catalog&action=install&extension=example%2Funtrusted&sid=' . $this->sid);
+
+		$form = $crawler->selectButton($this->lang('YES'))->form();
+		$crawler = self::submit($form);
+		$this->assertContainsLang('EXTENSIONS_ACTION_NOT_ALLOWED', $crawler->filter('.errorbox')->text());
+		$this->assertStringContainsString('mode=main', $crawler->selectLink($this->lang('RETURN_TO_EXTENSION_MANAGER'))->link()->getUri());
+		$this->assertStringContainsString('mode=catalog', $crawler->selectLink($this->lang('RETURN_TO_EXTENSION_CATALOG'))->link()->getUri());
 	}
 
 	public function test_extensions_catalog_installing_extension()
@@ -330,7 +376,17 @@ class phpbb_functional_extension_acp_test extends phpbb_functional_test_case
 
 		// Attempt to install phpbb/viglink extension
 		$crawler = self::$client->click($viglink_install_link);
+		$this->assertContainsLang('CONFIRM', $crawler->filter('form#confirm h1')->text());
+		$this->assertStringContainsString('phpbb/viglink', $crawler->filter('fieldset > p')->text());
+		$form = $crawler->selectButton($this->lang('YES'))->form();
+		$crawler = self::submit($form);
+		$this->assertGreaterThan(0, $crawler->filter('.successbox > p')->count(), $crawler->filter('body')->text());
 		$this->assertContainsLang('EXTENSIONS_INSTALLED', $crawler->filter('.successbox > p')->text());
+		$back_links = $crawler->filter('.successbox > p a');
+		$this->assertContainsLang('RETURN_TO_EXTENSION_CATALOG', $back_links->eq(0)->text());
+		$this->assertContainsLang('RETURN_TO_EXTENSION_MANAGER', $back_links->eq(1)->text());
+		$this->assertStringContainsString('mode=catalog', $back_links->eq(0)->link()->getUri());
+		$this->assertStringContainsString('mode=main', $back_links->eq(1)->link()->getUri());
 		// Assert there's console log output
 		$this->assertStringContainsString('Locking phpbb/viglink', $crawler->filter('.console-output > pre')->text());
 
@@ -339,7 +395,7 @@ class phpbb_functional_extension_acp_test extends phpbb_functional_test_case
 		$this->assertStringContainsString('VigLink', $crawler->filter('strong[title="phpbb/viglink"]')->text());
 	}
 
-	public function test_extensions_catalog_updating_extension()
+	public function test_extensions_catalog_hides_update_for_current_extension()
 	{
 		// Enable 'VigLink' extension installed earlier
 		$crawler = self::request('GET', 'adm/index.php?i=acp_extensions&mode=main&sid=' . $this->sid);
@@ -354,22 +410,18 @@ class phpbb_functional_extension_acp_test extends phpbb_functional_test_case
 		$crawler = self::submit($form);
 		$this->assertContainsLang('EXTENSION_ENABLE_SUCCESS', $crawler->filter('.successbox')->text());
 
-		// Update 'VigLink' enabled extension
+		// The installed version is the current catalog version, so no update is offered
+		$this->mock_extensions_catalog_cache();
 		$crawler = self::request('GET', 'adm/index.php?i=acp_extensions&mode=main&sid=' . $this->sid);
-		$viglink_update_link = $crawler->filter('tr')->reduce(
+		$viglink_row = $crawler->filter('tr')->reduce(
 			function ($node, $i)
 			{
 				return (bool) (strpos($node->text(), 'VigLink') !== false);
 			}
-		)->selectLink($this->lang('EXTENSION_UPDATE'))->link();
-		$crawler = self::$client->click($viglink_update_link);
-		$this->assertContainsLang('EXTENSIONS_UPDATED', $crawler->filter('.successbox > p')->text());
-		// Assert there's console log output
-		$this->assertStringContainsString('Updating packages', $crawler->filter('.console-output > pre')->text());
+		);
 
-		// Ensure installed extension still appears in available extensions list
-		$crawler = self::request('GET', 'adm/index.php?i=acp_extensions&mode=main&sid=' . $this->sid);
-		$this->assertStringContainsString('VigLink', $crawler->filter('strong[title="phpbb/viglink"]')->text());
+		$this->assertCount(0, $viglink_row->selectLink($this->lang('EXTENSION_UPDATE')));
+		$this->assertCount(1, $viglink_row->selectLink($this->lang('EXTENSION_REMOVE')));
 	}
 
 	public function test_extensions_catalog_removing_extension()
@@ -387,7 +439,14 @@ class phpbb_functional_extension_acp_test extends phpbb_functional_test_case
 		// Test extensions removal
 		// Remove 'VigLink' enabled extension
 		$crawler = self::$client->click($viglink_remove_link);
+		$form = $crawler->selectButton($this->lang('YES'))->form();
+		$crawler = self::submit($form);
 		$this->assertContainsLang('EXTENSIONS_REMOVED', $crawler->filter('.successbox > p')->text());
+		$back_links = $crawler->filter('.successbox > p a');
+		$this->assertContainsLang('RETURN_TO_EXTENSION_MANAGER', $back_links->eq(0)->text());
+		$this->assertContainsLang('RETURN_TO_EXTENSION_CATALOG', $back_links->eq(1)->text());
+		$this->assertStringContainsString('mode=main', $back_links->eq(0)->link()->getUri());
+		$this->assertStringContainsString('mode=catalog', $back_links->eq(1)->link()->getUri());
 		// Assert there's console log output
 		$this->assertStringContainsString('Removing phpbb/viglink', $crawler->filter('.console-output > pre')->text());
 


### PR DESCRIPTION
PHPBB-17684

Checklist:

- [x] Correct branch: master for new features; 3.3.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master](https://area51.phpbb.com/docs/master/coding-guidelines.html) and [3.3.x](https://area51.phpbb.com/docs/dev/3.3.x/development/coding_guidelines.html)
- [x] Commit follows commit message [format](https://area51.phpbb.com/docs/dev/3.3.x/development/git.html)

Tracker ticket:

https://tracker.phpbb.com/browse/PHPBB-17684

- Added CSRF protection and hardened package/action validation against unauthorized package operations and remote code execution risks.
- Improved Composer operation locking, failure recovery, and manifest/lock-file restoration.
- Fixed repository priority handling so Packagist dependencies are not incorrectly shadowed by canonical phpBB repositories.
- Prevented extensions likely to fail dependency resolution from appearing as installable.
- Fixed compatible `composer/installers` v1/v2 constraints.
- Made the Extension Manager’s “Update” action appear only when a newer compatible version is actually available.
- Added explicit “Back to Extension Catalog” and “Back to Extension Manager” links to Composer success and error pages.
- Added a “Restore defaults” button for the standard phpBB Composer repository URLs.
- Made unavailable custom repositories gracefully fall back to Packagist when Packagist is enabled.
- Fixed unavailable-repository detection for Composer’s non-canonical `FilterRepository` wrappers.
- Added missing Composer error language strings and clearer repository warnings.