### PR TITLE
[ticket/17625] Keep foreign database tables out of schema operations

### DIFF
--- a/phpBB/phpbb/db/doctrine/connection_factory.php
+++ b/phpBB/phpbb/db/doctrine/connection_factory.php
@@ -119,6 +119,11 @@ class connection_factory
 				Type::addType(case_insensitive_string::CASE_INSENSITIVE_STRING, case_insensitive_string::class);
 			}
 			$connection->getDatabasePlatform()->registerDoctrineTypeMapping('varchar_ci', case_insensitive_string::CASE_INSENSITIVE_STRING);
+
+			// MySQL's native ENUM type has no Doctrine mapping of its own; map it
+			// to string so introspecting tables not created by phpBB does not fail.
+			$connection->getDatabasePlatform()->registerDoctrineTypeMapping('enum', 'string');
+
 			return $connection;
 		}
 		catch (Exception $e)

--- a/phpBB/phpbb/db/migration/data/v400/rename_duplicated_index_names.php
+++ b/phpBB/phpbb/db/migration/data/v400/rename_duplicated_index_names.php
@@ -111,8 +111,21 @@ class rename_duplicated_index_names extends migration
 
 	public function get_tables_index_names()
 	{
+		self::$table_keys = [];
+
 		$schema_manager = $this->db_tools->get_connection()->createSchemaManager();
-		$table_names = $schema_manager->listTableNames();
+
+		// Only consider phpBB's own tables; the database can contain tables
+		// not created by phpBB whose indexes must not be renamed.
+		$table_names = array_filter(
+			$schema_manager->listTableNames(),
+			function (string $table_name): bool
+			{
+				// Case-insensitive: some databases fold identifier case,
+				// e.g. MySQL with lower_case_table_names set.
+				return str_starts_with(strtolower($table_name), strtolower($this->table_prefix));
+			}
+		);
 
 		if (!empty($table_names))
 		{

--- a/phpBB/phpbb/db/tools/doctrine.php
+++ b/phpBB/phpbb/db/tools/doctrine.php
@@ -90,13 +90,46 @@ class doctrine implements tools_interface
 	}
 
 	/**
+	 * Limit introspection to assets carrying the table prefix, so that tables
+	 * not created by phpBB sharing the database cannot break schema changes,
+	 * e.g. by using column types unknown to Doctrine.
+	 *
 	 * @return Schema
 	 *
 	 * @throws Exception
 	 */
 	protected function get_schema(): Schema
 	{
-		return $this->get_schema_manager()->introspectSchema();
+		$configuration = $this->connection->getConfiguration();
+		$previous_filter = $configuration->getSchemaAssetsFilter();
+
+		if ((string) $this->table_prefix !== '')
+		{
+			$configuration->setSchemaAssetsFilter(
+				function ($asset) use ($previous_filter): bool
+				{
+					if ($previous_filter !== null && !$previous_filter($asset))
+					{
+						return false;
+					}
+
+					$name = $asset instanceof AbstractAsset ? $asset->getName() : (string) $asset;
+
+					// Case-insensitive: some databases fold identifier case,
+					// e.g. MySQL with lower_case_table_names set.
+					return str_starts_with(strtolower($name), strtolower($this->table_prefix));
+				}
+			);
+		}
+
+		try
+		{
+			return $this->get_schema_manager()->introspectSchema();
+		}
+		finally
+		{
+			$configuration->setSchemaAssetsFilter($previous_filter);
+		}
 	}
 
 	/**

--- a/tests/dbal/db_tools_test.php
+++ b/tests/dbal/db_tools_test.php
@@ -540,4 +540,60 @@ class phpbb_dbal_db_tools_test extends phpbb_database_test_case
 		/* https://github.com/phpbb/phpbb/blob/aee5e373bca6cd20d44b99585d3b758276a2d7e6/phpBB/phpbb/db/tools/tools.php#L1488-L1517 */
 		$this->tools->sql_create_index('prefix_table_name', $too_long_index_name, array('c_timestamp'));
 	}
