### PR TITLE
[ticket/17664] Align pagination start values with page boundaries

### DIFF
--- a/phpBB/phpbb/pagination.php
+++ b/phpBB/phpbb/pagination.php
@@ -316,12 +316,19 @@ class pagination
 	*/
 	public function validate_start($start, $per_page, $num_items)
 	{
-		if ($start < 0 || $start >= $num_items)
+		if ($start < 0 || $num_items <= 0)
 		{
-			return ($start < 0 || $num_items <= 0) ? 0 : floor(($num_items - 1) / $per_page) * $per_page;
+			return 0;
 		}
 
-		return $start;
+		if ($start >= $num_items)
+		{
+			$start = $num_items - 1;
+		}
+
+		// Align the start value with the beginning of its page, so the
+		// displayed items always match the page shown in the pagination
+		return (int) floor($start / $per_page) * $per_page;
 	}
 
 	/**

--- a/tests/pagination/pagination_test.php
+++ b/tests/pagination/pagination_test.php
@@ -297,6 +297,36 @@ class phpbb_pagination_pagination_test extends phpbb_template_template_test_case
 				20,
 				10,
 			),
+			array(
+				2,
+				20,
+				0,
+			),
+			array(
+				9,
+				20,
+				0,
+			),
+			array(
+				11,
+				20,
+				10,
+			),
+			array(
+				19,
+				20,
+				10,
+			),
+			array(
+				25,
+				20,
+				10,
+			),
+			array(
+				-11,
+				20,
+				0,
+			),
 		);
 	}
 


### PR DESCRIPTION
Checklist:

* [x] Correct branch: 3.3.x for fixes
* [x] Tests pass
* [x] Code follows coding guidelines
* [x] Commit follows commit message format

Tracker ticket:

https://tracker.phpbb.com/browse/PHPBB-17664

A start value taken from the URL that does not sit on a page boundary highlights the page the value falls into while the item list is offset by the raw value, so the displayed items match no page of the pagination. Validated start values now snap to the beginning of their page and the list always shows the page the pagination marks as active. Out of range values keep their current behaviour of landing on the first or last page, covered by the existing tests, and new test cases cover the alignment. Verified on a live board that an off boundary start renders the same items as the boundary value and that the jump to post links in viewtopic are unaffected, as they already compute aligned values.