### PR TITLE
[ticket/17644] Prevent hidden pagination labels from causing overflow

### DIFF
--- a/phpBB/styles/prosilver/theme/common.css
+++ b/phpBB/styles/prosilver/theme/common.css
@@ -843,7 +843,7 @@ fieldset.fields1 dl.pmlist dd.recipients {
 	vertical-align: middle;
 }
 
-.pagination li a, .pagination li span {
+.pagination li a, .pagination li > span {
 	border-radius: 2px;
 	padding: 2px 5px;
 }


### PR DESCRIPTION
Checklist:

* [x] Correct branch: 3.3.x for fixes
* [x] Tests pass
* [x] Code follows coding guidelines
* [x] Commit follows commit message format

Tracker ticket:

https://tracker.phpbb.com/browse/PHPBB-17644

The horizontal scrollbar between 500px and 700px viewport width comes from the screen reader labels inside the pagination arrow buttons. The labels are visually hidden one pixel boxes, but `.pagination li span` also matches them and its padding inflates them to eleven pixels. Chrome includes such clipped boxes in the scrollable area, so with the pagination floated right the hidden label protrudes past the viewport and triggers the scrollbar.

Using a child combinator restricts the padding to the page number and ellipsis spans it was meant for. Measured in Chrome on both viewtopic and viewforum: four pixels of overflow at 600, 650 and 700 wide viewports before, zero overflow at every width from 320 to 700 after, with no change to any visible element, including mobile viewports. This fixes the root cause instead of moving the small screen pagination rule to a wider media query, which would have changed the layout between 500px and 700px.