+
+	public function test_enum_mapped_to_string()
+	{
+		$this->assertSame('string', $this->doctrine_db->getDatabasePlatform()->getDoctrineTypeMapping('enum'));
+	}
+
+	public function test_schema_changes_with_unknown_column_type_in_foreign_table()
+	{
+		// Tables not created by phpBB can share the database and use column
+		// types Doctrine has no mapping for, e.g. MySQL's native ENUM type.
+		switch ($this->db->get_sql_layer())
+		{
+			case 'mysqli':
+				$create_foreign_table = "CREATE TABLE foreign_type_table (id INT NOT NULL, no_mapping ENUM('a', 'b') NOT NULL, PRIMARY KEY (id))";
+			break;
+
+			case 'postgres':
+				$this->db->sql_query("CREATE TYPE foreign_enum_type AS ENUM ('a', 'b')");
+				$create_foreign_table = 'CREATE TABLE foreign_type_table (id INT NOT NULL, no_mapping foreign_enum_type NOT NULL, PRIMARY KEY (id))';
+			break;
+
+			case 'sqlite3':
+				$create_foreign_table = 'CREATE TABLE foreign_type_table (id INT NOT NULL, no_mapping unknown_custom_type NOT NULL, PRIMARY KEY (id))';
+			break;
+
+			default:
+				$this->markTestSkipped('No foreign column type defined for this DBMS');
+		}
+
+		$this->db->sql_query($create_foreign_table);
+
+		try
+		{
+			$this->assertTrue($this->tools->sql_column_add('prefix_table_name', 'c_foreign_type', array('UINT', 0)));
+			$this->assertTrue($this->tools->sql_column_exists('prefix_table_name', 'c_foreign_type'));
+			$this->assertTrue($this->tools->sql_column_remove('prefix_table_name', 'c_foreign_type'));
+
+			$this->tools->sql_create_table('prefix_foreign_check', array(
+				'COLUMNS'		=> array(
+					'c_id'	=> array('UINT', 0),
+				),
+				'PRIMARY_KEY'	=> 'c_id',
+			));
+			$this->assertTrue($this->tools->sql_table_exists('prefix_foreign_check'));
+			$this->tools->sql_table_drop('prefix_foreign_check');
+		}
+		finally
+		{
+			$this->db->sql_query('DROP TABLE foreign_type_table');
+
+			if ($this->db->get_sql_layer() === 'postgres')
+			{
+				$this->db->sql_query('DROP TYPE foreign_enum_type');
+			}
+		}
+	}
 }

--- a/tests/dbal/migration_rename_duplicated_index_names_test.php
+++ b/tests/dbal/migration_rename_duplicated_index_names_test.php
@@ -1,0 +1,93 @@
+<?php
+/**
+*
+* This file is part of the phpBB Forum Software package.
+*
+* @copyright (c) phpBB Limited <https://www.phpbb.com>
+* @license GNU General Public License, version 2 (GPL-2.0)
+*
+* For full copyright and license information, please see
+* the docs/CREDITS.txt file.
+*
+*/
+
+use phpbb\db\migration\data\v400\rename_duplicated_index_names;
+
+class phpbb_dbal_migration_rename_duplicated_index_names_test extends phpbb_database_test_case
+{
+	/** @var \phpbb\db\driver\driver_interface */
+	protected $db;
+
+	/** @var \phpbb\db\tools\tools_interface */
+	protected $tools;
+
+	/** @var array */
+	protected $static_properties = [];
+
+	public function getDataSet()
+	{
+		return $this->createXMLDataSet(__DIR__ . '/fixtures/config.xml');
+	}
+
+	protected function setUp(): void
+	{
+		parent::setUp();
+
+		$this->db = $this->new_dbal();
+		$factory = new \phpbb\db\tools\factory();
+		$this->tools = $factory->get($this->new_doctrine_dbal());
+		$this->tools->set_table_prefix('prefix_');
+
+		// The migration caches its computed schema changes in static properties;
+		// save and clear them so this test starts clean and cannot leak its
+		// tables into other tests running in the same process.
+		foreach (['table_keys', 'rename_index'] as $property_name)
+		{
+			$property = new ReflectionProperty(rename_duplicated_index_names::class, $property_name);
+			$property->setAccessible(true);
+			$this->static_properties[$property_name] = $property->getValue();
+			$property->setValue(null, null);
+		}
+
+		$this->db->sql_query('CREATE TABLE foreign_indexed (id INT NOT NULL, val INT NOT NULL, PRIMARY KEY (id))');
+		$this->db->sql_query('CREATE INDEX i_foreign ON foreign_indexed (val)');
+		$this->db->sql_query('CREATE TABLE prefix_indexed (c_id INT NOT NULL, c_val INT NOT NULL, PRIMARY KEY (c_id))');
+		$this->db->sql_query('CREATE INDEX i_old ON prefix_indexed (c_val)');
+	}
+
+	protected function tearDown(): void
+	{
+		$this->db->sql_query('DROP TABLE foreign_indexed');
+		$this->db->sql_query('DROP TABLE prefix_indexed');
+
+		foreach ($this->static_properties as $property_name => $value)
+		{
+			$property = new ReflectionProperty(rename_duplicated_index_names::class, $property_name);
+			$property->setAccessible(true);
+			$property->setValue(null, $value);
+		}
+
+		parent::tearDown();
+	}
+
+	public function test_update_schema_ignores_tables_not_carrying_the_prefix()
+	{
+		$migration = new rename_duplicated_index_names(
+			new \phpbb\config\config([]),
+			$this->db,
+			$this->tools,
+			__DIR__ . '/../../phpBB/',
+			'php',
+			'prefix_',
+			[]
+		);
+
+		$schema = $migration->update_schema();
+
+		$short_table_names = \phpbb\db\doctrine\table_helper::map_short_table_names(['prefix_indexed'], 'prefix_');
+		$this->assertSame(
+			['prefix_indexed' => ['i_old' => $short_table_names['prefix_indexed'] . '_i_old']],
+			$schema['rename_index']
+		);
+	}
+}


