### PR TITLE
[ticket/17649] Pass function reference to setTimeout in progress popup

### DIFF
--- a/phpBB/adm/style/progress_bar.html
+++ b/phpBB/adm/style/progress_bar.html
@@ -19,7 +19,7 @@
 				}
 			}
 		}
-		setTimeout("close_popup()", 1000);
+		setTimeout(close_popup, 1000);
 		return 0;
 	}
 // ]]>


### PR DESCRIPTION
Checklist:

* [x] Correct branch: master for 4.x fixes
* [x] Tests pass
* [x] Code follows coding guidelines
* [x] Commit follows commit message format

Tracker ticket:

https://tracker.phpbb.com/browse/PHPBB-17649

Passing a string to `setTimeout` is an implicit eval, so a Content Security Policy protecting the ACP has to allow `'unsafe-eval'` in `script-src` just for this one call. Passing the function reference behaves identically — the popup's one-second poll and its self-close when the parent page finishes were verified unchanged on a live board — and lets administrators deploy a stricter policy. This was the only string-argument timer call in the codebase.