### PR TITLE
[ticket/17668] Prevent managing special groups from the UCP

### DIFF
--- a/phpBB/includes/ucp/ucp_groups.php
+++ b/phpBB/includes/ucp/ucp_groups.php
@@ -430,6 +430,12 @@ class ucp_groups
 						trigger_error($user->lang['NOT_ALLOWED_MANAGE_GROUP'] . $return_page, E_USER_WARNING);
 					}
 
+					// Special groups can only be managed from the ACP
+					if ($group_row['group_type'] == GROUP_SPECIAL)
+					{
+						trigger_error($user->lang['NOT_ALLOWED_MANAGE_GROUP'] . $return_page, E_USER_WARNING);
+					}
+
 					$group_name = $group_row['group_name'];
 					$group_type = $group_row['group_type'];
 
@@ -1115,6 +1121,7 @@ class ucp_groups
 							WHERE ug.user_id = ' . $user->data['user_id'] . '
 								AND g.group_id = ug.group_id
 								AND ug.group_leader = 1
+								AND g.group_type <> ' . GROUP_SPECIAL . '
 							ORDER BY g.group_type DESC, g.group_name';
 						$result = $db->sql_query($sql);
 

--- a/tests/functional/avatar_ucp_groups_test.php
+++ b/tests/functional/avatar_ucp_groups_test.php
@@ -17,9 +17,33 @@ require_once __DIR__ . '/common_avatar_test_case.php';
  */
 class phpbb_functional_avatar_ucp_groups_test extends phpbb_functional_common_avatar_test_case
 {
+	/** @var int Group id of the group used for testing */
+	protected $group_id;
+
 	public function get_url()
 	{
-		return 'ucp.php?i=ucp_groups&mode=manage&action=edit&g=5';
+		return 'ucp.php?i=ucp_groups&mode=manage&action=edit&g=' . $this->group_id;
+	}
+
+	protected function setUp(): void
+	{
+		parent::setUp();
+
+		// Special groups can not be managed from the UCP, so use a normal
+		// group with the admin user as group leader
+		$this->group_id = $this->get_group_id('avatar-group');
+		if (!$this->group_id)
+		{
+			$crawler = self::request('GET', 'adm/index.php?i=acp_groups&mode=manage&sid=' . $this->sid);
+			$form = $crawler->selectButton($this->lang('SUBMIT'))->form();
+			$crawler = self::submit($form, ['group_name' => 'avatar-group']);
+
+			$form = $crawler->selectButton($this->lang('SUBMIT'))->form();
+			self::submit($form, ['group_name' => 'avatar-group']);
+
+			$this->group_id = $this->get_group_id('avatar-group');
+			$this->add_user_group('avatar-group', ['admin'], false, true);
+		}
 	}
 
 	public static function avatar_ucp_groups_data()

--- a/tests/functional/ucp_groups_test.php
+++ b/tests/functional/ucp_groups_test.php
@@ -23,13 +23,53 @@ class phpbb_functional_ucp_groups_test extends phpbb_functional_common_groups_te
 		return 'ucp.php?i=groups&mode=manage&action=edit';
 	}
 
