### PR TITLE
[ticket/17646] Use phrasing elements for the avatar placeholder

### DIFF
--- a/phpBB/adm/style/avatar.html
+++ b/phpBB/adm/style/avatar.html
@@ -8,10 +8,10 @@
 	{% set color_classes = ['avatar-color-0', 'avatar-color-1', 'avatar-color-2', 'avatar-color-3', 'avatar-color-4'] %}
 	{% set color_class = not(avatar_data.id starts with 'g') ? color_classes[avatar_data.id % 5] : 'avatar-color-default' %}
 	{% if avatar_link %}<a href="{{ avatar_link }}" class="avatar">{% endif %}
-	<div class="avatar-placeholder {{ color_class }}">
+	<span class="avatar-placeholder {{ color_class }}">
 		{% set username = username ?: avatar_data.username %}
 		{% set initials = username|striptags|trim(' -+_[]', 'left')|slice(0, 1)|upper %}
-		<div class="avatar-initials">{% if initials %}{{ initials }}{% else %}{{ Icon('font', 'user', '', true) }}{% endif %}</div>
-	</div>
+		<span class="avatar-initials">{% if initials %}{{ initials }}{% else %}{{ Icon('font', 'user', '', true) }}{% endif %}</span>
+	</span>
 	{% if avatar_link %}</a>{% endif %}
 {% endif %}

--- a/phpBB/styles/prosilver/template/avatar.html
+++ b/phpBB/styles/prosilver/template/avatar.html
@@ -8,10 +8,10 @@
 	{% set color_classes = ['avatar-color-0', 'avatar-color-1', 'avatar-color-2', 'avatar-color-3', 'avatar-color-4'] %}
 	{% set color_class = not(avatar_data.id starts with 'g') ? color_classes[avatar_data.id % 5] : 'avatar-color-default' %}
 	{% if avatar_link %}<a href="{{ avatar_link }}" class="avatar">{% endif %}
-	<div class="avatar-placeholder {{ color_class }}">
+	<span class="avatar-placeholder {{ color_class }}">
 		{% set username = username ?: avatar_data.username %}
 		{% set initials = username|striptags|trim(' -+_[]', 'left')|slice(0, 1)|upper %}
-		<div class="avatar-initials">{% if initials %}{{ initials }}{% else %}{{ Icon('font', 'user', '', true) }}{% endif %}</div>
-	</div>
+		<span class="avatar-initials">{% if initials %}{{ initials }}{% else %}{{ Icon('font', 'user', '', true) }}{% endif %}</span>
+	</span>
 	{% if avatar_link %}</a>{% endif %}
 {% endif %}

--- a/tests/test_framework/phpbb_functional_test_case.php
+++ b/tests/test_framework/phpbb_functional_test_case.php
@@ -1708,7 +1708,7 @@ class phpbb_functional_test_case extends phpbb_test_case
 		$is_logged_in = strpos($crawler->filter('div[class="navbar"]')->text(), 'Login') === false;
 		if ($is_logged_in)
 		{
-			$username_logged_in = $crawler->filter('li[id="username_logged_in"] > div > a > span:not(.avatar)')->text();
+			$username_logged_in = $crawler->filter('li[id="username_logged_in"] > div > a > span:not(.avatar):not(.avatar-placeholder)')->text();
 		}
 		return $username_logged_in;
 	}


### PR DESCRIPTION
Checklist:

* [x] Correct branch: master for 4.x fixes
* [x] Tests pass
* [x] Code follows coding guidelines
* [x] Commit follows commit message format

Tracker ticket:

https://tracker.phpbb.com/browse/PHPBB-17646

The markup reported in the ticket, with the placeholder inside `<span class="avatar">`, cannot be produced by current core, as that span only ever wraps image avatars. The real instance is the group view page, where the placeholder divs render inside a paragraph. Browsers eject the invalid divs from the paragraph while parsing, so the DOM no longer matches the delivered markup and validators reject the page.

The placeholder now renders as spans. Its styling addresses the classes with explicit display values and the initials element keeps its layout as a flex item, so rendering is identical everywhere. Verified on a live board, including the avatar cropper page where the show and hide cycle still restores the flex display.