### PR TITLE
[ticket/17655] Do not render raw codepoint shortcodes as emoji

### DIFF
--- a/phpBB/phpbb/textformatter/s9e/factory.php
+++ b/phpBB/phpbb/textformatter/s9e/factory.php
@@ -364,6 +364,12 @@ class factory implements \phpbb\textformatter\cache_interface
 		</xsl:choose>';
 		$tag->template = '<xsl:choose><xsl:when test="$S_VIEWSMILIES">' . str_replace('class="emoji"', 'class="emoji smilies"', $tag->template) . '</xsl:when><xsl:otherwise><xsl:value-of select="."/></xsl:otherwise></xsl:choose>';
 
+		// Reject shortcodes that consist of raw codepoints in hexadecimal such as ":123c:",
+		// which commonly appear as segments of IPv6 addresses
+		$tag->filterChain
+			->append(__NAMESPACE__ . '\\parser::filter_emoji')
+			->addParameterByName('tagText');
+
 		/**
 		* Modify the s9e\TextFormatter configurator after the default settings are set
 		*

--- a/phpBB/phpbb/textformatter/s9e/parser.php
+++ b/phpBB/phpbb/textformatter/s9e/parser.php
@@ -302,6 +302,25 @@ class parser implements \phpbb\textformatter\parser_interface
 	}
 
 	/**
+	* Filter an EMOJI tag to reject shortcodes that consist of raw codepoints
+	*
+	* Sequences of hexadecimal digits between colons such as ":123c:" commonly
+	* appear as segments of IPv6 addresses and should remain plain text rather
+	* than be rendered as an emoji image
+	*
+	* @param  Tag    $tag      The EMOJI tag
+	* @param  string $tag_text Original text consumed by the tag
+	* @return void
+	*/
+	static public function filter_emoji(Tag $tag, $tag_text)
+	{
+		if (preg_match('/^:[0-3][0-9a-f]{3,4}(?:-[0-9a-f]{4,5})*:$/D', $tag_text))
+		{
+			$tag->invalidate();
+		}
+	}
+
+	/**
 	* Filter a flash object's height
 	*
 	* @see bbcode_firstpass::bbcode_flash()

--- a/tests/text_formatter/s9e/default_formatting_test.php
+++ b/tests/text_formatter/s9e/default_formatting_test.php
@@ -320,6 +320,26 @@ class phpbb_textformatter_s9e_default_formatting_test extends phpbb_test_case
 					$container->get('text_formatter.renderer')->set_viewsmilies(false);
 				}
 			),
+			array(
+				// PHPBB-17655 - Segments of IPv6 addresses should not be rendered as emoji
+				'IPv6: 2a09:bac3:616e:123c::1d1:f0',
+				'IPv6: 2a09:bac3:616e:123c::1d1:f0'
+			),
+			array(
+				'IPv6: 2607:fb90:ec1d:0e17:e0c6:af94:1224:28a8',
+				'IPv6: 2607:fb90:ec1d:0e17:e0c6:af94:1224:28a8'
+			),
+			array(
+				// Raw codepoint shortcodes are rejected as they cannot be told apart
+				// from segments of IPv6 addresses
+				'Codepoints: :264d: :1f600: :1234:',
+				'Codepoints: :264d: :1f600: :1234:'
+			),
+			array(
+				// Emoji shortnames keep working
+				'Shortname: :joy:',
+				'Shortname: <img alt=":joy:" class="emoji smilies" draggable="false" src="//cdn.jsdelivr.net/gh/twitter/twemoji@latest/assets/svg/1f602.svg">'
+			),
 		);
 	}
 }


### PR DESCRIPTION
Checklist:

* [x] Correct branch: 3.3.x for fixes
* [x] Tests pass
* [x] Code follows coding guidelines
* [x] Commit follows commit message format

Tracker ticket:

https://tracker.phpbb.com/browse/PHPBB-17655

The Emoji plugin renders sequences of hexadecimal digits between colons such as `:123c:` as emoji images of the corresponding codepoint. Such sequences commonly appear as segments of IPv6 addresses, so posting an address like `2a09:bac3:616e:123c::1d1:f0` mangles the text and generates failing image requests to the emoji CDN, which slow down the page for the reader.

This adds a filter to the EMOJI tag that rejects these raw codepoint shortcodes so they remain plain text. Emoji shortnames such as `:joy:`, Unicode emoji and regular smilies are unaffected, verified by new test cases. The `:1234:` shortname is rejected as well since it cannot be told apart from a segment of an IPv6 address.