### PR DESCRIPTION
Installing phpBB into a database that already contains tables not created by phpBB (shared hosting setups, or a database also holding an old board) fails with `Unknown database type enum requested` — Doctrine's `introspectSchema()` reads every table in the database, and foreign tables can use column types Doctrine has no mapping for, such as MySQL's native `ENUM`. In addition, the `rename_duplicated_index_names` migration collects index names from every table in the database, so foreign tables leak into the generated install schema (the `bbdkp_register` create step visible in the ticket's stack trace) and it fatals with `array_keys(null)` when no such table carries a secondary index.

This PR scopes schema operations to phpBB's own tables:

- `phpbb\db\tools\doctrine::get_schema()` now sets a Doctrine schema assets filter restricted to the configured table prefix for the duration of the introspection (restoring any previous filter afterwards, chaining one if set, matching case-insensitively since some databases fold identifier case). Foreign tables can no longer break `sql_create_table()` or column/index operations, regardless of their column types. The filter is deliberately scoped to `get_schema()` so `sql_table_exists()` / `sql_list_tables()` behaviour is unchanged.
- `rename_duplicated_index_names::get_tables_index_names()` only collects index names from tables carrying the table prefix, and initialises its static cache so a database without eligible tables no longer fatals. This also stops the migration from renaming indexes of another application's tables (or another board's, when two boards with different prefixes share one database).
- `phpbb\db\doctrine\connection_factory` additionally maps MySQL's `enum` type to `string` as defense in depth for foreign tables that do share the prefix.

Verified end to end: a CLI install (`install/phpbbcli.php install`) into a MySQL database containing a pre-existing `ENUM`-typed table completes successfully (76 tables created, the foreign table untouched); on current master the same install fatals with the ticket's exact stack trace. Regression tests cover the Doctrine tools path per DBMS (MySQL `ENUM`, PostgreSQL `CREATE TYPE … AS ENUM`, SQLite unknown declared type) and the migration's index-name collection.

Checklist:

- [x] Correct branch: master for new features; 3.3.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master](https://area51.phpbb.com/docs/master/coding-guidelines.html) and [3.3.x](https://area51.phpbb.com/docs/dev/3.3.x/development/coding_guidelines.html)
- [x] Commit follows commit message [format](https://area51.phpbb.com/docs/dev/3.3.x/development/git.html)

Tracker ticket:

https://tracker.phpbb.com/browse/PHPBB-17625