### PR TITLE
[ticket/17648] Keep avatar cropper within its box for large size limits

### DIFF
--- a/phpBB/assets/javascript/phpbb-avatars.js
+++ b/phpBB/assets/javascript/phpbb-avatars.js
@@ -297,11 +297,17 @@
 			// Hide placeholder avatar
 			this.$box.children('.avatar-placeholder').hide();
 
+			// Double the maximum allowed size for better usability, but keep the
+			// workspace within the avatar box so large size limits do not force
+			// the cropper to overflow the surrounding form
+			const maxBoxHeight = parseInt(this.$box.css('max-height'), 10) || Infinity;
+			const boxWidth = this.$box.width();
+
 			this.cropper = this.image.cropper({
 				aspectRatio: 1,
 				autoCropArea: 1,
-				minContainerHeight: this.allowedSizes.height.max * 2, // Double max size for better usability
-				minContainerWidth: this.allowedSizes.width.max * 2, // Double max size for better usability
+				minContainerHeight: Math.min(this.allowedSizes.height.max * 2, maxBoxHeight),
+				minContainerWidth: Math.min(this.allowedSizes.width.max * 2, boxWidth),
 			}).data('cropper');
 
 			this.image.off('crop.phpbb.avatars').on('crop.phpbb.avatars', phpbb.avatars.onCrop);


### PR DESCRIPTION
Checklist:

* [x] Correct branch: master for 4.x fixes
* [x] Tests pass
* [x] Code follows coding guidelines
* [x] Commit follows commit message format

Tracker ticket:

https://tracker.phpbb.com/browse/PHPBB-17648

The avatar cropper container is forced to twice the maximum allowed avatar size. With larger limits this exceeds the avatar box: in the UCP the box is capped at 400px height with visible overflow, so any limit above 200px pushes the cropper out of the box and it overlays the delete checkbox and the avatar type selection below. On narrow layouts the forced width has the same effect sideways — in the ACP at smaller window sizes a 250px limit forces a 500px wide cropper into a 278px wide box, spilling over the adjacent content. This is what makes the problem appear from around 150px limits on smaller screens.

Capping the doubled workspace at the box's own width and computed maximum height keeps the cropper inside the box in every case while leaving the stylesheet as the single source of truth — the ACP box has no height cap and keeps its natural growth. Verified on a live board: with a 250px limit the cropper now fills the box exactly with no overflow in UCP and ACP, and an upload still saves the avatar at the full 250px dimensions, since crop coordinates map to image pixels rather than container pixels. With the default 120px limit the computed minimums are unchanged from before and the cropper renders identically.