### PR TITLE
ticket/17690 Subject field not utf8 encoded when a draft is re-saved

### DIFF
--- a/phpBB/includes/ucp/ucp_main.php
+++ b/phpBB/includes/ucp/ucp_main.php
@@ -597,6 +597,11 @@ class ucp_main
 				if ($submit && $edit)
 				{
 					$draft_subject = $request->variable('subject', '', true);
+					/**
+					 * Replace Emojis and other 4bit UTF-8 chars not allowed by MySQL to UCR/NCR.
+					 * Using their Numeric Character Reference's Hexadecimal notation.
+					 */
+					$draft_subject = utf8_encode_ucr($draft_subject);
 					$draft_message = $request->variable('message', '', true);
 					if (check_form_key('ucp_draft'))
 					{


### PR DESCRIPTION
Add code to ensure that subject is utf-8 encoded before saving to database.

Checklist:

- [ √] Correct branch: master for new features; 3.3.x for fixes
- [ *] Tests pass (i don't see increased failures)
- [ √] Code follows coding guidelines: [master](https://area51.phpbb.com/docs/master/coding-guidelines.html) and [3.3.x](https://area51.phpbb.com/docs/dev/3.3.x/development/coding_guidelines.html)
- [ √ Commit follows commit message [format](https://area51.phpbb.com/docs/dev/3.3.x/development/git.html)

Tracker ticket:

https://tracker.phpbb.com/browse/PHPBB-17690
