### PR TITLE
[ticket/17647] Do not treat gallery buttons as the avatar form submit

### DIFF
--- a/phpBB/assets/javascript/phpbb-avatars.js
+++ b/phpBB/assets/javascript/phpbb-avatars.js
@@ -171,7 +171,9 @@
 					return;
 				}
 
-				const $submitButton = this.$form.find('fieldset > input[type=submit]').first();
+				// Restrict to the form's own submit area; avatar driver sections may
+				// contain their own submit buttons (e.g. the gallery's "Go" button)
+				const $submitButton = this.$form.find('fieldset.submit-buttons, fieldset.quick').find('input[type=submit]').first();
 
 				const avatarCanvas = phpbb.avatars.cropper.getCroppedCanvas({
 					maxWidth: 4096, // High values for max quality cropping


### PR DESCRIPTION
Checklist:

* [x] Correct branch: master for 4.x fixes
* [x] Tests pass
* [x] Code follows coding guidelines
* [x] Commit follows commit message format

Tracker ticket:

https://tracker.phpbb.com/browse/PHPBB-17647

The AJAX avatar upload copies the name and value of the form's submit button into the request so the server treats it as a regular submission. Selecting the first submit input in the form picks the gallery's "Go" button when gallery avatars are enabled, because the UCP templates render it as a direct fieldset child ahead of the real submit button. The server then responds with the gallery page instead of saving the upload, and the avatar is silently discarded.

Restricting the selection to the form's submit area (`fieldset.submit-buttons` in the UCP and ACP group forms, `fieldset.quick` in the ACP user form) picks the correct button in all four places the cropper runs. Reproduced and verified on a live board: with gallery avatars enabled, uploads on the UCP profile page and the UCP group management page previously posted `avatar_local_go=Go` and nothing was saved; with the fix both post the real submit button and the avatar is stored and displayed. The ACP user and group pages were unaffected by the bug (their "Go" button is not a direct fieldset child) and select the same button as before.