### PR TITLE
[ticket/17568] Add unit selector to avatar filesize setting

### DIFF
--- a/phpBB/includes/acp/acp_board.php
+++ b/phpBB/includes/acp/acp_board.php
@@ -570,6 +570,15 @@ class acp_board
 
 			$this->new_config[$config_name] = $config_value = $cfg_array[$config_name];
 
+			if ($config_name == 'avatar_filesize')
+			{
+				$size_var = $request->variable($config_name, '');
+
+				$config_value = (int) $config_value;
+
+				$this->new_config[$config_name] = $config_value = ($size_var == 'kb') ? round($config_value * 1024) : (($size_var == 'mb') ? round($config_value * 1048576) : $config_value);
+			}
+
 			if ($submit)
 			{
 				if (isset($data['type']) && strpos($data['type'], 'password') === 0 && $config_value === '********')
@@ -1026,6 +1035,20 @@ class acp_board
 		}
 
 		return '<input id="' . $key . '" type="text" size="3" maxlength="4" name="config[bump_interval]" value="' . $value . '" />&nbsp;<select name="config[bump_type]">' . $s_bump_type . '</select>';
+	}
+
+	/**
+	* Adjust the maximum avatar filesize config var for display
+	*/
+	function max_avatar_filesize($value, $key = '')
+	{
+		// Determine size var and adjust the value accordingly
+		$filesize = get_formatted_filesize($value, false, array('mb', 'kb', 'b'));
+		$size_var = $filesize['si_identifier'];
+		$value = $filesize['value'];
+
+		// size and maxlength must not be specified for input of type number
+		return '<input type="number" id="' . $key . '" min="0" max="999999999999999" step="any" name="config[' . $key . ']" value="' . $value . '" /> <select name="' . $key . '">' . size_select_options($size_var) . '</select>';
 	}
 
 	/**

--- a/phpBB/phpbb/avatar/driver/upload.php
+++ b/phpBB/phpbb/avatar/driver/upload.php
@@ -261,7 +261,7 @@ class upload extends \phpbb\avatar\driver\driver
 	{
 		return array(
 			'allow_avatar_remote_upload'=> array('lang' => 'ALLOW_REMOTE_UPLOAD', 'validate' => 'bool',	'type' => 'radio:yes_no', 'explain' => true),
-			'avatar_filesize'		=> array('lang' => 'MAX_FILESIZE',			'validate' => 'int:0',	'type' => 'number:0', 'explain' => true, 'append' => ' ' . $user->lang['BYTES']),
+			'avatar_filesize'		=> array('lang' => 'MAX_FILESIZE',			'validate' => 'int:0',	'type' => 'custom', 'method' => 'max_avatar_filesize', 'explain' => true),
 			'avatar_path'			=> array('lang' => 'AVATAR_STORAGE_PATH',	'validate' => 'rpath',	'type' => 'text:20:255', 'explain' => true),
 		);
 	}


### PR DESCRIPTION
The maximum avatar filesize setting in the ACP was entered and shown in raw **bytes**, while the user-facing avatar explanation and the parallel **attachment** settings present the value in KiB/MiB. This made the admin input inconsistent with the units shown to users.

This gives the avatar filesize field the same Bytes/KiB/MiB selector already used by the attachment settings (`acp_attachments`), converting the selected unit back to bytes on save. It reuses the existing `get_formatted_filesize()` and `size_select_options()` helpers, mirroring the `max_filesize` handling in `acp_attachments`.

Tracker: https://tracker.phpbb.com/browse/PHPBB-17568

### Testing
Verified manually on a 3.3 board:
- The ACP avatar setting now renders the value with a unit dropdown (a stored 6144 bytes displays as `6` + `KiB`, previously `6144 Bytes`).
- Saving `10` + `MiB` stores `10485760` bytes; the value round-trips on reload.

Note: the automated test suite was not run locally, so the "Tests pass" box is left unchecked.
