### PR TITLE
[ticket/17695] Add event to modify the email envelope sender

### DIFF
--- a/phpBB/includes/functions_messenger.php
+++ b/phpBB/includes/functions_messenger.php
@@ -528,6 +528,26 @@ class messenger
 	}
 
 	/**
+	* Return a valid email envelope sender or the configured board email
+	*
+	* @param mixed $envelope_sender Email envelope sender to validate
+	* @return string
+	*/
+	static function get_valid_envelope_sender($envelope_sender)
+	{
+		global $config;
+
+		if (!is_string($envelope_sender)
+			|| preg_match('/[\r\n]/', $envelope_sender)
+			|| !preg_match('/^' . get_preg_expression('email') . '$/iD', $envelope_sender))
+		{
+			return $config['board_email'];
+		}
+
+		return $envelope_sender;
+	}
+
+	/**
 	* Send out emails
 	*/
 	function msg_email()
@@ -621,6 +641,24 @@ class messenger
 
 		// Build header
 		$headers = $this->build_header($to, $cc, $bcc);
+		$envelope_sender = $config['board_email'];
+
+		/**
+		* Modify the email envelope sender before the message is sent or queued
+		*
+		* A modified value forces use of the -f parameter for the PHP mail
+		* transport even when email_force_sender is disabled. The null reverse
+		* path is not supported.
+		*
+		* @event core.modify_email_envelope_sender
+		* @var string envelope_sender The RFC 5321 envelope sender address
+		* @var array  headers         Mutable entries for keeping Return-Path or Sender consistent
+		* @since 3.3.18-RC1
+		*/
+		$vars = array('envelope_sender', 'headers');
+		extract($phpbb_dispatcher->trigger_event('core.modify_email_envelope_sender', compact($vars)));
+
+		$envelope_sender = $this->get_valid_envelope_sender($envelope_sender);
 
 		// Send message ...
 		if (!$use_queue)
@@ -630,11 +668,11 @@ class messenger
 
 			if ($config['smtp_delivery'])
 			{
-				$result = smtpmail($this->addresses, mail_encode($this->subject), wordwrap(utf8_wordwrap($this->msg), 997, "\n", true), $err_msg, $headers);
+				$result = smtpmail($this->addresses, mail_encode($this->subject), wordwrap(utf8_wordwrap($this->msg), 997, "\n", true), $err_msg, $headers, $envelope_sender);
 			}
 			else
 			{
-				$result = phpbb_mail($mail_to, $this->subject, $this->msg, $headers, $encode_eol, $err_msg);
+				$result = phpbb_mail($mail_to, $this->subject, $this->msg, $headers, $encode_eol, $err_msg, $envelope_sender);
 			}
 
 			if (!$result)
@@ -650,7 +688,8 @@ class messenger
 				'addresses'		=> $this->addresses,
 				'subject'		=> $this->subject,
 				'msg'			=> $this->msg,
-				'headers'		=> $headers)
+				'headers'		=> $headers,
+				'envelope_sender' => $envelope_sender)
 			);
 		}
 
