### PR TITLE
[ticket/17678] Let topic list pagination buttons grow with page number

### DIFF
--- a/phpBB/styles/prosilver/theme/common.css
+++ b/phpBB/styles/prosilver/theme/common.css
@@ -1002,10 +1002,12 @@ fieldset.fields1 dl.pmlist dd.recipients {
 .row .pagination li a,
 .row .pagination li span {
 	font-size: var(--ps-font-tiny);
+	text-align: center;
 	border-radius: 2px;
-	width: calc(var(--ps-font-tiny) + 6px);
+	box-sizing: border-box;
+	min-width: calc(var(--ps-font-tiny) + 6px);
 	height: calc(var(--ps-font-normal) + 6px);
-	padding: 1px 3px;
+	padding: 1px 5px;
 }
 
 /* jQuery popups


### PR DESCRIPTION
Checklist:

* [x] Correct branch: master for 4.0 fixes
* [x] Tests pass
* [x] Code follows coding guidelines
* [x] Commit follows commit message format

Tracker ticket:

https://tracker.phpbb.com/browse/PHPBB-17678

The small pagination buttons next to multipage topics in the topic list have a fixed width sized for a single digit, so page numbers with two or more digits sit cramped against the button borders, and three digit numbers wrap onto a second line and overflow the button.

This replaces the fixed width with a minimum width and border box sizing so the buttons keep their compact size for single digits but grow with the content, with the page number centered. Measured on prosilver: a single digit button stays 18px, a two digit button grows to 25px and a three digit button to 33px, all with even spacing around the number. The same block styles the topic list pagination in search results, the MCP forum view and the UCP topic lists, so those views are fixed as well. This follows the fix suggested in the ticket report.
