### PR TITLE
[ticket/17695] Port envelope sender event to Symfony Mailer

### DIFF
--- a/phpBB/phpbb/messenger/method/email.php
+++ b/phpBB/phpbb/messenger/method/email.php
@@ -303,6 +303,44 @@ class email extends base
 		$vars = ['headers'];
 		extract($this->dispatcher->trigger_event('core.modify_email_headers', compact($vars)));
 
+		$envelope_sender = $this->config['board_email'];
+		foreach (['Sender', 'Return-Path'] as $sender_header)
+		{
+			if (!isset($headers[$sender_header]))
+			{
+				continue;
+			}
+			$envelope_sender = $headers[$sender_header] instanceof Address
+				? $headers[$sender_header]->getAddress()
+				: $headers[$sender_header];
+			break;
+		}
+
+		/**
+		 * Modify the email envelope sender before the message is sent or queued
+		 *
+		 * The value inherits a Sender or Return-Path changed by the earlier
+		 * header event. The null reverse path is not supported. Header entries
+		 * may be changed to keep Return-Path consistent with the envelope sender.
+		 *
+		 * @event core.modify_email_envelope_sender
+		 * @var string envelope_sender The RFC 5321 envelope sender address
+		 * @var array  headers         Array containing email header entries
+		 * @since 3.3.18-RC1
+		 * @changed 4.0.0-a3 Header entries use Symfony Mailer compatible values
+		 */
+		$vars = ['envelope_sender', 'headers'];
+		extract($this->dispatcher->trigger_event('core.modify_email_envelope_sender', compact($vars)));
+
+		if (!is_string($envelope_sender)
+			|| preg_match('/[\r\n]/', $envelope_sender)
+			|| !preg_match('/^' . get_preg_expression('email') . '$/iD', $envelope_sender))
+		{
+			$envelope_sender = $this->config['board_email'];
+		}
+
+		$headers['Sender'] = new Address($envelope_sender);
+
 		foreach ($headers as $header => $value)
 		{
 			$this->header($header, $value);

--- a/tests/messenger/method_email_test.php
+++ b/tests/messenger/method_email_test.php
@@ -439,6 +439,94 @@ class phpbb_messenger_method_email_test extends \phpbb_test_case
 		);
 	}
 
+	public function test_modify_email_envelope_sender()
+	{
+		$this->config->set('board_contact', 'contact@yourdomain.com');
+		$this->config->set('board_contact_name', '');
+		$this->config->set('board_email', 'admin@yourdomain.com');
+
+		$this->dispatcher
+			->expects($this->exactly(2))
+			->method('trigger_event')
+			->willReturnCallback(function($event_name, $value_array) {
+				if ($event_name === 'core.modify_email_headers')
+				{
+					$value_array['headers']['Sender'] = new \Symfony\Component\Mime\Address('existing@yourdomain.com');
+				}
+				if ($event_name === 'core.modify_email_envelope_sender')
+				{
+					$this->assertEquals('existing@yourdomain.com', $value_array['envelope_sender']);
+					$value_array['envelope_sender'] = 'bounce@yourdomain.com';
+					$value_array['headers']['Return-Path'] = new \Symfony\Component\Mime\Address('bounce@yourdomain.com');
+				}
+
+				return $value_array;
+			});
+
+		$this->method_email->init();
+		$this->method_email->to('foo@bar.com');
+
+		$email_reflection = new \ReflectionClass($this->method_email);
+		$email_reflection->getMethod('build_headers')->invoke($this->method_email);
+		/** @var \Symfony\Component\Mime\Email $email */
+		$email = $email_reflection->getProperty('email')->getValue($this->method_email);
+
+		$this->assertEquals('bounce@yourdomain.com', $email->getSender()->getAddress());
+		$this->assertEquals(
+			'bounce@yourdomain.com',
+			$email->getHeaders()->get('Return-Path')->getAddress()->getAddress()
+		);
+		$this->assertEquals(
+			'bounce@yourdomain.com',
+			\Symfony\Component\Mailer\Envelope::create($email)->getSender()->getAddress()
+		);
+
+		/** @var \Symfony\Component\Mime\Email $queued_email */
+		$queued_email = unserialize(serialize($email));
+		$this->assertEquals('bounce@yourdomain.com', $queued_email->getSender()->getAddress());
+	}
+
+	/**
+	 * @dataProvider invalid_envelope_sender_data
+	 */
+	public function test_invalid_envelope_sender_falls_back_to_board_email($invalid_sender)
+	{
+		$this->config->set('board_contact', 'contact@yourdomain.com');
+		$this->config->set('board_contact_name', '');
+		$this->config->set('board_email', 'admin@yourdomain.com');
+
+		$this->dispatcher
+			->method('trigger_event')
+			->willReturnCallback(function($event_name, $value_array) use ($invalid_sender) {
+				if ($event_name === 'core.modify_email_envelope_sender')
+				{
+					$value_array['envelope_sender'] = $invalid_sender;
+				}
+
+				return $value_array;
+			});
+
+		$this->method_email->init();
+		$email_reflection = new \ReflectionClass($this->method_email);
+		$email_reflection->getMethod('build_headers')->invoke($this->method_email);
+		/** @var \Symfony\Component\Mime\Email $email */
+		$email = $email_reflection->getProperty('email')->getValue($this->method_email);
+
+		$this->assertEquals('admin@yourdomain.com', $email->getSender()->getAddress());
+	}
+
+	public static function invalid_envelope_sender_data()
+	{
+		return [
+			'empty'				=> [''],
+			'invalid email'		=> ['not-an-email'],
+			'null reverse path'	=> ['<>'],
+			'header newline'	=> ["bounce@example.com\r\nBcc: victim@example.com"],
+			'non-string'		=> [['bounce@example.com']],
+			'null'				=> [null],
+		];
+	}
+
 	public function test_set_mail_priority()
 	{
 		$email_reflection = new \ReflectionClass($this->method_email);


### PR DESCRIPTION
Adapt the envelope sender event to the Symfony Mailer implementation.

Preserve existing Sender and Return-Path header changes, set the structured Sender header,
and rely on the serialized Email object for queued delivery.


Checklist:

- [x] Correct branch: master for new features; 3.3.x for fixes
- [x] Tests pass
- [x] Code follows coding guidelines: [master](https://area51.phpbb.com/docs/master/coding-guidelines.html) and [3.3.x](https://area51.phpbb.com/docs/dev/3.3.x/development/coding_guidelines.html)
- [x] Commit follows commit message [format](https://area51.phpbb.com/docs/dev/3.3.x/development/git.html)

Tracker ticket:

https://tracker.phpbb.com/browse/PHPBB-17695