@@ -922,6 +961,7 @@ class queue
 			for ($i = 0; $i < $num_items; $i++)
 			{
 				// Make variables available...
+				$envelope_sender = $config['board_email'];
 				extract(array_shift($this->queue_data[$object]['data']));
 
 				switch ($object)
@@ -953,12 +993,12 @@ class queue
 
 							if ($config['smtp_delivery'])
 							{
-								$result = smtpmail($addresses, mail_encode($subject), wordwrap(utf8_wordwrap($msg), 997, "\n", true), $err_msg, $headers);
+								$result = smtpmail($addresses, mail_encode($subject), wordwrap(utf8_wordwrap($msg), 997, "\n", true), $err_msg, $headers, $envelope_sender);
 							}
 							else
 							{
 								$encode_eol = $config['smtp_delivery'] || PHP_VERSION_ID >= 80000 ? "\r\n" : PHP_EOL;
-								$result = phpbb_mail($to, $subject, $msg, $headers, $encode_eol, $err_msg);
+								$result = phpbb_mail($to, $subject, $msg, $headers, $encode_eol, $err_msg, $envelope_sender);
 							}
 
 							if (!$result)
@@ -1090,9 +1130,11 @@ class queue
 /**
 * Replacement or substitute for PHP's mail command
 */
-function smtpmail($addresses, $subject, $message, &$err_msg, $headers = false)
+function smtpmail($addresses, $subject, $message, &$err_msg, $headers = false, $envelope_sender = false)
 {
 	global $config, $user;
+
+	$envelope_sender = messenger::get_valid_envelope_sender($envelope_sender);
 
 	// Fix any bare linefeeds in the message to make it RFC821 Compliant.
 	$message = preg_replace("#(?<!\r)\n#si", "\r\n", $message);
@@ -1222,7 +1264,7 @@ function smtpmail($addresses, $subject, $message, &$err_msg, $headers = false)
 
 	// From this point onward most server response codes should be 250
 	// Specify who the mail is from....
-	$smtp->server_send('MAIL FROM:<' . $config['board_email'] . '>');
+	$smtp->server_send('MAIL FROM:<' . $envelope_sender . '>');
 	if ($err_msg = $smtp->server_parse('250', __LINE__))
 	{
 		$smtp->close_session($err_msg);
@@ -1932,9 +1974,11 @@ function mail_encode($str, $eol = "\r\n")
 /**
  * Wrapper for sending out emails with the PHP's mail function
  */
-function phpbb_mail($to, $subject, $msg, $headers, $eol, &$err_msg)
+function phpbb_mail($to, $subject, $msg, $headers, $eol, &$err_msg, $envelope_sender = false)
 {
 	global $config, $phpbb_root_path, $phpEx, $phpbb_dispatcher;
+
+	$envelope_sender = messenger::get_valid_envelope_sender($envelope_sender);
 
 	// Convert Numeric Character References to UTF-8 chars (ie. Emojis)
 	$subject = utf8_decode_ncr($subject);
@@ -1961,7 +2005,10 @@ function phpbb_mail($to, $subject, $msg, $headers, $eol, &$err_msg)
 	 * Because PHP can't decide what is wanted we revert back to the non-RFC-compliant way of separating by one space
 	 * (Use '' as parameter to mail_encode() results in SPACE used)
 	 */
-	$additional_parameters = $config['email_force_sender'] ? '-f' . $config['board_email'] : '';
+	// A changed envelope sender requires -f regardless of email_force_sender.
+	$additional_parameters = ($config['email_force_sender'] || $envelope_sender !== $config['board_email'])
+		? '-f' . $envelope_sender
+		: '';
 
 	/**
 	 * Modify data before sending out emails with PHP's mail function

--- a/tests/messenger/envelope_sender_test.php
+++ b/tests/messenger/envelope_sender_test.php
@@ -1,0 +1,148 @@
+<?php
+/**
+*
+* This file is part of the phpBB Forum Software package.
+*
+* @copyright (c) phpBB Limited <https://www.phpbb.com>
+* @license GNU General Public License, version 2 (GPL-2.0)
+*
+* For full copyright and license information, please see
+* the docs/CREDITS.txt file.
+*
+*/
+
+class phpbb_messenger_envelope_sender_test extends phpbb_test_case
+{
+	/** @var \phpbb\config\config */
+	protected $config;
+
+	protected function setUp(): void
+	{
+		global $config, $phpbb_dispatcher, $phpbb_root_path, $phpEx, $request, $user;
+
+		$this->config = $config = new \phpbb\config\config(array(
+			'board_contact'			=> 'contact@example.com',
+			'board_contact_name'	=> '',
+			'board_email'			=> 'board@example.com',
+			'cookie_secure'			=> false,
+			'email_enable'			=> true,
+			'email_package_size'	=> 10,
+			'force_server_vars'		=> true,
+			'script_path'			=> '/phpbb',
+			'server_name'			=> 'example.com',
+			'server_port'			=> 80,
+			'server_protocol'		=> 'http://',
+			'smtp_delivery'			=> true,
+		));
+		$request = new phpbb_mock_request();
+		$user = (object) array('host' => '');
+		$phpbb_dispatcher = new phpbb_messenger_envelope_sender_dispatcher();
+
+		if (!class_exists('messenger'))
+		{
+			include $phpbb_root_path . 'includes/functions_messenger.' . $phpEx;
+		}
+	}
+
+	public function test_event_sender_and_headers_are_stored_with_queued_message()
+	{
+		global $phpbb_dispatcher;
+
+		$phpbb_dispatcher->envelope_sender = 'bounce@example.com';
+		$queue = new phpbb_messenger_envelope_sender_queue();
+		$messenger = new messenger();
+		$messenger->queue = $queue;
+		$messenger->to('recipient@example.com');
+		$messenger->subject('Subject');
+		$messenger->msg = 'Message';
+
+		$this->assertTrue($messenger->msg_email());
+		$this->assertCount(1, $queue->messages);
+		$this->assertSame('email', $queue->messages[0]['object']);
+		$this->assertSame('bounce@example.com', $queue->messages[0]['data']['envelope_sender']);
+		$this->assertContains('X-Envelope-Sender-Test: present', $queue->messages[0]['data']['headers']);
+		$this->assertContains('core.modify_email_envelope_sender', $phpbb_dispatcher->events);
+	}
+
+	/**
+	* @dataProvider invalid_envelope_sender_data
+	*/
+	public function test_invalid_event_sender_falls_back_to_board_email($invalid_sender)
+	{
+		global $phpbb_dispatcher;
+
+		$phpbb_dispatcher->envelope_sender = $invalid_sender;
+		$queue = new phpbb_messenger_envelope_sender_queue();
+		$messenger = new messenger();
+		$messenger->queue = $queue;
+		$messenger->to('recipient@example.com');
+		$messenger->msg = 'Message';
+
+		$this->assertTrue($messenger->msg_email());
+		$this->assertSame('board@example.com', $queue->messages[0]['data']['envelope_sender']);
+	}
+
+	public function invalid_envelope_sender_data()
+	{
+		return array(
+			'empty'			=> array(''),
+			'invalid email'	=> array('not-an-email'),
+			'header newline'	=> array("bounce@example.com\r\nBcc: victim@example.com"),
+			'non-string'	=> array(array('bounce@example.com')),
+			'null'			=> array(null),
+		);
+	}
+
+	public function test_transport_parameters_remain_optional()
+	{
+		$smtp = new ReflectionFunction('smtpmail');
+		$local_mail = new ReflectionFunction('phpbb_mail');
+
+		$this->assertSame(4, $smtp->getNumberOfRequiredParameters());
+		$this->assertSame(6, $smtp->getNumberOfParameters());
+		$this->assertSame(6, $local_mail->getNumberOfRequiredParameters());
+		$this->assertSame(7, $local_mail->getNumberOfParameters());
+	}
+
+	public function test_sender_uses_phpbb_email_validation()
+	{
+		$sender = 'bounce&amp;tag@example.com';
+
+		$this->assertSame($sender, messenger::get_valid_envelope_sender($sender));
+	}
+}
+
+class phpbb_messenger_envelope_sender_dispatcher
+{
+	/** @var mixed */
+	public $envelope_sender = 'board@example.com';
+
+	/** @var string[] */
+	public $events = array();
+
+	public function trigger_event($event_name, $data)
+	{
+		$this->events[] = $event_name;
+		if ($event_name === 'core.modify_email_envelope_sender')
+		{
+			$data['envelope_sender'] = $this->envelope_sender;
+			$data['headers'][] = 'X-Envelope-Sender-Test: present';
+		}
+
+		return $data;
+	}
+}
+
+class phpbb_messenger_envelope_sender_queue
+{
+	/** @var array */
+	public $messages = array();
+
+	public function put($object, $data)
+	{
+		$this->messages[] = array(
+			'object'	=> $object,
+			'data'		=> $data,
+		);
+	}
+}


### PR DESCRIPTION
Expose the RFC 5321 envelope sender after headers are built and preserve it through queued delivery.

Validate the value before SMTP and PHP mail transport use, falling back to board_email for invalid or legacy queue values.


Checklist:

- [X] Correct branch: master for new features; 3.3.x for fixes
- [X] Tests pass
- [X] Code follows coding guidelines: [master](https://area51.phpbb.com/docs/master/coding-guidelines.html) and [3.3.x](https://area51.phpbb.com/docs/dev/3.3.x/development/coding_guidelines.html)
- [X] Commit follows commit message [format](https://area51.phpbb.com/docs/dev/3.3.x/development/git.html)

Tracker ticket:

https://tracker.phpbb.com/browse/PHPBB-17695
