### PR TITLE
[ticket/17627] Carry topic views over when merging posts deletes the topic

### DIFF
--- a/phpBB/includes/mcp/mcp_topic.php
+++ b/phpBB/includes/mcp/mcp_topic.php
@@ -817,9 +817,11 @@ function merge_posts($topic_id, $to_topic_id)
 	}
 
 	$sync_forums = array();
+	$topic_views = 0;
 	foreach ($topic_data as $data)
 	{
 		$sync_forums[$data['forum_id']] = $data['forum_id'];
+		$topic_views = max($topic_views, $data['topic_views']);
 	}
 
 	$topic_data = $topic_data[$to_topic_id];
@@ -891,6 +893,13 @@ function merge_posts($topic_id, $to_topic_id)
 
 			// If the topic no longer exist, we will update the bookmarks table.
 			phpbb_update_rows_avoiding_duplicates($db, BOOKMARKS_TABLE, 'topic_id', array($topic_id), $to_topic_id);
+
+			// If the topic no longer exists, carry its view count over to the
+			// destination topic like merge_topics() does (maximum, not sum)
+			$sql = 'UPDATE ' . TOPICS_TABLE . '
+				SET topic_views = ' . $topic_views . '
+				WHERE topic_id = ' . $to_topic_id;
+			$db->sql_query($sql);
 		}
 
 		// Re-sync the topics and forums because the auto-sync was deactivated in the call of move_posts()

--- a/tests/functional/mcp/mcp_merge_posts_views_test.php
+++ b/tests/functional/mcp/mcp_merge_posts_views_test.php
@@ -1,0 +1,94 @@
+<?php
+/**
+*
+* This file is part of the phpBB Forum Software package.
+*
+* @copyright (c) phpBB Limited <https://www.phpbb.com>
+* @license GNU General Public License, version 2 (GPL-2.0)
+*
+* For full copyright and license information, please see
+* the docs/CREDITS.txt file.
+*
+*/
+
+/**
+* @group functional
+*/
+class phpbb_functional_mcp_merge_posts_views_test extends phpbb_functional_test_case
+{
+	public function test_merge_posts_carries_over_topic_views()
+	{
+		$this->add_lang(['common', 'mcp']);
+		$this->login();
+
+		$source = $this->create_topic(2, 'Merge views source topic', 'Source topic for the topic views merge test.');
+		$target = $this->create_topic(2, 'Merge views target topic', 'Target topic for the topic views merge test.');
+
+		$db = $this->get_db();
+
+		$sql = 'SELECT post_id
+			FROM phpbb_posts
+			WHERE topic_id = ' . (int) $source['topic_id'];
+		$result = $db->sql_query($sql);
+		$post_id_list = [];
+		while ($row = $db->sql_fetchrow($result))
+		{
+			$post_id_list[] = (int) $row['post_id'];
+		}
+		$db->sql_freeresult($result);
+		$this->assertCount(1, $post_id_list);
+
+		// Open the source topic's MCP topic view and start merging all its posts
+		$crawler = self::request('GET', "viewtopic.php?t={$source['topic_id']}&sid={$this->sid}");
+		$crawler = self::$client->click($crawler->selectLink($this->lang('MCP_SHORT'))->link());
+
+		// Give both topics distinct view counts; set after the viewtopic request
+		// so the counts cannot be bumped by our own page views
+		$db->sql_query('UPDATE phpbb_topics SET topic_views = 7 WHERE topic_id = ' . (int) $source['topic_id']);
+		$db->sql_query('UPDATE phpbb_topics SET topic_views = 3 WHERE topic_id = ' . (int) $target['topic_id']);
+
+		$form = $crawler->selectButton($this->lang('SUBMIT'))->form()->disableValidation()->setValues([
+			'action'		=> 'merge_posts',
+			'post_id_list'	=> $post_id_list,
+		]);
+		$crawler = self::submit($form);
+
+		// Select the target topic to merge into
+		$crawler = self::$client->click($crawler->selectLink($this->lang('SELECT_TOPIC'))->link());
+
+		$to_topic_id = (int) $target['topic_id'];
+		$select_for_merge_link = $crawler->selectLink($this->lang('SELECT_MERGE'))->reduce(
+			function ($node, $i) use ($to_topic_id)
+			{
+				return (bool) strpos($node->attr('href'), "to_topic_id=$to_topic_id");
+			}
+		)->link();
+		$crawler = self::$client->click($select_for_merge_link);
+		$this->assertEquals($to_topic_id, (int) $crawler->filter('#to_topic_id')->attr('value'));
+
+		$form = $crawler->selectButton($this->lang('SUBMIT'))->form()->disableValidation()->setValues([
+			'post_id_list'	=> $post_id_list,
+		]);
+		$crawler = self::submit($form);
+
+		$form = $crawler->selectButton($this->lang('YES'))->form();
+		$crawler = self::submit($form);
+		$this->assertStringContainsString($this->lang('POSTS_MERGED_SUCCESS'), $crawler->filter('#message p')->text());
+
+		// The fully merged source topic is gone and its higher view count
+		// has been carried over to the target topic
+		$sql = 'SELECT COUNT(topic_id) AS num_topics
+			FROM phpbb_topics
+			WHERE topic_id = ' . (int) $source['topic_id'];
+		$result = $db->sql_query($sql);
+		$this->assertEquals(0, (int) $db->sql_fetchfield('num_topics'));
+		$db->sql_freeresult($result);
+
+		$sql = 'SELECT topic_views
+			FROM phpbb_topics
+			WHERE topic_id = ' . (int) $target['topic_id'];
+		$result = $db->sql_query($sql);
+		$this->assertEquals(7, (int) $db->sql_fetchfield('topic_views'));
+		$db->sql_freeresult($result);
+	}
+}


### PR DESCRIPTION
Merging topics from the MCP forum view (merge_topics) has kept the highest view count of the merged topics since PHPBB-14795. Merging a whole topic into another one via the MCP topic view or the quickmod "Merge topic" option (merge_posts) never received the same treatment: when all of a topic's posts are moved and the emptied topic is deleted, its view count is silently lost.

This applies the established behaviour to merge_posts(): the destination topic takes the maximum of both topics' view counts, and only when the source topic was fully merged away. Partially merged topics keep their counts untouched. Using the maximum rather than the sum follows the explicit decision made in PHPBB-14795.

Covered by a new functional test that performs the full merge through the MCP and asserts the destination topic inherits the higher view count once the source topic is gone.

Checklist:

- [x] Correct branch: master for new features; 3.3.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master](https://area51.phpbb.com/docs/master/coding-guidelines.html) and [3.3.x](https://area51.phpbb.com/docs/dev/3.3.x/development/coding_guidelines.html)
- [x] Commit follows commit message [format](https://area51.phpbb.com/docs/dev/3.3.x/development/git.html)

Tracker ticket:

https://tracker.phpbb.com/browse/PHPBB-17627