### PR TITLE
[ticket/17472] Prevent web push fatal error when there are no users to notify

### DIFF
--- a/phpBB/phpbb/notification/method/webpush.php
+++ b/phpBB/phpbb/notification/method/webpush.php
@@ -198,6 +198,14 @@ class webpush extends base implements extended_method_interface
 
 		// Load all the users we need
 		$notify_users = array_diff($user_ids, $banned_users);
+
+		// Nothing to do if all users to notify are banned
+		if (!count($notify_users))
+		{
+			$this->empty_queue();
+			return;
+		}
+
 		$this->user_loader->load_users($notify_users, array(USER_IGNORE));
 
 		// Get subscriptions for users

--- a/tests/notification/fixtures/webpush_notification.type.post.xml
+++ b/tests/notification/fixtures/webpush_notification.type.post.xml
@@ -304,4 +304,14 @@
 			<value>1</value>
 		</row>
 	</table>
+	<table name="phpbb_bans">
+		<column>ban_id</column>
+		<column>ban_userid</column>
+		<column>ban_mode</column>
+		<column>ban_item</column>
+		<column>ban_start</column>
+		<column>ban_end</column>
+		<column>ban_reason</column>
+		<column>ban_reason_display</column>
+	</table>
 </dataset>

--- a/tests/notification/notification_method_webpush_test.php
+++ b/tests/notification/notification_method_webpush_test.php
@@ -462,6 +462,42 @@ class notification_method_webpush_test extends phpbb_tests_notification_base
 		$this->assertEquals($expected_users, $notified_users2, 'Assert that expected users stay the same after replying to same topic');
 	}
 
+	public function test_notify_banned_user(): void
+	{
+		$subscription = $this->create_subscription_for_user(2);
+
+		// The ban manager logs the action and excludes the acting user from the ban
+		$this->user->data['user_id'] = ANONYMOUS;
+		$this->user->ip = '127.0.0.1';
+
+		// Ban the only user that would be notified
+		$start_time = new \DateTime();
+		$end_time = new \DateTime();
+		$end_time->setTimestamp(0);
+		$this->container->get('ban.manager')->ban('user', ['poster'], $start_time, $end_time, '');
+
+		$post_data = [
+			'forum_id'		=> '1',
+			'post_id'		=> '4',
+			'topic_id'		=> '2',
+			'post_time'		=> 1349413322,
+			'poster_id'		=> 1,
+			'topic_title'	=> '',
+			'post_subject'	=> '',
+			'post_username'	=> '',
+			'forum_name'	=> '',
+		];
+
+		// Notifying only banned users should not cause an error
+		$this->notifications->add_notifications('notification.type.post', $post_data);
+
+		// The queue should have been emptied, calling notify again should have no effect
+		$this->notification_method_webpush->notify();
+
+		$messages = $this->get_messages_for_subscription($subscription['clientHash']);
+		$this->assertEmpty($messages, 'Failed asserting that banned user has not received messages.');
+	}
+
 	/**
 	 * @dataProvider data_notification_webpush
 	 */


### PR DESCRIPTION
Checklist:

- [x] Correct branch: master for new features; 3.3.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master](https://area51.phpbb.com/docs/master/coding-guidelines.html) and [3.3.x](https://area51.phpbb.com/docs/dev/3.3.x/development/coding_guidelines.html)
- [x] Commit follows commit message [format](https://area51.phpbb.com/docs/dev/3.3.x/development/git.html)

Tracker ticket:

https://tracker.phpbb.com/browse/PHPBB-17472

Web push fataled with "No values specified for SQL IN comparison" when removing banned users left nobody to notify. The queue is now emptied and skipped instead.