-	protected function get_teampage_settings()
+	/**
+	* Create a normal group with the admin user as group leader
+	*
+	* Special groups can no longer be managed from the UCP, so the UCP
+	* management tests need a regular group led by the admin user.
+	*
+	* @return int Group id of the created group
+	*/
+	protected function create_manage_group()
+	{
+		$group_id = $this->get_group_id('manage-group');
+		if ($group_id)
+		{
+			return $group_id;
+		}
+
+		$crawler = self::request('GET', 'adm/index.php?i=acp_groups&mode=manage&sid=' . $this->sid);
+		$form = $crawler->selectButton($this->lang('SUBMIT'))->form();
+		$crawler = self::submit($form, array('group_name' => 'manage-group'));
+
+		$form = $crawler->selectButton($this->lang('SUBMIT'))->form();
+		$crawler = self::submit($form, array('group_name' => 'manage-group'));
+
+		$this->assertContainsLang('GROUP_CREATED', $crawler->filter('#main')->text());
+
+		$group_id = $this->get_group_id('manage-group');
+
+		// Make admin group leader
+		$crawler = self::request('GET', 'adm/index.php?i=acp_groups&mode=manage&action=list&g=' . $group_id . '&sid=' . $this->sid);
+		$form = $crawler->filter('input[name=addusers]')->selectButton($this->lang('SUBMIT'))->form();
+		$crawler = self::submit($form, [
+			'leader'	=> 1,
+			'usernames'	=> 'admin',
+		]);
+
+		$this->assertContainsLang('GROUP_MODS_ADDED', $crawler->filter('#main')->text());
+
+		return $group_id;
+	}
+
+	protected function get_teampage_settings($group_id)
 	{
 		$sql = 'SELECT g.group_legend AS group_legend, t.teampage_position AS group_teampage
 			FROM ' . GROUPS_TABLE . ' g
 			LEFT JOIN ' . TEAMPAGE_TABLE . ' t
 				ON (t.group_id = g.group_id)
-			WHERE g.group_id = 5';
+			WHERE g.group_id = ' . (int) $group_id;
 		$result = $this->db->sql_query($sql);
 		$group_row = $this->db->sql_fetchrow($result);
 		$this->db->sql_freeresult($result);
@@ -39,14 +79,46 @@ class phpbb_functional_ucp_groups_test extends phpbb_functional_common_groups_te
 	public function test_ucp_groups_teampage()
 	{
 		$this->group_manage_login();
+		$group_id = $this->create_manage_group();
 
 		// Test if group_legend or group_teampage are modified while
 		// submitting the ucp_group_manage page
-		$form = $this->get_group_manage_form();
-		$teampage_settings = $this->get_teampage_settings();
+		$form = $this->get_group_manage_form($group_id);
+		$teampage_settings = $this->get_teampage_settings($group_id);
 		$crawler = self::submit($form);
 		$this->assertStringContainsString($this->lang('GROUP_UPDATED'), $crawler->text());
-		$this->assertEquals($teampage_settings, $this->get_teampage_settings());
+		$this->assertEquals($teampage_settings, $this->get_teampage_settings($group_id));
+	}
+
+	/**
+	* @dataProvider groups_manage_test_data
+	*/
+	public function test_groups_manage($input, $expected)
+	{
+		$this->group_manage_login();
+		$group_id = $this->create_manage_group();
+
+		$form = $this->get_group_manage_form($group_id);
+		$form['group_colour']->setValue($input);
+		$crawler = self::submit($form);
+		$this->assertStringContainsString($this->lang($expected), $crawler->text());
+	}
+
+	public function test_manage_special_group_denied()
+	{
+		$this->group_manage_login();
+
+		// The Administrators group is not listed on the UCP manage groups page
+		// even though the admin user is its group leader
+		$crawler = self::request('GET', 'ucp.php?i=groups&mode=manage&sid=' . $this->sid);
+		$this->assertStringNotContainsString('action=edit&amp;g=5', $crawler->html());
+
+		// Special groups can not be managed from the UCP
+		$crawler = self::request('GET', 'ucp.php?i=groups&mode=manage&action=edit&g=5&sid=' . $this->sid);
+		$this->assertContainsLang('NOT_ALLOWED_MANAGE_GROUP', $crawler->text());
+
+		$crawler = self::request('GET', 'ucp.php?i=groups&mode=manage&action=list&g=5&sid=' . $this->sid);
+		$this->assertContainsLang('NOT_ALLOWED_MANAGE_GROUP', $crawler->text());
 	}
 
 	public function test_create_request_group()


### PR DESCRIPTION
Checklist:

- [x] Correct branch: master for new features; 3.3.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master](https://area51.phpbb.com/docs/master/coding-guidelines.html) and [3.3.x](https://area51.phpbb.com/docs/dev/3.3.x/development/coding_guidelines.html)
- [x] Commit follows commit message [format](https://area51.phpbb.com/docs/dev/3.3.x/development/git.html)

Tracker ticket:

https://tracker.phpbb.com/browse/PHPBB-17668

Group leaders could manage special groups from the UCP without any ACP permission check, so a leader of the Administrators group was able to add new admins. Special groups now have to be managed from the ACP and are no longer listed on the UCP manage groups page. The existing UCP group tests managed the Administrators group directly, they now use regular groups led by the admin user instead.